### PR TITLE
Fix key_value_field translation

### DIFF
--- a/lib/avo/fields/key_value_field.rb
+++ b/lib/avo/fields/key_value_field.rb
@@ -3,10 +3,6 @@ require "json"
 module Avo
   module Fields
     class KeyValueField < BaseField
-      attr_reader :key_label
-      attr_reader :value_label
-      attr_reader :action_text
-      attr_reader :delete_text
       attr_reader :disable_editing_keys
       attr_reader :disable_adding_rows
 
@@ -15,10 +11,10 @@ module Avo
 
         hide_on :index
 
-        @key_label = args[:key_label].present? ? args[:key_label].to_s : I18n.translate('avo.key_value_field.key')
-        @value_label = args[:value_label].present? ? args[:value_label].to_s : I18n.translate('avo.key_value_field.value')
-        @action_text = args[:action_text].present? ? args[:action_text].to_s : I18n.translate('avo.key_value_field.add_row')
-        @delete_text = args[:delete_text].present? ? args[:delete_text].to_s : I18n.translate('avo.key_value_field.delete_row')
+        @key_label = args[:key_label].to_s if args[:key_label].present?
+        @value_label = args[:value_label].to_s if args[:value_label].present?
+        @action_text = args[:action_text].to_s if args[:action_text].present?
+        @delete_text = args[:delete_text].to_s if args[:delete_text].present?
 
         @disable_editing_keys = args[:disable_editing_keys].present? ? args[:disable_editing_keys] : false
         # disabling editing keys also disables adding rows (doesn't take into account the value of disable_adding_rows)
@@ -30,6 +26,30 @@ module Avo
           false
         end
         @disable_deleting_rows = args[:disable_deleting_rows].present? ? args[:disable_deleting_rows] : false
+      end
+
+      def key_label
+        return @key_label if @key_label && !@key_label.empty?
+
+        I18n.translate('avo.key_value_field.key')
+      end
+
+      def value_label
+        return @value_label if @value_label && !@value_label.empty?
+
+        I18n.translate('avo.key_value_field.value')
+      end
+
+      def action_text
+        return @action_text if @action_text && !@action_text.empty?
+
+        I18n.translate('avo.key_value_field.add_row')
+      end
+
+      def delete_text
+        return @delete_text if @delete_text && !@delete_text.empty?
+
+        I18n.translate('avo.key_value_field.delete_row')
       end
 
       def to_permitted_param


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The `key_value_field` translations don't currently in some cases (haven't figured exactly when it does). But the problem is the order in which Avo is loaded (and `key_value_field` class is instantiated) and when rails loads the translations. I've found that usually, other language translations are loaded after Avo has instantiated this class, so the default English translations are assigned.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://docs.avohq.io)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Covered by automated tests.


## Manual review steps

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
