### PR TITLE
feature: Allow Avo::NavigationLinkComponent to accept an optional target param

### DIFF
--- a/app/components/avo/navigation_link_component.html.erb
+++ b/app/components/avo/navigation_link_component.html.erb
@@ -1,3 +1,3 @@
-<%= active_link_to @path, class: 'text-gray-800 py-2 px-4 block font-normal hover:bg-gray-100 rounded-md mb-1 mx-3 text-sm leading-none', active: @active do %>
+<%= active_link_to @path, class: 'text-gray-800 py-2 px-4 block font-normal hover:bg-gray-100 rounded-md mb-1 mx-3 text-sm leading-none', active: @active, target: @target do %>
   <div class="w-4"></div> <%= @label %>
 <% end %>

--- a/app/components/avo/navigation_link_component.rb
+++ b/app/components/avo/navigation_link_component.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class Avo::NavigationLinkComponent < ViewComponent::Base
-  def initialize(label: nil, path: nil, active: :inclusive, size: :md)
+  def initialize(label: nil, path: nil, active: :inclusive, size: :md, target: "_self")
     @label = label
     @path = path
     @active = active
     @size = size
+    @target = target
   end
 end


### PR DESCRIPTION
# Description

While working on adding out some custom tools, some of the items I'm linking to are provided by other gems (Sidekiq, PGHero, etc.) and I'd like to pop them in new windows. This option will allow me to specify a target of `_blank`.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works