### PR TITLE
Helper `turbo_frame_wrap` will delegate to turbo_frame_tag

### DIFF
--- a/app/components/avo/turbo_frame_wrapper_component.html.erb
+++ b/app/components/avo/turbo_frame_wrapper_component.html.erb
@@ -1,11 +1,11 @@
-<% if name.present? %><turbo-frame id="<%= name %>"><% end %>
+<%= turbo_frame_tag(*args, **kwargs) do %>
   <%
     # When rendering the frames the flashed content gets lost.
     # By including the alerts partial, the stimulus will pick them up and display them to the user.
   %>
   <% if helpers.turbo_frame_request? %>
-    <%= render Avo::AlertsComponent.new if helpers.flash.present? && name.present? %>
+    <%= render Avo::AlertsComponent.new if helpers.flash.present? %>
   <% end %>
 
   <%= content %>
-<% if name.present? %></turbo-frame><% end %>
+<% end %>

--- a/app/components/avo/turbo_frame_wrapper_component.rb
+++ b/app/components/avo/turbo_frame_wrapper_component.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
 class Avo::TurboFrameWrapperComponent < ViewComponent::Base
-  attr_reader :name
+  # Refer: https://github.com/github/view_component/issues/1099
+  # delegating `turbo_frame_tag` to helpers doesn't capture the
+  # content in the block.
+  include Turbo::FramesHelper
 
-  def initialize(name = nil)
-    @name = name
+  attr_reader :args, :kwargs
+
+  def initialize(*args, **kwargs)
+    @args = args
+    @kwargs = kwargs
   end
 end

--- a/app/helpers/avo/application_helper.rb
+++ b/app/helpers/avo/application_helper.rb
@@ -20,10 +20,8 @@ module Avo
       render partial: "avo/partials/empty_state", locals: {resource_name: resource_name}
     end
 
-    def turbo_frame_wrap(name, &block)
-      render Avo::TurboFrameWrapperComponent.new name do
-        capture(&block)
-      end
+    def turbo_frame_wrap(*args, **kwargs, &block)
+      render(Avo::TurboFrameWrapperComponent.new(*args, **kwargs), &block)
     end
 
     def a_button(label = nil, **args, &block)


### PR DESCRIPTION
# Description

* Instead of creating the `turbo-frame` component ourself,
  it can be delegated to the `turbo_frame_tag` helper.
* Because of this change, we will be able to provide all arguments
  to `turbo_frame_wrap`, that are accepted by `turbo_frame_tag`.
  For example, `src` to load the `turbo-frame` in a separate request.
* Issue Fixed: Previously it was not possible to supply arguments like `src`,
  now it is possible.

Fixes # (issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps

1. Create a controller
`HomeController`
```ruby
class HomeController < ApplicationController
  def index
  end

  def show
    flash.now[:info] = 'Show loaded'
    sleep(4) # Simulate slow operation
  end
end
```
2. Add routes.rb
`routes.rb`
```ruby
Rails.application.routes.draw do
  root to: 'home#index'
  get 'show', 'home#show'
end
```
3. Add views4.
`index.html.erb`
```erb
<%= turbo_frame_wrap('show', src: show_path) do %>
  Loading show
<% end %>
```
`show.html.erb`
```erb
<%= turbo_frame_wrap('show') do %>
  Show loaded from turbo frame...
<% end %>
```

Verification: After visiting the root page, the `Loading show...` will get replaced by `Show loaded from turbo frame...` after a few seconds, along with a flash notification.
Manual reviewer: please leave a comment with output from the test if that's the case.
