### PR TITLE
turbo_frame_wrap: render alerts only for turbo requests

### DIFF
--- a/app/components/avo/turbo_frame_wrapper_component.html.erb
+++ b/app/components/avo/turbo_frame_wrapper_component.html.erb
@@ -3,7 +3,9 @@
     # When rendering the frames the flashed content gets lost.
     # By including the alerts partial, the stimulus will pick them up and display them to the user.
   %>
-  <%= render Avo::AlertsComponent.new if helpers.flash.present? && name.present? %>
+  <% if helpers.turbo_frame_request? %>
+    <%= render Avo::AlertsComponent.new if helpers.flash.present? && name.present? %>
+  <% end %>
 
   <%= content %>
 <% if name.present? %></turbo-frame><% end %>

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -24,7 +24,7 @@ module Avo
     rescue_from Pundit::NotAuthorizedError, with: :render_unauthorized
     rescue_from ActiveRecord::RecordInvalid, with: :exception_logger
 
-    helper_method :_current_user, :resources_path, :resource_path, :new_resource_path, :edit_resource_path, :resource_attach_path, :resource_detach_path, :related_resources_path
+    helper_method :_current_user, :resources_path, :resource_path, :new_resource_path, :edit_resource_path, :resource_attach_path, :resource_detach_path, :related_resources_path, :turbo_frame_request?
     add_flash_types :info, :warning, :success, :error
 
     def init_app
@@ -77,6 +77,12 @@ module Avo
 
     def context
       instance_eval(&Avo.configuration.context)
+    end
+
+    # This is coming from Turbo::Frames::FrameRequest module.
+    # Exposing it as public method
+    def turbo_frame_request?
+      super
     end
 
     private


### PR DESCRIPTION
# Description
* It should render the alerts only if it is a turbo frame request.
* If it is rendered on a normal page load, for example, a redirect then it should not render the alerts again, since they are rendered from the layout.
* When turbo_frame_wrap is rendered as a part of normal page load, alerts are rendered twice leading to duplicate alerts. So rendering the AlertsComponent only when a turbo_frame is requested.

# Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
This bug was happening in our production app. After this fix it is not happening anymore.