### PR TITLE
fix: remove default current user value

### DIFF
--- a/lib/generators/avo/templates/initializer/avo.rb
+++ b/lib/generators/avo/templates/initializer/avo.rb
@@ -7,7 +7,7 @@ Avo.configure do |config|
   # config.license_key = ENV['AVO_LICENSE_KEY']
 
   ## == Authentication ==
-  config.current_user_method(&:current_user)
+  # config.current_user_method(&:current_user)
   # config.authenticate_with do
   #   warden.authenticate! scope: :user
   # end


### PR DESCRIPTION
Removes the default `config.current_user_method(&:current_user)` value introduced in https://github.com/avo-hq/avo/pull/205.