### PR TITLE
fix: turbo breaks action downloads

### DIFF
--- a/app/javascript/js/controllers/modal_controller.js
+++ b/app/javascript/js/controllers/modal_controller.js
@@ -8,4 +8,13 @@ export default class extends Controller {
 
     document.dispatchEvent(new Event('actions-modal:close'))
   }
+
+  delayedClose() {
+    const vm = this
+
+    setTimeout(() => {
+      vm.modalTarget.remove()
+      document.dispatchEvent(new Event('actions-modal:close'))
+    }, 500)
+  }
 }

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -7,7 +7,11 @@
     data-resource-id="<%= params[:id] %>"
     class="hidden text-slate-800"
   >
-    <%= form_with model: @model, scope: 'fields', url: "#{@resource.records_path}/actions/#{@action.param_id}", data: {'turbo-frame': '_top', 'action-target': 'form'} do |form| %>
+    <%= form_with model: @model,
+      scope: 'fields',
+      url: "#{@resource.records_path}/actions/#{@action.param_id}",
+      data: @action.class.form_data_attributes do |form|
+    %>
       <%= render Avo::ModalComponent.new do |c| %>
         <% c.heading do %>
           <%= @action.action_name %>
@@ -26,8 +30,8 @@
         <% end %>
 
         <% c.controls do %>
-          <%= a_button @action.cancel_button_label, 'data-action': 'click->modal#close', size: :sm %>
-          <%= a_button @action.confirm_button_label, type: :submit, color: :green, size: :sm %>
+          <%= a_button @action.cancel_button_label, data: { action: 'click->modal#close' }, size: :sm %>
+          <%= a_button @action.confirm_button_label, type: :submit, color: :green, size: :sm, data: @action.class.submit_button_data_attributes %>
         <% end %>
       <% end %>
     <% end %>

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -15,12 +15,31 @@ module Avo
     class_attribute :fields
     class_attribute :standalone, default: false
     class_attribute :visible
+    class_attribute :may_download_file, default: false
 
     attr_accessor :response
     attr_accessor :model
     attr_accessor :resource
     attr_accessor :user
     attr_accessor :fields_loader
+
+    class << self
+      def form_data_attributes
+        if may_download_file
+          { 'turbo': false }
+        else
+          { 'turbo-frame': '_top', 'action-target': 'form' }
+        end
+      end
+
+      def submit_button_data_attributes
+        if may_download_file
+          { action: 'click->modal#delayedClose' }
+        else
+          {}
+        end
+      end
+    end
 
     def action_name
       return name if name.present?

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -25,6 +25,7 @@ module Avo
 
     class << self
       def form_data_attributes
+        # We can't respond with a file download from Turbo se we disable it on the form
         if may_download_file
           { 'turbo': false }
         else
@@ -32,6 +33,7 @@ module Avo
         end
       end
 
+      # We can't respond with a file download from Turbo se we disable close the modal manually after a while (it's a hack, we know)
       def submit_button_data_attributes
         if may_download_file
           { action: 'click->modal#delayedClose' }

--- a/spec/dummy/app/avo/actions/download_file.rb
+++ b/spec/dummy/app/avo/actions/download_file.rb
@@ -1,0 +1,20 @@
+class DownloadFile < Avo::BaseAction
+  self.name = "Download file"
+  self.standalone = true
+  self.may_download_file = true
+
+  field :read_from_file, as: :boolean, name: "Read from file", default: false
+
+  def handle(**args)
+    fields = args[:fields]
+
+    # Testing both ways
+    if fields['read_from_file']
+      file = File.open(Avo::Engine.root.join('spec', 'dummy', 'dummy-file.txt'))
+
+      download file.read, 'dummy-file.txt'
+    else
+      download 'On the fly dummy content.', 'dummy-content.txt'
+    end
+  end
+end

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -62,6 +62,7 @@ class UserResource < Avo::BaseResource
   action ToggleInactive
   action ToggleAdmin
   action DummyAction
+  action DownloadFile
 
   filter UserNamesFilter
 end

--- a/spec/dummy/dummy-file.txt
+++ b/spec/dummy/dummy-file.txt
@@ -1,0 +1,1 @@
+Dummy content from the file.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,6 +43,8 @@ Avo::App.boot
 
 # ActiveRecord::Migrator.migrate(File.join(Rails.root, 'db/migrate'))
 
