### PR TITLE
refactor: remove configure methods in favor of class attributes

### DIFF
--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -35,7 +35,6 @@ module Avo
         end
 
         @action = action_name.safe_constantize.new
-        @action.configure
         @action.hydrate(model: model, resource: resource, user: _current_user)
         @action.boot_fields request
       end

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -186,8 +186,6 @@ module Avo
         @filters = @resource.get_filters.map do |filter_class|
           filter = filter_class.new
 
-          filter.configure
-
           filter
         end
       end
@@ -216,7 +214,6 @@ module Avo
 
         @resource.get_filters.each do |filter_class|
           filter = filter_class.new
-          filter.configure
 
           if filter.default.present?
             filter_defaults[filter_class.to_s] = filter.default

--- a/app/controllers/avo/relations_controller.rb
+++ b/app/controllers/avo/relations_controller.rb
@@ -35,7 +35,7 @@ module Avo
       @options = query.all.map do |model|
         {
           value: model.id,
-          label: model.send(@attachment_resource.title)
+          label: model.send(@attachment_resource.class.title)
         }
       end
     end

--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -35,7 +35,7 @@ module Avo
         resources.map do |model|
           {
             id: model.id,
-            search_label: model.send(avo_resource.title),
+            search_label: model.send(avo_resource.class.title),
             link: "/resources/#{model.class.to_s.singularize.underscore}/#{model.id}",
           }
         end

--- a/lib/avo/app/action.rb
+++ b/lib/avo/app/action.rb
@@ -4,21 +4,13 @@ require_relative 'fields_loader'
 module Avo
   module Actions
     class Action
-      attr_accessor :name
-      attr_accessor :message
-      attr_accessor :default
-      attr_accessor :theme
-      attr_accessor :confirm_text
-      attr_accessor :cancel_text
-      # response: {
-      #   message: String
-      #   message_type: success | error
-      #   type: reload | reload_resources | redirect | http_redirect | open_in_new_tab | download
-      #   path: String
-      #   filename: String
-      # }
+      class_attribute :name, default: self.class.to_s.demodulize.underscore.humanize(keep_id_suffix: true)
+      class_attribute :message, default: I18n.t('avo.are_you_sure_you_want_to_run_this_option')
+      class_attribute :confirm_text, default: I18n.t('avo.run')
+      class_attribute :cancel_text, default: I18n.t('avo.cancel')
+      class_attribute :no_confirmation, default: false
+
       attr_accessor :response
-      attr_accessor :no_confirmation
       attr_accessor :model
       attr_accessor :resource
       attr_accessor :user
@@ -28,20 +20,11 @@ module Avo
       alias :field :field_loader
       alias :f :field
 
-      @@default = nil
-
       def initialize
-        @name ||= name
-        @message ||= I18n.t('avo.are_you_sure_you_want_to_run_this_option')
-        @default ||= ''
         @fields ||= []
-        @confirm_text ||= I18n.t('avo.run')
-        @cancel_text ||= I18n.t('avo.cancel')
         @response ||= {}
         @response[:message_type] ||= :notice
         @response[:message] ||= I18n.t('avo.action_ran_successfully')
-        @theme ||= 'success'
-        @no_confirmation ||= false
       end
 
       def boot_fields(request)
@@ -91,11 +74,7 @@ module Avo
       end
 
       def param_id
-        self.class.name.underscore.gsub '/', '_'
-      end
-
-      def name
-        self.class.name.demodulize.underscore.humanize(keep_id_suffix: true)
+        self.class.to_s.demodulize.underscore.gsub '/', '_'
       end
 
       def succeed(text)
@@ -135,10 +114,6 @@ module Avo
         self.response[:filename] = filename
 
         self
-      end
-
-      def self.param_id
-        self.name.underscore.gsub '/', '_'
       end
     end
   end

--- a/lib/avo/app/fields/belongs_to.rb
+++ b/lib/avo/app/fields/belongs_to.rb
@@ -17,7 +17,7 @@ module Avo
         target_resource.model_class.all.map do |model|
           {
             value: model.id,
-            label: model.send(target_resource.title)
+            label: model.send(target_resource.class.title)
           }
         end
       end
@@ -43,7 +43,7 @@ module Avo
       end
 
       def label
-        value.send(target_resource.title)
+        value.send(target_resource.class.title)
       end
 
       def to_permitted_param

--- a/lib/avo/app/filter.rb
+++ b/lib/avo/app/filter.rb
@@ -1,14 +1,8 @@
 module Avo
   class Filter
