### PR TITLE
fix: searchable belongs to with associated record does not prefill the new form

### DIFF
--- a/app/components/avo/fields/belongs_to_field/autocomplete_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/autocomplete_component.html.erb
@@ -8,15 +8,20 @@
   <div class="relative w-full" autocomplete="off">
     <%= @form.text_field @field.foreign_key,
       value: field_label,
-      class: helpers.input_classes('w-full', has_error: @field.model_errors.include?(@field.id)), 'data-search-target': 'button clearValue',
+      class: helpers.input_classes('w-full', has_error: @field.model_errors.include?(@field.id)),
       placeholder: @field.placeholder,
+      'data-search-target': 'button clearValue',
+      'data-should-be-disabled': @disabled,
       disabled: true %>
-    <div class="absolute top-1/2 left-auto right-3 mr-px -mt-2 cursor-pointer hidden text-gray-500"
-      data-tippy="tooltip"
-      data-search-target="clearButton"
-      title="<%= I18n.translate 'avo.clear_value' %>"
-      data-action="click->search#clearValue"
-      ><%= helpers.svg 'x', class: 'h-4' %></div>
+    <% unless @disabled %>
+      <div class="absolute top-1/2 left-auto right-3 mr-px -mt-2 cursor-pointer hidden text-gray-500"
+        data-tippy="tooltip"
+        data-search-target="clearButton"
+        title="<%= I18n.translate 'avo.clear_value' %>"
+        data-action="click->search#clearValue"
+        ><%= helpers.svg 'x', class: 'h-4' %>
+      </div>
+    <% end %>
   </div>
   <%= @form.hidden_field @foreign_key, value: field_value, 'data-search-target': 'hiddenId clearValue' %>
 </div>

--- a/app/components/avo/fields/belongs_to_field/autocomplete_component.rb
+++ b/app/components/avo/fields/belongs_to_field/autocomplete_component.rb
@@ -1,17 +1,24 @@
 # frozen_string_literal: true
 
 class Avo::Fields::BelongsToField::AutocompleteComponent < ViewComponent::Base
-  def initialize(form:, field:, type: nil, model_key:, foreign_key:)
+  def initialize(form:, field:, model_key:, foreign_key:, disabled:, type: nil, resource: nil)
     @form = form
     @field = field
     @type = type
     @model_key = model_key
     @foreign_key = foreign_key
+    @resource = resource
+    @disabled = disabled
   end
 
   def field_label
     if searchable?
-      @field.value&.class == @type ? @field.field_label : nil
+      # New records won't have the value (instantiated model) present but the polymorphic_type and polymorphic_id prefilled
+      if new_record? && has_polymorphic_association?
+        polymorphic_record.send(polymorphic_fields[:label])
+      else
+        @field.value&.class == @type ? @field.field_label : nil
+      end
     else
       @field.field_label
     end
@@ -19,7 +26,12 @@ class Avo::Fields::BelongsToField::AutocompleteComponent < ViewComponent::Base
 
   def field_value
     if searchable?
-      @field.value&.class == @type ? @field.field_value : nil
+      # New records won't have the value (instantiated model) present but the polymorphic_type and polymorphic_id prefilled
+      if new_record? && has_polymorphic_association?
+        polymorphic_record.send(polymorphic_fields[:id])
+      else
+        @field.value&.class == @type ? @field.field_value : nil
+      end
     else
       @field.field_value
     end
@@ -29,5 +41,40 @@ class Avo::Fields::BelongsToField::AutocompleteComponent < ViewComponent::Base
 
   def searchable?
     @type.present?
+  end
+
+  def new_record?
+    @resource.model.new_record?
+  end
+
+  def has_polymorphic_association?
+    polymorphic_class.present? && polymorphic_id.present?
+  end
+
+  # Get the polymorphic class
+  def polymorphic_class
+    @resource.model["#{@field.foreign_key}_type"]
+  end
+
+  # Get the polymorphic id
+  def polymorphic_id
+    @resource.model["#{@field.foreign_key}_id"]
+  end
+
+  # Get the resource for that polymorphic class
+  def polymorphic_resource
+    ::Avo::App.get_resource_by_model_name polymorphic_class
+  end
+
+  # Get the actual resource
+  def polymorphic_record
+    polymorphic_class.safe_constantize.find polymorphic_id
+  end
+
+  def polymorphic_fields
+    {
+      id: :id,
+      label: polymorphic_resource.title
+    }
   end
 end

--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -1,5 +1,5 @@
 <%
-  if @field.types.present? # It's a polymorphic association
+  if is_polymorphic?
 
   # Set the model keys so we can pass them over
   model_keys = @field.types.map do |type|
