### PR TITLE
fix: index/show will display dash for wrong input

### DIFF
--- a/app/frontend/js/components/Index/BooleanGroupField.vue
+++ b/app/frontend/js/components/Index/BooleanGroupField.vue
@@ -38,7 +38,7 @@ export default {
     setInitialValue() {
       const result = {}
       Object.keys(this.field.options).forEach((key) => {
-        result[key] = (this.field.value && this.field.value[key] === true) ? this.field.value[key] : false
+        result[key] = (this.field.value && key in this.field.value && this.field.value[key] !== false)
       })
       this.value = result
     },

--- a/app/frontend/js/components/Index/BooleanGroupField.vue
+++ b/app/frontend/js/components/Index/BooleanGroupField.vue
@@ -1,21 +1,18 @@
 <template>
   <index-field-wrapper :field="field" class="text-center">
-    <template v-if="value">
-        <v-popover>
-          <a href="javascript:void(0);" class="tooltip-target">View</a>
-          <template slot="popover">
-            <div class="space-y-2">
-              <template v-for="(val, key, index) in value">
-                <div v-bind:key="index">
-                  <boolean-check :checked="val"/>
-                  <div class="ml-6 text-left py-px">{{ label(key) }}</div>
-                </div>
-              </template>
+    <v-popover>
+      <a href="javascript:void(0);" class="tooltip-target">View</a>
+      <template slot="popover">
+        <div class="space-y-2">
+          <template v-for="(val, key, index) in value">
+            <div v-bind:key="index">
+              <boolean-check :checked="val"/>
+              <div class="ml-6 text-left py-px">{{ label(key) }}</div>
             </div>
           </template>
-        </v-popover>
-    </template>
-    <empty-dash v-else />
+        </div>
+      </template>
+    </v-popover>
   </index-field-wrapper>
 </template>
 
@@ -39,21 +36,11 @@ export default {
   }),
   methods: {
     setInitialValue() {
-      if (this.field.value) {
-        const values = this.field.value
-        const result = {}
-        Object.keys(values).forEach((key) => {
-          const value = values[key]
-          if (value === true || value === false) {
-            result[key] = value
-          }
-        })
-        if (Object.keys(result).length > 0) {
-          this.value = result
-        } else {
-          this.value = null
-        }
-      }
+      const result = {}
+      Object.keys(this.field.options).forEach((key) => {
+        result[key] = (this.field.value && this.field.value[key]) ? this.field.value[key] : false
+      })
+      this.value = result
     },
     label(key) {
       if (this.field.options[key]) return this.field.options[key]

--- a/app/frontend/js/components/Index/BooleanGroupField.vue
+++ b/app/frontend/js/components/Index/BooleanGroupField.vue
@@ -38,7 +38,7 @@ export default {
     setInitialValue() {
       const result = {}
       Object.keys(this.field.options).forEach((key) => {
-        result[key] = (this.field.value && this.field.value[key]) ? this.field.value[key] : false
+        result[key] = (this.field.value && this.field.value[key] === true) ? this.field.value[key] : false
       })
       this.value = result
     },

--- a/app/frontend/js/components/Index/BooleanGroupField.vue
+++ b/app/frontend/js/components/Index/BooleanGroupField.vue
@@ -48,7 +48,11 @@ export default {
             result[key] = value
           }
         })
-        this.value = result
+        if (Object.keys(result).length > 0) {
+          this.value = result
+        } else {
+          this.value = null
+        }
       }
     },
     label(key) {

--- a/app/frontend/js/components/Index/BooleanGroupField.vue
+++ b/app/frontend/js/components/Index/BooleanGroupField.vue
@@ -38,7 +38,7 @@ export default {
     setInitialValue() {
       const result = {}
       Object.keys(this.field.options).forEach((key) => {
-        result[key] = (this.field.value && key in this.field.value && this.field.value[key] !== false)
+        result[key] = (this.field.value && key in this.field.value && this.field.value[key] === true)
       })
       this.value = result
     },

--- a/app/frontend/js/components/Show/BooleanGroupField.vue
+++ b/app/frontend/js/components/Show/BooleanGroupField.vue
@@ -31,7 +31,11 @@ export default {
             result[key] = value
           }
         })
