### PR TITLE
fix: KeyValue disable options issues

### DIFF
--- a/app/frontend/js/components/Edit/KeyValueField.vue
+++ b/app/frontend/js/components/Edit/KeyValueField.vue
@@ -4,7 +4,7 @@
       v-model="value"
       :key-label="field.key_label"
       :value-label="field.value_label"
-      :read-only="false"
+      :read-only="disabled"
       :action-text="field.action_text"
       :delete-text="field.delete_text"
       :disable-editing-keys="field.disable_editing_keys"

--- a/app/frontend/js/components/KeyValueComponent.vue
+++ b/app/frontend/js/components/KeyValueComponent.vue
@@ -78,9 +78,11 @@ export default {
       }
     },
     addRow() {
-      const length = this.rows.push({ key: '', value: '' })
+      if (!this.disableAddingRows) {
+        const length = this.rows.push({ key: '', value: '' })
 
-      setTimeout(() => this.focusRow(length - 1), 1)
+        setTimeout(() => this.focusRow(length - 1), 1)
+      }
     },
     goToNextRow(index) {
       this.focusRow(index + 1)
@@ -89,7 +91,9 @@ export default {
       this.$refs[`keyValueRow${index}`][0].$emit('focus')
     },
     deleteRow(index) {
-      this.$delete(this.rows, index)
+      if (!this.disableDeletingRows) {
+        this.$delete(this.rows, index)
+      }
     },
   },
   watch: {

--- a/app/frontend/js/components/KeyValueComponent.vue
+++ b/app/frontend/js/components/KeyValueComponent.vue
@@ -35,7 +35,7 @@
         @delete-row="deleteRow"
         @value-updated="valueUpdated"
         @key-updated="keyUpdated"
-        @keyup-enter.stop.prevent="onEnterPress(index)"
+        @keyup-enter="onEnterPress(index)"
       />
     </div>
   </div>

--- a/app/frontend/js/components/KeyValueComponent.vue
+++ b/app/frontend/js/components/KeyValueComponent.vue
@@ -13,7 +13,7 @@
           <a href="javascript:void(0);"
             @click="addRow"
             v-tooltip="actionText"
-            :style="disableAddingRows ? 'cursor: not-allowed;' : ''"
+            :class="{'cursor-not-allowed': disableAddingRows}"
             data-button="add-row"
           ><plus-circle-icon class="text-gray-400 h-5 hover:text-gray-500"/></a>
         </div>

--- a/app/frontend/js/components/KeyValueRow.vue
+++ b/app/frontend/js/components/KeyValueRow.vue
@@ -8,6 +8,7 @@
       :placeholder="keyLabel"
       :disabled="readOnly || disableEditingKeys"
       @input="updateKey"
+      @keydown.native.enter.prevent=""
     />
     <input-component
       :class="inputClasses"
@@ -17,6 +18,7 @@
       :disabled="readOnly"
       @input="updateValue"
       @keyup.native.enter="$emit('keyup-enter')"
+      @keydown.native.enter.prevent=""
     />
     <div class="flex items-center justify-center px-3 bg-gray-200 border-l border-gray-600" v-if="!readOnly">
       <a

--- a/app/frontend/js/components/KeyValueRow.vue
+++ b/app/frontend/js/components/KeyValueRow.vue
@@ -6,7 +6,7 @@
       ref="keyInput"
       :value="loopKey"
       :placeholder="keyLabel"
-      :disabled="readOnly"
+      :disabled="readOnly || disableEditingKeys"
       @input="updateKey"
     />
     <input-component


### PR DESCRIPTION
There were some problems with the keyvalue field.

Pressing enter in the keyvalue key or value inputs doesnt submit the form. In case of value, enter either focuses on next row(if existing) or adds a new row.