### PR TITLE
refactor: remove intermediary avo filters

### DIFF
--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -6,8 +6,6 @@ require_relative 'avo/app/fields/field'
 require_relative 'avo/app/action'
 
 require_relative 'avo/app/filter'
-require_relative 'avo/app/filters/boolean_filter'
-require_relative 'avo/app/filters/select_filter'
 
 require_relative 'avo/app/fields_loader'
 require_relative 'avo/app/actions_loader'

--- a/lib/avo/app/filters/boolean_filter.rb
+++ b/lib/avo/app/filters/boolean_filter.rb
@@ -1,9 +1,0 @@
-require_relative '../filter'
-
-module Avo
-  module Filters
-    class BooleanFilter < Avo::Filter
-      self.template = 'avo/base/boolean_filter'
-    end
-  end
-end

--- a/lib/avo/app/filters/select_filter.rb
+++ b/lib/avo/app/filters/select_filter.rb
@@ -1,9 +1,0 @@
-require_relative '../filter'
-
-module Avo
-  module Filters
-    class SelectFilter < Avo::Filter
-      self.template = 'avo/base/select_filter'
-    end
-  end
-end

--- a/spec/dummy/app/avo/filters/boolean_filter.rb
+++ b/spec/dummy/app/avo/filters/boolean_filter.rb
@@ -1,3 +1,3 @@
-class BooleanFilter < Avo::Filters::BooleanFilter
-
+class BooleanFilter < Avo::Filter
+  self.template = 'avo/base/select_filter'
 end

--- a/spec/dummy/app/avo/filters/select_filter.rb
+++ b/spec/dummy/app/avo/filters/select_filter.rb
@@ -1,3 +1,3 @@
-class SelectFilter < Avo::Filters::SelectFilter
-
+class SelectFilter < Avo::Filter
+  self.template = 'avo/base/select_filter'
 end


### PR DESCRIPTION
This PR sheds two intermediary `Filter` classes from Avo, moving their functionality to the public base classes.

Each class inherits from the `Filter` class and adds it's own configuration (`self.template`). Not sure if we should expose this in the public base classes.

What do you think?