### PR TITLE
chore: field API for declaring fields

### DIFF
--- a/app/components/avo/index/grid_item_component.rb
+++ b/app/components/avo/index/grid_item_component.rb
@@ -12,14 +12,14 @@ class Avo::Index::GridItemComponent < ViewComponent::Base
 
   private
     def cover
-      @grid_fields[:cover].first
+      @grid_fields.cover_field
     end
 
     def title
-      @grid_fields[:title].first
+      @grid_fields.title_field
     end
 
     def body
-      @grid_fields[:body].first
+      @grid_fields.body_field
     end
 end

--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -6,7 +6,9 @@ module Avo
     before_action :set_resource
     before_action :set_action, only: [:show, :handle]
 
-    def show; end
+    def show
+      @model = ActionModel.new @action.get_attributes_for_action
+    end
 
     def handle
       resource_ids = action_params[:fields][:resource_ids].split(',').map(&:to_i)
@@ -33,8 +35,7 @@ module Avo
           model = @resource.model_class.find params[:id]
         end
 
-        @action = action_class.new
-        @action.hydrate(model: model, resource: resource, user: _current_user)
+        @action = action_class.new(model: model, resource: resource, user: _current_user)
       end
 
       def respond(response)

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -193,7 +193,7 @@ module Avo
         end
 
         @actions = @resource.get_actions.map do |action|
-          action.new.hydrate(model: model, resource: @resource)
+          action.new(model: model, resource: @resource)
         end
       end
 

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -7,7 +7,7 @@
     data-resource-id="<%= params[:id] %>"
     class="hidden text-blue-gray-800"
   >
-    <%= form_with scope: 'fields', url: "/avo/resources/#{@resource.model_class.model_name.route_key}/actions/#{@action.param_id}", data: {'turbo-frame': '_top', 'action-target': 'form'} do |form| %>
+    <%= form_with model: @model, scope: 'fields', url: "/avo/resources/#{@resource.model_class.model_name.route_key}/actions/#{@action.param_id}", data: {'turbo-frame': '_top', 'action-target': 'form'} do |form| %>
       <%= render Avo::ModalComponent.new do |c| %>
         <% c.with :heading do %>
           <%= @action.name %>

--- a/lib/avo/action_model.rb
+++ b/lib/avo/action_model.rb
@@ -1,0 +1,20 @@
+module Avo
+  class ActionModel
+    include ActiveModel::Model
+
+    # This class augments a model the action form declaration.
+    def initialize(attributes = {})
+      set_attr_accessors attributes
+
+      super(attributes)
+    end
+
+    private
+
+    def set_attr_accessors(attributes)
+      attributes.each do |k, v|
+        self.class.class_eval { attr_accessor k }
+      end
+    end
+  end
+end

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -1,30 +1,30 @@
 module Avo
   class BaseAction
+    extend FieldsCollector
+    extend HasContext
+
     class_attribute :name, default: self.class.to_s.demodulize.underscore.humanize(keep_id_suffix: true)
     class_attribute :message
     class_attribute :confirm_button_label
     class_attribute :cancel_button_label
     class_attribute :no_confirmation, default: false
-    class_attribute :fields_loader
+    class_attribute :model
+    class_attribute :view
+    class_attribute :user
+    class_attribute :resource
+    class_attribute :fields
 
     attr_accessor :response
     attr_accessor :model
     attr_accessor :resource
     attr_accessor :user
+    attr_accessor :fields_loader
 
-    class << self
-      def fields(&block)
-        self.fields_loader ||= Avo::Loaders::FieldsLoader.new
+    def initialize(model: nil, resource: nil, user: nil)
+      self.class.model = model if model.present?
+      self.class.resource = resource if resource.present?
+      self.class.user = user if user.present?
 
-        yield(fields_loader)
-      end
-
-      def context
-        App.context
-      end
-    end
-
-    def initialize
       self.class.message ||= I18n.t('avo.are_you_sure_you_want_to_run_this_option')
       self.class.confirm_button_label ||= I18n.t('avo.run')
       self.class.cancel_button_label ||= I18n.t('avo.cancel')
@@ -38,29 +38,28 @@ module Avo
       self.class.context
     end
 
-    def get_fields(view_type: :table)
-      get_field_definitions.map do |field|
-        field.hydrate(action: self, model: @model)
-      end
-      .select do |field|
-        field.can_see.present? ? field.can_see.call : true
-      end
-    end
-
     def get_field_definitions
