### PR TITLE
fix: wrong redirect after validation failed when wediting a has many association

### DIFF
--- a/app/components/avo/referrer_params_component.html.erb
+++ b/app/components/avo/referrer_params_component.html.erb
@@ -1,0 +1,4 @@
+<%= hidden_field_tag :via_resource_class, params[:via_resource_class] if params[:via_resource_class] %>
+<%= hidden_field_tag :via_resource_id, params[:via_resource_id] if params[:via_resource_id] %>
+<%= hidden_field_tag :via_relation, params[:via_relation] if params[:via_relation] %>
+<%= hidden_field_tag :referrer, back_path if params[:via_resource_class] %>

--- a/app/components/avo/referrer_params_component.rb
+++ b/app/components/avo/referrer_params_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Avo::ReferrerParamsComponent < ViewComponent::Base
+  attr_reader :back_path
+
+  def initialize(back_path: nil)
+    @back_path = back_path
+  end
+end

--- a/app/components/avo/views/resource_edit_component.html.erb
+++ b/app/components/avo/views/resource_edit_component.html.erb
@@ -6,7 +6,7 @@
         method: :put,
         local: true,
         multipart: true do |form| %>
-      <%= hidden_field_tag :referrer, back_path if params[:via_resource_class] %>
+      <%= render Avo::ReferrerParamsComponent.new back_path: back_path %>
       <%= render Avo::PanelComponent.new(title: resource_panel[:name], description: @resource.resource_description, display_breadcrumbs: true) do |c| %>
         <% c.tools do %>
           <%= a_link back_path, icon: 'arrow-left' do %>

--- a/app/components/avo/views/resource_new_component.html.erb
+++ b/app/components/avo/views/resource_new_component.html.erb
@@ -10,6 +10,7 @@
       ),
       local: true,
       multipart: true do |form| %>
+      <%= render Avo::ReferrerParamsComponent.new back_path: back_path %>
       <%= render Avo::PanelComponent.new(title: resource_panel[:name], description: @resource.resource_description, display_breadcrumbs: true) do |c| %>
         <% c.tools do %>
           <div class="flex justify-end space-x-2">

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -7,6 +7,7 @@ module Avo
     before_action :hydrate_resource
     before_action :set_model, only: [:show, :edit, :destroy, :update, :order]
     before_action :set_model_to_fill
+    before_action :set_edit_title_and_breadcrumbs, only: [:edit, :update]
     before_action :fill_model, only: [:create, :update]
     before_action :authorize_action
     before_action :reset_pagination_if_filters_changed, only: :index
@@ -91,27 +92,6 @@ module Avo
       add_breadcrumb t("avo.new").humanize
     end
 
-    def edit
-      @resource = @resource.hydrate(model: @model, view: :edit, user: _current_user)
-
-      @page_title = @resource.default_panel_name.to_s
-
-      # If we're accessing this resource via another resource add the parent to the breadcrumbs.
-      if params[:via_resource_class].present? && params[:via_resource_id].present?
-        via_resource = Avo::App.get_resource_by_model_name params[:via_resource_class]
-        via_model = via_resource.class.find_scope.find params[:via_resource_id]
-        via_resource.hydrate model: via_model
-
-        add_breadcrumb via_resource.plural_name, resources_path(resource: @resource)
-        add_breadcrumb via_resource.model_title, resource_path(model: via_model, resource: via_resource)
-      else
-        add_breadcrumb @resource.plural_name.humanize, resources_path(resource: @resource)
-      end
-
-      add_breadcrumb @resource.model_title, resource_path(model: @resource.model, resource: @resource)
-      add_breadcrumb t("avo.edit").humanize
-    end
-
     def create
       # model gets instantiated and filled in the fill_model method
       saved = save_model
@@ -161,6 +141,9 @@ module Avo
           format.html { render :new, status: :unprocessable_entity }
         end
       end
+    end
+
+    def edit
     end
 
     def update
@@ -354,6 +337,25 @@ module Avo
 
     def applied_filters_cache_key
       "avo.base_controller.#{@resource.model_key}.applied_filters"
+    end
+
+    def set_edit_title_and_breadcrumbs
+      @resource = @resource.hydrate(model: @model, view: :edit, user: _current_user)
+      @page_title = @resource.default_panel_name.to_s
+      # If we're accessing this resource via another resource add the parent to the breadcrumbs.
+      if params[:via_resource_class].present? && params[:via_resource_id].present?
+        via_resource = Avo::App.get_resource_by_model_name params[:via_resource_class]
+        via_model = via_resource.class.find_scope.find params[:via_resource_id]
+        via_resource.hydrate model: via_model
+
+        add_breadcrumb via_resource.plural_name, resources_path(resource: @resource)
+        add_breadcrumb via_resource.model_title, resource_path(model: via_model, resource: via_resource)
+      else
+        add_breadcrumb @resource.plural_name.humanize, resources_path(resource: @resource)
+      end
+
+      add_breadcrumb @resource.model_title, resource_path(model: @resource.model, resource: @resource)
+      add_breadcrumb t("avo.edit").humanize
     end
   end
 end

--- a/spec/components/avo/referrer_params_component_spec.rb
+++ b/spec/components/avo/referrer_params_component_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Avo::ReferrerParamsComponent, type: :component do
+  # it "renders something useful" do
+  #   expect(
+  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
+  #   ).to include(
+  #     "Hello, components!"
+  #   )
+  # end
+end

--- a/spec/dummy/app/models/comment.rb
+++ b/spec/dummy/app/models/comment.rb
@@ -1,12 +1,20 @@
 class Comment < ApplicationRecord
   validates :body, presence: true
+  validate :body_different
 
   belongs_to :commentable, polymorphic: true, optional: true
   belongs_to :user, optional: true
 
-  scope :starts_with, -> (prefix) { where('LOWER(body) LIKE ?', "#{prefix}%") }
+  scope :starts_with, ->(prefix) { where("LOWER(body) LIKE ?", "#{prefix}%") }
 
   def tiny_name
     ActionView::Base.full_sanitizer.sanitize(body.to_s).truncate 60
+  end
+
+  def body_different
+    possible_comment = Comment.where(body: body).where.not(id: id).first
+    if possible_comment.present?
+      errors.add :body, message: "exists in another Comment."
+    end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/693

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to a Post
2. create a comment with the body `bb` and another with a different body. both should be attache to the that post
3. return to the post and hit edit on the second comment (not the `bb` one)
4. try to edit it and set the body to `bb`
5. the validation should fail and keep you on that page
6. when you change the body to something else the validation passes and you are redirected to that post.

Manual reviewer: please leave a comment with output from the test if that's the case.
