### PR TITLE
fix: date object alters date based on timezone

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,8 +12,9 @@ Fixes # (issue)
 
 
 ## Manual review steps
+<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+Description...
 
 1. Step 1
 1. Step 2

--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -1,7 +1,12 @@
 import { Controller } from 'stimulus'
 import { DateTime } from 'luxon'
-import { castBoolean } from '../../helpers/cast_boolean'
 import flatpickr from 'flatpickr'
+
+import { castBoolean } from '../../helpers/cast_boolean'
+
+function universalTimestamp(timestampStr) {
+  return new Date(new Date(timestampStr).getTime() + (new Date(timestampStr).getTimezoneOffset() * 60 * 1000))
+}
 
 export default class extends Controller {
   static targets = ['input']
@@ -43,7 +48,7 @@ export default class extends Controller {
       // this.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
       options.appTimezone = this.inputTarget.dataset.timezone
     } else {
-      currentValue = new Date(this.inputTarget.value)
+      currentValue = universalTimestamp(this.inputTarget.value)
     }
 
     options.defaultDate = currentValue

--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -4,6 +4,7 @@ import flatpickr from 'flatpickr'
 
 import { castBoolean } from '../../helpers/cast_boolean'
 
+// Get the DateTime with the TZ offset applied.
 function universalTimestamp(timestampStr) {
   return new Date(new Date(timestampStr).getTime() + (new Date(timestampStr).getTimezoneOffset() * 60 * 1000))
 }
@@ -48,6 +49,8 @@ export default class extends Controller {
       // this.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
       options.appTimezone = this.inputTarget.dataset.timezone
     } else {
+      // Because the browser treats the date like a timestamp and updates it ot 00:00 hour, when on a western timezone the date will be converted with one day offset.
+      // Ex: 2022-01-30 will render as 2022-01-29 on an American timezone
       currentValue = universalTimestamp(this.inputTarget.value)
     }
 

--- a/spec/system/avo/date_spec.rb
+++ b/spec/system/avo/date_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe 'Date field', type: :system do
+  let!(:user) { create :user, birthday: Date.new(1988, 02, 10) }
+
+  describe "in a western (negative) Timezone" do
+    before do
+      ENV['TZ'] = 'America/Chicago'
+    end
+
+    context 'edit' do
+      it 'sets the proper date without the TZ modifications' do
+        visit "/admin/resources/users/#{user.id}"
+
+        click_on 'Edit'
+        wait_for_loaded
+
+        hidden_input = find '[data-controller="date-field"] input[type="hidden"]', visible: false
+        text_input = find '[data-controller="date-field"] input[type="text"]'
+
+        expect(hidden_input.value).to eq "1988-02-10"
+        expect(text_input.value).to eq "February 10th 1988"
+      end
+    end
+  end
+
+  describe "in an eastern (positive) Timezone" do
+    before do
+      ENV['TZ'] = 'Europe/Bucharest'
+    end
+
+    context 'edit' do
+      it 'sets the proper date without' do
+        visit "/admin/resources/users/#{user.id}"
+
+        click_on 'Edit'
+        wait_for_loaded
+
+        hidden_input = find '[data-controller="date-field"] input[type="hidden"]', visible: false
+        text_input = find '[data-controller="date-field"] input[type="text"]'
+
+        expect(hidden_input.value).to eq "1988-02-10"
+        expect(text_input.value).to eq "February 10th 1988"
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/658

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps

1. Change the browser timezone to `America/Chicago` (or any western TZ) 
1. Go to a resource with a date field.
1. Edit that resource, save, edit, save at least twice.
1. The date you set should be the same
1. You should get the same results on an eastern TZ

Manual reviewer: please leave a comment with output from the test if that's the case.
