### PR TITLE
fix: Support older version of Pundit

### DIFF
--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -1,6 +1,11 @@
 module Avo
   class ApplicationController < ::ActionController::Base
-    include Pundit::Authorization
+    if defined?(Pundit::Authorization)
+      include Pundit::Authorization
+    else
+      include Pundit
+    end
+
     include Pagy::Backend
     include Avo::ApplicationHelper
     include Avo::UrlHelpers


### PR DESCRIPTION
# Description
Pundit 2.2.0 changes the Module that is required to be included, which is a breaking change. Since Pundit 2.1.x is still very viable for most apps, support both options.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works