### PR TITLE
fix: some association fields are invisible in has_many index views

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,3 +34,18 @@ Steps to reproduce the behavior:
 
 ### Additional context
 <!-- Add any other context about the problem here. -->
+
+### How much are you impacted by this issue
+<!-- Please set a level for Impact and Urgency -->
+
+#### Impact
+
+ - [ ] High impact
+ - [ ] Medium impact
+ - [ ] Low impact
+
+#### Urgency
+
+ - [ ] High urgency
+ - [ ] Medium urgency
+ - [ ] low urgency

--- a/db/factories.rb
+++ b/db/factories.rb
@@ -42,11 +42,11 @@ FactoryBot.define do
   end
 
   factory :comment do
-    body { Faker::Lorem.paragraphs(number: rand(4...10)) }
+    body { Faker::Lorem.paragraphs(number: rand(4...10)).join(' ') }
   end
 
   factory :review do
-    body { Faker::Lorem.paragraphs(number: rand(4...10)) }
+    body { Faker::Lorem.paragraphs(number: rand(4...10)).join(' ') }
   end
 
   factory :person do

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -119,12 +119,6 @@ module Avo
     end
 
     def get_fields(panel: nil, reflection: nil)
-      if reflection.present? && reflection.active_record.present?
-        # Get the field ID for the reflection
-        reflection_resource = App.get_resource_by_model_name reflection.active_record.to_s
-        reflection_resource.get_field reflection.name
-      end
-
       fields = get_field_definitions
         .select do |field|
           field.send("show_on_#{@view}")

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -136,6 +136,8 @@ module Avo
 
       def is_polymorphic?
         polymorphic_as.present?
+      rescue
+        false
       end
 
       def foreign_key
@@ -150,6 +152,20 @@ module Avo
 
       def reflection_for_key(key)
         get_model_class(get_model).reflections[key.to_s]
+      rescue
+        nil
+      end
+
+      # Get the model reflection instance
+      def reflection
+        reflection_for_key(id)
+      rescue
+        nil
+      end
+
+      # Get the model class of the field reflection
+      def reflection_class
+        get_model_class(reflection.active_record)
       rescue
         nil
       end

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -163,13 +163,6 @@ module Avo
         nil
       end
 
-      # Get the model class of the field reflection
-      def reflection_class
-        get_model_class(reflection.active_record)
-      rescue
-        nil
-      end
-
       def relation_model_class
         @resource.model_class
       end

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -47,11 +47,11 @@ class UserResource < Avo::BaseResource
 
   field :post, as: :has_one, translation_key: 'avo.field_translations.people'
   field :posts, as: :has_many
+  field :teams, as: :has_and_belongs_to_many
   field :people, as: :has_many, translation_key: 'avo.field_translations.people'
   field :spouses, as: :has_many # STI has_many resource
   field :comments, as: :has_many, scope: -> { starts_with :a }
   field :projects, as: :has_and_belongs_to_many
-  field :teams, as: :has_and_belongs_to_many
 
   grid do
     cover :email, as: :gravatar, link_to_resource: true

--- a/spec/features/avo/belongs_to_spec.rb
+++ b/spec/features/avo/belongs_to_spec.rb
@@ -127,10 +127,10 @@ RSpec.feature "belongs_to", type: :feature do
 
   describe "hidden columns if current polymorphic association" do
     let!(:user) { create :user }
-    let!(:project) { create :project }
+    let!(:project) { create :project, name: 'Haha project' }
     let!(:comment) { create :comment, body: 'a comment', user: user, commentable: project }
 
-    it "hides the User column" do
+    it "hides the Commentable column" do
       visit "/admin/resources/projects/#{project.id}/comments?turbo_frame=has_many_field_show_comments"
 
       expect(find('thead')).to have_text 'Id'
@@ -146,10 +146,10 @@ RSpec.feature "belongs_to", type: :feature do
 
   describe "hidden columns if current polymorphic association" do
     let!(:user) { create :user }
-    let!(:team) { create :team }
+    let!(:team) { create :team, name: 'Haha team' }
     let!(:review) { create :review, body: 'a review', user: user, reviewable: team }
 
-    it "hides the User column" do
+    it "hides the Reviewable column" do
       visit "/admin/resources/teams/#{team.id}/reviews?turbo_frame=has_many_field_show_reviews"
 
       expect(find('thead')).to have_text 'Id'

