### PR TITLE
Minor improve sidebar profile component

### DIFF
--- a/app/components/avo/sidebar_profile_component.html.erb
+++ b/app/components/avo/sidebar_profile_component.html.erb
@@ -1,15 +1,19 @@
 <div class="text-black border-t border-gray-200 p-4 flex">
   <div class="flex-1 flex space-x-4">
+    <% if avatar.present? %>
     <div class="relative aspect-square w-10 h-10 overflow-hidden rounded">
       <%= image_tag avatar, class: "object-cover min-w-full min-h-full h-full" %>
     </div>
+    <% end %>
     <div class="flex flex-col">
       <div class="font-medium">
         <%= name %>
       </div>
+      <% if title.present? %>
       <div class="text-xs text-gray-500 uppercase">
         <%= title %>
       </div>
+      <% end %>
     </div>
   </div>
   <div class="relative" data-controller="toggle-panel">

--- a/app/components/avo/sidebar_profile_component.html.erb
+++ b/app/components/avo/sidebar_profile_component.html.erb
@@ -1,18 +1,18 @@
 <div class="text-black border-t border-gray-200 p-4 flex">
   <div class="flex-1 flex space-x-4">
     <% if avatar.present? %>
-    <div class="relative aspect-square w-10 h-10 overflow-hidden rounded">
-      <%= image_tag avatar, class: "object-cover min-w-full min-h-full h-full" %>
-    </div>
+      <div class="relative aspect-square w-10 h-10 overflow-hidden rounded">
+        <%= image_tag avatar, class: "object-cover min-w-full min-h-full h-full" %>
+      </div>
     <% end %>
     <div class="flex flex-col">
       <div class="font-medium">
         <%= name %>
       </div>
       <% if title.present? %>
-      <div class="text-xs text-gray-500 uppercase">
-        <%= title %>
-      </div>
+        <div class="text-xs text-gray-500 uppercase">
+          <%= title %>
+        </div>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
# Description

When user doesn't have a `title` and / or `avatar`, the username is misaligned.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Description...

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
