### PR TITLE
fix: change param from locale->set_locale

### DIFF
--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -284,7 +284,7 @@ module Avo
     end
 
     def set_locale
-      I18n.locale = params[:locale] || I18n.default_locale
+      I18n.locale = params[:set_locale] || I18n.default_locale
 
       I18n.default_locale = I18n.locale
     end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

`params[:locale]` renamed to `params[:set_locale]`

Fixes https://github.com/avo-hq/avo/issues/828

We initially put the `locale` param as a temporary fix to allow users to edit multilingual content. The multilingual content editor is not really a feature yet and we'll probably tweak it when we make it a feature.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