-      return [] if self.class.fields_loader.blank?
+      return [] if self.class.fields.blank?
 
-      self.class.fields_loader.bag.map do |field|
+      self.class.fields.map do |field|
         field.hydrate(action: self)
       end
     end
 
-    def hydrate(model: nil, resource: nil, user: nil)
-      @model = model if model.present?
-      @resource = resource if resource.present?
-      @user = user if user.present?
+    def get_fields
+      get_field_definitions.map do |field|
+        field.hydrate(action: self, model: @model)
+      end
+      .select do |field|
+        field.visible?
+      end
+    end
 
-      self
+    def get_attributes_for_action
+      get_fields.map do |field|
+        [field.id, field.value]
+      end
+      .to_h
     end
 
     def handle_action(models:, fields:)

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -9,8 +9,6 @@ module Avo
     attr_accessor :locale
     attr_accessor :currency
     attr_accessor :default_view_type
-    attr_accessor :hide_resource_overview_component
-    attr_accessor :hide_documentation_link
     attr_accessor :license
     attr_accessor :license_key
     attr_accessor :authorization_methods
@@ -32,8 +30,6 @@ module Avo
       @locale = 'en-US'
       @currency = 'USD'
       @default_view_type = :table
-      @hide_resource_overview_component = false
-      @hide_documentation_link = false
       @license = 'community'
       @license_key = nil
       @current_user = proc {}

--- a/lib/avo/engine.rb
+++ b/lib/avo/engine.rb
@@ -24,6 +24,22 @@ module Avo
       ::Avo::App.init_fields
     end
 
+    initializer 'avo.reload_avo_files' do |app|
+      if Avo::IN_DEVELOPMENT && ENV['RELOAD_AVO_FILES']
+        avo_root_path = Avo::Engine.root.to_s
+        # Register reloader
+        app.reloaders << app.config.file_watcher.new([], {
+          Avo::Engine.root.join('lib', 'avo').to_s => ['rb'],
+        }) {}
+
+        # What to do on file change
+        config.to_prepare do
+          Dir.glob(avo_root_path + '/lib/avo/**/*.rb'.to_s).each { |c| load c }
+          Avo::App.boot
+        end
+      end
+    end
+
     initializer 'webpacker.proxy' do |app|
       app.config.debug_exception_response_format = :api
       # app.config.logger = ::Logger.new(STDOUT)

--- a/lib/avo/fields/field_extensions/has_field_name.rb
+++ b/lib/avo/fields/field_extensions/has_field_name.rb
@@ -2,21 +2,14 @@ module Avo
   module Fields
     module FieldExtensions
       module HasFieldName
-        @@field_name_attribute = ''
-
         # Set the field name
         def field_name(name)
-          @field_name_attribute = name
+          self.field_name_attribute = name
         end
 
         # Get the field name
-        def field_name_attribute
-          @field_name_attribute
-        end
-
-        # Get the field name from outside
         def get_field_name
-          return field_name_attribute if field_name_attribute.present?
+          return self.field_name_attribute if self.field_name_attribute.present?
 
           self.to_s.demodulize.underscore.gsub '_field', ''
         end

--- a/lib/avo/fields_collector.rb
+++ b/lib/avo/fields_collector.rb
@@ -23,5 +23,9 @@ module Avo
         field
       end
     end
+
+    def heading(body, **args)
+      self.fields << Avo::Fields::HeadingField.new(body, **args)
+    end
   end
 end

--- a/lib/avo/fields_collector.rb
+++ b/lib/avo/fields_collector.rb
@@ -1,0 +1,27 @@
+module Avo
+  module FieldsCollector
+    def field(field_name, as:, **args, &block)
+      self.fields ||= []
+
+      self.fields << parse_field(field_name, as: as, **args, &block)
+    end
+
+    def parse_field(field_name, as:, **args, &block)
+      matched_field = Avo::App.fields.find do |field|
+        field[:name].to_s == as.to_s
+      end
+
+      if matched_field.present? and matched_field[:class].present?
+        klass = matched_field[:class]
+
+        if block_given?
+          field = klass.new(field_name, **args || {}, &block)
+        else
+          field = klass.new(field_name, **args || {})
+        end
+
+        field
+      end
+    end
+  end
+end

--- a/lib/avo/grid_collector.rb
+++ b/lib/avo/grid_collector.rb
@@ -1,0 +1,39 @@
+module Avo
+  class GridCollector
+    include FieldsCollector
+
+    attr_accessor :cover_field
+    attr_accessor :title_field
+    attr_accessor :body_field
+
+    def initialize
+      @cover_field = nil
+      @title_field = nil
+      @body_field = nil
+    end
+
+    def cover(field_name, as:, **args, &block)
+      self.cover_field = parse_field(field_name, as: as, **args, &block)
+    end
+
+    def title(field_name, as:, **args, &block)
+      self.title_field = parse_field(field_name, as: as, **args, &block)
+    end
+
+    def body(field_name, as:, **args, &block)
+      self.body_field = parse_field(field_name, as: as, **args, &block)
+    end
+
+    def hydrate(model:, view:, resource:)
+      cover_field.hydrate(model: model, view: view, resource: resource) if cover_field.present?
+      title_field.hydrate(model: model, view: view, resource: resource) if title_field.present?
+      body_field.hydrate(model: model, view: view, resource: resource) if title_field.present?
+
+      self
+    end
+
+    def blank?
+      title_field.blank?
+    end
+  end
+end

--- a/lib/avo/has_context.rb
+++ b/lib/avo/has_context.rb
@@ -1,0 +1,7 @@
+module Avo
+  module HasContext
+    def context
+      App.context
+    end
+  end
+end

--- a/spec/dummy/app/avo/actions/toggle_inactive.rb
+++ b/spec/dummy/app/avo/actions/toggle_inactive.rb
@@ -1,6 +1,9 @@
 class ToggleInactive < Avo::BaseAction
   self.name = 'Toggle inactive'
 
+  field :notify_user, as: :boolean, default: true
+  field :message,     as: :text, default: 'Your account has been marked as inactive.'
+
   def handle(models:, fields:)
     models.each do |model|
       if model.active
@@ -13,10 +16,5 @@ class ToggleInactive < Avo::BaseAction
     end
 
     succeed 'Perfect!'
-  end
-
-  fields do |f|
-    f.boolean :notify_user, default: true
-    f.text :message, default: 'Your account has been marked as inactive.'
   end
 end

--- a/spec/dummy/app/avo/actions/toggle_published.rb
+++ b/spec/dummy/app/avo/actions/toggle_published.rb
@@ -4,6 +4,9 @@ class TogglePublished < Avo::BaseAction
   self.confirm_button_label = 'Toggle'
   self.cancel_button_label = "Don't toggle yet"
 
+  field :notify_user, as: :boolean, default: true
+  field :message, as: :text, default: 'Your account has been marked as inactive.'
+
   def handle(models:, fields:)
     models.each do |model|
       if model.published_at.present?
@@ -14,10 +17,5 @@ class TogglePublished < Avo::BaseAction
     end
 
     succeed 'Purrrfect!'
-  end
-
-  fields do |f|
-    f.boolean :notify_user, default: true
-    f.text :message, default: 'Your account has been marked as inactive.'
   end
 end

--- a/spec/dummy/app/avo/resources/post_resource.rb
+++ b/spec/dummy/app/avo/resources/post_resource.rb
@@ -4,23 +4,20 @@ class PostResource < Avo::BaseResource
   self.includes = :user
   self.default_view_type = :grid
 
-  fields do |f|
-    f.id
-    f.text :name, required: true
-    f.trix :body, placeholder: 'Enter text', always_show: false
-    f.file :cover_photo, is_image: true, link_to_resource: true
-    f.boolean :is_featured, can_see: -> () { context[:user].is_admin? }
-    f.boolean :is_published do |model|
-      model.published_at.present?
-    end
-
-    f.belongs_to :user, meta: { searchable: false }, placeholder: '—'
+  field :id, as: :id
+  field :name, as: :text, required: true
+  field :body, as: :trix, placeholder: 'Enter text', always_show: false
+  field :cover_photo, as: :file, is_image: true, link_to_resource: true
+  field :is_featured, as: :boolean, visible: -> () { context[:user].is_admin? }
+  field :is_published, as: :boolean do |model|
+    model.published_at.present?
   end
+  field :user, as: :belongs_to, meta: { searchable: false }, placeholder: '—'
 
