### PR TITLE
Feature: Add is_audio option to file fields to show a html audio_tag

### DIFF
--- a/app/components/avo/fields/common/files_list_viewer_component.html.erb
+++ b/app/components/avo/fields/common/files_list_viewer_component.html.erb
@@ -1,5 +1,5 @@
 <div class="relative p-3 bg-slate-200 grid grid-cols-3 xl:grid-cols-4 gap-3 rounded-xl">
   <% @field.value.attachments.each do |file| %>
-    <%= render Avo::Fields::Common::MultipleFileViewerComponent.new id: @field.id, file: file, is_image: @field.is_image, button_size: :xs, resource: @resource %>
+    <%= render Avo::Fields::Common::MultipleFileViewerComponent.new id: @field.id, file: file, is_image: @field.is_image, is_audio: @field.is_audio, button_size: :xs, resource: @resource %>
   <% end %>
 </div>

--- a/app/components/avo/fields/common/multiple_file_viewer_component.html.erb
+++ b/app/components/avo/fields/common/multiple_file_viewer_component.html.erb
@@ -2,6 +2,8 @@
   <% if @file.present? %>
     <% if @file.representable? && @is_image %>
       <%= image_tag helpers.main_app.url_for(@file), class: 'rounded-lg max-h-168 max-w-full' %>
+    <% elsif @is_audio %>
+      <%= audio_tag(helpers.main_app.url_for(@file), controls: true, preload: false, class: 'w-full')%>
     <% else %>
       <div class="relative flex flex-col justify-evenly items-center px-2 rounded-lg border bg-white border-gray-500 py-6 flex-1">
         <div class="flex flex-col justify-center items-center w-full">

--- a/app/components/avo/fields/common/multiple_file_viewer_component.rb
+++ b/app/components/avo/fields/common/multiple_file_viewer_component.rb
@@ -3,10 +3,11 @@
 class Avo::Fields::Common::MultipleFileViewerComponent < ViewComponent::Base
   include Avo::ApplicationHelper
 
-  def initialize(id:, file:, is_image:, direct_upload: false, resource:, button_size: :md)
+  def initialize(id:, file:, is_image:, is_audio:, direct_upload: false, resource:, button_size: :md)
     @id = id
     @file = file
     @is_image = is_image
+    @is_audio = is_audio
     @direct_upload = direct_upload
     @button_size = button_size
     @resource = resource

--- a/app/components/avo/fields/common/single_file_viewer_component.html.erb
+++ b/app/components/avo/fields/common/single_file_viewer_component.html.erb
@@ -2,6 +2,8 @@
   <% if @file.present? %>
     <% if @file.representable? && @is_image %>
       <%= image_tag helpers.main_app.url_for(@file), class: 'rounded-lg max-h-168 max-w-full' %>
+    <% elsif @is_audio %>
+      <%= audio_tag(helpers.main_app.url_for(@file), controls: true, preload: false, class: 'w-full')%>
     <% else %>
       <div class="relative flex flex-col justify-evenly items-center px-2 rounded-lg border bg-white border-gray-500 min-h-48">
         <div class="flex flex-col justify-center items-center w-full">

--- a/app/components/avo/fields/common/single_file_viewer_component.rb
+++ b/app/components/avo/fields/common/single_file_viewer_component.rb
@@ -3,10 +3,11 @@
 class Avo::Fields::Common::SingleFileViewerComponent < ViewComponent::Base
   include Avo::ApplicationHelper
 
-  def initialize(id:, file:, is_image:, direct_upload: false, resource:, button_size: :md)
+  def initialize(id:, file:, is_image:, is_audio:, direct_upload: false, resource:, button_size: :md)
     @id = id
     @file = file
     @is_image = is_image
+    @is_audio = is_audio
     @direct_upload = direct_upload
     @button_size = button_size
     @resource = resource

--- a/app/components/avo/fields/file_field/edit_component.html.erb
+++ b/app/components/avo/fields/file_field/edit_component.html.erb
@@ -1,7 +1,7 @@
 <%= edit_field_wrapper field: @field, index: @index, form: @form, resource: @resource, displayed_in_modal: @displayed_in_modal do %>
   <% if @field.value.present? %>
     <div class="mb-2">
