### PR TITLE
fix: alert dropdowns on small screens

### DIFF
--- a/app/components/avo/actions_component.html.erb
+++ b/app/components/avo/actions_component.html.erb
@@ -12,7 +12,7 @@
     <%= t 'avo.actions' %>
   <% end %>
   <div
-    class="absolute flex inset-auto right-0 top-full bg-white w-full sm:w-auto sm:min-w-[300px] mt-2 z-20 shadow-modal rounded overflow-hidden hidden"
+    class="absolute flex inset-auto <%= Avo::PanelComponent.const_get(:RIGHT_ALIGNED_BUTTONS_BREAKPOINT).to_s %>:right-0 top-full bg-white w-full sm:w-auto sm:min-w-[300px] mt-2 z-20 shadow-modal rounded overflow-hidden hidden"
     data-toggle-panel-target="panel"
   >
     <div class="w-full space divide-y">

--- a/app/components/avo/panel_component.html.erb
+++ b/app/components/avo/panel_component.html.erb
@@ -1,6 +1,6 @@
 <div <%== data_attributes %>>
   <% if render_header? %>
-    <div class="bg-white rounded shadow p-4 flex-1 flex flex-col xl:flex-row justify-between mb-6">
+    <div class="bg-white rounded shadow p-4 flex-1 flex flex-col <%= bp %>:flex-row justify-between mb-6">
       <div class="overflow-hidden mr-4">
         <% if display_breadcrumbs? %>
           <div class="breadcrumbs truncate mb-2">
@@ -19,7 +19,7 @@
         <% end %>
       </div>
 
-      <div class="flex-1 w-full flex flex-col sm:flex-row xl:justify-end sm:items-end space-y-2 sm:space-y-0 sm:space-x-2 mt-4 xl:mt-0">
+      <div class="flex-1 w-full flex flex-col sm:flex-row <%= bp %>:justify-end sm:items-end space-y-2 sm:space-y-0 sm:space-x-2 mt-4 <%= bp %>:mt-0">
         <%= tools %>
       </div>
     </div>

--- a/app/components/avo/panel_component.rb
+++ b/app/components/avo/panel_component.rb
@@ -3,6 +3,8 @@
 class Avo::PanelComponent < ViewComponent::Base
   attr_reader :title
 
+  RIGHT_ALIGNED_BUTTONS_BREAKPOINT = "xl"
+
   renders_one :tools
   renders_one :body
   renders_one :bare_content
@@ -37,5 +39,9 @@ class Avo::PanelComponent < ViewComponent::Base
 
   def render_header?
     @title.present? || description.present? || tools.present? || display_breadcrumbs?
+  end
+
+  def bp
+    RIGHT_ALIGNED_BUTTONS_BREAKPOINT
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Move the dropdown to the left on small screens.

<img width="394" alt="image" src="https://user-images.githubusercontent.com/1334409/160631718-ea699b57-1107-4676-9aca-a89575734577.png">
<img width="608" alt="image" src="https://user-images.githubusercontent.com/1334409/160631742-79d27dfc-b80e-400a-9363-2f44959dbfab.png">


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

