### PR TITLE
Add edit link to has_one field

### DIFF
--- a/app/components/avo/views/resource_show_component.html.erb
+++ b/app/components/avo/views/resource_show_component.html.erb
@@ -14,6 +14,11 @@
                 <%= svg 'trash' %> <%= t('avo.detach_item', item: @reflection.name.to_s).capitalize %>
               <% end %>
             <% end %>
+            <% if @resource.authorization.authorize_action(:edit, raise_exception: false) %>
+              <%= a_link edit_path, color: 'indigo' do %>
+                <%= svg 'edit' %> <%= t('avo.edit').capitalize %>
+              <% end %>
+            <% end %>
           <% else %>
             <%= a_link back_path do %>
               <%= svg 'arrow-left' %> <%= t('avo.go_back') %>


### PR DESCRIPTION
This branch adds the `edit` button to the `has_one` field.

Note that this introduces a situation wherein the `detach` and `edit` buttons are situated right next to each other, both of which are conventionally solid indigo. Not a terribly huge deal, but just thought I'd mention it.