### PR TITLE
Ensure fields array is initialized for heading

### DIFF
--- a/lib/avo/fields_collector.rb
+++ b/lib/avo/fields_collector.rb
@@ -40,6 +40,7 @@ module Avo
     end
 
     def heading(body, **args)
+      self.fields ||= []
       self.fields << Avo::Fields::HeadingField.new(body, **args)
     end
 


### PR DESCRIPTION
This fixes a bug wherein the fields array is not initialized if a heading is used before any fields in a resource definition.