### PR TITLE
Rails 7 deprecates Date#to_s in favor of Date#to_formatted_s

### DIFF
--- a/lib/avo/fields/date_field.rb
+++ b/lib/avo/fields/date_field.rb
@@ -19,7 +19,7 @@ module Avo
         return if value.blank?
 
         if @format.is_a?(Symbol)
-          value.to_s(@format)
+          value.to_formatted_s(@format)
         else
           value.strftime(@format)
         end


### PR DESCRIPTION
# Description

This fixes a deprecation warning in Rails 7 where dates should be formatted using `to_formatted_s` when passing a named format type.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps

Tried in my existing app and everything seems fine. `to_s` simply forwarded to `to_formatted_s`, so it's a benign change.