### PR TITLE
Add `parent_controller` config option

### DIFF
--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -1,5 +1,5 @@
 module Avo
-  class ApplicationController < ::ActionController::Base
+  class ApplicationController < Avo.configuration.parent_controller
     if defined?(Pundit::Authorization)
       include Pundit::Authorization
     else

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -28,6 +28,7 @@ module Avo
     attr_accessor :current_user_resource_name
     attr_accessor :raise_error_on_missing_policy
     attr_accessor :disabled_features
+    attr_writer :parent_controller
 
     def initialize
       @root_path = "/avo"
@@ -120,6 +121,12 @@ module Avo
 
     def feature_enabled?(feature)
       !@disabled_features.map(&:to_sym).include?(feature.to_sym)
+    end
+
+    # The class representing the configured base controller.
+    # In the default configuration, this is the `::ActionController::Base` class.
+    def parent_controller
+      (@parent_controller || "::ActionController::Base").to_s.constantize
     end
   end
 

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -12,6 +12,10 @@ Avo.configure do |config|
     # Return a context object that gets evaluated in Avo::ApplicationController
   end
 
+  ## == Set the base controller used for all Avo controllers ==
+  ## By default, it uses '::ActionController::Base'
+  # config.parent_controller = 'ApplicationController'
+
   ## == Authentication ==
   # config.current_user_method = {}
   # config.authenticate_with = {}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds a new configuration option `parent_controller` that allows to override what is the controller from where `Avo::ApplicationController` inherits. This allows to keep business logic in the main application `ApplicationController` like `before_action`'s and propagated to `Avo::ApplicationController` and `Avo::BaseController`.

By default, uses `::ActionController::Base` which is the current parent class.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Description...

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