-  grid do |cover, title, body|
-    cover.file :cover_photo, required: true, link_to_resource: true
-    title.text :name, required: true, link_to_resource: true
-    body.text :excerpt do |model|
+  grid do
+    cover :cover_photo, as: :file, link_to_resource: true
+    title :name, as: :text, required: true, link_to_resource: true
+    body :excerpt, as: :text do |model|
       begin
         ActionView::Base.full_sanitizer.sanitize(model.body).truncate 130
       rescue => exception
@@ -29,12 +26,8 @@ class PostResource < Avo::BaseResource
     end
   end
 
-  filters do |f|
-    f.use FeaturedFilter
-    f.use PublishedFilter
-  end
+  filter FeaturedFilter
+  filter PublishedFilter
 
-  actions do |a|
-    a.use TogglePublished
-  end
+  action TogglePublished
 end

--- a/spec/dummy/app/avo/resources/project_resource.rb
+++ b/spec/dummy/app/avo/resources/project_resource.rb
@@ -3,27 +3,23 @@ class ProjectResource < Avo::BaseResource
   self.search = [:name, :id]
   self.includes = :users
 
-  fields do |f|
-    f.id link_to_resource: true
-    f.text :name, required: true
-    f.status :status, failed_when: [:closed, :rejected, :failed], loading_when: [:loading, :running, :waiting], nullable: true
-    f.select :stage, hide_on: [:show, :index], enum: ::Project.stages, placeholder: 'Choose the stage'
-    f.badge :stage, options: { info: ['Discovery', 'Idea'], success: 'Done', warning: 'On hold', danger: 'Cancelled' }
-    # currency :budget, currency: 'EUR', locale: 'de-DE'
-    f.country :country
-    f.number :users_required, min: 10, max: 1000000, step: 1
-    f.date_time :started_at, name: 'Started', time_24hr: true, relative: true, timezone: 'EET'
-    f.markdown :description, height: '350px'
-    f.files :files, translation_key: 'avo.field_translations.file', is_image: true
-    # key_value :meta, key_label: 'Meta key', value_label: 'Meta value', action_text: 'New item', delete_text: 'Remove item', disable_editing_keys: false, disable_adding_rows: false, disable_deleting_rows: false
+  field :id, as: :id, link_to_resource: true
+  field :name, as: :text, required: true
+  field :status, as: :status, failed_when: [:closed, :rejected, :failed], loading_when: [:loading, :running, :waiting], nullable: true
+  field :stage, as: :select, hide_on: [:show, :index], enum: ::Project.stages, placeholder: 'Choose the stage'
+  field :stage, as: :badge, options: { info: ['Discovery', 'Idea'], success: 'Done', warning: 'On hold', danger: 'Cancelled' }
+  # currency :budget, currency: 'EUR', locale: 'de-DE'
+  field :country, as: :country
+  field :users_required, as: :number, min: 10, max: 1000000, step: 1
+  field :started_at, as: :date_time, name: 'Started', time_24hr: true, relative: true, timezone: 'EET'
+  field :description, as: :markdown, height: '350px'
+  field :files, as: :files, translation_key: 'avo.field_translations.file', is_image: true
+  # key_value :meta, key_label: 'Meta key', value_label: 'Meta value', action_text: 'New item', delete_text: 'Remove item', disable_editing_keys: false, disable_adding_rows: false, disable_deleting_rows: false
 
-    f.has_and_belongs_to_many :users
-  end
+  field :users, as: :has_and_belongs_to_many
 
-  filters do |filter|
-    # filter.use PeopleFilter
-    # filter.use People2Filter
-    # filter.use FeaturedFilter
-    # filter.use MembersFilter
-  end
+  # filter PeopleFilter
+  # filter People2Filter
+  # filter FeaturedFilter
+  # filter MembersFilter
 end

--- a/spec/dummy/app/avo/resources/team_membership_resource.rb
+++ b/spec/dummy/app/avo/resources/team_membership_resource.rb
@@ -3,11 +3,9 @@ class TeamMembershipResource < Avo::BaseResource
   self.search = :id
   self.includes = [:user, :team]
 
-  fields do |f|
-    f.id
-    f.select :level, options: { 'Beginner': :beginner, 'Intermediate': :intermediate, 'Advanced': :advanced }, display_value: true, default: -> (model, resource, view, field) { Time.now.hour < 12 ? 'advanced' : 'beginner' }
-    f.belongs_to :user
-    f.belongs_to :team
-  end
+  field :id, as: :id
+  field :level, as: :select, options: { 'Beginner': :beginner, 'Intermediate': :intermediate, 'Advanced': :advanced }, display_value: true, default: -> (model, resource, view, field) { Time.now.hour < 12 ? 'advanced' : 'beginner' }
+  field :user, as: :belongs_to
+  field :team, as: :belongs_to
 end
 

