### PR TITLE
fix: index pages has wrong label

### DIFF
--- a/app/frontend/js/components/EmptyState.vue
+++ b/app/frontend/js/components/EmptyState.vue
@@ -40,7 +40,7 @@ export default {
     label() {
       if (this.viaResourceName) return this.$t('avo.no_related_item_found', { item: this.resourceName.toLowerCase() })
 
-      return this.$t('avo.no_related_item_found', { item: this.resourceName.toLowerCase() })
+      return this.$t('avo.no_item_found', { item: this.resourceName.toLowerCase() })
     },
   },
 }

--- a/spec/system/avo/user_forms_spec.rb
+++ b/spec/system/avo/user_forms_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'UserForms', type: :system do
   it 'Shows the empty posts page' do
     visit '/avo/resources/posts'
 
-    expect(page).to have_text('No related posts found')
+    expect(page).to have_text('No posts found')
   end
 
   it 'accesses the create user page' do
@@ -30,7 +30,7 @@ RSpec.describe 'UserForms', type: :system do
 
     click_on 'Cancel'
 
-    expect(page).to have_text 'No related posts found'
+    expect(page).to have_text 'No posts found'
     expect(page).to have_css 'a', text: 'Create new post'
     expect(current_path).to eq '/avo/resources/posts'
   end


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1334409/100374976-c3103d80-3015-11eb-8d13-3f51b3daa020.png)

After:
![image](https://user-images.githubusercontent.com/1334409/100374946-b5f34e80-3015-11eb-9b98-a6c6eef54ee4.png)
