### PR TITLE
fix: belongs_to broken for some model names

### DIFF
--- a/lib/avo/app/fields/belongs_to.rb
+++ b/lib/avo/app/fields/belongs_to.rb
@@ -64,10 +64,10 @@ module Avo
       end
 
       def get_target_resource(model)
-        if model._reflections[id.to_s].options[:class_name].present?
-          App.get_resource_by_model_name model._reflections[id.to_s].options[:class_name]
-        elsif model._reflections[id.to_s].klass.present?
+        if model._reflections[id.to_s].klass.present?
           App.get_resource_by_model_name model._reflections[id.to_s].klass.to_s
+        elsif model._reflections[id.to_s].options[:class_name].present?
+          App.get_resource_by_model_name model._reflections[id.to_s].options[:class_name]
         else
           App.get_resource_by_name class_name.to_s
         end

--- a/lib/avo/app/fields/belongs_to.rb
+++ b/lib/avo/app/fields/belongs_to.rb
@@ -22,7 +22,8 @@ module Avo
         fields[:searchable] = @searchable
         fields[:is_relation] = true
         fields[:database_id] = foreign_key model
-        target_resource = App.get_resources.find { |r| r.class == "Avo::Resources::#{name}".safe_constantize }
+
+        target_resource = get_target_resource model
 
         relation_model = model.public_send(@relation_method)
 
@@ -59,6 +60,16 @@ module Avo
           model.reflections[@relation_method].foreign_key
         else
           model.class.reflections[@relation_method].foreign_key
+        end
+      end
+
+      def get_target_resource(model)
+        if model._reflections[id.to_s].options[:class_name].present?
+          App.get_resource_by_model_name model._reflections[id.to_s].options[:class_name]
+        elsif model._reflections[id.to_s].klass.present?
+          App.get_resource_by_model_name model._reflections[id.to_s].klass.to_s
+        else
+          App.get_resource_by_name class_name.to_s
         end
       end
     end


### PR DESCRIPTION
`belongs_to` avo relation is broken for some two-names models (`belongs_to :team_membership`). This should fix it by providing a better way of searching for an Avo resource.

Fixes https://github.com/avo-hq/avo/issues/202