-        this.value = result
+        if (Object.keys(result).length > 0) {
+          this.value = result
+        } else {
+          this.value = null
+        }
       }
     },
     label(key) {

--- a/app/frontend/js/components/Show/BooleanGroupField.vue
+++ b/app/frontend/js/components/Show/BooleanGroupField.vue
@@ -21,7 +21,7 @@ export default {
     setInitialValue() {
       const result = {}
       Object.keys(this.field.options).forEach((key) => {
-        result[key] = (this.field.value && key in this.field.value && this.field.value[key] !== false)
+        result[key] = (this.field.value && key in this.field.value && this.field.value[key] === true)
       })
       this.value = result
     },

--- a/app/frontend/js/components/Show/BooleanGroupField.vue
+++ b/app/frontend/js/components/Show/BooleanGroupField.vue
@@ -21,7 +21,7 @@ export default {
     setInitialValue() {
       const result = {}
       Object.keys(this.field.options).forEach((key) => {
-        result[key] = (this.field.value && this.field.value[key] === true) ? this.field.value[key] : false
+        result[key] = (this.field.value && key in this.field.value && this.field.value[key] !== false)
       })
       this.value = result
     },

--- a/app/frontend/js/components/Show/BooleanGroupField.vue
+++ b/app/frontend/js/components/Show/BooleanGroupField.vue
@@ -1,14 +1,11 @@
 <template>
   <show-field-wrapper :field="field" :index="index">
-    <div class="space-y-2" v-if="value">
-      <template v-for="(val, key, index) in value">
-        <div v-bind:key="index">
-          <boolean-check :checked="val"/>
-          <div class="ml-6 text-left py-px">{{ label(key) }}</div>
-        </div>
-      </template>
-    </div>
-    <empty-dash v-else />
+    <template v-for="(val, key, index) in value">
+      <div v-bind:key="index">
+        <boolean-check :checked="val"/>
+        <div class="ml-6 text-left py-px">{{ label(key) }}</div>
+      </div>
+    </template>
   </show-field-wrapper>
 </template>
 
@@ -22,21 +19,11 @@ export default {
   components: { BooleanCheck },
   methods: {
     setInitialValue() {
-      if (this.field.value) {
-        const values = this.field.value
-        const result = {}
-        Object.keys(values).forEach((key) => {
-          const value = values[key]
-          if (value === true || value === false) {
-            result[key] = value
-          }
-        })
-        if (Object.keys(result).length > 0) {
-          this.value = result
-        } else {
-          this.value = null
-        }
-      }
+      const result = {}
+      Object.keys(this.field.options).forEach((key) => {
+        result[key] = (this.field.value && this.field.value[key]) ? this.field.value[key] : false
+      })
+      this.value = result
     },
     label(key) {
       if (this.field.options[key]) return this.field.options[key]

--- a/app/frontend/js/components/Show/BooleanGroupField.vue
+++ b/app/frontend/js/components/Show/BooleanGroupField.vue
@@ -21,7 +21,7 @@ export default {
     setInitialValue() {
       const result = {}
       Object.keys(this.field.options).forEach((key) => {
-        result[key] = (this.field.value && this.field.value[key]) ? this.field.value[key] : false
+        result[key] = (this.field.value && this.field.value[key] === true) ? this.field.value[key] : false
       })
       this.value = result
     },


### PR DESCRIPTION
let's discuss more on this

currently for `{"admin":"false","manager":"false","writer":"false"}` input it will display - because "true" is not taken as true but as string

we have the following options:
- keep dash for wrong written object as `{"admin":"false","manager":"false","writer":"false"}`
- allow true_values and false_values as boolean and always save true or false
- we can allow also strings `true` and `false` by default
- why not restrict to have options only from the configured options, because on edit we are overwriting them?