### PR TITLE
fix: has_many turbo frame crash

### DIFF
--- a/app/components/avo/blank_field_component.rb
+++ b/app/components/avo/blank_field_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Avo::BlankFieldComponent < ViewComponent::Base
+end

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -190,6 +190,7 @@ module Avo
         "#{type.camelize}Field"
       end
 
+      # Try and build the component class or fallback to a blank one
       def component_for_view(view = :index)
         component_class = "::Avo::Fields::#{view_component_name}::#{view.to_s.camelize}Component"
         component_class.constantize

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -191,7 +191,10 @@ module Avo
       end
 
       def component_for_view(view = :index)
-        "Avo::Fields::#{view_component_name}::#{view.to_s.camelize}Component".safe_constantize
+        component_class = "::Avo::Fields::#{view_component_name}::#{view.to_s.camelize}Component"
+        component_class.constantize
+      rescue
+        ::Avo::BlankFieldComponent
       end
 
       def model_errors

--- a/spec/components/avo/blank_field_component_spec.rb
+++ b/spec/components/avo/blank_field_component_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe BlankFieldComponent, type: :component do
+  # it "renders something useful" do
+  #   expect(
+  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
+  #   ).to include(
+  #     "Hello, components!"
+  #   )
+  # end
+end

--- a/spec/components/avo/blank_field_component_spec.rb
+++ b/spec/components/avo/blank_field_component_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe BlankFieldComponent, type: :component do
+RSpec.describe Avo::BlankFieldComponent, type: :component do
   # it "renders something useful" do
   #   expect(
   #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/743.

This is a possible fix on the sporadically crashes when a lot of `has_many` turbo frames are present on the page.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Go on a page where the `has_many` turbo frame was failing sporadically. Try and see if it still does that. If it still does it, then, this doesn't fix it.
I haven't been able to trigger the crash on my end.

Manual reviewer: please leave a comment with output from the test if that's the case.
