### PR TITLE
Avo 1.x Backport: Rails 7 deprecates Date#to_s in favor of Date#to_formatted_s

### DIFF
--- a/lib/avo/fields/date_field.rb
+++ b/lib/avo/fields/date_field.rb
@@ -19,7 +19,7 @@ module Avo
         return if value.blank?
 
         if @format.is_a?(Symbol)
-          value.to_s(@format)
+          value.to_formatted_s(@format)
         else
           value.strftime(@format)
         end


### PR DESCRIPTION
# Description

Backport #774 to 1.x

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature work