### PR TITLE
fix: uncountable models search

### DIFF
--- a/app/components/avo/fields/belongs_to_field/index_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/index_component.html.erb
@@ -1,3 +1,3 @@
 <%= index_field_wrapper field: @field do %>
-  <%= link_to @field.label, helpers.resource_path(@field.value, for_resource: @field.target_resource) %>
+  <%= link_to @field.label, helpers.resource_path(model: @field.value, resource: @field.target_resource) %>
 <% end %>

--- a/app/components/avo/fields/belongs_to_field/show_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/show_component.html.erb
@@ -1,3 +1,3 @@
 <%= show_field_wrapper field: @field, index: @index do %>
-  <%= link_to @field.label, helpers.resource_path(@field.value, for_resource: @field.target_resource, via_resource_class: @resource.model_class, via_resource_id: @resource.model.id) %>
+  <%= link_to @field.label, helpers.resource_path(model: @field.value, resource: @field.target_resource, via_resource_class: @resource.model_class, via_resource_id: @resource.model.id) %>
 <% end %>

--- a/app/components/avo/fields/common/multiple_file_viewer_component.html.erb
+++ b/app/components/avo/fields/common/multiple_file_viewer_component.html.erb
@@ -23,7 +23,7 @@
       </div>
       <div>
         <% if @resource.authorization.authorize_action(:delete_attachments?, raise_exception: false) %>
-          <%= a_link "#{Avo::App.root_path}/resources/#{@resource.model.model_name.route_key}/#{@resource.model.id}/active_storage_attachments/#{@id}/#{@file.id}", color: :red, variant: :outlined, size: :xs, class: 'text-center', 'data-turbo-frame': 'destroy_attachment_form', data: { confirm: t('avo.are_you_sure')} do %>
+          <%= a_link "#{@resource.record_path}/active_storage_attachments/#{@id}/#{@file.id}", color: :red, variant: :outlined, size: :xs, class: 'text-center', 'data-turbo-frame': 'destroy_attachment_form', data: { confirm: t('avo.are_you_sure')} do %>
             <%= helpers.svg 'trash' %> <span class="hidden lg:block lg:flex-1"><%= t 'avo.delete_file', item: @file.filename %></span>
           <% end %>
         <% end %>

--- a/app/components/avo/fields/common/single_file_viewer_component.html.erb
+++ b/app/components/avo/fields/common/single_file_viewer_component.html.erb
@@ -23,8 +23,7 @@
       </div>
       <div>
         <% if @resource.authorization.authorize_action(:delete_attachments?, raise_exception: false) %>
-          <%= a_link "#{Avo::App.root_path}/resources/#{@resource.model.model_name.route_key}/#{@resource.model.id
-          }/active_storage_attachments/#{@id}/#{@file.blob_id}", color: :red, variant: :outlined, size: :md, class: '', 'data-turbo-frame': 'destroy_attachment_form', data: { confirm: t('avo.are_you_sure')} do %>
+          <%= a_link "#{@resource.record_path}/active_storage_attachments/#{@id}/#{@file.blob_id}", color: :red, variant: :outlined, size: :md, class: '', 'data-turbo-frame': 'destroy_attachment_form', data: { confirm: t('avo.are_you_sure')} do %>
             <%= helpers.svg 'trash' %> <%= t 'avo.delete_file', item: @file.filename %>
           <% end %>
         <% end %>

--- a/app/components/avo/fields/has_one_field/index_component.html.erb
+++ b/app/components/avo/fields/has_one_field/index_component.html.erb
@@ -1,3 +1,3 @@
 <%= index_field_wrapper field: @field do %>
-  <%= link_to @field.label, helpers.resource_path(@field.value, for_resource: @field.target_resource) %>
+  <%= link_to @field.label, helpers.resource_path(model: @field.value, resource: @field.target_resource) %>
 <% end %>

--- a/app/components/avo/fields/has_one_field/show_component.rb
+++ b/app/components/avo/fields/has_one_field/show_component.rb
@@ -8,8 +8,9 @@ class Avo::Fields::HasOneField::ShowComponent < Avo::Fields::ShowComponent
     if @field.present?
       reflection_resource = @field.target_resource
       if reflection_resource.present? && @resource.present?
-        method_name = ('attach_' + reflection_resource.model_class.model_name.singular_route_key.underscore + '?').to_sym
+        method_name = ("attach_#{reflection_resource.model_key}?").to_sym
         defined_policy_methods = @resource.authorization.defined_methods(@resource.model_class, raise_exception: false)
+
         if defined_policy_methods.present? && defined_policy_methods.include?(method_name)
           attach_policy = @resource.authorization.authorize_action(method_name, raise_exception: false)
         end

--- a/app/components/avo/fields/has_one_field/show_component.rb
+++ b/app/components/avo/fields/has_one_field/show_component.rb
@@ -20,8 +20,6 @@ class Avo::Fields::HasOneField::ShowComponent < Avo::Fields::ShowComponent
   end
 
   def attach_path
-    class_name = helpers.singular_resource_name(nil, @resource)
-
-    helpers.avo.resources_associations_new_path(class_name, @resource.model.id, @field.id)
+    helpers.avo.resources_associations_new_path(@resource.singular_model_key, @resource.model.id, @field.id)
   end
 end

--- a/app/components/avo/fields/index_component.rb
+++ b/app/components/avo/fields/index_component.rb
@@ -12,9 +12,9 @@ class Avo::Fields::IndexComponent < ViewComponent::Base
 
   def resource_path
     if @parent_model.present?
-      helpers.resource_path(@resource.model, for_resource: @resource, via_resource_class: @parent_model.class, via_resource_id: @parent_model.id)
+      helpers.resource_path(model: @resource.model, resource: @resource, via_resource_class: @parent_model.class, via_resource_id: @parent_model.id)
     else
-      helpers.resource_path(@resource.model, for_resource: @resource)
+      helpers.resource_path(model: @resource.model, resource: @resource)
     end
   end
 end

--- a/app/components/avo/fields/trix_field/edit_component.html.erb
+++ b/app/components/avo/fields/trix_field/edit_component.html.erb
@@ -2,7 +2,7 @@
   <div
     data-controller="trix-field"
     data-trix-field-target="controller"
-    data-resource-name="<%= @resource.model_class.model_name.route_key %>"
+    data-resource-name="<%= @resource.model_key %>"
     data-resource-id="<%= @resource.model.id %>"
     data-attachments-disabled="<%= @field.attachments_disabled %>"
     data-attachment-key="<%= @field.attachment_key %>"

--- a/app/components/avo/index/grid_item_component.html.erb
+++ b/app/components/avo/index/grid_item_component.html.erb
@@ -7,17 +7,17 @@
     <% if cover.blank? %>
       <%= render Avo::Index::GridCoverEmptyStateComponent.new %>
     <% elsif cover.respond_to?(:to_image) && cover.to_image.present? %>
