### PR TITLE
Add sidebar extra partial for custom sidebar elements

### DIFF
--- a/app/components/avo/sidebar_component.html.erb
+++ b/app/components/avo/sidebar_component.html.erb
@@ -43,6 +43,8 @@
             </div>
           </div>
         <% end %>
+
+        <%= render partial: "/avo/partials/sidebar_extra" %>
       </div>
     </div>
     <%= helpers.render_license_warnings %>


### PR DESCRIPTION
# Description

Adds a new partial at the end of the sidebar for more customization (ie: in my case, I needed to add more items of custom reports I've created)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Description...

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