@@ -39,7 +39,14 @@
       >
       <%= edit_field_wrapper field: @field, index: @index, form: @form, resource: @resource, displayed_in_modal: @displayed_in_modal, label: type.to_s.underscore.humanize do %>
         <% if @field.searchable %>
-          <%= render Avo::Fields::BelongsToField::AutocompleteComponent.new form: @form, field: @field, type: type, model_key: model_keys[type.to_s], foreign_key: "#{@field.foreign_key}_id" %>
+          <%= render Avo::Fields::BelongsToField::AutocompleteComponent.new form: @form,
+            field: @field,
+            type: type,
+            model_key: model_keys[type.to_s],
+            foreign_key: "#{@field.foreign_key}_id",
+            resource: @resource,
+            disabled: disabled
+          %>
         <% else %>
           <%= @form.select "#{@field.foreign_key}_id", options_for_select(@field.values_for_type(type), @field.value&.class == type ? @field.field_value : nil),
             {
@@ -58,7 +65,13 @@
 <% else %>
   <%= edit_field_wrapper field: @field, index: @index, form: @form, resource: @resource, displayed_in_modal: @displayed_in_modal do %>
     <% if @field.searchable %>
-      <%= render Avo::Fields::BelongsToField::AutocompleteComponent.new form: @form, field: @field, model_key: @field.target_resource&.model_key, foreign_key: @field.foreign_key %>
+      <%= render Avo::Fields::BelongsToField::AutocompleteComponent.new form: @form,
+        field: @field,
+        model_key: @field.target_resource&.model_key,
+        foreign_key: @field.foreign_key,
+        resource: @resource,
+        disabled: disabled
+      %>
     <% else %>
       <%= @form.select @field.foreign_key, @field.options.map { |o| [o[:label], o[:value]] },
         {

--- a/app/components/avo/fields/belongs_to_field/edit_component.rb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.rb
@@ -8,4 +8,8 @@ class Avo::Fields::BelongsToField::EditComponent < Avo::Fields::EditComponent
 
     false
   end
+
+  def is_polymorphic?
+    @field.types.present?
+  end
 end

--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -82,7 +82,9 @@ export default class extends Controller {
 
       document.querySelector('.aa-DetachedOverlay').remove()
 
-      this.clearButtonTarget.classList.remove('hidden')
+      if (this.hasClearButtonTarget) {
+        this.clearButtonTarget.classList.remove('hidden')
+      }
     } else {
       Turbo.visit(item._url, { action: 'advance' })
     }
@@ -157,7 +159,7 @@ export default class extends Controller {
     this.buttonTarget.onclick = () => this.showSearchPanel()
 
     this.clearValueTargets.forEach((target) => {
-      if (target.getAttribute('value')) {
+      if (target.getAttribute('value') && this.hasClearButtonTarget) {
         this.clearButtonTarget.classList.remove('hidden')
       }
     })
@@ -184,6 +186,9 @@ export default class extends Controller {
       },
     })
 
-    this.buttonTarget.removeAttribute('disabled')
+    // When using search for belongs-to
+    if (this.buttonTarget.dataset.shouldBeDisabled !== 'true') {
+      this.buttonTarget.removeAttribute('disabled')
+    }
   }
 }

--- a/spec/dummy/app/avo/resources/team_resource.rb
+++ b/spec/dummy/app/avo/resources/team_resource.rb
@@ -23,6 +23,7 @@ class TeamResource < Avo::BaseResource
 
   field :admin, as: :has_one
   field :team_members, as: :has_many, through: :memberships
+  field :reviews, as: :has_many
 
   grid do
     cover :logo, as: :external_image, link_to_resource: true do |model|

--- a/spec/features/avo/belongs_to_searchable_spec.rb
+++ b/spec/features/avo/belongs_to_searchable_spec.rb
@@ -205,4 +205,14 @@ RSpec.feature "belongs_to searchable", type: :system do
       end
     end
   end
+
+  describe "with associated record" do
+    it "prefills the associated record details" do
+      visit "/admin/resources/reviews/new?via_relation=reviewable&via_relation_class=Team&via_resource_id=#{team.id}"
+
+      expect(find("#review_reviewable_type").value).to eq "Team"
+      expect(find("[data-type='Team'] #review_reviewable").value).to eq team.name
+      expect(find("[data-type='Team'] #review_reviewable_id", visible: false).value).to eq team.id.to_s
+    end
+  end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/660

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go visit a team
2. Click on "create a review"
3. The `Reviewable` field should be `Team`
4. The `Team` field should be the respective team
5. When you hit save the reviews should be associated to that team

Manual reviewer: please leave a comment with output from the test if that's the case.

![image](https://user-images.githubusercontent.com/1334409/154513705-46e41548-5014-400f-967d-a84b01b59bc2.png)