-    attr_accessor :name
-    attr_accessor :component
-    attr_accessor :default
-
-    def initialize
-      @name ||= 'Filter'
-      @component ||= 'boolean-filter'
-      @default ||= ''
-    end
+    class_attribute :name, default: 'Filter'
+    class_attribute :component, default: 'boolean-filter'
+    class_attribute :default, default: ''
 
     def apply_query(request, query, value)
       value.symbolize_keys! if value.is_a? Hash

--- a/lib/avo/app/resource.rb
+++ b/lib/avo/app/resource.rb
@@ -4,15 +4,6 @@ require_relative 'fields/field'
 module Avo
   module Resources
     class Resource
-      attr_writer :name
-
-      attr_accessor :id
-      attr_accessor :title
-      attr_accessor :search
-      attr_accessor :includes
-      attr_accessor :translation_key
-      attr_accessor :default_view_type
-      attr_accessor :devise_password_optional
       attr_accessor :view
       attr_accessor :model
       attr_accessor :user
@@ -29,16 +20,15 @@ module Avo
       alias :a :action
       alias :filter :filters_loader
 
-      def initialize(request = nil)
-        @id = :id
-        @title = 'Resource'
-        @search = []
-        @includes = []
-        @translation_key = nil
-        @default_view_type = :table
-        @devise_password_optional = false
+      class_attribute :id, default: :id
+      class_attribute :title, default: :id
+      class_attribute :search, default: [:id]
+      class_attribute :includes, default: []
+      class_attribute :translation_key
+      class_attribute :default_view_type, default: :table
+      class_attribute :devise_password_optional, default: false
 
-        configure
+      def initialize(request = nil)
         boot_fields request
       end
 

--- a/spec/dummy/app/avo/actions/toggle_admin.rb
+++ b/spec/dummy/app/avo/actions/toggle_admin.rb
@@ -1,10 +1,8 @@
 module Avo
   module Actions
     class ToggleAdmin < Action
-      def configure
-        @name = 'Toggle admin'
-        @no_confirmation = true
-      end
+      self.name = 'Toggle admin'
+      self.no_confirmation = true
 
       def handle(request, models, fields)
         models.each do |model|

--- a/spec/dummy/app/avo/actions/toggle_inactive.rb
+++ b/spec/dummy/app/avo/actions/toggle_inactive.rb
@@ -1,9 +1,7 @@
 module Avo
   module Actions
     class ToggleInactive < Action
-      def configure
-        @name = 'Toggle inactive'
-      end
+      self.name = 'Toggle inactive'
 
       def handle(request, models, fields)
         models.each do |model|

--- a/spec/dummy/app/avo/actions/toggle_published.rb
+++ b/spec/dummy/app/avo/actions/toggle_published.rb
@@ -1,12 +1,10 @@
 module Avo
   module Actions
     class TogglePublished < Action
-      def configure
-        @name = 'Toggle post published'
-        @message = 'Are you sure, sure?'
-        @confirm_text = 'Toggle'
-        @cancel_text = "Don't toggle yet"
-      end
+      self.name = 'Toggle post published'
+      self.message = 'Are you sure, sure?'
+      self.confirm_text = 'Toggle'
+      self.cancel_text = "Don't toggle yet"
 
       def handle(request, models, fields)
         models.each do |model|

--- a/spec/dummy/app/avo/filters/featured_filter.rb
+++ b/spec/dummy/app/avo/filters/featured_filter.rb
@@ -1,9 +1,7 @@
 module Avo
   module Filters
     class FeaturedFilter < BooleanFilter
-      def configure
-        @name = 'Featured status'
-      end
+      self.name = 'Featured status'
 
       def apply(request, query, values)
         return query if values[:is_featured] && values[:is_unfeatured]

--- a/spec/dummy/app/avo/filters/members_filter.rb
+++ b/spec/dummy/app/avo/filters/members_filter.rb
@@ -1,9 +1,7 @@
 module Avo
   module Filters
     class MembersFilter < BooleanFilter
-      def configure
-        @name = 'Members filter'
-      end
+      self.name = 'Members filter'
 
       def apply(request, query, value)
         return query.where(id: Team.joins(:memberships).group('teams.id').count.keys) if value[:has_members]

--- a/spec/dummy/app/avo/filters/people_2_filter.rb
+++ b/spec/dummy/app/avo/filters/people_2_filter.rb
@@ -1,9 +1,7 @@
 module Avo
   module Filters
     class People2Filter < BooleanFilter
