### PR TITLE
feature: expose user and resource in actions

### DIFF
--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -19,7 +19,9 @@ module Avo
       end
 
       args = {
-        fields: fields
+        fields: fields,
+        current_user: _current_user,
+        resource: resource,
       }
 
       args[:models] = models unless @action.standalone

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -70,7 +70,7 @@ module Avo
     end
 
     def handle_action(**args)
-      models, fields = args.values_at(:models, :fields)
+      models, fields, current_user, resource = args.values_at(:models, :fields, :current_user, :resource)
       avo_fields = get_fields.map { |field| [field.id, field] }.to_h
 
       if fields.present?
@@ -84,7 +84,9 @@ module Avo
       end
 
       args = {
-        fields: processed_fields
+        fields: processed_fields,
+        current_user: current_user,
+        resource: resource,
       }
 
       args[:models] = models unless standalone

--- a/lib/generators/avo/templates/action.tt
+++ b/lib/generators/avo/templates/action.tt
@@ -1,7 +1,9 @@
 class <%= class_name.camelize %> < Avo::BaseAction
   self.name = '<%= name.underscore.humanize %>'
 
-  def handle(models:, fields:)
+  def handle(**args)
+    models, fields, current_user, resource = args.values_at(:models, :fields, :current_user, :resource)
+
     models.each do |model|
       # Do something with your models.
     end

--- a/spec/dummy/app/avo/actions/dummy_action.rb
+++ b/spec/dummy/app/avo/actions/dummy_action.rb
@@ -2,7 +2,7 @@ class DummyAction < Avo::BaseAction
   self.name = "Dummy action"
   self.standalone = true
 
-  def handle(fields:)
+  def handle(**args)
     # Do something here
     succeed 'Yup'
   end

--- a/spec/dummy/app/avo/actions/toggle_admin.rb
+++ b/spec/dummy/app/avo/actions/toggle_admin.rb
@@ -2,7 +2,9 @@ class ToggleAdmin < Avo::BaseAction
   self.name = "Toggle admin"
   self.no_confirmation = true
 
-  def handle(models:, fields:)
+  def handle(**args)
+    models, fields, current_user, resource = args.values_at(:models, :fields, :current_user, :resource)
+
     models.each do |model|
       if model.roles["admin"].present?
         model.update roles: model.roles.merge!({"admin": false})

--- a/spec/dummy/app/avo/actions/toggle_inactive.rb
+++ b/spec/dummy/app/avo/actions/toggle_inactive.rb
@@ -4,7 +4,9 @@ class ToggleInactive < Avo::BaseAction
   field :notify_user, as: :boolean, default: true
   field :message, as: :text, default: "Your account has been marked as inactive."
 
-  def handle(models:, fields:)
+  def handle(**args)
+    models, fields, current_user, resource = args.values_at(:models, :fields, :current_user, :resource)
+
     models.each do |model|
       if model.active
         model.update active: false

--- a/spec/dummy/app/avo/actions/toggle_published.rb
+++ b/spec/dummy/app/avo/actions/toggle_published.rb
@@ -7,7 +7,9 @@ class TogglePublished < Avo::BaseAction
   field :notify_user, as: :boolean, default: true
   field :message, as: :text, default: "Your account has been marked as inactive."
 
-  def handle(models:, fields:)
+  def handle(**args)
+    models, fields, current_user, resource = args.values_at(:models, :fields, :current_user, :resource)
+
     models.each do |model|
       if model.published_at.present?
         model.update published_at: nil


### PR DESCRIPTION
Fixes https://github.com/avo-hq/avo/issues/541

This adds `current_user` and `resource` to actions context. 

## Breaking change:

You need to update all your actions to support the new arguments.

```diff
-  def handle(models:, fields:)
+  def handle(**args)
+    models, fields, current_user, resource = args.values_at(:models, :fields, :current_user, :resource)
```