--- a/spec/dummy/app/avo/resources/team_resource.rb
+++ b/spec/dummy/app/avo/resources/team_resource.rb
@@ -3,38 +3,34 @@ class TeamResource < Avo::BaseResource
   self.search = [:id, :name]
   self.includes = :admin
 
-  fields do |f|
-    f.id
-    f.text :name
-    f.text :url
-    f.external_image :logo do |model|
-      if model.url
-        "//logo.clearbit.com/#{URI.parse(model.url).host}?size=180"
-      else
-        nil
-      end
+  field :id, as: :id
+  field :name, as: :text
+  field :url, as: :text
+  field :logo, as: :external_image do |model|
+    if model.url
+      "//logo.clearbit.com/#{URI.parse(model.url).host}?size=180"
+    else
+      nil
     end
-    f.textarea :description, rows: 5, readonly: false, hide_on: :index, format_using: -> (value) { value.to_s.truncate 30 }, default: 'This team is wonderful!', nullable: true, null_values: ['0', '', 'null', 'nil']
+  end
+  field :description, as: :textarea, rows: 5, readonly: false, hide_on: :index, format_using: -> (value) { value.to_s.truncate 30 }, default: 'This team is wonderful!', nullable: true, null_values: ['0', '', 'null', 'nil']
 
-    f.number :members_count do |model|
-      model.members.count
-    end
-
-    f.has_one :admin
-    f.has_many :members, through: :memberships
+  field :members_count, as: :number do |model|
+    model.members.count
   end
 
-  grid do |cover, title, body|
-    cover.external_image :logo, link_to_resource: true do |model|
+  field :admin, as: :has_one
+  field :members, as: :has_many, through: :memberships
+
+  grid do
+    cover :logo, as: :external_image, link_to_resource: true do |model|
       if model.url.present?
         "//logo.clearbit.com/#{URI.parse(model.url).host}?size=180"
       end
     end
-    title.text :name, link_to_resource: true
-    body.text :url
+    title :name, as: :text, link_to_resource: true
+    body :url, as: :text
   end
 
-  filters do |filter|
-    filter.use MembersFilter
-  end
+  filter MembersFilter
 end

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -5,28 +5,27 @@ class UserResource < Avo::BaseResource
   self.includes = [:posts, :post]
   self.devise_password_optional = true
 
-  field :id,                    as: :id, link_to_resource: true
-  field :email,                 as: :gravatar, link_to_resource: true
-  field 'User Information',     as: :heading
-  field :first_name,            as: :text, required: true, placeholder: 'John', default: 'default first name for resource'
-  field :last_name,             as: :text, required: true, placeholder: 'Doe'
-  field :email,                 as: :text, name: 'User Email', required: true
-  field :active,                as: :boolean, name: 'Is active', show_on: :show
-  field :cv,                    as: :file, name: 'CV'
-  field :is_admin?,             as: :boolean, name: 'Is admin', only_on: :index
-  field :roles,                 as: :boolean_group, options: { admin: 'Administrator', manager: 'Manager', writer: 'Writer' }
-  field :birthday,              as: :date, first_day_of_week: 1, picker_format: 'F J Y', format: '%Y-%m-%d', placeholder: 'Feb 24th 1955', required: true
-  field :is_writer,             as: :text, format_using: -> (value) { value.truncate 3 }, hide_on: :edit do |model, resource, view, field|
+  field :id,         as: :id, link_to_resource: true
+  field :email,      as: :gravatar, link_to_resource: true
+  heading 'User Information'
+  field :first_name, as: :text, required: true, placeholder: 'John', default: 'default first name for resource'
+  field :last_name,  as: :text, required: true, placeholder: 'Doe'
+  field :email,      as: :text, name: 'User Email', required: true
+  field :active,     as: :boolean, name: 'Is active', show_on: :show
+  field :cv,         as: :file, name: 'CV'
+  field :is_admin?,  as: :boolean, name: 'Is admin', only_on: :index
+  field :roles,      as: :boolean_group, options: { admin: 'Administrator', manager: 'Manager', writer: 'Writer' }
+  field :birthday,   as: :date, first_day_of_week: 1, picker_format: 'F J Y', format: '%Y-%m-%d', placeholder: 'Feb 24th 1955', required: true
+  field :is_writer,  as: :text, format_using: -> (value) { value.truncate 3 }, hide_on: :edit do |model, resource, view, field|
     model.posts.to_a.count > 0 ? 'yes' : 'no'
   end
 