-      <%= link_to_if cover.link_to_resource, image_tag(cover.to_image, class: 'absolute h-full w-full object-cover'), helpers.resource_path(@resource.model, for_resource: @resource), class: 'absolute h-full w-full object-cover', title: title.value %>
+      <%= link_to_if cover.link_to_resource, image_tag(cover.to_image, class: 'absolute h-full w-full object-cover'), helpers.resource_path(model: @resource.model, resource: @resource), class: 'absolute h-full w-full object-cover', title: title.value %>
     <% elsif cover.type == 'file' %>
       <% if cover.value.attached? && cover.value.representable? %>
-        <%= link_to_if cover.link_to_resource, image_tag(helpers.main_app.url_for(cover.value.variant(resize_to_limit: [480, 480])), class: 'absolute h-full w-full object-cover'), helpers.resource_path(@resource.model, for_resource: @resource), class: 'absolute h-full w-full object-cover', title: title.value %>
+        <%= link_to_if cover.link_to_resource, image_tag(helpers.main_app.url_for(cover.value.variant(resize_to_limit: [480, 480])), class: 'absolute h-full w-full object-cover'), helpers.resource_path(model: @resource.model, resource: @resource), class: 'absolute h-full w-full object-cover', title: title.value %>
       <% else %>
         <div class="absolute bg-gray-100 w-full h-full">
           <%= helpers.svg 'avocado', class: 'relative transform -translate-x-1/2 -translate-y-1/2 h-20 text-gray-400 inset-auto top-1/2 left-1/2' %>
         </div>
       <% end %>
     <% elsif cover.value.present? %>
-      <%= link_to_if cover.link_to_resource, image_tag(cover.value, class: 'absolute h-full w-full object-cover'), helpers.resource_path(@resource.model, for_resource: @resource), class: 'absolute h-full w-full object-cover', title: title.value %>
+      <%= link_to_if cover.link_to_resource, image_tag(cover.value, class: 'absolute h-full w-full object-cover'), helpers.resource_path(model: @resource.model, resource: @resource), class: 'absolute h-full w-full object-cover', title: title.value %>
     <% else %>
       <%= render Avo::Index::GridCoverEmptyStateComponent.new %>
     <% end %>
@@ -25,7 +25,7 @@
   <div class="grid grid-cols-1 place-content-between p-4 h-full">
     <div class="mb-4">
       <div class="grid font-semibold leading-tight text-lg mb-2">
-        <%= link_to_if title.link_to_resource, title.value, helpers.resource_path(@resource.model, for_resource: @resource) if title.present? %>
+        <%= link_to_if title.link_to_resource, title.value, helpers.resource_path(model: @resource.model, resource: @resource) if title.present? %>
       </div>
       <div class="text-sm break-words">
         <%= body.value if body.present? %>

--- a/app/components/avo/index/resource_controls_component.html.erb
+++ b/app/components/avo/index/resource_controls_component.html.erb
@@ -42,7 +42,7 @@
   <% end %>
 
   <% if can_delete? %>