--- a/spec/features/avo/belongs_to_spec.rb
+++ b/spec/features/avo/belongs_to_spec.rb
@@ -107,29 +107,59 @@ RSpec.feature "belongs_to", type: :feature do
 
     it { is_expected.to have_select "post_user_id", selected: admin.name, options: [empty_dash, admin.name], disabled: true }
   end
-end
 
-RSpec.feature "belongs_to", type: :system do
-  context "new" do
-    describe "with belongs_to foreign key field disabled" do
-      let!(:course) { create :course }
+  describe "hidden columns if current association" do
+    let!(:user) { create :user }
+    let!(:comment) { create :comment, body: 'a comment', user: user }
 
-      it "saves the related comment" do
-        expect(Course::Link.count).to be 0
+    it "hides the User column" do
+      visit "/admin/resources/users/#{user.id}/comments?turbo_frame=has_many_field_show_comments"
 
-        visit "/admin/resources/course_links/new?via_relation=course&via_relation_class=Course&via_resource_id=#{course.id}"
+      expect(find('thead')).to have_text 'Id'
+      expect(find('thead')).to have_text 'Tiny name'
+      expect(find('thead')).to have_text 'Commentable'
+      expect(find('thead')).not_to have_text 'User'
+      expect(page).to have_text comment.id
+      expect(page).to have_text 'a comment'
+      expect(page).not_to have_text user.name
+    end
+  end
 
-        fill_in "course_link_link", with: "https://avo.cool"
+  describe "hidden columns if current polymorphic association" do
+    let!(:user) { create :user }
+    let!(:project) { create :project }
+    let!(:comment) { create :comment, body: 'a comment', user: user, commentable: project }
 
-        click_on "Save"
-        wait_for_loaded
+    it "hides the User column" do
+      visit "/admin/resources/projects/#{project.id}/comments?turbo_frame=has_many_field_show_comments"
 
-        # When the validation fails for any reason, the user is redirected to this weird `/new` path with the newly created model populating the form
-        # This test is valid only as a system test. The feature test does not cover this edge-case
-        expect(current_path).not_to eq "/admin/resources/course_links/new"
-        expect(Course::Link.count).to be 1
-        expect(Course::Link.first.course_id).to eq course.id
-      end
+      expect(find('thead')).to have_text 'Id'
+      expect(find('thead')).to have_text 'Tiny name'
+      expect(find('thead')).to have_text 'User'
+      expect(find('thead')).not_to have_text 'Commentable'
+      expect(page).to have_text comment.id
+      expect(page).to have_text 'a comment'
+      expect(page).to have_text user.name
+      expect(page).not_to have_text project.name
+    end
+  end
+
+  describe "hidden columns if current polymorphic association" do
+    let!(:user) { create :user }
+    let!(:team) { create :team }
+    let!(:review) { create :review, body: 'a review', user: user, reviewable: team }
+
+    it "hides the User column" do
+      visit "/admin/resources/teams/#{team.id}/reviews?turbo_frame=has_many_field_show_reviews"
+
+      expect(find('thead')).to have_text 'Id'
+      expect(find('thead')).to have_text 'Excerpt'
+      expect(find('thead')).to have_text 'User'
+      expect(find('thead')).not_to have_text 'Reviewable'
+      expect(page).to have_text review.id
+      expect(page).to have_text 'a review'
+      expect(page).to have_text user.name
+      expect(page).not_to have_text team.name
     end
   end
 end

--- a/spec/system/avo/belongs_to_spec.rb
+++ b/spec/system/avo/belongs_to_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.feature "belongs_to", type: :system do
+  context "new" do
+    describe "with belongs_to foreign key field disabled" do
+      let!(:course) { create :course }
+
+      it "saves the related comment" do
+        expect(Course::Link.count).to be 0
+
+        visit "/admin/resources/course_links/new?via_relation=course&via_relation_class=Course&via_resource_id=#{course.id}"
+
+        fill_in "course_link_link", with: "https://avo.cool"
+
+        click_on "Save"
+        wait_for_loaded
+
+        # When the validation fails for any reason, the user is redirected to this weird `/new` path with the newly created model populating the form
+        # This test is valid only as a system test. The feature test does not cover this edge-case
+        expect(current_path).not_to eq "/admin/resources/course_links/new"
+        expect(Course::Link.count).to be 1
+        expect(Course::Link.first.course_id).to eq course.id
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/668

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to a team. The reviews should not have a reviewable column
2. go to a post. the comments should not have a commendable column
3. go to a user. the comments should not have a user column

Manual reviewer: please leave a comment with output from the test if that's the case.
