### PR TITLE
Fix CoreMirror fullscreen hiding under the sidebar

### DIFF
--- a/app/packs/stylesheets/components/code.css
+++ b/app/packs/stylesheets/components/code.css
@@ -9,3 +9,8 @@
   height: var(--height) !important;
   min-height: auto;
 }
+
+/* overlay CodeMirror fullscreen & Preview on small screens */
+.CodeMirror-fullscreen, .editor-preview-active-side {
+  z-index: 50;
+}


### PR DESCRIPTION
Hi Adrian,
A little fix for the CodeMirror editor on small screens as it falls under the sidebar and top navigation bar:

Before: 
<img width="964" alt="Schermafbeelding 2021-04-08 om 09 37 16" src="https://user-images.githubusercontent.com/1255290/113986851-02655b00-984e-11eb-93b0-15717c0d7393.png">

After:
<img width="959" alt="Schermafbeelding 2021-04-08 om 09 37 47" src="https://user-images.githubusercontent.com/1255290/113986925-14df9480-984e-11eb-86da-4c8f5c053ede.png">

