### PR TITLE
fix: remove save button from edit when update is restricted

### DIFF
--- a/app/controllers/avo/resources_controller.rb
+++ b/app/controllers/avo/resources_controller.rb
@@ -257,6 +257,7 @@ module Avo
           default_view_type: avo_resource.default_view_type || Avo.configuration.default_view_type,
           authorization: {
             create: AuthorizationService::authorize(current_user, avo_resource.model, Avo.configuration.authorization_methods.stringify_keys['create']),
+            edit: AuthorizationService::authorize(current_user, avo_resource.model, Avo.configuration.authorization_methods.stringify_keys['edit']),
             update: AuthorizationService::authorize(current_user, avo_resource.model, Avo.configuration.authorization_methods.stringify_keys['update']),
             show: AuthorizationService::authorize(current_user, avo_resource.model, Avo.configuration.authorization_methods.stringify_keys['show']),
             destroy: AuthorizationService::authorize(current_user, avo_resource.model, Avo.configuration.authorization_methods.stringify_keys['destroy']),

--- a/app/frontend/js/components/Index/ItemControls.vue
+++ b/app/frontend/js/components/Index/ItemControls.vue
@@ -81,7 +81,7 @@ export default {
       return `/resources/${this.resourceName}`
     },
     canEdit() {
-      return this.resource.authorization.update
+      return this.resource.authorization.edit
     },
     canView() {
       return this.resource.authorization.show

--- a/app/frontend/js/views/ResourceEdit.vue
+++ b/app/frontend/js/views/ResourceEdit.vue
@@ -9,7 +9,7 @@
         <template #tools>
           <div class="flex justify-end space-x-2">
             <a-button :to="cancelActionParams"><arrow-left-icon class="h-4 mr-1"/> Cancel</a-button>
-            <a-button color="green" @click="submitResource"><save-icon class="h-4 mr-1"/> Save</a-button>
+            <a-button v-if="allowUpdate" color="green" @click="submitResource"><save-icon class="h-4 mr-1"/> Save</a-button>
           </div>
         </template>
 
@@ -77,6 +77,9 @@ export default {
       }
 
       return action
+    },
+    canUpdate() {
+      return this.resource.authorization.update
     },
   },
 }

--- a/app/frontend/js/views/ResourceEdit.vue
+++ b/app/frontend/js/views/ResourceEdit.vue
@@ -9,7 +9,7 @@
         <template #tools>
           <div class="flex justify-end space-x-2">
             <a-button :to="cancelActionParams"><arrow-left-icon class="h-4 mr-1"/> Cancel</a-button>
-            <a-button v-if="allowUpdate" color="green" @click="submitResource"><save-icon class="h-4 mr-1"/> Save</a-button>
+            <a-button v-if="canUpdate" color="green" @click="submitResource"><save-icon class="h-4 mr-1"/> Save</a-button>
           </div>
         </template>
 

--- a/app/frontend/js/views/ResourceShow.vue
+++ b/app/frontend/js/views/ResourceShow.vue
@@ -117,7 +117,7 @@ export default {
       return this.fields.filter((field) => ['has_and_belongs_to_many', 'has_many'].indexOf(field.relationship) > -1)
     },
     canEdit() {
-      return this.resource.authorization.update
+      return this.resource.authorization.edit
     },
     canDelete() {
       return this.resource.authorization.destroy

--- a/lib/avo/app/resource.rb
+++ b/lib/avo/app/resource.rb
@@ -80,7 +80,7 @@ module Avo
         end
 
         def get_authorization(user, model)
-          [:create, :update, :show, :destroy].map do |action|
+          [:create, :edit, :update, :show, :destroy].map do |action|
             [action, AuthorizationService::authorize_action(user, model, action)]
           end.to_h
         end

--- a/spec/features/avo/resources_controller_spec.rb
+++ b/spec/features/avo/resources_controller_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Avo::ResourcesController, type: :controller do
         expect(response).to have_http_status(200)
         expect(parsed_response).to eql({
           meta: {
-            authorization: { create: false, destroy: false, show: false, update: true },
+            authorization: { create: false, edit: true, destroy: false, show: false, update: true },
             per_page_steps: [12, 24, 48, 72],
             available_view_types: ['grid', 'table'],
             default_view_type: 'grid',


### PR DESCRIPTION
Edit=true Update=true => ShowEditButtons=true ShowSaveButton=true
Edit=false Update=false => ShowEditButtons=false ShowSaveButton=false
Edit=true Update=false => ShowEditButtons=true ShowSaveButton=false
Edit=false Update=true => ShowEditButtons=false ShowSaveButton=true(won’t be accessible)

EditButtons = Edit Button on Index + Edit Button on Show
SaveButtom = Save Button on Edit