### PR TITLE
fix: route key for uncountable resource

### DIFF
--- a/lib/avo/app.rb
+++ b/lib/avo/app.rb
@@ -164,13 +164,11 @@ module Avo
             end
             .map do |resource|
               route_key = if resource.model_class.present?
-                resource.model_class.model_name.route_key
+                resource.model_class.model_name.plural.to_sym
               else
                 resource.to_s.underscore.gsub("_resource", "").downcase.pluralize.to_sym
               end
 
-              # Handle uncountable routes
-              route_key = route_key.to_sym
               resources route_key
             end
         end


### PR DESCRIPTION
Using as example fish resource
```ruby
class FishResource < Avo::BaseResource
  self.model_class = Fish
  self.title = :id
  self.includes = []

  field :id, as: :id
end
```

For this resources in draw_routes we need to call resource method with `fish` param, to build routes right to avo.
But the line `resource.model_class.model_name.route_key `returns fish_index, and routes were generated in the wrong way, so i change this line to use plural method from active model naming and its works.


References:
- https://api.rubyonrails.org/classes/ActiveModel/Naming.html#method-c-route_key
- https://markembling.info/2011/06/uncountable-nouns-rails-3-resource-routing