### PR TITLE
Allow file fields to work with UUID-based records

### DIFF
--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -78,7 +78,6 @@ module Avo
           existing_params = Addressable::URI.parse(request.fullpath).query_values.symbolize_keys
         end
       rescue; end
-
       avo.send :"resources_#{model.model_name.route_key}_path", **existing_params, **args
     end
 
@@ -221,7 +220,7 @@ module Avo
             "attachment"
           end
 
-          return query.eager_load "#{field.id}_#{attachment}": :blob
+          return query.includes "#{field.id}_#{attachment}": :blob
         end
       end
 


### PR DESCRIPTION
## Eager loading files with #includes rather than #eager_load

Following #461 , current implementation forbids using `ActiveStorage` with UUID-based records raising a 500 error on ressources that feature a `FileField`.

In the`Avo::ApplicationController#eager_load_files` method, changing the call to `#eager_load` into `includes` solves that problem. I don't think it should affect performance in a dramatic way, but let me know what you think.

Fixes https://github.com/avo-hq/avo/issues/461