+require 'support/download_helpers'
+
 Capybara.register_driver :chrome_headless do |app|
   Capybara::Selenium::Driver.new app,
                                  browser: :chrome,
@@ -55,7 +57,10 @@ Capybara.register_driver :chrome_headless do |app|
                                        disable-gpu
                                        no-sandbox
                                        window-size=1440,1024
-                                     ]
+                                     ],
+                                     'prefs' => {
+                                      'download.default_directory' => DownloadHelpers::PATH.to_s
+                                     }
                                    )
                                  ]
 end
@@ -71,7 +76,10 @@ Capybara.register_driver :chrome do |app|
                                        disable-gpu
                                        no-sandbox
                                        window-size=1440,1024
-                                     ]
+                                     ],
+                                     'prefs' => {
+                                      'download.default_directory' => DownloadHelpers::PATH.to_s
+                                     }
                                    )
                                  ]
 end
@@ -86,6 +94,7 @@ RSpec.configure do |config|
   config.include TestHelpers::DisableAuthentication, type: :feature
   config.include TestHelpers::DisableHQRequest
   config.include Warden::Test::Helpers
+  config.include DownloadHelpers
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -100,6 +109,9 @@ RSpec.configure do |config|
   config.before(:each, type: :system, js: true) { driven_by test_driver }
 
   config.before(:example) { Rails.cache.clear }
+
+  config.before(:example) { clear_downloads }
+  config.after(:example) { clear_downloads }
 
   config.around(:example, type: :system) do |example|
     # Stub license request for system tests.

--- a/spec/support/download_helpers.rb
+++ b/spec/support/download_helpers.rb
@@ -1,0 +1,39 @@
+# Downloaded from https://collectiveidea.com/blog/archives/2012/01/27/testing-file-downloads-with-capybara-and-chromedriver
+
+module DownloadHelpers
+  TIMEOUT = 10
+  PATH    = Rails.root.join("tmp/downloads")
+
+  extend self
+
+  def downloads
+    Dir[PATH.join("*")]
+  end
+
+  def download
+    downloads.first
+  end
+
+  def download_content
+    wait_for_download
+    File.read(download)
+  end
+
+  def wait_for_download
+    Timeout.timeout(TIMEOUT) do
+      sleep 0.1 until downloaded?
+    end
+  end
+
+  def downloaded?
+    !downloading? && downloads.any?
+  end
+
+  def downloading?
+    downloads.grep(/\.crdownload$/).any?
+  end
+
+  def clear_downloads
+    FileUtils.rm_f(downloads)
+  end
+end

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -46,6 +46,47 @@ RSpec.describe 'Actions', type: :system do
     end
   end
 
+  describe "downloading files" do
+    context "without File.open().read" do
+      let(:content) { "On the fly dummy content." }
+      let(:file_name) { "dummy-content.txt" }
+
+      it "downloads the file and closes the modal" do
+        visit "/admin/resources/users"
+
+        click_on "Actions"
+        click_on "Download file"
+        click_on "Run"
+
+        wait_for_download
+
+        expect(downloaded?).to be true
+        expect(download_content).to eq content
+        expect(download.split('/').last).to eq file_name
+      end
+    end
+
+    context "without File.open().read" do
+      let(:content) { "Dummy content from the file.\n" }
+      let(:file_name) { "dummy-file.txt" }
+
+      it "downloads the file and closes the modal" do
+        visit "/admin/resources/users"
+
+        click_on "Actions"
+        click_on "Download file"
+        check "fields[read_from_file]"
+        click_on "Run"
+
+        wait_for_download
+
+        expect(downloaded?).to be true
+        expect(download_content).to eq content
+        expect(download.split('/').last).to eq file_name
+      end
+    end
+  end
+
   #   let!(:roles) { { admin: false, manager: false, writer: false } }
   #   let!(:user) { create :user, active: true, roles: roles }
 

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Actions', type: :system do
       end
     end
 
-    context "without File.open().read" do
+    context "with File.open().read" do
       let(:content) { "Dummy content from the file.\n" }
       let(:file_name) { "dummy-file.txt" }
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/700

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](http://localhost:3011/1.0/actions.html#download)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to users
2. click Actions
3. click download file
4. click run. you should get a `dummy-content.txt` file downloaded and the modal should close
5. Open the action again and check the "read from file" checkbox. 
6. click run. you should get a `dummy-file.txt` file downloaded and the modal should close

Manual reviewer: please leave a comment with output from the test if that's the case.
