### PR TITLE
Hide header, sidebar and footer when print in browser

### DIFF
--- a/app/components/avo/sidebar_component.html.erb
+++ b/app/components/avo/sidebar_component.html.erb
@@ -1,4 +1,4 @@
-<div class="fixed z-[60] application-sidebar hidden lg:flex h-full bg-white text-white w-64 border-r" data-mobile-target="sidebar">
+<div class="fixed z-[60] application-sidebar hidden lg:flex h-full bg-white text-white w-64 border-r print:hidden" data-mobile-target="sidebar">
   <div class="flex flex-col w-full h-full">
     <div class="flex justify-between">
       <%= render partial: "avo/partials/logo" %>

--- a/app/components/avo/sidebar_component.html.erb
+++ b/app/components/avo/sidebar_component.html.erb
@@ -1,4 +1,7 @@
-<div class="fixed z-[60] application-sidebar hidden lg:flex h-full bg-white text-white w-64 border-r print:hidden" data-mobile-target="sidebar">
+<div
+  class="fixed z-[60] application-sidebar hidden lg:flex h-full bg-white text-white w-64 border-r <%= 'print:hidden' if Avo.configuration.hide_layout_when_printing %>"
+  data-mobile-target="sidebar"
+>
   <div class="flex flex-col w-full h-full">
     <div class="flex justify-between">
       <%= render partial: "avo/partials/logo" %>

--- a/app/views/avo/partials/_footer.html.erb
+++ b/app/views/avo/partials/_footer.html.erb
@@ -1,3 +1,3 @@
-<div class="text-center text-sm text-gray-700 print:hidden">
+<div class="text-center text-sm text-gray-700 <%= 'print:hidden' if Avo.configuration.hide_layout_when_printing %>">
   <a href="https://avohq.io/" target="_blank">Avo</a> · &copy; <%= Date.today.year %> AvoHQ · <span title="<%= Avo::App.license.valid ? 'valid' : 'invalid'%> <%= Avo::App.license.id %> license">v<%= Avo::VERSION %></span>
 </div>

--- a/app/views/avo/partials/_footer.html.erb
+++ b/app/views/avo/partials/_footer.html.erb
@@ -1,3 +1,3 @@
-<div class="text-center text-sm text-gray-700">
+<div class="text-center text-sm text-gray-700 print:hidden">
   <a href="https://avohq.io/" target="_blank">Avo</a> · &copy; <%= Date.today.year %> AvoHQ · <span title="<%= Avo::App.license.valid ? 'valid' : 'invalid'%> <%= Avo::App.license.id %> license">v<%= Avo::VERSION %></span>
 </div>

--- a/app/views/avo/partials/_navbar.html.erb
+++ b/app/views/avo/partials/_navbar.html.erb
@@ -1,4 +1,4 @@
-<div class="relative bg-white p-2 w-full flex flex-shrink-0 items-center z-50 px-4 lg:px-8 border-b space-x-4 lg:space-x-0 min-h-[4rem]" v-if="layout !== 'blank'">
+<div class="relative bg-white p-2 w-full flex flex-shrink-0 items-center z-50 px-4 lg:px-8 border-b space-x-4 lg:space-x-0 min-h-[4rem] print:hidden" v-if="layout !== 'blank'">
   <%= a_button class: 'lg:hidden', icon: 'menu', data: { action: 'click->mobile#toggleSidebar' } %>
   <div class="flex-1 flex items-center justify-between lg:justify-start space-x-8">
     <div class="m-0">

--- a/app/views/avo/partials/_navbar.html.erb
+++ b/app/views/avo/partials/_navbar.html.erb
@@ -1,4 +1,7 @@
-<div class="relative bg-white p-2 w-full flex flex-shrink-0 items-center z-50 px-4 lg:px-8 border-b space-x-4 lg:space-x-0 min-h-[4rem] print:hidden" v-if="layout !== 'blank'">
+<div
+  class="relative bg-white p-2 w-full flex flex-shrink-0 items-center z-50 px-4 lg:px-8 border-b space-x-4 lg:space-x-0 min-h-[4rem] <%= 'print:hidden' if Avo.configuration.hide_layout_when_printing %>"
+  v-if="layout !== 'blank'"
+>
   <%= a_button class: 'lg:hidden', icon: 'menu', data: { action: 'click->mobile#toggleSidebar' } %>
   <div class="flex-1 flex items-center justify-between lg:justify-start space-x-8">
     <div class="m-0">

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -20,6 +20,7 @@ module Avo
     attr_accessor :cache_resources_on_index_view
     attr_accessor :context
     attr_accessor :display_breadcrumbs
+    attr_accessor :hide_layout_when_printing
     attr_accessor :initial_breadcrumbs
     attr_accessor :home_path
     attr_accessor :search_debounce
@@ -62,6 +63,7 @@ module Avo
         add_breadcrumb I18n.t("avo.home").humanize, avo.root_path
       }
       @display_breadcrumbs = true
+      @hide_layout_when_printing = false
       @home_path = nil
       @search_debounce = 300
       @view_component_path = "app/components"

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -38,6 +38,7 @@ Avo.configure do |config|
   # config.per_page_steps = [12, 24, 48, 72]
   # config.via_per_page = 8
   # config.default_view_type = :table
+  # config.hide_layout_when_printing = false
   # config.id_links_to_resource = false
   # config.full_width_container = false
   # config.full_width_index_view = false


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Not sure if it's worth adding this at this point as I think you are working on a UI revamp, but thought I would share it regardless in case you want to merge it.

When printing through the browser, it will hide the header, sidebar and footer as they are usually not required / useful.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Description...

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
