### PR TITLE
feat: height option for Code field

### DIFF
--- a/app/frontend/js/components/CodeComponent.vue
+++ b/app/frontend/js/components/CodeComponent.vue
@@ -4,6 +4,7 @@
       v-model="valueInput"
       :options="cmOptions"
       class="rounded-lg overflow-hidden"
+      :style="heightStyle"
     />
     <empty-dash v-else />
 </template>
@@ -34,7 +35,6 @@ import 'codemirror/mode/sql/sql'
 import 'codemirror/mode/vue/vue'
 import 'codemirror/mode/xml/xml'
 
-
 export default {
   components: { codemirror },
   props: {
@@ -42,8 +42,14 @@ export default {
     language: String,
     theme: String,
     editable: Boolean,
+    height: String,
   },
   computed: {
+    heightStyle() {
+      return {
+        '--height': this.height,
+      }
+    },
     cmOptions() {
       return {
         readOnly: !this.editable,
@@ -68,3 +74,9 @@ export default {
   },
 }
 </script>
+
+<style>
+.CodeMirror {
+  height: var(--height) !important;
+}
+</style>

--- a/app/frontend/js/components/Edit/CodeField.vue
+++ b/app/frontend/js/components/Edit/CodeField.vue
@@ -5,6 +5,7 @@
       :language="field.language"
       :theme="field.theme"
       :editable="true"
+      :height="field.height"
       @value-updated="valueUpdated"
     />
   </edit-field-wrapper>

--- a/app/frontend/js/components/Show/CodeField.vue
+++ b/app/frontend/js/components/Show/CodeField.vue
@@ -5,6 +5,7 @@
       :language="field.language"
       :theme="field.theme"
       :editable="false"
+      :height="field.height"
     />
   </show-field-wrapper>
 </template>

--- a/lib/avo/app/fields/code_field.rb
+++ b/lib/avo/app/fields/code_field.rb
@@ -12,12 +12,14 @@ module Avo
 
         @language = args[:language].present? ? args[:language].to_s : 'javascript'
         @theme = args[:theme].present? ? args[:theme].to_s : 'material-darker'
+        @height = args[:height].present? ? args[:height].to_s : 'auto'
       end
 
       def hydrate_field(fields, model, resource, view)
         {
           language: @language,
           theme: @theme,
+          height: @height,
         }
       end
     end

--- a/spec/dummy/app/avo/resources/user.rb
+++ b/spec/dummy/app/avo/resources/user.rb
@@ -28,7 +28,7 @@ module Avo
         password :password_confirmation, name: 'Password confirmation', required: false, only_on: :create
 
         heading '<div class="text-gray-300 uppercase font-bold">DEV</div>', as_html: true
-        code :custom_css, theme: 'dracula', language: 'css', help: "This enables you to edit the user's custom styles."
+        code :custom_css, theme: 'dracula', language: 'css', help: "This enables you to edit the user's custom styles.", height: '125px'
 
         hidden :team_id, default: 0 # For testing purposes
 


### PR DESCRIPTION
Instead of `rows` and `auto` I thought about implementing a `height` option that will enforce the size of the field(if specified), otherwise it defaults to auto and the size will fit all content. I think it will be easier for the administrator to configure and also makes sense to default to auto. Let me know what you think about this.