### PR TITLE
fix: sidebar navigation link default  target forces reload

### DIFF
--- a/app/components/avo/navigation_link_component.rb
+++ b/app/components/avo/navigation_link_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::NavigationLinkComponent < ViewComponent::Base
-  def initialize(label: nil, path: nil, active: :inclusive, size: :md, target: "_self")
+  def initialize(label: nil, path: nil, active: :inclusive, size: :md, target: nil)
     @label = label
     @path = path
     @active = active

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -84,7 +84,6 @@ module Avo
     def new
       @model = @resource.model_class.new
       @resource = @resource.hydrate(model: @model, view: :new, user: _current_user)
-      # abort @model.course.inspect
 
       @page_title = @resource.default_panel_name
       add_breadcrumb resource_name.humanize, resources_path(resource: @resource)

--- a/spec/dummy/app/avo/resources/person_resource.rb
+++ b/spec/dummy/app/avo/resources/person_resource.rb
@@ -7,6 +7,7 @@ class PersonResource < Avo::BaseResource
   #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
   # end
 
+  field :id, as: :id
   field :name, as: :text, link_to_resource: true
   field :type, as: :select, name: "Type", options: { Spouse: "Spouse" }
   field :link, as: :text, as_html: true do |model, &args|

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -1,5 +1,4 @@
 class Person < ApplicationRecord
   belongs_to :user, optional: true
   has_many :spouses, foreign_key: :person_id
-  # has_many :qualifications, class_name: "Person::Qualification", dependent: :destroy
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

[This](https://github.com/avo-hq/avo/pull/685) PR introduced this bug that fully reloads a page when you click a sidebar item instead of it using Turbo.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

