### PR TITLE
fix: Add 'tools' key to i18n

### DIFF
--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -94,3 +94,4 @@ en:
     was_successfully_created: 'was successfully created'
     was_successfully_updated: 'was successfully updated'
     clear_value: "Clear value"
+    tools: Tools

--- a/lib/generators/avo/templates/locales/avo.nb-NO.yml
+++ b/lib/generators/avo/templates/locales/avo.nb-NO.yml
@@ -81,3 +81,4 @@ nb-NO:
     search_placeholder: 'Søk'
     search_cancel_button: 'Avbryt'
     sign_out: 'Logg ut'
+    tools: Redskapene

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -83,3 +83,4 @@ pt-BR:
       placeholder: 'Procurar'
       cancel_button: 'Cancelar'
     sign_out: 'sair'
+    tools: Ferramentas

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -78,3 +78,4 @@ ro:
       delete_row: 'Sterge rand'
     was_successfully_created: 'a fost creat'
     was_successfully_updated: 'a fost actualizat'
+    tools: Instrumente

--- a/spec/dummy/config/locales/avo.en.yml
+++ b/spec/dummy/config/locales/avo.en.yml
@@ -98,3 +98,4 @@ en:
     was_successfully_created: 'was successfully created'
     was_successfully_updated: 'was successfully updated'
     clear_value: "Clear value"
+    tools: Tools


### PR DESCRIPTION
# Description
When add my first "Tool", I ran into a missing i18n key.

Adding to all languages. NOTE: I don't know the other languages so this was just a lookup via google translate


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works
