### PR TITLE
Update inline javascript tags to allow for csp nonces

### DIFF
--- a/app/views/layouts/avo/_javascript.html.erb
+++ b/app/views/layouts/avo/_javascript.html.erb
@@ -1,8 +1,8 @@
-<script>
+<%= javascript_tag nonce: true do %>
   var rootPath = '<%= Avo.configuration.root_path %>';
   var timezone = '<%= Avo.configuration.timezone %>';
   var locale = '<%= Avo.configuration.locale %>';
   var defaultViewType = '<%= Avo.configuration.default_view_type %>';
   var license = <%= Avo::App.license.properties.to_json.html_safe %>;
   var avoResources = <%= Avo::App.get_available_resources(current_user).as_json.html_safe %>;
-</script>
+<% end %>

--- a/app/views/layouts/avo/_translations.html.erb
+++ b/app/views/layouts/avo/_translations.html.erb
@@ -1,5 +1,5 @@
-<script>
+<%= javascript_tag nonce: true do %>
   I18n.defaultLocale = 'en';
   I18n.locale = "<%= Avo.configuration.language_code %>";
-</script>
+<% end %>
 <%= javascript_include_tag 'translations', skip_pipeline: true %>


### PR DESCRIPTION
Avo currently does not work if you have a content security policy which blocks `unsafe-inline`.  This Pull Request uses the built-in option for `javascript_tag` to allow a nonce to mark the inline script as safe.  

This change is also safe for apps without a content_security_policy.