### PR TITLE
chore: remove ActiveStorage dependency

### DIFF
--- a/lib/avo/app.rb
+++ b/lib/avo/app.rb
@@ -27,7 +27,11 @@ module Avo
         self.context = context
 
         # Set the current host for ActiveStorage
-        ActiveStorage::Current.host = request.base_url
+        begin
+          ActiveStorage::Current.host = request.base_url
+        rescue => exception
+          Rails.logger.debug "[Avo] Failed to set ActiveStorage::Current.host, #{exception.inspect}"
+        end
 
         init_resources
 


### PR DESCRIPTION
Avo assumes you have `ActiveStorage` installed and tries to use it in the `App.ini` method. We're removing that dependency.