-      def configure
-        @name = 'People 2 status (temporary)'
-      end
+      self.name = 'People 2 status (temporary)'
 
       def apply(request, query, value = {})
         if value[:a_lot]

--- a/spec/dummy/app/avo/filters/people_filter.rb
+++ b/spec/dummy/app/avo/filters/people_filter.rb
@@ -1,9 +1,7 @@
 module Avo
   module Filters
     class PeopleFilter < SelectFilter
-      def configure
-        @name = 'People status (temporary)'
-      end
+      self.name = 'People status (temporary)'
 
       def apply(request, query, value)
         case value

--- a/spec/dummy/app/avo/filters/published_filter.rb
+++ b/spec/dummy/app/avo/filters/published_filter.rb
@@ -1,9 +1,7 @@
 module Avo
   module Filters
     class PublishedFilter < SelectFilter
-      def configure
-        @name = 'Published status'
-      end
+      self.name = 'Published status'
 
       def apply(request, query, value)
         case value

--- a/spec/dummy/app/avo/resources/post.rb
+++ b/spec/dummy/app/avo/resources/post.rb
@@ -1,12 +1,10 @@
 module Avo
   module Resources
     class Post < Resource
-      def configure
-        @title = :name
-        @search = [:name, :id]
-        @includes = :user
-        @default_view_type = :grid
-      end
+      self.title = :name
+      self.search = [:name, :id]
+      self.includes = :user
+      self.default_view_type = :grid
 
       def fields(request)
         f.id

--- a/spec/dummy/app/avo/resources/project.rb
+++ b/spec/dummy/app/avo/resources/project.rb
@@ -1,11 +1,9 @@
 module Avo
   module Resources
     class Project < Resource
-      def configure
-        @title = :name
-        @search = [:name, :id]
-        @includes = :users
-      end
+      self.title = :name
+      self.search = [:name, :id]
+      self.includes = :users
 
       def fields(request)
         f.id link_to_resource: true

--- a/spec/dummy/app/avo/resources/team.rb
+++ b/spec/dummy/app/avo/resources/team.rb
@@ -1,11 +1,9 @@
 module Avo
   module Resources
     class Team < Resource
-      def configure
-        @title = :name
-        @search = [:id, :name]
-        @includes = :admin
-      end
+      self.title = :name
+      self.search = [:id, :name]
+      self.includes = :admin
 
       def fields(request)
         f.id

--- a/spec/dummy/app/avo/resources/team_membership.rb
+++ b/spec/dummy/app/avo/resources/team_membership.rb
@@ -1,11 +1,9 @@
 module Avo
   module Resources
     class TeamMembership < Resource
-      def configure
-        @title = :id
-        @search = :id
-        @includes = [:user, :team]
-      end
+      self.title = :id
+      self.search = :id
+      self.includes = [:user, :team]
 
       def fields(request)
         f.id

--- a/spec/dummy/app/avo/resources/user.rb
+++ b/spec/dummy/app/avo/resources/user.rb
@@ -35,8 +35,6 @@ class Avo::Resources::User < Avo::Resources::Resource
     f.has_and_belongs_to_many :teams
   end
 
-  # filter :admins, use_scope: :admins
-
   def grid(request)
     g.gravatar :email, grid_position: :preview, link_to_resource: true
     g.text :name, grid_position: :title, link_to_resource: true

--- a/spec/dummy/app/avo/resources/user.rb
+++ b/spec/dummy/app/avo/resources/user.rb
@@ -1,11 +1,9 @@
 class Avo::Resources::User < Avo::Resources::Resource
-  def configure
-    @title = :name
-    @translation_key = 'avo.resource_translations.user'
-    @search = [:id, :first_name, :last_name]
-    @includes = [:posts, :post]
-    @devise_password_optional = true
-  end
+  self.title = :name
+  self.translation_key = 'avo.resource_translations.user'
+  self.search = [:id, :first_name, :last_name]
+  self.includes = [:posts, :post]
+  self.devise_password_optional = true
 
   def fields(request)
     f.id :id, link_to_resource: true
@@ -36,6 +34,8 @@ class Avo::Resources::User < Avo::Resources::Resource
     f.has_and_belongs_to_many :projects
     f.has_and_belongs_to_many :teams
   end
+
+  # filter :admins, use_scope: :admins
 
   def grid(request)
     g.gravatar :email, grid_position: :preview, link_to_resource: true


### PR DESCRIPTION
This PR removes the `def configure` method from `Resource`, `Action` and `Filter` classes in favor of `class_attribute`s.