### PR TITLE
feature: hide resources from global search

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -10,7 +10,11 @@ module Avo
     def index
       raise ActionController::BadRequest.new("This feature requires the pro license https://avohq.io/purchase/pro") if App.license.lacks_with_trial(:global_search)
 
-      render json: search_resources(Avo::App.resources)
+      resources = Avo::App.resources.reject do |resource|
+        resource.class.search_hide_from_global_search
+      end
+
+      render json: search_resources(resources)
     end
 
     def show

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -39,6 +39,7 @@ module Avo
     class_attribute :resolve_query_scope
     class_attribute :resolve_find_scope
     class_attribute :ordering
+    class_attribute :search_hide_from_global_search, default: false
 
     class << self
       delegate :t, to: ::I18n

--- a/spec/dummy/app/avo/resources/team_membership_resource.rb
+++ b/spec/dummy/app/avo/resources/team_membership_resource.rb
@@ -2,9 +2,14 @@ class TeamMembershipResource < Avo::BaseResource
   self.title = :id
   self.includes = [:user, :team]
   self.visible_on_sidebar = false
+  self.search_query = ->(params:) do
+    scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
+  end
+  self.search_hide_from_global_search = true
 
   field :id, as: :id
-  field :level, as: :select, options: ->(**args) { {'Beginner': :beginner, 'Intermediate': :intermediate, 'Advanced': :advanced, "#{args[:model].id}": "model_id", "#{args[:resource].name}": "resource_name", "#{args[:view]}": "view", "#{args[:field].id}": "field"} }, display_value: true, default: -> { Time.now.hour < 12 ? "advanced" : "beginner" }
+  field :id, as: :number, only_on: :edit
+  field :level, as: :select, as_description: true, options: ->(**args) { {'Beginner': :beginner, 'Intermediate': :intermediate, 'Advanced': :advanced, "#{args[:model].id}": "model_id", "#{args[:resource].name}": "resource_name", "#{args[:view]}": "view", "#{args[:field].id}": "field"} }, display_value: true, default: -> { Time.now.hour < 12 ? "advanced" : "beginner" }
 
   field :user, as: :belongs_to
   field :team, as: :belongs_to

--- a/spec/features/avo/hidden_from_global_search_spec.rb
+++ b/spec/features/avo/hidden_from_global_search_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.feature Avo::SearchController, type: :controller do
+  let!(:user) { create :user, first_name: 'John' }
+  let!(:team) { create :team, name: 'Apple' }
+  let!(:team_membership) { team.team_members << user }
+
+  describe "global search" do
+    it "does not return the ream membership" do
+      get :index
+
+      expect(json['users']['count']).to eq 1
+      expect(json['users']['results'].first['_id']).to eq user.id
+      expect(json.keys).to include "users"
+      expect(json.keys).not_to include "team memberships"
+    end
+  end
+
+  describe "resource search" do
+    it "does not return the ream membership" do
+      get :show, params: {
+        resource_name: 'team_memberships'
+      }
+
+      expect(json.keys).not_to include "users"
+      expect(json.keys).to include "team memberships"
+      expect(json['team memberships']['count']).to eq 1
+      expect(json['team memberships']['results'].first['_id']).to eq team.memberships.first.id
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,7 @@ Avo::App.boot
 # ActiveRecord::Migrator.migrate(File.join(Rails.root, 'db/migrate'))
 
 require 'support/download_helpers'
+require 'support/request_helpers'
 
 Capybara.register_driver :chrome_headless do |app|
   Capybara::Selenium::Driver.new app,
@@ -90,6 +91,7 @@ require 'support/controller_routes'
 
 RSpec.configure do |config|
   config.include TestHelpers::ControllerRoutes, type: :controller
+  config.include Requests::JsonHelpers, :type => :controller
   config.include TestHelpers::DisableAuthentication, type: :system
   config.include TestHelpers::DisableAuthentication, type: :feature
   config.include TestHelpers::DisableHQRequest

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,7 @@
+module Requests
+  module JsonHelpers
+    def json
+      @json ||= JSON.parse(response.body)
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/688
[Docs](https://docs.avohq.io/2.0/search.html#hide-a-resource-from-the-global-search)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://docs.avohq.io/2.0/search.html#hide-a-resource-from-the-global-search)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to the team memberships (http://localhost:3030/admin/resources/team_memberships) and open the resource search. That should work
2. Try researching in global search. The team memberships should be hidden from that search.

Manual reviewer: please leave a comment with output from the test if that's the case.