-    <%= form_with url: helpers.resource_path(@resource.model, for_resource: @resource), method: :delete, html: {
+    <%= form_with url: helpers.resource_path(model: @resource.model, resource: @resource), method: :delete, html: {
         'data-turbo-frame': params[:turbo_frame]
       } do |form| %>
       <%= form.button helpers.svg('trash', class: 'text-gray-400 h-6 hover:text-gray-600'),

--- a/app/components/avo/index/resource_controls_component.rb
+++ b/app/components/avo/index/resource_controls_component.rb
@@ -23,19 +23,29 @@ class Avo::Index::ResourceControlsComponent < Avo::ResourceComponent
   end
 
   def show_path
+    args = {}
+
     if @parent_model.present?
-      helpers.resource_path(@resource.model, for_resource: @resource, via_resource_class: parent_resource.model_class, via_resource_id: @parent_model.id)
-    else
-      helpers.resource_path(@resource.model, for_resource: @resource)
+      args = {
+        via_resource_class: parent_resource.model_class,
+        via_resource_id: @parent_model.id
+      }
     end
+
+    helpers.resource_path(model: @resource.model, resource: @resource, **args)
   end
 
   def edit_path
+    args = {}
+
     if @parent_model.present?
-      helpers.edit_resource_path(@resource.model, for_resource: @resource, via_resource_class: parent_resource.model_class, via_resource_id: @parent_model.id)
-    else
-      helpers.edit_resource_path(@resource.model, for_resource: @resource)
+      args = {
+        via_resource_class: parent_resource.model_class,
+        via_resource_id: @parent_model.id
+      }
     end
+
+    helpers.edit_resource_path(model: @resource.model, resource: @resource, **args)
   end
 
   def singular_resource_name

--- a/app/components/avo/index/resource_table_component.html.erb
+++ b/app/components/avo/index/resource_table_component.html.erb
@@ -1,6 +1,6 @@
 <div class="w-full">
   <% if @resources.present?%>
-    <table class="w-full px-4 overflow-hidden" data-resource-name='<%= @resource.model_class.model_name.route_key %>' data-controller='item-select-all'>
+    <table class="w-full px-4 overflow-hidden" data-resource-name='<%= @resource.model_key %>' data-controller='item-select-all'>
       <%= render partial: 'avo/partials/table_header', locals: {fields: @resource.get_fields(reflection: @reflection)} %>
       <tbody>
         <% @resources.each_with_index do |resource, index| %>

--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -12,7 +12,7 @@ class Avo::ResourceComponent < ViewComponent::Base
     if @reflection.present?
       reflection_resource = ::Avo::App.get_resource_by_model_name(@reflection.active_record.name)
       if reflection_resource.present?
-        method_name = ("#{policy_method}_#{@reflection.name.to_s.underscore}?").to_sym
+        method_name = "#{policy_method}_#{@reflection.name.to_s.underscore}?".to_sym
         defined_policy_methods = reflection_resource.authorization.defined_methods(reflection_resource.model_class, raise_exception: false)
         if defined_policy_methods.present? && defined_policy_methods.include?(method_name)
           association_policy = reflection_resource.authorization.authorize_action(method_name, raise_exception: false)

--- a/app/components/avo/views/resource_edit_component.html.erb
+++ b/app/components/avo/views/resource_edit_component.html.erb
@@ -1,6 +1,6 @@
 <div data-model-id="<%= @resource.model.id %>">
   <% @resource.panels.each do |resource_panel| %>
-    <%= form_with model: @resource.model, scope: @resource.form_scope, url: helpers.resource_path(@resource.model, for_resource: @resource), method: :put, multipart: true do |form| %>
+    <%= form_with model: @resource.model, scope: @resource.form_scope, url: helpers.resource_path(model: @resource.model, resource: @resource), method: :put, multipart: true do |form| %>
       <%= hidden_field_tag :referrer, back_path if params[:via_resource_class] %>
 
       <%= render Avo::PanelComponent.new(title: resource_panel[:name], display_breadcrumbs: true) do |c| %>

--- a/app/components/avo/views/resource_edit_component.rb
+++ b/app/components/avo/views/resource_edit_component.rb
@@ -10,10 +10,9 @@ class Avo::Views::ResourceEditComponent < Avo::ResourceComponent
 
   def back_path
     if via_resource?
-
-      helpers.resource_path(params[:via_resource_class].safe_constantize, for_resource: relation_resource, resource_id: params[:via_resource_id])
+      helpers.resource_path(model: params[:via_resource_class].safe_constantize, resource: relation_resource, resource_id: params[:via_resource_id])
     else
-      helpers.resource_path(@resource.model, for_resource: @resource)
+      helpers.resource_path(model: @resource.model, resource: @resource)
     end
   end
 

--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -18,7 +18,7 @@
 
     <% c.body do %>
       <div class="flex justify-between pt-2 pb-2 min-h-16"
-        data-selected-resources-name="<%= @resource.model_class.model_name.route_key %>"
+        data-selected-resources-name="<%= @resource.model_key %>"
         data-selected-resources="[]"
       >
         <div class="flex items-center px-6 w-64">

--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -22,7 +22,7 @@
         data-selected-resources="[]"
       >
         <div class="flex items-center px-6 w-64">
-          <%= render partial: 'avo/partials/resource_search', locals: {resource: @resource.route_key} if @resource.search_query.present? %>
+          <%= render partial: 'avo/partials/resource_search', locals: {resource: @resource.model_class.model_name.plural} if @resource.search_query.present? %>
         </div>
         <div class="flex justify-end items-center px-6 space-x-3">
           <%= render partial: 'avo/partials/view_toggle_button', locals: { available_view_types: available_view_types, view_type: view_type, turbo_frame: @turbo_frame } if @models.present? %>

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -71,20 +71,20 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
   end
 
   def create_path
+    args = {}
+
     if @reflection.present?
-      path_args = {
+      args = {
         via_relation_class: @parent_model.model_name,
         via_resource_id: @parent_model.id
       }
 
       if @reflection.inverse_of.present?
-        path_args[:via_relation] = @reflection.inverse_of.name
+        args[:via_relation] = @reflection.inverse_of.name
       end
-
-      helpers.new_resource_path(@resource.model_class, for_resource: @resource, **path_args)
-    else
-      helpers.new_resource_path(@resource.model_class, for_resource: @resource)
     end
+
+    helpers.new_resource_path(model: @resource.model_class, resource: @resource, **args)
   end
 
   def attach_path
@@ -95,7 +95,7 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
     if @reflection.present?
       ::Avo::App.get_resource_by_model_name(@reflection.class_name).name
     else
-      @resource.singular_name.present? ? @resource.singular_name : @resource.model_class.model_name.name.downcase
+      @resource.singular_name || @resource.model_class.model_name.name.downcase
     end
   end
 

--- a/app/components/avo/views/resource_new_component.html.erb
+++ b/app/components/avo/views/resource_new_component.html.erb
@@ -1,6 +1,6 @@
 <div>
   <% @resource.panels.each do |resource_panel| %>
-    <%= form_with model: @resource.model, url: helpers.resources_path(@resource.model, for_resource: @resource, via_relation_class: params[:via_relation_class], via_resource_id: params[:via_resource_id]), local: true, multipart: true do |form| %>
+    <%= form_with model: @resource.model, url: helpers.resources_path(resource: @resource, via_relation_class: params[:via_relation_class], via_resource_id: params[:via_resource_id]), local: true, multipart: true do |form| %>
       <%= render Avo::PanelComponent.new(title: resource_panel[:name], display_breadcrumbs: true) do |c| %>
         <% c.tools do %>
           <div class="flex justify-end space-x-2">

--- a/app/components/avo/views/resource_new_component.rb
+++ b/app/components/avo/views/resource_new_component.rb
@@ -14,7 +14,6 @@ class Avo::Views::ResourceNewComponent < ViewComponent::Base
 
   def back_path
     if via_resource?
-      # abort relation_resource.inspect
       helpers.resource_path(model: params[:via_relation_class].safe_constantize, resource: relation_resource, resource_id: params[:via_resource_id])
     else
       helpers.resources_path(resource: @resource)

--- a/app/components/avo/views/resource_new_component.rb
+++ b/app/components/avo/views/resource_new_component.rb
@@ -14,9 +14,10 @@ class Avo::Views::ResourceNewComponent < ViewComponent::Base
 
   def back_path
     if via_resource?
-      helpers.resource_path(params[:via_relation_class].safe_constantize, for_resource: relation_resource, resource_id: params[:via_resource_id])
+      # abort relation_resource.inspect
+      helpers.resource_path(model: params[:via_relation_class].safe_constantize, resource: relation_resource, resource_id: params[:via_resource_id])
     else
-      helpers.resources_path(@resource.model, for_resource: @resource)
+      helpers.resources_path(resource: @resource)
     end
   end
 

--- a/app/components/avo/views/resource_show_component.html.erb
+++ b/app/components/avo/views/resource_show_component.html.erb
@@ -25,7 +25,7 @@
             <% end %>
 
             <% if @resource.authorization.authorize_action(:destroy, raise_exception: false) %>
-              <%= form_with url: helpers.resource_path(@resource.model, for_resource: @resource), method: :delete, html: { 'data-turbo-frame': params[:turbo_frame] } do |form| %>
+              <%= form_with url: helpers.resource_path(model: @resource.model, resource: @resource), method: :delete, html: { 'data-turbo-frame': params[:turbo_frame] } do |form| %>
                 <%= a_button title: t('avo.delete_item', item: @resource.model.model_name.name.downcase).capitalize,
                   spinner: true,
                   color: 'red',

--- a/app/components/avo/views/resource_show_component.html.erb
+++ b/app/components/avo/views/resource_show_component.html.erb
@@ -1,5 +1,5 @@
 <div data-model-id="<%= @resource.model.id %>"
-  data-selected-resources-name="<%= @resource.model.model_name.route_key %>"
+  data-selected-resources-name="<%= @resource.model_key %>"
   data-selected-resources='["<%= @resource.model.id %>"]'
 >
   <% @resource.panels.each_with_index do |resource_panel, index| %>

--- a/app/components/avo/views/resource_show_component.rb
+++ b/app/components/avo/views/resource_show_component.rb
@@ -15,18 +15,23 @@ class Avo::Views::ResourceShowComponent < Avo::ResourceComponent
 
   def back_path
     if via_resource?
-      helpers.resource_path(params[:via_resource_class].safe_constantize, for_resource: relation_resource, resource_id: params[:via_resource_id])
+      helpers.resource_path(model: params[:via_resource_class].safe_constantize, resource: relation_resource, resource_id: params[:via_resource_id])
     else
-      helpers.resources_path(@resource.model, for_resource: @resource)
+      helpers.resources_path(resource: @resource)
     end
   end
 
   def edit_path
+    args = {}
+
     if via_resource?
-      helpers.edit_resource_path(@resource.model, for_resource: @resource, via_resource_class: params[:via_resource_class], via_resource_id: params[:via_resource_id])
-    else
-      helpers.edit_resource_path(@resource.model, for_resource: @resource)
+      args = {
+        via_resource_class: params[:via_resource_class],
+        via_resource_id: params[:via_resource_id]
+      }
     end
+
+    helpers.edit_resource_path(model: @resource.model, resource: @resource, **args)
   end
 
   def detach_path
@@ -34,7 +39,7 @@ class Avo::Views::ResourceShowComponent < Avo::ResourceComponent
   end
 
   def destroy_path
-    helpers.resource_path(@resource.model, for_resource: @resource)
+    helpers.resource_path(model: @resource.model, resource: @resource)
   end
 
   def can_detach?

--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -67,7 +67,7 @@ module Avo
 
             redirect_to path, "#{response[:message_type]}": response[:message]
           elsif response[:type] == :reload
-            redirect_back fallback_location: resources_path(@resource.model_class, for_resource: @resource), "#{response[:message_type]}": response[:message]
+            redirect_back fallback_location: resources_path(resource: @resource), "#{response[:message_type]}": response[:message]
           end
         end
       end

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -16,7 +16,7 @@ module Avo
     rescue_from Pundit::NotAuthorizedError, with: :render_unauthorized
     rescue_from ActiveRecord::RecordInvalid, with: :exception_logger
 
-    helper_method :_current_user, :resources_path, :resource_path, :new_resource_path, :edit_resource_path, :resource_attach_path, :resource_detach_path, :related_resources_path, :singular_resource_name, :plural_resource_name
+    helper_method :_current_user, :resources_path, :resource_path, :new_resource_path, :edit_resource_path, :resource_attach_path, :resource_detach_path, :related_resources_path
     add_flash_types :info, :warning, :success, :error
 
     def init_app

--- a/app/controllers/avo/attachments_controller.rb
+++ b/app/controllers/avo/attachments_controller.rb
@@ -23,13 +23,14 @@ module Avo
     def destroy
       blob = ActiveStorage::Blob.find(params[:signed_attachment_id])
       attachment = blob.attachments.find_by record_id: params[:id], record_type: @model.class.to_s
+      path = resource_path(model: @model, resource: @resource)
 
       if attachment.present?
         attachment.destroy
 
-        redirect_to params[:referrer] || resource_path(@model, for_resource: @resource), notice: t("avo.attachment_destroyed")
+        redirect_to params[:referrer] || path, notice: t("avo.attachment_destroyed")
       else
-        redirect_back fallback_location: resource_path(@model, for_resource: @resource), notice: t("avo.failed_to_find_attachment")
+        redirect_back fallback_location: path, notice: t("avo.failed_to_find_attachment")
       end
     end
   end

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -165,12 +165,10 @@ module Avo
 
     private
 
-    def model_route_key
-      singular_name @resource.model_class
-    end
-
     def model_params
-      request_params = params.require(model_route_key).permit(permitted_params)
+      model_param_key = @resource.singular_model_key
+
+      request_params = params.require(model_param_key).permit(permitted_params)
 
       if @resource.devise_password_optional && request_params[:password].blank? && request_params[:password_confirmation].blank?
         request_params.delete(:password_confirmation)

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -72,10 +72,10 @@ module Avo
         via_model = via_resource.class.find_scope.find params[:via_resource_id]
         via_resource.hydrate model: via_model
 
-        add_breadcrumb via_resource.plural_name, resources_path(via_resource.model_class, for_resource: via_resource)
-        add_breadcrumb via_resource.model_title, resource_path(via_model, for_resource: via_resource)
+        add_breadcrumb via_resource.plural_name, resources_path(resource: via_resource)
+        add_breadcrumb via_resource.model_title, resource_path(model: via_model, resource: via_resource)
       else
-        add_breadcrumb resource_name.humanize, resources_path(@resource.model_class, for_resource: @resource)
+        add_breadcrumb resource_name.humanize, resources_path(resource: @resource)
       end
 
       add_breadcrumb @resource.model_title
@@ -87,7 +87,7 @@ module Avo
       @resource = @resource.hydrate(model: @model, view: :new, user: _current_user)
 
       @page_title = @resource.default_panel_name
-      add_breadcrumb resource_name.humanize, resources_path(@resource.model_class, for_resource: @resource)
+      add_breadcrumb resource_name.humanize, resources_path(resource: @resource)
       add_breadcrumb t("avo.new").humanize
     end
 
@@ -103,13 +103,13 @@ module Avo
         via_model = via_resource.class.find_scope.find params[:via_resource_id]
         via_resource.hydrate model: via_model
 
-        add_breadcrumb via_resource.plural_name, resources_path(via_resource.model_class, for_resource: @resource)
-        add_breadcrumb via_resource.model_title, resource_path(via_model, for_resource: via_resource)
+        add_breadcrumb via_resource.plural_name, resources_path(resource: @resource)
+        add_breadcrumb via_resource.model_title, resource_path(model: via_model, resource: via_resource)
       else
-        add_breadcrumb resource_name.humanize, resources_path(@resource.model_class, for_resource: @resource)
+        add_breadcrumb resource_name.humanize, resources_path(resource: @resource)
       end
 
-      add_breadcrumb @resource.model_title, resource_path(@resource.model, for_resource: @resource)
+      add_breadcrumb @resource.model_title, resource_path(model: @resource.model, resource: @resource)
       add_breadcrumb t("avo.edit").humanize
     end
 
@@ -122,9 +122,9 @@ module Avo
         if saved
           redirect_path = if params[:via_relation_class].present? && params[:via_resource_id].present?
             parent_resource = ::Avo::App.get_resource_by_model_name params[:via_relation_class].safe_constantize
-            resource_path(params[:via_relation_class].safe_constantize, for_resource: parent_resource, resource_id: params[:via_resource_id])
+            resource_path(model: params[:via_relation_class].safe_constantize, resource: parent_resource, resource_id: params[:via_resource_id])
           else
-            resource_path(@model, for_resource: @resource)
+            resource_path(model: @model, resource: @resource)
           end
 
           format.html { redirect_to redirect_path, notice: "#{@model.class.name} was successfully created." }
@@ -144,7 +144,7 @@ module Avo
 
       respond_to do |format|
         if saved
-          format.html { redirect_to params[:referrer] || resource_path(@model, for_resource: @resource), notice: "#{@model.class.name} was successfully updated." }
+          format.html { redirect_to params[:referrer] || resource_path(model: @model, resource: @resource), notice: "#{@model.class.name} was successfully updated." }
           format.json { render :show, status: :ok, location: @model }
         else
           flash[:error] = t "avo.you_missed_something_check_form"
@@ -158,7 +158,7 @@ module Avo
       @model.destroy!
 
       respond_to do |format|
-        format.html { redirect_to params[:referrer] || resources_path(@model, for_resource: @resource, turbo_frame: params[:turbo_frame], view_type: params[:view_type]), notice: t("avo.resource_destroyed", attachment_class: @attachment_class) }
+        format.html { redirect_to params[:referrer] || resources_path(resource: @resource, turbo_frame: params[:turbo_frame], view_type: params[:view_type]), notice: t("avo.resource_destroyed", attachment_class: @attachment_class) }
         format.json { head :no_content }
       end
     end

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -291,7 +291,7 @@ module Avo
     end
 
     def applied_filters_cache_key
-      "avo.base_controller.#{@resource.route_key}.applied_filters"
+      "avo.base_controller.#{@resource.model_key}.applied_filters"
     end
   end
 end

--- a/app/controllers/avo/home_controller.rb
+++ b/app/controllers/avo/home_controller.rb
@@ -7,7 +7,7 @@ module Avo
         redirect_to Avo.configuration.home_path
       elsif !Rails.env.development?
         @page_title = "Get started"
-        resource = Avo::App.resources.min_by { |resource| resource.route_key }
+        resource = Avo::App.resources.min_by { |resource| resource.model_key }
         redirect_to resources_path(resource.model_class, for_resource: resource)
       end
     end

--- a/app/controllers/avo/home_controller.rb
+++ b/app/controllers/avo/home_controller.rb
@@ -8,7 +8,7 @@ module Avo
       elsif !Rails.env.development?
         @page_title = "Get started"
         resource = Avo::App.resources.min_by { |resource| resource.model_key }
-        redirect_to resources_path(resource.model_class, for_resource: resource)
+        redirect_to resources_path(resource: resource)
       end
     end
 

--- a/app/controllers/avo/relations_controller.rb
+++ b/app/controllers/avo/relations_controller.rb
@@ -48,8 +48,8 @@ module Avo
 
       respond_to do |format|
         if @model.save
-          format.html { redirect_to resource_path(@model, for_resource: @resource), notice: t("avo.attachment_class_attached", attachment_class: @attachment_class) }
-          format.json { render :show, status: :created, location: resource_path(@model, for_resource: @resource) }
+          format.html { redirect_to resource_path(model: @model, resource: @resource), notice: t("avo.attachment_class_attached", attachment_class: @attachment_class) }
+          format.json { render :show, status: :created, location: resource_path(model: @model, resource: @resource) }
         else
           format.html { render :new }
           format.json { render json: @model.errors, status: :unprocessable_entity }
@@ -65,7 +65,7 @@ module Avo
       end
 
       respond_to do |format|
-        format.html { redirect_to params[:referrer] || resource_path(@model, for_resource: @resource), notice: t("avo.attachment_class_detached", attachment_class: @attachment_class) }
+        format.html { redirect_to params[:referrer] || resource_path(model: @model, resource: @resource), notice: t("avo.attachment_class_detached", attachment_class: @attachment_class) }
       end
     end
 

--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -59,7 +59,7 @@ module Avo
         result = {
           _id: model.id,
           _label: resource.label,
-          _url: resource.avo_path,
+          _url: resource.record_path,
           model: model
         }
 

--- a/app/helpers/avo/application_helper.rb
+++ b/app/helpers/avo/application_helper.rb
@@ -166,15 +166,5 @@ module Avo
         model.class
       end
     end
-
-    def singular_name(model_or_class)
-      model_class = get_model_class model_or_class
-
-      if ActiveModel::Naming.uncountable? model_class
-        model_class.model_name.route_key.singularize.gsub('_index', '')
-      else
-        model_class.model_name.route_key.singularize
-      end
-    end
   end
 end

--- a/app/helpers/avo/resources_helper.rb
+++ b/app/helpers/avo/resources_helper.rb
@@ -42,7 +42,7 @@ module Avo
     end
 
     def item_selector_init(resource)
-      "data-resource-name='#{resource.model_class.model_name.route_key}' data-resource-id='#{resource.model.id}' data-controller='item-selector'"
+      "data-resource-name='#{resource.model_key}' data-resource-id='#{resource.model.id}' data-controller='item-selector'"
     end
 
     def item_selector_input(floating: false, size: :md)

--- a/app/helpers/avo/url_helpers.rb
+++ b/app/helpers/avo/url_helpers.rb
@@ -37,7 +37,6 @@ module Avo
     end
 
     def edit_resource_path(model:, resource:, **args)
-      # abort args.inspect
       avo.send :"edit_resources_#{resource.singular_model_key}_path", model, **args
     end
 

--- a/app/helpers/avo/url_helpers.rb
+++ b/app/helpers/avo/url_helpers.rb
@@ -1,9 +1,7 @@
 module Avo
   module UrlHelpers
-    def resources_path(model, for_resource:, keep_query_params: false, **args)
-      return if model.nil? && for_resource.nil?
-
-      class_name = plural_resource_name(model, for_resource)
+    def resources_path(resource:, keep_query_params: false, **args)
+      return if resource.nil?
 
       existing_params = {}
       begin
@@ -14,7 +12,46 @@ module Avo
       rescue
       end
 
-      avo.send :"resources_#{class_name}_path", **existing_params, **args
+      # This entry uses `route_key` instead of `model_key` because it's rails that needs `fish_index` to build the correct path
+      avo.send :"resources_#{resource.route_key}_path", **existing_params, **args
+    end
+
+    def resource_path(
+      model:,
+      resource:,
+      resource_id: nil,
+      keep_query_params: false,
+      **args
+    )
+      if model.respond_to? :id
+        id = model
+      elsif resource_id.present?
+        id = resource_id
+      end
+
+      avo.send :"resources_#{resource.singular_model_key}_path", id, **args
+    end
+
+    def new_resource_path(model:, resource:, **args)
+      avo.send :"new_resources_#{resource.singular_model_key}_path", **args
+    end
+
+    def edit_resource_path(model:, resource:, **args)
+      # abort args.inspect
+      avo.send :"edit_resources_#{resource.singular_model_key}_path", model, **args
+    end
+
+    def resource_attach_path(resource, model_id, related_name, related_id = nil)
+      helpers.avo.resources_associations_new_path(resource.singular_model_key, model_id, related_name)
+    end
+
+    def resource_detach_path(
+      model_name, # teams
+      model_id, # 1
+      related_name, # admin
+      related_id = nil
+    )
+      avo.resources_associations_destroy_path(model_name, model_id, related_name, related_id)
     end
 
     def related_resources_path(
@@ -36,71 +73,6 @@ module Avo
       end
 
       avo.resources_associations_index_path(@parent_resource.model_class.model_name.route_key, @parent_resource.model.id, **existing_params, **args )
-    end
-
-    def resource_path(
-      model = nil,
-      for_resource:,
-      resource_id: nil,
-      keep_query_params: false,
-      **args
-    )
-      class_name = singular_resource_name(model, for_resource)
-
-      if resource_id.present?
-        return avo.send :"resources_#{class_name}_path", resource_id, **args
-      end
-
-      avo.send :"resources_#{class_name}_path", model, **args
-    end
-
-    def new_resource_path(model, for_resource:, **args)
-      class_name = singular_resource_name(model, for_resource)
-
-      avo.send :"new_resources_#{class_name}_path", **args
-    end
-
-    def edit_resource_path(model, for_resource:, **args)
-      class_name = singular_resource_name(model, for_resource)
-
-      avo.send :"edit_resources_#{class_name}_path", model, **args
-    end
-
-    def resource_attach_path(resource, model_id, related_name, related_id = nil)
-      class_name = helpers.singular_resource_name(nil, resource)
-
-      helpers.avo.resources_associations_new_path(class_name, model_id, related_name)
-    end
-
-    def resource_detach_path(
-      model_name, # teams
-      model_id, # 1
-      related_name, # admin
-      related_id = nil
-    )
-      avo.resources_associations_destroy_path(model_name, model_id, related_name, related_id)
-    end
-
-    private
-
-    # This method figures out the the name of the model from the model or the resource.
-    # This is needed when dealing with STI models.
-    def singular_resource_name(model, resource)
-      singular_name(model_class(model, resource))
-    end
-
-    # This method figures out the the name of the model from the model or the resource.
-    # This is needed when dealing with STI models.
-    def plural_resource_name(model, resource)
-      model_class(model, resource).model_name.route_key
-    end
-
-    def model_class(model, resource)
-      if resource.present?
-        resource.model_class
-      else
-        model
-      end
     end
   end
 end

--- a/app/helpers/avo/url_helpers.rb
+++ b/app/helpers/avo/url_helpers.rb
@@ -1,12 +1,11 @@
 module Avo
   module UrlHelpers
     def resources_path(model, for_resource:, keep_query_params: false, **args)
-      return if model.nil?
+      return if model.nil? && for_resource.nil?
 
       class_name = plural_resource_name(model, for_resource)
 
       existing_params = {}
-
       begin
         if keep_query_params
           existing_params =
@@ -14,6 +13,7 @@ module Avo
         end
       rescue
       end
+
       avo.send :"resources_#{class_name}_path", **existing_params, **args
     end
 

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -3,11 +3,11 @@
     data-controller="action"
     data-no-confirmation="<%= @action.no_confirmation %>"
     data-action-target="controllerDiv"
-    data-resource-name="<%= @resource.model_class.model_name.route_key %>"
+    data-resource-name="<%= @resource.model_key %>"
     data-resource-id="<%= params[:id] %>"
     class="hidden text-blue-gray-800"
   >
-    <%= form_with model: @model, scope: 'fields', url: "#{avo.root_path}resources/#{@resource.model_class.model_name.route_key}/actions/#{@action.param_id}", data: {'turbo-frame': '_top', 'action-target': 'form'} do |form| %>
+    <%= form_with model: @model, scope: 'fields', url: "#{@resource.records_path}/actions/#{@action.param_id}", data: {'turbo-frame': '_top', 'action-target': 'form'} do |form| %>
       <%= render Avo::ModalComponent.new do |c| %>
         <% c.heading do %>
           <%= @action.action_name %>

--- a/app/views/avo/base/_actions.html.erb
+++ b/app/views/avo/base/_actions.html.erb
@@ -3,7 +3,7 @@
     <%= a_button class: "focus:outline-none",
       color: 'light-blue',
       'data-action': "click->toggle-panel#togglePanel",
-      'data-actions-dropdown-button': @resource.model_class.model_name.route_key do
+      'data-actions-dropdown-button': @resource.model_key do
     %>
       <%= svg 'arrow-left', class: 'h-4 mr-1 transform -rotate-90' %> <%= t 'avo.actions' %>
     <% end %>

--- a/app/views/avo/base/_actions.html.erb
+++ b/app/views/avo/base/_actions.html.erb
@@ -14,8 +14,8 @@
       <%
         @actions.each_with_index do |action, index|
           path = action_name == 'show' ?
-            "#{avo.root_path}resources/#{@resource.model_class.model_name.route_key}/#{@model.id}/actions/#{action.param_id}" :
-            "#{avo.root_path}resources/#{@resource.model_class.model_name.route_key}/actions/#{action.param_id}"
+            "#{@resource.record_path}/actions/#{action.param_id}" :
+            "#{@resource.records_path}/actions/#{action.param_id}"
           if action_name == 'show' || action.standalone
             disabled = false
           else

--- a/app/views/avo/base/_filters.html.erb
+++ b/app/views/avo/base/_filters.html.erb
@@ -24,7 +24,7 @@
 
       <div class="p-4 border-gray-300 border-t">
         <% if params[:filters].present? %>
-          <%= a_link t('avo.reset_filters'), resources_path(@resource.model_class, for_resource: @resource, filters: nil, keep_query_params: true), color: 'blue-gray', class: 'w-full justify-center' %>
+          <%= a_link t('avo.reset_filters'), resources_path(resource: @resource, filters: nil, keep_query_params: true), color: 'blue-gray', class: 'w-full justify-center' %>
         <% else %>
           <%= a_button t('avo.reset_filters'), color: 'blue-gray', class: 'w-full justify-center', disabled: true %>
         <% end %>

--- a/app/views/avo/partials/_paginator.html.erb
+++ b/app/views/avo/partials/_paginator.html.erb
@@ -31,7 +31,7 @@
             <% if @parent_resource.present? %>
               <%= link_to "Change to #{option} items per page", related_resources_path(@parent_resource.model_class, @resource.model_class, per_page: option, keep_query_params: true), class: 'hidden', 'data-per-page-option': option, 'data-turbo-frame': turbo_frame %>
             <% else %>
-              <%= link_to "Change to #{option} items per page", resources_path(@resource.model_class, for_resource: @resource, per_page: option, keep_query_params: true), class: 'hidden', 'data-per-page-option': option, 'data-turbo-frame': turbo_frame %>
+              <%= link_to "Change to #{option} items per page", resources_path(resource: @resource, per_page: option, keep_query_params: true), class: 'hidden', 'data-per-page-option': option, 'data-turbo-frame': turbo_frame %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/avo/sidebar/_sidebar.html.erb
+++ b/app/views/avo/sidebar/_sidebar.html.erb
@@ -12,7 +12,7 @@
 
         <div class="w-full">
           <% Avo::App.resources_navigation(_current_user).sort_by { |r| r.navigation_label }.each do |resource| %>
-            <%= render Avo::NavigationLinkComponent.new label: resource.navigation_label, path: resources_path(resource.model_class, for_resource: resource) %>
+            <%= render Avo::NavigationLinkComponent.new label: resource.navigation_label, path: resources_path(resource: resource) %>
           <% end %>
 
           <% sidebar_partials = Avo::App.get_sidebar_partials %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,4 +1,4 @@
-<% url = resources_path(@resource.model_class, for_resource: @resource, page: page, keep_query_params: true) %>
+<% url = resources_path(resource: @resource, page: page, keep_query_params: true) %>
 <% if page.current? %>
   <button type="button" class="hidden md:inline-flex -ml-px relative items-center px-4 py-2 border bg-gray-100 text-sm leading-5 font-medium text-gray-700 hover:text-gray-500 z-10 outline-none border-primary-300 active:bg-gray-100 transition ease-in-out duration-150">
     <%= page %>

--- a/lib/avo/app.rb
+++ b/lib/avo/app.rb
@@ -169,13 +169,7 @@ module Avo
               resource.is_a? Class
             end
             .map do |resource|
-              route_key = if resource.model_class.present?
-                resource.model_class.model_name.plural.to_sym
-              else
-                resource.to_s.underscore.gsub("_resource", "").downcase.pluralize.to_sym
-              end
-
-              resources route_key
+              resources resource.new.model_key
             end
         end
       end

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -376,6 +376,10 @@ module Avo
       model_class.model_name.plural
     end
 
+    def singular_model_key
+      model_class.model_name.plural
+    end
+
     def record_path
       resource_path(model, for_resource: self)
     end

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -9,6 +9,8 @@ module Avo
     delegate :view_context, to: 'Avo::App'
     delegate :main_app, to: :view_context
     delegate :avo, to: :view_context
+    delegate :resource_path, to: :view_context
+    delegate :resources_path, to: :view_context
 
     attr_accessor :view
     attr_accessor :model
@@ -264,10 +266,6 @@ module Avo
       view_types
     end
 
-    def route_key
-      model_class.model_name.route_key
-    end
-
     def context
       self.class.context
     end
@@ -366,8 +364,24 @@ module Avo
       end
     end
 
-    def avo_path
-      "#{Avo::App.root_path}/resources/#{model_class.model_name.plural}/#{model.id}"
+    def route_key
+      model_class.model_name.route_key
+    end
+
+    # This is used as the model class ID
+    # We use this instead of the route_key to maintain compatibility with uncountable models
+    # With uncountable models route key appends an _index suffix (Fish->fish_index)
+    # Example: User->users, MediaItem->medie_items, Fish->fish
+    def model_key
+      model_class.model_name.plural
+    end
+
+    def record_path
+      resource_path(model, for_resource: self)
+    end
+
+    def records_path
+      resources_path(model, for_resource: self)
     end
 
     def label_field

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -367,7 +367,7 @@ module Avo
     end
 
     def avo_path
-      "#{Avo::App.root_path}/resources/#{model_class.model_name.route_key}/#{model.id}"
+      "#{Avo::App.root_path}/resources/#{model_class.model_name.plural}/#{model.id}"
     end
 
     def label_field

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -377,15 +377,15 @@ module Avo
     end
 
     def singular_model_key
-      model_class.model_name.plural
+      model_class.model_name.singular
     end
 
     def record_path
-      resource_path(model, for_resource: self)
+      resource_path(model: model, resource: self)
     end
 
     def records_path
-      resources_path(model, for_resource: self)
+      resources_path(resource: self)
     end
 
     def label_field

--- a/lib/avo/fields/has_and_belongs_to_many_field.rb
+++ b/lib/avo/fields/has_and_belongs_to_many_field.rb
@@ -1,6 +1,6 @@
 module Avo
   module Fields
-    class HasAndBelongsToManyField < BaseField
+    class HasAndBelongsToManyField < HasBaseField
       def initialize(id, **args, &block)
         args[:updatable] = false
 
@@ -12,24 +12,6 @@ module Avo
 
       def view_component_name
         "HasManyField"
-      end
-
-      def turbo_frame
-        "#{self.class.name.demodulize.to_s.underscore}_#{id}"
-      end
-
-      def frame_url
-        "#{Avo::App.root_path}/resources/#{@model.model_name.route_key}/#{@model.id}/#{id}?turbo_frame=#{turbo_frame}"
-      end
-
-      def target_resource
-        if @model._reflections[id.to_s].klass.present?
-          Avo::App.get_resource_by_model_name @model._reflections[id.to_s].klass.to_s
-        elsif @model._reflections[id.to_s].options[:class_name].present?
-          Avo::App.get_resource_by_model_name @model._reflections[id.to_s].options[:class_name]
-        else
-          Avo::App.get_resource_by_name id.to_s
-        end
       end
     end
   end

--- a/lib/avo/fields/has_base_field.rb
+++ b/lib/avo/fields/has_base_field.rb
@@ -1,6 +1,14 @@
 module Avo
   module Fields
     class HasBaseField < BaseField
+      attr_accessor :display
+
+      def initialize(id, **args, &block)
+        super(id, **args, &block)
+
+        @display = args[:display].present? ? args[:display] : :show
+      end
+
       def resource
         Avo::App.get_resource_by_model_name @model.class
       end
@@ -10,7 +18,7 @@ module Avo
       end
 
       def frame_url
-        "#{@resource.record_path}/#{id}/#{value.id}?turbo_frame=#{turbo_frame}"
+        "#{@resource.record_path}/#{id}?turbo_frame=#{turbo_frame}"
       end
 
       def target_resource

--- a/lib/avo/fields/has_base_field.rb
+++ b/lib/avo/fields/has_base_field.rb
@@ -1,0 +1,27 @@
+module Avo
+  module Fields
+    class HasBaseField < BaseField
+      def resource
+        Avo::App.get_resource_by_model_name @model.class
+      end
+
+      def turbo_frame
+        "#{self.class.name.demodulize.to_s.underscore}_#{display}_#{id}"
+      end
+
+      def frame_url
+        "#{@resource.record_path}/#{id}/#{value.id}?turbo_frame=#{turbo_frame}"
+      end
+
+      def target_resource
+        if @model._reflections[id.to_s].klass.present?
+          Avo::App.get_resource_by_model_name @model._reflections[id.to_s].klass.to_s
+        elsif @model._reflections[id.to_s].options[:class_name].present?
+          Avo::App.get_resource_by_model_name @model._reflections[id.to_s].options[:class_name]
+        else
+          Avo::App.get_resource_by_name id.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/avo/fields/has_many_field.rb
+++ b/lib/avo/fields/has_many_field.rb
@@ -1,6 +1,6 @@
 module Avo
   module Fields
-    class HasManyField < BaseField
+    class HasManyField < HasBaseField
       def initialize(id, **args, &block)
         args[:updatable] = false
 
@@ -8,24 +8,6 @@ module Avo
 
         hide_on :all
         show_on :show
-      end
-
-      def turbo_frame
-        "#{self.class.name.demodulize.to_s.underscore}_#{id}"
-      end
-
-      def frame_url
-        "#{Avo::App.root_path}/resources/#{@model.model_name.route_key}/#{@model.id}/#{id}?turbo_frame=#{turbo_frame}"
-      end
-
-      def target_resource
-        if @model._reflections[id.to_s].klass.present?
-          Avo::App.get_resource_by_model_name @model._reflections[id.to_s].klass.to_s
-        elsif @model._reflections[id.to_s].options[:class_name].present?
-          Avo::App.get_resource_by_model_name @model._reflections[id.to_s].options[:class_name]
-        else
-          Avo::App.get_resource_by_name id.to_s
-        end
       end
     end
   end

--- a/lib/avo/fields/has_one_field.rb
+++ b/lib/avo/fields/has_one_field.rb
@@ -1,6 +1,6 @@
 module Avo
   module Fields
-    class HasOneField < BaseField
+    class HasOneField < HasBaseField
       attr_accessor :relation_method
       attr_accessor :display
 
@@ -21,24 +21,6 @@ module Avo
 
       def resource
         Avo::App.get_resource_by_model_name @model.class
-      end
-
-      def turbo_frame
-        "#{self.class.name.demodulize.to_s.underscore}_#{display}_#{id}"
-      end
-
-      def frame_url
-        "#{Avo::App.root_path}/resources/#{resource.model_class.model_name.route_key}/#{@model.id}/#{id}/#{value.id}?turbo_frame=#{turbo_frame}"
-      end
-
-      def target_resource
-        if @model._reflections[id.to_s].klass.present?
-          Avo::App.get_resource_by_model_name @model._reflections[id.to_s].klass.to_s
-        elsif @model._reflections[id.to_s].options[:class_name].present?
-          Avo::App.get_resource_by_model_name @model._reflections[id.to_s].options[:class_name]
-        else
-          Avo::App.get_resource_by_name id.to_s
-        end
       end
 
       def fill_field(model, key, value, params)

--- a/lib/avo/fields/has_one_field.rb
+++ b/lib/avo/fields/has_one_field.rb
@@ -2,7 +2,6 @@ module Avo
   module Fields
     class HasOneField < HasBaseField
       attr_accessor :relation_method
-      attr_accessor :display
 
       def initialize(id, **args, &block)
         super(id, **args, &block)
@@ -12,7 +11,6 @@ module Avo
         @placeholder ||= I18n.t "avo.choose_an_option"
 
         @relation_method = name.to_s.parameterize.underscore
-        @display = args[:display].present? ? args[:display] : :show
       end
 
       def label
@@ -21,6 +19,10 @@ module Avo
 
       def resource
         Avo::App.get_resource_by_model_name @model.class
+      end
+
+      def frame_url
+        "#{@resource.record_path}/#{id}/#{value.id}?turbo_frame=#{turbo_frame}"
       end
 
       def fill_field(model, key, value, params)

--- a/spec/dummy/app/avo/actions/dummy_action.rb
+++ b/spec/dummy/app/avo/actions/dummy_action.rb
@@ -5,6 +5,9 @@ class DummyAction < Avo::BaseAction
 
   def handle(**args)
     # Do something here
+
+    puts 'DummyAction triggered'
+
     succeed 'Yup'
   end
 end

--- a/spec/dummy/app/avo/resources/fish_resource.rb
+++ b/spec/dummy/app/avo/resources/fish_resource.rb
@@ -1,11 +1,10 @@
 class FishResource < Avo::BaseResource
-  self.title = :id
+  self.title = :name
   self.includes = []
-  # self.search_query = ->(params:) do
-  #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
-  # end
+  self.search_query = ->(params:) do
+    scope.ransack(id_eq: params[:q], name_cont: params[:q], m: "or").result(distinct: false)
+  end
 
   field :id, as: :id
   field :name, as: :text
-  # add fields here
 end

--- a/spec/dummy/app/avo/resources/fish_resource.rb
+++ b/spec/dummy/app/avo/resources/fish_resource.rb
@@ -7,4 +7,6 @@ class FishResource < Avo::BaseResource
 
   field :id, as: :id
   field :name, as: :text
+
+  action DummyAction
 end

--- a/spec/dummy/app/policies/project_policy.rb
+++ b/spec/dummy/app/policies/project_policy.rb
@@ -39,6 +39,14 @@ class ProjectPolicy < ApplicationPolicy
     true
   end
 
+  def attach_comments?
+    true
+  end
+
+  def detach_comments?
+    true
+  end
+
   class Scope < Scope
     def resolve
       scope.all

--- a/spec/features/avo/belongs_to_polymorphic_spec.rb
+++ b/spec/features/avo/belongs_to_polymorphic_spec.rb
@@ -133,8 +133,8 @@ RSpec.feature "belongs_to", type: :system do
       it "has the comment listed" do
         visit "/admin/resources/projects/#{project.id}"
 
-        expect(find('turbo-frame[id="has_many_field_comments"]')).not_to have_text "Commentable"
-        expect(find('turbo-frame[id="has_many_field_comments"]')).to have_link comment.id.to_s, href: "/admin/resources/comments/#{comment.id}?via_resource_class=Project&via_resource_id=#{project.id}"
+        expect(find('turbo-frame[id="has_many_field_show_comments"]')).not_to have_text "Commentable"
+        expect(find('turbo-frame[id="has_many_field_show_comments"]')).to have_link comment.id.to_s, href: "/admin/resources/comments/#{comment.id}?via_resource_class=Project&via_resource_id=#{project.id}"
 
         click_on comment.id.to_s
 

--- a/spec/features/avo/search_spec.rb
+++ b/spec/features/avo/search_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature "Search", type: :system do
 
         sleep 0.2
 
-        expect(current_path).to eql "/admin/resources/users/#{user.id}"
+        expect(current_path).to eql "/admin/resources/users/#{user.slug}"
       end
     end
   end


### PR DESCRIPTION
Changed the `route_key` to `plural` in a few more places.

 - [x] Check all the places we used `route_key`

This PR brings quite some refactorings to the code. We remove a lot of "magic strings" URLs and used Rails's URL helpers. We also removed `route_key` from a lot of places and created `model_key` on the resource that gets the proper model or the resource.