-      <%= render Avo::Fields::Common::SingleFileViewerComponent.new resource: @resource, id: @field.id, file: @field.value, is_image: @field.is_image, button_size: :md %>
+      <%= render Avo::Fields::Common::SingleFileViewerComponent.new resource: @resource, id: @field.id, file: @field.value, is_image: @field.is_image, is_audio: @field.is_audio, button_size: :md %>
     </div>
   <% end %>
 

--- a/app/components/avo/fields/file_field/index_component.html.erb
+++ b/app/components/avo/fields/file_field/index_component.html.erb
@@ -1,7 +1,9 @@
 <%= index_field_wrapper field: @field do %>
   <% if @field.value.present? %>
     <% if @field.value.attached? && @field.value.representable? && @field.is_image %>
-      <%= link_to_if @field.link_to_resource, image_tag(helpers.main_app.url_for(@field.value), class: 'max-h-full'), resource_path, class: 'block h-8' %>
+      <%= link_to_if @field.link_to_resource, image_tag(helpers.main_app.url_for(@field.value), class: 'max-h-full'), resource_path, class: 'block' %>
+    <% elsif @field.value.attached? && @field.is_audio %>
+      <%= link_to_if @field.link_to_resource, audio_tag(helpers.main_app.url_for(@field.value), controls: true, preload: false, class: 'max-h-full'), resource_path, class: 'block h-8' %>
     <% else %>
       <%= @field.value.filename %>
     <% end %>

--- a/app/components/avo/fields/file_field/show_component.html.erb
+++ b/app/components/avo/fields/file_field/show_component.html.erb
@@ -1,3 +1,3 @@
 <%= show_field_wrapper field: @field do %>
-  <%= render Avo::Fields::Common::SingleFileViewerComponent.new resource: @resource, id: @field.id, file: @field.value.attachment, is_image: @field.is_image, button_size: :md %>
+  <%= render Avo::Fields::Common::SingleFileViewerComponent.new resource: @resource, id: @field.id, file: @field.value.attachment, is_image: @field.is_image, is_audio: @field.is_audio,  button_size: :md %>
 <% end %>

--- a/lib/avo/fields/file_field.rb
+++ b/lib/avo/fields/file_field.rb
@@ -4,6 +4,7 @@ module Avo
       attr_accessor :link_to_resource
       attr_accessor :is_avatar
       attr_accessor :is_image
+      attr_accessor :is_audio
       attr_accessor :direct_upload
 
       def initialize(id, **args, &block)
@@ -12,6 +13,7 @@ module Avo
         @link_to_resource = args[:link_to_resource].present? ? args[:link_to_resource] : false
         @is_avatar = args[:is_avatar].present? ? args[:is_avatar] : false
         @is_image = args[:is_image].present? ? args[:is_image] : @is_avatar
+        @is_audio = args[:is_audio].present? ? args[:is_audio] : false
         @direct_upload = args[:direct_upload].present? ? args[:direct_upload] : false
       end
 

--- a/lib/avo/fields/files_field.rb
+++ b/lib/avo/fields/files_field.rb
@@ -8,6 +8,7 @@ module Avo
         super(id, **args, &block)
 
         @is_image = args[:is_image].present? ? args[:is_image] : @is_avatar
+        @is_audio = args[:is_audio].present? ? args[:is_audio] : false
         @direct_upload = args[:direct_upload].present? ? args[:direct_upload] : false
       end
 

--- a/spec/dummy/app/avo/resources/post_resource.rb
+++ b/spec/dummy/app/avo/resources/post_resource.rb
@@ -11,6 +11,7 @@ class PostResource < Avo::BaseResource
   field :name, as: :text, required: true
   field :body, as: :trix, placeholder: "Enter text", always_show: false, attachment_key: :attachments, hide_attachment_url: true, hide_attachment_filename: true, hide_attachment_filesize: true
   field :cover_photo, as: :file, is_image: true, as_avatar: :rounded
+  field :audio, as: :file, is_audio: true
   field :excerpt, as: :text, hide_on: :all, as_description: true do |model|
     ActionView::Base.full_sanitizer.sanitize(model.body).truncate 130
   rescue

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -3,6 +3,7 @@ class Post < ApplicationRecord
   validates :name, presence: true
 
   has_one_attached :cover_photo
+  has_one_attached :audio
   has_many_attached :attachments
 
   belongs_to :user, optional: true


### PR DESCRIPTION
feature: add is_audio option to file field. If this option is set to true, then we show a default html audio_tag with controls = true and preload = false

# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://docs.avohq.io)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
