### PR TITLE
fix: records with no title have show view broken

### DIFF
--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -254,10 +254,10 @@ module Avo
 
         return the_title if the_title.present?
 
-        return model_id
+        model_id
+      else
+        name
       end
-
-      name
     rescue
       name
     end

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -249,15 +249,12 @@ module Avo
     end
 
     def model_title
-      if @model.present?
-        the_title = @model.send title
+      return name if @model.nil?
 
-        return the_title if the_title.present?
+      the_title = @model.send title
+      return the_title if the_title.present?
 
-        model_id
-      else
-        name
-      end
+      model_id
     rescue
       name
     end

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -245,8 +245,18 @@ module Avo
     end
 
     def model_title
-      return @model.send title if @model.present?
+      if @model.present?
+        the_title = @model.send title
 
+        if the_title.present?
+          return the_title
+        else
+          return @model.send self.id
+        end
+      end
+
+      name
+    rescue
       name
     end
 

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -244,15 +244,17 @@ module Avo
       class_name_without_resource.safe_constantize
     end
 
+    def model_id
+      @model.send id
+    end
+
     def model_title
       if @model.present?
         the_title = @model.send title
 
-        if the_title.present?
-          return the_title
-        else
-          return @model.send self.id
-        end
+        return the_title if the_title.present?
+
+        return model_id
       end
 
       name

--- a/spec/features/avo/show_page_spec.rb
+++ b/spec/features/avo/show_page_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.feature "ShowPages", type: :feature do
+  describe "fish without name" do
+    let(:fish) { create :fish, name: "" }
+
+    it "shows the record panel" do
+      visit "/admin/resources/fish/#{fish.id}"
+
+      expect(find_field_value_element("name")).to have_text empty_dash
+    end
+  end
+
+  describe "fish with name" do
+    let(:fish) { create :fish, name: "Coco" }
+
+    it "shows the record panel" do
+      visit "/admin/resources/fish/#{fish.id}"
+
+      expect(find_field_value_element("name")).to have_text "Coco"
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Because of how the `Show` panels are rendered, if a record has an empty title the default panel is hidden.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Create a fish with no name.
2. Visit that fish
3. the panel should be visible

Manual reviewer: please leave a comment with output from the test if that's the case.
