### PR TITLE
fix: missing inverse_of crashes has_many association

### DIFF
--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -135,6 +135,7 @@ module Avo
             # we're matching the reflection inverse_of foriegn key with the field's foreign_key
             if field.is_a?(Avo::Fields::BelongsToField)
               if field.respond_to?(:foreign_key) &&
+                reflection.inverse_of.present? &&
                 reflection.inverse_of.foreign_key == field.foreign_key
                 is_valid = false
               end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   validates :last_name, presence: true
 
   has_one :post
-  has_many :posts
+  has_many :posts, inverse_of: :user
   has_many :people
   has_many :spouses
   has_many :comments


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs/commit/ce855c5eea3ce2787e2dd5698ef9bac405f947f5)
- [ ] I have added tests that prove my fix is effective or that my feature works
