### PR TITLE
fix: license has -> lacks ability

### DIFF
--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -78,7 +78,7 @@ module Avo
         field.hydrate(resource: self, panel_name: default_panel_name, user: user)
       end
 
-      if Avo::App.license.has_with_trial(:custom_fields)
+      if Avo::App.license.lacks_with_trial(:custom_fields)
         fields = fields.reject do |field|
           field.custom?
         end


### PR DESCRIPTION
Instead of rejecting custom fields if the license lacked that ability, it rejected them if the license had that ability.