### PR TITLE
Path change to handle uncountable nouns

### DIFF
--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -119,7 +119,7 @@ module Avo
     end
 
     def new_resource_path(model, **args)
-      avo.send :"new_resources_#{model.model_name.route_key.singular_route_key}_path", **args
+      avo.send :"new_resources_#{model.model_name.singular_route_key}_path", **args
     end
 
     def edit_resource_path(model, **args)

--- a/lib/avo/app.rb
+++ b/lib/avo/app.rb
@@ -166,11 +166,11 @@ module Avo
               route_key = if resource.model_class.present?
                 resource.model_class.model_name.route_key
               else
-                resource.to_s.underscore.gsub("_resource", "").downcase.pluralize.to_sym
+                resource.to_s.underscore.gsub("_resource", "").downcase.pluralize
               end
 
               # Handle uncountable routes
-              route_key = route_key.gsub("_index", "").to_sym
+              route_key = route_key.to_s.gsub("_index", "").to_sym
               resources route_key
             end
         end


### PR DESCRIPTION
Changed singularize method to ActiveModel::Naming.singular_route_key method (https://api.rubyonrails.org/classes/ActiveModel/Naming.html#method-c-singular_route_key), what handles uncountable nouns.

Closes #524 