### PR TITLE
feature: Select all on controller

### DIFF
--- a/app/components/avo/index/resource_table_component.html.erb
+++ b/app/components/avo/index/resource_table_component.html.erb
@@ -1,6 +1,6 @@
 <div class="w-full">
   <% if @resources.present?%>
-    <table class="w-full px-4 overflow-hidden">
+    <table class="w-full px-4 overflow-hidden" data-resource-name='<%= @resource.model_class.model_name.route_key %>' data-controller='item-select-all'>
       <%= render partial: 'avo/partials/table_header', locals: {fields: @resource.get_fields(reflection: @reflection)} %>
       <tbody>
         <% @resources.each_with_index do |resource, index| %>

--- a/app/helpers/avo/resources_helper.rb
+++ b/app/helpers/avo/resources_helper.rb
@@ -48,8 +48,21 @@ module Avo
     def item_selector_input(floating: false, size: :md)
       "<input type='checkbox'
         class='mx-3 #{"absolute inset-auto left-0 mt-2 z-10 hidden group-hover:block checked:block" if floating} #{size.to_sym == :lg ? "w-5 h-5" : "w-4 h-4"}'
-        data-action='input->item-selector#toggle'
+        data-action='input->item-selector#toggle input->item-select-all#update'
+        data-item-select-all-target='itemCheckbox'
+        name='#{t "avo.select_item"}'
         title='#{t "avo.select_item"}'
+        data-tippy='tooltip'
+      />"
+    end
+
+    def item_select_all_input
+      "<input type='checkbox'
+        class='mx-3 w-4 h-4'
+        data-action='input->item-select-all#toggle'
+        data-item-select-all-target='checkbox'
+        name='#{t "avo.select_all"}'
+        title='#{t "avo.select_all"}'
         data-tippy='tooltip'
       />"
     end

--- a/app/packs/js/controllers/item_select_all_controller.js
+++ b/app/packs/js/controllers/item_select_all_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from 'stimulus'
+
+export default class extends Controller {
+  static targets = [ "itemCheckbox", "checkbox" ]
+
+  connect() {
+    this.resourceName = this.element.dataset.resourceName
+  }
+
+  toggle(event) {
+    var value = !!event.target.checked
+    document.querySelectorAll(`[data-controller="item-selector"][data-resource-name="${this.resourceName}"] input[type=checkbox]`)
+      .forEach((checkbox) => checkbox.checked != value && checkbox.click())
+  }
+
+  update() {
+    var allSelected = true
+    this.itemCheckboxTargets.forEach((checkbox) => allSelected = allSelected && checkbox.checked)
+    this.checkboxTarget.checked = allSelected
+  }
+}

--- a/app/views/avo/partials/_table_header.html.erb
+++ b/app/views/avo/partials/_table_header.html.erb
@@ -1,7 +1,7 @@
 
 <thead class="bg-blue-gray-100 border-t border-b border-gray-300 pb-1">
   <th>
-    <!-- Select cell -->
+    <%== item_select_all_input %>
   </th>
   <%
     fields.each_with_index do |field, index|

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -23,6 +23,7 @@ en:
     you_missed_something_check_form: 'You might have missed something. Please check the form.'
     remove_selection: 'Remove selection'
     select_item: 'Select item'
+    select_all: 'Select all on page'
     delete_file: 'Delete file'
     delete: 'delete'
     delete_item: 'Delete %{item}'

--- a/spec/system/avo/select_spec.rb
+++ b/spec/system/avo/select_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "Filters", type: :system do
+  describe "Boolean filter without default" do
+    let!(:featured_post) { create :post, name: "Featured post", is_featured: true, published_at: nil }
+    let!(:unfeatured_post) { create :post, name: "Unfeatured post", is_featured: false, published_at: nil }
+
+    let(:url) { "/admin/resources/posts?view_type=table" }
+
+
+    it "allows selecting and deselecting all" do
+      visit url
+      expect(page.all("input[name='Select item']").any?(&:checked?)).to be false
+
+      check("Select all on page")
+
+      expect(page.all("input[name='Select item']").all?(&:checked?)).to be true
+
+      uncheck("Select item", match: :first)
+      expect(page.all("input[name='Select item']").map(&:checked?)).to match_array([false, true])
+
+      expect(page.find("input[name='Select all on page']")).not_to be_checked
+    end
+  end
+end


### PR DESCRIPTION
Simple Stimulus controller which uses JS to click all select buttons on the page at once, and additionally ensures the status of the checkbox is consistent with the row checkboxes.

The implementation isn't efficient and might get slow with very large pages, but felt like the simplest option for now that could work.

First proper PR - feedback very welcome! Happy to work on improving this as needed.

Closes #452.