### PR TITLE
fix: invalid license erros on /avo

### DIFF
--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -42,7 +42,7 @@ module Avo
     end
 
     def check_avo_license
-      unless request.original_url.match?(/.*\/#{Avo.configuration.namespace}\/resources\/.*/)
+      unless on_root_path || on_resources_path
         if @license.invalid? || @license.lacks(:custom_tools)
           if Rails.env.development?
             @custom_tools_alert_visible = true
@@ -263,6 +263,14 @@ module Avo
 
     def add_initial_breadcrumbs
       instance_eval(&Avo.configuration.initial_breadcrumbs) if Avo.configuration.initial_breadcrumbs.present?
+    end
+
+    def on_root_path
+      [Avo.configuration.root_path, "#{Avo.configuration.root_path}/"].include?(request.original_fullpath)
+    end
+
+    def on_resources_path
+      request.original_url.match?(/.*\/#{Avo.configuration.namespace}\/resources\/.*/)
     end
   end
 end

--- a/app/controllers/avo/home_controller.rb
+++ b/app/controllers/avo/home_controller.rb
@@ -3,11 +3,10 @@ require_dependency "avo/application_controller"
 module Avo
   class HomeController < ApplicationController
     def index
-      @page_title = "Get started"
-
       if Avo.configuration.home_path.present?
         redirect_to Avo.configuration.home_path
       elsif !Rails.env.development?
+        @page_title = "Get started"
         redirect_to resources_path Avo::App.get_resources.min_by { |resource| resource.route_key }.model_class
       end
     end

--- a/spec/features/avo/license_tinkering_in_application_controller_spec.rb
+++ b/spec/features/avo/license_tinkering_in_application_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "LicenseTinkeringInApplicationController", type: :feature do
       end
     end
 
-    context "without tinkering" do
+    context "with tinkering" do
       before do
         Avo::ToolsController.define_method :check_avo_license do
           ""


### PR DESCRIPTION
This fixes a bug where `/avo` path would raise an invalid license error.