### PR TITLE
chore: initial locale support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,8 @@ GEM
     nokogiri (1.13.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.3-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     pagy (5.10.1)
       activesupport

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -13,6 +13,7 @@ module Avo
     protect_from_forgery with: :exception
     before_action :init_app
     before_action :check_avo_license
+    before_action :set_locale
     before_action :set_authorization
     before_action :_authenticate!
     before_action :set_container_classes
@@ -244,6 +245,12 @@ module Avo
 
     def model_param_key
       @resource.form_scope
+    end
+
+    def set_locale
+      I18n.locale = params[:locale] || I18n.default_locale
+
+      I18n.default_locale = I18n.locale
     end
   end
 end

--- a/app/views/avo/partials/_profile_dropdown.html.erb
+++ b/app/views/avo/partials/_profile_dropdown.html.erb
@@ -17,9 +17,17 @@
     <% end %>
   </a>
 
+  <% classes = "appearance-none bg-white text-left cursor-pointer text-green-600 font-semibold hover:text-white hover:bg-green-500 block px-4 py-1 w-full" %>
+
   <% if main_app.respond_to?(destroy_user_session_path) %>
     <div class="hidden absolute inset-auto right-0 mr-6 mt-0 py-4 bg-white rounded-xl min-w-[200px] shadow-context" data-toggle-panel-target="panel">
-      <%= button_to t('avo.sign_out'), main_app.send(:destroy_user_session_path), method: :delete, form: { "data-turbo" => "false" }, class: "appearance-none bg-white text-left cursor-pointer text-green-600 font-semibold hover:text-white hover:bg-green-500 block px-4 py-1 w-full" %>
+      <% if I18n.locale == :en %>
+        <%= link_to "Switch to Portuguese", { locale: 'pt-BR' }, class: classes %>
+      <% else %>
+        <%= link_to "Switch to English", { locale: 'en' }, class: classes %>
+      <%end%>
+
+      <%= button_to t('avo.sign_out'), main_app.send(:destroy_user_session_path), method: :delete, form: { "data-turbo" => "false" }, class: classes %>
     </div>
   <% end %>
 </div>

--- a/app/views/avo/partials/_profile_dropdown.html.erb
+++ b/app/views/avo/partials/_profile_dropdown.html.erb
@@ -17,17 +17,9 @@
     <% end %>
   </a>
 
-  <% classes = "appearance-none bg-white text-left cursor-pointer text-green-600 font-semibold hover:text-white hover:bg-green-500 block px-4 py-1 w-full" %>
-
   <% if main_app.respond_to?(destroy_user_session_path) %>
     <div class="hidden absolute inset-auto right-0 mr-6 mt-0 py-4 bg-white rounded-xl min-w-[200px] shadow-context" data-toggle-panel-target="panel">
-      <% if I18n.locale == :en %>
-        <%= link_to "Switch to Portuguese", { locale: 'pt-BR' }, class: classes %>
-      <% else %>
-        <%= link_to "Switch to English", { locale: 'en' }, class: classes %>
-      <%end%>
-
-      <%= button_to t('avo.sign_out'), main_app.send(:destroy_user_session_path), method: :delete, form: { "data-turbo" => "false" }, class: classes %>
+      <%= button_to t('avo.sign_out'), main_app.send(:destroy_user_session_path), method: :delete, form: { "data-turbo" => "false" }, class: "appearance-none bg-white text-left cursor-pointer text-green-600 font-semibold hover:text-white hover:bg-green-500 block px-4 py-1 w-full" %>
     </div>
   <% end %>
 </div>

--- a/spec/support/wait_for_loaded.rb
+++ b/spec/support/wait_for_loaded.rb
@@ -36,7 +36,7 @@ def wait_for_body_class_missing(klass = 'turbo-loading', time = Capybara.default
           page.find("body")[:class].present? &&
           !page.find("body")[:class].to_s.include?(klass)
     else
-      sleep 0.3
+      sleep 0.1
     end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds a `before_action` to the main `ApplicationController` that changes the `I18n.locale` and `I18n.default_locale` based on the `locale` param.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works
