### PR TITLE
fix: duplicated alerts

### DIFF
--- a/app/javascript/avo.js
+++ b/app/javascript/avo.js
@@ -59,6 +59,7 @@ document.addEventListener('turbo:before-fetch-response', (e) => {
 })
 document.addEventListener('turbo:visit', () => document.body.classList.add('turbo-loading'))
 document.addEventListener('turbo:submit-start', () => document.body.classList.add('turbo-loading'))
+document.addEventListener('turbo:submit-end', () => document.body.classList.remove('turbo-loading'))
 document.addEventListener('turbo:before-cache', () => {
   document.querySelectorAll('[data-turbo-remove-before-cache]').forEach((element) => element.remove())
 })

--- a/app/views/avo/partials/_turbo_frame_wrap.html.erb
+++ b/app/views/avo/partials/_turbo_frame_wrap.html.erb
@@ -3,7 +3,7 @@
     # When rendering the frames the flashed content gets lost.
     # By including the alerts partial, the stimulus will pick them up and display them to the user.
   %>
-  <%= render partial: 'avo/partials/alerts'if flash.present? if flash.present? %>
+  <%= render partial: 'avo/partials/alerts' if flash.present? && name.present? %>
 
   <%= yield %>
 <% if name.present? %></turbo-frame><% end %>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,7 +54,7 @@ Capybara.register_driver :chrome_headless do |app|
                                        headless
                                        disable-gpu
                                        no-sandbox
-                                       window-size=1024,768
+                                       window-size=1440,1024
                                      ]
                                    )
                                  ]
@@ -70,7 +70,7 @@ Capybara.register_driver :chrome do |app|
                                      args: %w[
                                        disable-gpu
                                        no-sandbox
-                                       window-size=1024,768
+                                       window-size=1440,1024
                                      ]
                                    )
                                  ]

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -37,6 +37,10 @@ def write_in_search(input)
   find('input.aa-Input').set(input)
 end
 
+def confirm_alert
+  page.driver.browser.switch_to.alert.accept
+end
+
 class DummyRequest
   attr_accessor :ip
   attr_accessor :host

--- a/spec/system/avo/app_spec.rb
+++ b/spec/system/avo/app_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "App", type: :system do
+  let!(:user) { create :user }
+
+  describe "alerts" do
+    let!(:project) { create :project }
+    let!(:comment) { create :comment, body: "hey there", user: user, commentable: project }
+
+    it "only displays one alert on record update" do
+      visit "/admin/resources/projects/#{project.id}"
+
+      expect(find('turbo-frame[id="has_many_field_show_comments"]')).not_to have_text "Commentable"
+      expect(find('turbo-frame[id="has_many_field_show_comments"]')).to have_link comment.id.to_s, href: "/admin/resources/comments/#{comment.id}?via_resource_class=Project&via_resource_id=#{project.id}"
+
+      within 'turbo-frame[id="has_many_field_show_comments"]' do
+        click_on comment.id.to_s
+      end
+
+      wait_for_loaded
+      click_on "Edit"
+
+      expect(find_field("comment_body").value).to eql "hey there"
+
+      fill_in 'comment_body', with: 'yes'
+      click_on 'Save'
+      wait_for_loaded
+
+      comment.reload
+      expect(comment.body).to eq 'yes'
+
+      expect(current_path).to eq "/admin/resources/projects/#{project.id}"
+      expect(page).to have_text("Comment was successfully updated.").once
+    end
+  end
+end

--- a/spec/system/avo/app_spec.rb
+++ b/spec/system/avo/app_spec.rb
@@ -32,5 +32,24 @@ RSpec.describe "App", type: :system do
       expect(current_path).to eq "/admin/resources/projects/#{project.id}"
       expect(page).to have_text("Comment was successfully updated.").once
     end
+
+    it "only displays one alert on record destroy from has_many" do
+      visit "/admin/resources/projects/#{project.id}"
+
+      expect(find('turbo-frame[id="has_many_field_show_comments"]')).not_to have_text "Commentable"
+      expect(find('turbo-frame[id="has_many_field_show_comments"]')).to have_link comment.id.to_s, href: "/admin/resources/comments/#{comment.id}?via_resource_class=Project&via_resource_id=#{project.id}"
+
+      destroy_button = find("turbo-frame[id='has_many_field_show_comments'] tr[data-resource-id='#{comment.id}'] button[data-control=\"destroy\"]")
+
+      expect {
+        destroy_button.click
+        confirm_alert
+        wait_for_loaded
+      }.to change(Comment, :count).by(-1)
+
+      expect(Comment.count).to eq 0
+
+      expect(page).to have_text("Resource destroyed").once
+    end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/687

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

You should only see one alert in the following scenarios:

1. delete a comment from the comments page
2. delete a comment from the projects has_many page

Manual reviewer: please leave a comment with output from the test if that's the case.
