### PR TITLE
Fix: Rename boolean filter argument `value` => `values`

### DIFF
--- a/lib/generators/avo/templates/filters/boolean_filter.tt
+++ b/lib/generators/avo/templates/filters/boolean_filter.tt
@@ -1,7 +1,7 @@
 class <%= class_name.camelize %> < Avo::Filters::BooleanFilter
   self.name = '<%= name.underscore.humanize %>'
 
-  def apply(request, query, value)
+  def apply(request, query, values)
     query
   end
 


### PR DESCRIPTION
NOTE: I didn't manage to get the tests running locally!

Boolean filter receives a hash of key-values: keys being names/strings/features/flags and values being `true` or `false` (selected or not)

Example `values`:

```rb
> values
{
      "Cart Button Effects": true,
  "Customer Scarcity Timer": false,
             "Discount Pop": false,
                "IQ Slider": false
}
```