### PR TITLE
fix: notifications delayed in turbo frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ bundle install
 
 # Quick Purchase
 
-Use [this](https://buy.stripe.com/9AQ6rX0uIbLF2CQdQQ) link to quickly purchase a Pro license to support this project. Thank you 🙏
+Use [this](https://avohq.io/purchase/pro) link to quickly purchase a Pro license to support this project. Thank you 🙏
 
 # Contributing
 

--- a/app/views/avo/partials/_turbo_frame_wrap.html.erb
+++ b/app/views/avo/partials/_turbo_frame_wrap.html.erb
@@ -1,3 +1,9 @@
 <% if name.present? %><turbo-frame id="<%= name %>"><% end %>
-<%= yield %>
+  <%
+    # When rendering the frames the flashed content gets lost.
+    # By including the alerts partial, the stimulus will pick them up and display them to the user.
+  %>
+  <%= render partial: 'avo/partials/alerts'if flash.present? if flash.present? %>
+
+  <%= yield %>
 <% if name.present? %></turbo-frame><% end %>

--- a/db/factories.rb
+++ b/db/factories.rb
@@ -58,11 +58,15 @@ FactoryBot.define do
     type { "Spouse" }
   end
 
-  factory :course do
-    name { Faker::Educator.course_name }
+  factory :fish do
+    name { %w[Tilapia Salmon Trout Catfish Pangasius Carp].sample }
   end
 
-  factory :link do
-    name { Faker::Internet.url }
+  factory :course do
+    name { Faker::Educator.unique.course_name }
+  end
+
+  factory :course_link, class: "Course::Link" do
+    link { Faker::Internet.url }
   end
 end

--- a/spec/dummy/app/avo/resources/comment_resource.rb
+++ b/spec/dummy/app/avo/resources/comment_resource.rb
@@ -7,11 +7,7 @@ class CommentResource < Avo::BaseResource
 
   field :id, as: :id
   field :body, as: :textarea
-  field :excerpt, as: :text, only_on: :index, as_description: true do |model|
-    ActionView::Base.full_sanitizer.sanitize(model.body.to_s).truncate 60
-  rescue
-    ""
-  end
+  field :tiny_name, as: :text, only_on: :index, as_description: true
 
   field :user, as: :belongs_to
   field :commentable, as: :belongs_to, polymorphic_as: :commentable, types: [::Post, ::Project]

--- a/spec/dummy/app/models/comment.rb
+++ b/spec/dummy/app/models/comment.rb
@@ -7,6 +7,6 @@ class Comment < ApplicationRecord
   scope :starts_with, -> (prefix) { where('LOWER(body) LIKE ?', "#{prefix}%") }
 
   def tiny_name
-    ActionView::Base.full_sanitizer.sanitize(body.to_s).truncate 30
+    ActionView::Base.full_sanitizer.sanitize(body.to_s).truncate 60
   end
 end

--- a/spec/dummy/db/seeds.rb
+++ b/spec/dummy/db/seeds.rb
@@ -9,14 +9,21 @@ require "securerandom"
 require "open-uri"
 require "faker"
 
-Comment.delete_all
-Post.delete_all
-Project.delete_all
+ActiveStorage::Attachment.all.each { |attachment| attachment.purge }
+Person.delete_all
+Review.delete_all
+Fish.delete_all
+Course.delete_all
+Course::Link.delete_all
+Fish.delete_all
 TeamMembership.delete_all
 Team.delete_all
+Comment.delete_all
+Post.delete_all
+# ProjectUser.delete_all
+Project.delete_all
 User.delete_all
-ActiveStorage::Attachment.all.each { |attachment| attachment.purge }
-["active_storage_blobs", "active_storage_attachments", "posts", "projects", "projects_users", "team_memberships", "teams", "users"].each do |table_name|
+['active_storage_blobs', 'active_storage_attachments', 'posts', 'projects', 'projects_users', 'team_memberships', 'teams', 'users', 'comments', 'people', 'reviews', 'courses', 'course_links', 'fish'].each do |table_name|
   ActiveRecord::Base.connection.execute("TRUNCATE #{table_name} RESTART IDENTITY CASCADE")
 end
 
@@ -42,6 +49,22 @@ User.create(
 users = []
 38.times do
   users.push(FactoryBot.create(:user, team_id: teams.sample.id))
+end
+
+# People and Spouses
+people = FactoryBot.create_list(:person, 12)
+people.each do |person|
+  person.spouses << FactoryBot.create(:spouse)
+end
+
+reviews = FactoryBot.create_list(:review, 32)
+reviews.each do |review|
+  reviewable = [:fish, :post, :project, :team].sample
+  review.reviewable = FactoryBot.create(reviewable, created_at: Time.now - 1.day)
+
+  review.user = users.sample
+
+  review.save
 end
 
 25.times do
@@ -82,4 +105,10 @@ projects.each do |project|
   rand(0..15).times do
     project.comments << FactoryBot.create(:comment, user_id: users.sample.id)
   end
+end
+
+# Courses and links
+courses = FactoryBot.create_list(:course, 28)
+courses.each do |course|
+  FactoryBot.create_list(:course_link, 3, course: course)
 end

--- a/spec/system/avo/has_many_spec.rb
+++ b/spec/system/avo/has_many_spec.rb
@@ -35,5 +35,31 @@ RSpec.feature "HasManyField", type: :system do
         end
       end
     end
+
+    describe "delete notification visible" do
+      let!(:project) { create :project }
+      let!(:comments) { create_list :comment, 3, commentable: project }
+      let(:url) { "/admin/resources/projects/#{project.id}" }
+
+      it "shows the notification" do
+        visit url
+
+        expect {
+          find("[data-resource-id='#{comments.first.id}'] [data-control='destroy']").click
+          page.driver.browser.switch_to.alert.accept
+          find("[data-resource-id='#{comments.third.id}'] [data-control='destroy']").click
+          page.driver.browser.switch_to.alert.accept
+          sleep 0.2
+        }.to change(Comment, :count).by(-2)
+
+        expect(page).to have_current_path url
+
+        expect(page).not_to have_text comments.first.tiny_name.to_s
+        expect(page).not_to have_text comments.third.tiny_name.to_s
+        expect(page).to have_text comments.second.tiny_name.to_s
+
+        expect(page).to have_text("Resource destroyed").twice
+      end
+    end
   end
 end

--- a/spec/system/avo/has_many_spec.rb
+++ b/spec/system/avo/has_many_spec.rb
@@ -58,6 +58,7 @@ RSpec.feature "HasManyField", type: :system do
         expect(page).not_to have_text comments.third.tiny_name.to_s
         expect(page).to have_text comments.second.tiny_name.to_s
 
+        sleep 0.1
         expect(page).to have_text("Resource destroyed").twice
       end
     end

--- a/spec/system/avo/has_many_spec.rb
+++ b/spec/system/avo/has_many_spec.rb
@@ -47,9 +47,10 @@ RSpec.feature "HasManyField", type: :system do
         expect {
           find("[data-resource-id='#{comments.first.id}'] [data-control='destroy']").click
           page.driver.browser.switch_to.alert.accept
+          sleep 0.1
           find("[data-resource-id='#{comments.third.id}'] [data-control='destroy']").click
           page.driver.browser.switch_to.alert.accept
-          sleep 0.2
+          sleep 0.1
         }.to change(Comment, :count).by(-2)
 
         expect(page).to have_current_path url


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/661

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Create a post with a few comments attached.
2. go to that post
3. delete a few comments
4. for each deleted comment you should have the "resource destroyed" notification

Manual reviewer: please leave a comment with output from the test if that's the case.