-  field :password,              as: :password, name: 'User Password', required: false, except_on: :forms, help: 'You may verify the password strength <a href="http://www.passwordmeter.com/" target="_blank">here</a>.'
+  field :password, as: :password, name: 'User Password', required: false, except_on: :forms, help: 'You may verify the password strength <a href="http://www.passwordmeter.com/" target="_blank">here</a>.'
   field :password_confirmation, as: :password, name: 'Password confirmation', required: false, only_on: :new
 
-  field '<div class="text-gray-300 uppercase font-bold">DEV</div>', as: :heading, as_html: true
-  field :custom_css,            as: :code, theme: 'dracula', language: 'css', help: "This enables you to edit the user's custom styles.", height: '250px'
-
-  field :team_id,               as: :hidden, default: 0 # For testing purposes
+  heading '<div class="text-gray-300 uppercase font-bold">DEV</div>', as_html: true
+  field :custom_css, as: :code, theme: 'dracula', language: 'css', help: "This enables you to edit the user's custom styles.", height: '250px'
+  field :team_id, as: :hidden, default: 0 # For testing purposes
 
   field :post,     as: :has_one
   field :posts,    as: :has_many

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -5,44 +5,40 @@ class UserResource < Avo::BaseResource
   self.includes = [:posts, :post]
   self.devise_password_optional = true
 
-  fields do |field|
-    field.id :id, link_to_resource: true
-    field.gravatar :email, link_to_resource: true
-    field.heading 'User Information'
-    field.text :first_name, required: true, placeholder: 'John', default: 'default'
-    field.text :last_name, required: true, placeholder: 'Doe'
-    field.text :email, name: 'User Email', required: true
-    field.boolean :active, name: 'Is active', show_on: :show
-    field.file :cv, name: 'CV'
-    field.boolean :is_admin?, name: 'Is admin', only_on: :index
-    field.boolean_group :roles, options: { admin: 'Administrator', manager: 'Manager', writer: 'Writer' }
-    field.date :birthday, first_day_of_week: 1, picker_format: 'F J Y', format: '%Y-%m-%d', placeholder: 'Feb 24th 1955', required: true
-    field.text :is_writer, format_using: -> (value) { value.truncate 3 }, hide_on: :edit do |model, resource, view, field|
-      model.posts.to_a.count > 0 ? 'yes' : 'no'
-    end
-
-    field.password :password, name: 'User Password', required: false, except_on: :forms, help: 'You may verify the password strength <a href="http://www.passwordmeter.com/" target="_blank">here</a>.'
-    field.password :password_confirmation, name: 'Password confirmation', required: false, only_on: :new
-
-    field.heading '<div class="text-gray-300 uppercase font-bold">DEV</div>', as_html: true
-    field.code :custom_css, theme: 'dracula', language: 'css', help: "This enables you to edit the user's custom styles.", height: '250px'
-
-    field.hidden :team_id, default: 0 # For testing purposes
-
-    field.has_one :post
-    field.has_many :posts
-    field.has_and_belongs_to_many :projects
-    field.has_and_belongs_to_many :teams
+  field :id,                    as: :id, link_to_resource: true
+  field :email,                 as: :gravatar, link_to_resource: true
+  field 'User Information',     as: :heading
+  field :first_name,            as: :text, required: true, placeholder: 'John', default: 'default first name for resource'
+  field :last_name,             as: :text, required: true, placeholder: 'Doe'
+  field :email,                 as: :text, name: 'User Email', required: true
+  field :active,                as: :boolean, name: 'Is active', show_on: :show
+  field :cv,                    as: :file, name: 'CV'
+  field :is_admin?,             as: :boolean, name: 'Is admin', only_on: :index
+  field :roles,                 as: :boolean_group, options: { admin: 'Administrator', manager: 'Manager', writer: 'Writer' }
+  field :birthday,              as: :date, first_day_of_week: 1, picker_format: 'F J Y', format: '%Y-%m-%d', placeholder: 'Feb 24th 1955', required: true
+  field :is_writer,             as: :text, format_using: -> (value) { value.truncate 3 }, hide_on: :edit do |model, resource, view, field|
+    model.posts.to_a.count > 0 ? 'yes' : 'no'
   end
 
