### PR TITLE
fix: panel component title alignment

### DIFF
--- a/app/components/avo/panel_component.html.erb
+++ b/app/components/avo/panel_component.html.erb
@@ -1,15 +1,15 @@
 <div <%== data_attributes %>>
   <% if render_header? %>
     <div class="<%= white_panel_classes %> p-4 flex-1 flex flex-col xl:flex-row justify-between mb-6">
-      <div class="overflow-hidden mr-4">
+      <div class="overflow-hidden mr-4 flex flex-col">
         <% if display_breadcrumbs? %>
           <div class="breadcrumbs truncate mb-2">
             <%= helpers.render_breadcrumbs(separator: helpers.svg('chevron-right', class: 'inline-block h-3 stroke-current relative top-[-1px] ml-1' )) if Avo.configuration.display_breadcrumbs %>
           </div>
         <% end %>
 
-        <div class="text-2xl tracking-normal font-semibold text-gray-800 truncate" data-target="title">
-          <%= @title %>
+        <div class="text-2xl tracking-normal font-semibold text-gray-800 truncate items-center flex flex-1" data-target="title">
+          <span><%= @title %></span>
         </div>
 
         <% if description.present? %>

--- a/lib/avo/reloader.rb
+++ b/lib/avo/reloader.rb
@@ -3,31 +3,31 @@ class Avo::Reloader
 
   def reload!
     # reload all files declared in paths
-    paths.each { |path| load path }
+    files.each { |file| load file }
 
     # reload all files declared in each directory
     directories.keys.each do |dir|
-      Dir.glob("#{dir}/**/*.rb".to_s).each { |c| load c }
+      Dir.glob("#{dir}/**/*.rb".to_s).each { |file| load file }
     end
   end
 
   private
     def updater
-      @updater ||= config.file_watcher.new(paths, directories) { reload! }
+      @updater ||= config.file_watcher.new(files, directories) { reload! }
     end
 
-    def paths
+    def files
       # we want to watch some files no matter what
-      files = [
+      paths = [
         Rails.root.join("config", "initializers", "avo.rb"),
       ]
 
       # we want to watch some files only in Avo development
       if reload_lib?
-        files += []
+        paths += []
       end
 
-      files
+      paths
     end
 
     def directories


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Before:

<img width="1065" alt="CleanShot 2022-04-11 at 11 48 39@2x" src="https://user-images.githubusercontent.com/1334409/162699970-6c05969d-9a17-47df-9845-5a9905230b5d.png">

## After
<img width="1052" alt="CleanShot 2022-04-11 at 11 48 54@2x" src="https://user-images.githubusercontent.com/1334409/162700115-7d103202-bbf4-4f91-b79f-0632285a837f.png">

This PR also contains a tiny rename in the reloader.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works