### PR TITLE
Fix typo on action generator template name

### DIFF
--- a/lib/generators/avo/action_generator.rb
+++ b/lib/generators/avo/action_generator.rb
@@ -7,7 +7,7 @@ module Generators
       namespace "avo:action"
 
       def create_resource_file
-        template "action.rb", "app/avo/actions/#{singular_name}.rb"
+        template "action.tt", "app/avo/actions/#{singular_name}.rb"
       end
     end
   end

--- a/lib/generators/avo/templates/action.tt
+++ b/lib/generators/avo/templates/action.tt
@@ -1,13 +1,9 @@
-module Avo
-  module Actions
-    class <%= class_name.camelize %> < Action
-      self.name = '<%= name.underscore.humanize %>'
+class <%= class_name.camelize %> < Avo::BaseAction
+  self.name = '<%= name.underscore.humanize %>'
 
-      def handle(models:, fields:)
-        models.each do |model|
-          # Do something with your models.
-        end
-      end
+  def handle(models:, fields:)
+    models.each do |model|
+      # Do something with your models.
     end
   end
 end


### PR DESCRIPTION
running the generator `bin/rails generate avo:action toggle_published`

results in the following error: 

```
Could not find "action.rb" in any of your source paths. Your current source paths are: 
~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/avo-1.2.10/lib/generators/avo/templates
```

Additionally the template referenced a parent class `Action` that doesn't exist. Refactored to use `BaseAction` and removed the name spacing to satisfy Zeitwerk autoloading 