### PR TITLE
refactor: remove ransack as a gem dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,6 @@ PATH
       pagy
       pundit
       rails (>= 6.0)
-      ransack
       view_component
       zeitwerk
 

--- a/avo.gemspec
+++ b/avo.gemspec
@@ -45,5 +45,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "meta-tags"
   spec.add_dependency "breadcrumbs_on_rails"
   spec.add_dependency "manifester"
-  spec.add_dependency "ransack"
 end

--- a/gemfiles/rails_6.0_ruby_2.6.gemfile.lock
+++ b/gemfiles/rails_6.0_ruby_2.6.gemfile.lock
@@ -14,7 +14,6 @@ PATH
       pagy
       pundit
       rails (>= 6.0)
-      ransack
       view_component
       zeitwerk
 

--- a/gemfiles/rails_6.0_ruby_2.7.gemfile.lock
+++ b/gemfiles/rails_6.0_ruby_2.7.gemfile.lock
@@ -14,7 +14,6 @@ PATH
       pagy
       pundit
       rails (>= 6.0)
-      ransack
       view_component
       zeitwerk
 

--- a/gemfiles/rails_6.1_ruby_2.6.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_2.6.gemfile.lock
@@ -14,7 +14,6 @@ PATH
       pagy
       pundit
       rails (>= 6.0)
-      ransack
       view_component
       zeitwerk
 

--- a/gemfiles/rails_6.1_ruby_2.7.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_2.7.gemfile.lock
@@ -14,7 +14,6 @@ PATH
       pagy
       pundit
       rails (>= 6.0)
-      ransack
       view_component
       zeitwerk
 


### PR DESCRIPTION
Fixes https://github.com/avo-hq/avo/issues/441