### PR TITLE
fix: missing dependency `iso` gem

### DIFF
--- a/avo.gemspec
+++ b/avo.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'pundit'
   spec.add_dependency 'httparty'
   spec.add_dependency 'i18n-js'
+  spec.add_dependency 'iso'
 end


### PR DESCRIPTION
Fixes https://github.com/avo-hq/avo/issues/212