### PR TITLE
refactor: raise_error_on_missing_policy

### DIFF
--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -26,6 +26,7 @@ module Avo
     attr_accessor :view_component_path
     attr_accessor :display_license_request_timeout_error
     attr_accessor :current_user_resource_name
+    attr_accessor :raise_error_on_missing_policy
 
     def initialize
       @root_path = "/avo"
@@ -64,6 +65,7 @@ module Avo
       @view_component_path = "app/components"
       @display_license_request_timeout_error = true
       @current_user_resource_name = "user"
+      @raise_error_on_missing_policy = false
     end
 
     def locale_tag

--- a/lib/avo/services/authorization_service.rb
+++ b/lib/avo/services/authorization_service.rb
@@ -48,8 +48,10 @@ module Avo
             end
 
             true
-          rescue Pundit::NotDefinedError
-            false
+          rescue Pundit::NotDefinedError => e
+            return false unless Avo.configuration.raise_error_on_missing_policy
+
+            raise e
           rescue => error
             if args[:raise_exception] == false
               false
@@ -73,8 +75,10 @@ module Avo
 
           begin
             Pundit.policy_scope! user, model
-          rescue
-            model
+          rescue Pundit::NotDefinedError => e
+            return model unless Avo.configuration.raise_error_on_missing_policy
+
+            raise e
           end
         end
 

--- a/spec/requests/avo/authorization/raise_error_on_missing_policy_spec.rb
+++ b/spec/requests/avo/authorization/raise_error_on_missing_policy_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'raise_error_on_missing_policy', type: :feature do
+  before { Avo.configuration.raise_error_on_missing_policy = true }
+  after { Avo.configuration.raise_error_on_missing_policy = false }
+
+  describe 'index?' do
+    it 'fails with a missing policy' do
+      expect {
+        visit '/admin/resources/people'
+      }.to raise_error Pundit::NotDefinedError
+    end
+
+    it 'succeeds with a present policy' do
+      RSpec::Expectations.configuration.on_potential_false_positives = :nothing
+      expect {
+        visit '/admin/resources/projects'
+      }.not_to raise_error an_instance_of(Pundit::NotDefinedError)
+      RSpec::Expectations.configuration.on_potential_false_positives = :warn
+    end
+  end
+end


### PR DESCRIPTION
https://docs.avohq.io/1.0/authorization.html#raise-errors-when-policies-are-missing