-  grid do |cover, title, body|
-    cover.gravatar :email, link_to_resource: true
-    title.text :name, link_to_resource: true
-    body.text :url
+  field :password,              as: :password, name: 'User Password', required: false, except_on: :forms, help: 'You may verify the password strength <a href="http://www.passwordmeter.com/" target="_blank">here</a>.'
+  field :password_confirmation, as: :password, name: 'Password confirmation', required: false, only_on: :new
+
+  field '<div class="text-gray-300 uppercase font-bold">DEV</div>', as: :heading, as_html: true
+  field :custom_css,            as: :code, theme: 'dracula', language: 'css', help: "This enables you to edit the user's custom styles.", height: '250px'
+
+  field :team_id,               as: :hidden, default: 0 # For testing purposes
+
+  field :post,     as: :has_one
+  field :posts,    as: :has_many
+  field :projects, as: :has_and_belongs_to_many
+  field :teams,    as: :has_and_belongs_to_many
+
+  grid do
+    cover :email, as: :gravatar, link_to_resource: true
+    title :name, as: :text, link_to_resource: true
+    body :url, as: :text
   end
 
-  actions do |a|
-    a.use ToggleInactive
-    a.use ToggleAdmin
-  end
+  action ToggleInactive
+  action ToggleAdmin
 end


### PR DESCRIPTION
There are a few changes with this PR:

1. Fields get declared using `field :name, as: :text` syntax. 
2. Grid fields get declared using `grid do` block
3. Actions and filters are declared using `action` and `filter` methods
4. Action fields get passed on to the action form using an `ActiveModel` like object for better compatibility.
5. `can_see` renamed to `visible` in field declaration

Example of fields declaration👇

```ruby
# app/avo/resource/user_resource.rbclass UserResource < Avo::BaseResource
class UserResource < Avo::BaseResource
  self.title = :name
  self.translation_key = 'avo.resource_translations.user'
  self.search = [:id, :first_name, :last_name]
  self.includes = [:posts, :post]
  self.devise_password_optional = true

  field :id,         as: :id, link_to_resource: true
  field :email,      as: :gravatar, link_to_resource: true
  heading 'User Information'
  field :first_name, as: :text, required: true, placeholder: 'John', default: 'default first name for resource'
  field :last_name,  as: :text, required: true, placeholder: 'Doe'
  field :email,      as: :text, name: 'User Email', required: true
  field :active,     as: :boolean, name: 'Is active', show_on: :show
  field :cv,         as: :file, name: 'CV'
  field :is_admin?,  as: :boolean, name: 'Is admin', only_on: :index
  field :roles,      as: :boolean_group, options: { admin: 'Administrator', manager: 'Manager', writer: 'Writer' }
  field :birthday,   as: :date, first_day_of_week: 1, picker_format: 'F J Y', format: '%Y-%m-%d', placeholder: 'Feb 24th 1955', required: true
  field :is_writer,  as: :text, format_using: -> (value) { value.truncate 3 }, hide_on: :edit do |model, resource, view, field|
    model.posts.to_a.count > 0 ? 'yes' : 'no'
  end

  field :password, as: :password, name: 'User Password', required: false, except_on: :forms, help: 'You may verify the password strength <a href="http://www.passwordmeter.com/" target="_blank">here</a>.'
  field :password_confirmation, as: :password, name: 'Password confirmation', required: false, only_on: :new

  heading '<div class="text-gray-300 uppercase font-bold">DEV</div>', as_html: true
  field :custom_css, as: :code, theme: 'dracula', language: 'css', help: "This enables you to edit the user's custom styles.", height: '250px'
  field :team_id, as: :hidden, default: 0 # For testing purposes

  field :post,     as: :has_one
  field :posts,    as: :has_many
  field :projects, as: :has_and_belongs_to_many
  field :teams,    as: :has_and_belongs_to_many

  grid do
    cover :email, as: :gravatar, link_to_resource: true
    title :name, as: :text, link_to_resource: true
    body :url, as: :text
  end

  filter PublishedFilter

  action ToggleInactive
  action ToggleAdmin
end
```