### PR TITLE
fix: related belongs to does not allow for proper resource creation

### DIFF
--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -7,54 +7,54 @@
     [type.to_s, resource.model_key]
   end.to_h
 %>
-  <div data-controller="belongs-to-field"
+<div data-controller="belongs-to-field"
     data-searchable="<%= @field.searchable %>"
     data-association="<%= @field.id %>"
     data-association-class="<%= @field&.target_resource&.model_class || nil %>"
   >
-    <%= edit_field_wrapper field: @field, index: @index, form: @form, resource: @resource, displayed_in_modal: @displayed_in_modal do %>
-      <%= @form.select "#{@field.foreign_key}_type", @field.types.map { |type| [type.to_s.underscore.humanize, type.to_s] },
-        {
-          value: @field.value,
-          include_blank: @field.placeholder,
-        },
-        {
-          class: helpers.input_classes('w-full', has_error: @field.model_errors.include?(@field.id)),
-          disabled: disabled,
-          'data-belongs-to-field-target': "select",
-          'data-action': 'change->belongs-to-field#changeType'
-        }
-        %>
-      <%
+  <%= edit_field_wrapper field: @field, index: @index, form: @form, resource: @resource, displayed_in_modal: @displayed_in_modal do %>
+    <%= @form.select "#{@field.foreign_key}_type", @field.types.map { |type| [type.to_s.underscore.humanize, type.to_s] },
+      {
+        value: @field.value,
+        include_blank: @field.placeholder,
+      },
+      {
+        class: helpers.input_classes('w-full', has_error: @field.model_errors.include?(@field.id)),
+        disabled: disabled,
+        'data-belongs-to-field-target': "select",
+        'data-action': 'change->belongs-to-field#changeType'
+      }
+    %>
+    <%
         # If the select field is disabled, no value will be sent. It's how HTML works.
         # Thus the extra hidden field to actually send the related id to the server.
         if disabled %>
-        <%= @form.hidden_field "#{@field.foreign_key}_type" %>
-      <% end %>
+      <%= @form.hidden_field "#{@field.foreign_key}_type" %>
     <% end %>
-    <% @field.types.each do |type| %>
-      <div class="hidden"
+  <% end %>
+  <% @field.types.each do |type| %>
+    <div class="hidden"
         data-belongs-to-field-target="type"
         data-type="<%= type %>"
       >
-        <%= edit_field_wrapper field: @field, index: @index, form: @form, resource: @resource, displayed_in_modal: @displayed_in_modal, label: type.to_s.underscore.humanize do %>
-          <% if @field.searchable %>
-            <%= render Avo::Fields::BelongsToField::AutocompleteComponent.new form: @form, field: @field, type: type, model_key: model_keys[type.to_s], foreign_key: "#{@field.foreign_key}_id" %>
-          <% else %>
-            <%= @form.select "#{@field.foreign_key}_id", options_for_select(@field.values_for_type(type), @field.value&.class == type ? @field.field_value : nil),
-              {
-                include_blank: @field.placeholder,
-              },
-              {
-                class: helpers.input_classes('w-full', has_error: @field.model_errors.include?(@field.id)),
-                disabled: disabled
-              }
-            %>
-          <% end %>
+      <%= edit_field_wrapper field: @field, index: @index, form: @form, resource: @resource, displayed_in_modal: @displayed_in_modal, label: type.to_s.underscore.humanize do %>
+        <% if @field.searchable %>
+          <%= render Avo::Fields::BelongsToField::AutocompleteComponent.new form: @form, field: @field, type: type, model_key: model_keys[type.to_s], foreign_key: "#{@field.foreign_key}_id" %>
+        <% else %>
+          <%= @form.select "#{@field.foreign_key}_id", options_for_select(@field.values_for_type(type), @field.value&.class == type ? @field.field_value : nil),
+            {
+              include_blank: @field.placeholder,
+            },
+            {
+              class: helpers.input_classes('w-full', has_error: @field.model_errors.include?(@field.id)),
+              disabled: disabled
+            }
+          %>
         <% end %>
-      </div>
-    <% end %>
-  </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>
 <% else %>
   <%= edit_field_wrapper field: @field, index: @index, form: @form, resource: @resource, displayed_in_modal: @displayed_in_modal do %>
     <% if @field.searchable %>
@@ -69,6 +69,12 @@
           disabled: disabled
         }
       %>
+      <%
+        # If the select field is disabled, no value will be sent. It's how HTML works.
+        # Thus the extra hidden field to actually send the related id to the server.
+        if disabled %>
+        <%= @form.hidden_field @field.foreign_key %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/spec/features/avo/belongs_to_spec.rb
+++ b/spec/features/avo/belongs_to_spec.rb
@@ -108,3 +108,28 @@ RSpec.feature "belongs_to", type: :feature do
     it { is_expected.to have_select "post_user_id", selected: admin.name, options: [empty_dash, admin.name], disabled: true }
   end
 end
+
+RSpec.feature "belongs_to", type: :system do
+  context "new" do
+    describe "with belongs_to foreign key field disabled" do
+      let!(:course) { create :course }
+
+      it "saves the related comment" do
+        expect(Course::Link.count).to be 0
+
+        visit "/admin/resources/course_links/new?via_relation=course&via_relation_class=Course&via_resource_id=#{course.id}"
+
+        fill_in "course_link_link", with: "https://avo.cool"
+
+        click_on "Save"
+        wait_for_loaded
+
+        # When the validation fails for any reason, the user is redirected to this weird `/new` path with the newly created model populating the form
+        # This test is valid only as a system test. The feature test does not cover this edge-case
+        expect(current_path).not_to eq "/admin/resources/course_links/new"
+        expect(Course::Link.count).to be 1
+        expect(Course::Link.first.course_id).to eq course.id
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes a weird issue where it created a related `belongs_to` but it didn't really allow the redirect to the created resource because the belongs_to dropdown was disabled.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works
