### PR TITLE
fix: height option for Markdown field

### DIFF
--- a/app/frontend/js/components/Edit/MarkdownField.vue
+++ b/app/frontend/js/components/Edit/MarkdownField.vue
@@ -15,6 +15,7 @@
       codeStyle="dracula"
       :toolbars="toolbars"
       default-open="edit"
+      :style="{height: field.height}"
     />
   </edit-field-wrapper>
 </template>

--- a/lib/avo/app/fields/markdown_field.rb
+++ b/lib/avo/app/fields/markdown_field.rb
@@ -13,11 +13,13 @@ module Avo
         hide_on :index
 
         @always_show = args[:always_show].present? ? args[:always_show] : false
+        @height = args[:height].present? ? args[:height].to_s : 'auto'
       end
 
       def hydrate_field(fields, model, resource, view)
         {
-          always_show: @always_show
+          always_show: @always_show,
+          height: @height
         }
       end
     end

--- a/spec/dummy/app/avo/resources/project.rb
+++ b/spec/dummy/app/avo/resources/project.rb
@@ -17,7 +17,7 @@ module Avo
         country :country
         number :users_required
         datetime :started_at, name: 'Started', time_24hr: true, relative: true
-        markdown :description
+        markdown :description, height: '350px'
         files :files
         key_value :meta, key_label: 'Meta key', value_label: 'Meta value', action_text: 'New item', delete_text: 'Remove item', disable_editing_keys: false, disable_adding_rows: false, disable_deleting_rows: false
 


### PR DESCRIPTION
Same logic as code, if not present or wrong height measure (ex: '3maini') the height of the field will be auto (expand as long as it's content). Unfortunately the MavonEditor for markdown has a minimum height of 300px that cannot be override, so for values less than 300px, the editor will have height 300px, otherwise setting more than 300px will set the height accordingly.

height: 4degetemici => auto height
height: 125px => height: 300px
height: 375px => height: 375px
height: 1cm => height: 300px
height: 10cm => height: 377.49px