### PR TITLE
refactor: use default cllapsed state for menus

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,5 +4,5 @@ plugins:
     config:
       languages:
         javascript:
-          mass_threshold: 40
+          mass_threshold: 64
 

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,8 @@
+plugins:
+  duplication:
+    enabled: true
+    config:
+      languages:
+        javascript:
+          mass_threshold: 40
+

--- a/app/components/avo/sidebar/group_component.html.erb
+++ b/app/components/avo/sidebar/group_component.html.erb
@@ -3,7 +3,7 @@
     data-controller="menu"
     data-menu-target="self"
     data-menu-key-param="<%= key %>"
-    data-menu-collapsed-param="<%= collapsed ? 'collapsed' : 'expanded' %>"
+    data-menu-default-collapsed-state="<%= collapsed ? 'collapsed' : 'expanded' %>"
   <% end %>
 >
   <div class="flex justify-between px-10 pt-2 pb-0 text-gray-600 ">
@@ -11,16 +11,16 @@
       <%= item.name %>
     </div>
     <% if collapsable %>
-      <div class="cursor-pointer"
+      <div class="cursor-pointer <%= 'rotate-90' if collapsed %>"
         data-action="click->menu#triggerCollapse"
         data-menu-target="svg"
         data-menu-key-param="<%= key %>"
         >
-        <%= helpers.svg 'heroicons/outline/chevron-down', class: 'h-4'%>
+        <%= helpers.svg 'heroicons/outline/chevron-down', class: "h-4"%>
       </div>
     <% end %>
   </div>
-  <div class="w-full space-y-1" data-menu-target="items">
+  <div class="w-full space-y-1 <%= 'hidden' if collapsed %>" data-menu-target="items">
     <% items.each do |item| %>
       <%= render Avo::Sidebar::ItemSwitcherComponent.new item: item %>
     <% end %>

--- a/app/components/avo/sidebar/heading_component.html.erb
+++ b/app/components/avo/sidebar/heading_component.html.erb
@@ -3,7 +3,7 @@
     <span class="min-w-[20px]"><%= icon %></span> <span><%= label %></span>
   </div>
   <% if collapsable %>
-    <div class="cursor-pointer"
+    <div class="cursor-pointer <%= 'rotate-90' if collapsed %>"
       data-action="click->menu#triggerCollapse"
       data-menu-key-param="<%= key %>"
       data-menu-target="svg"

--- a/app/components/avo/sidebar/heading_component.rb
+++ b/app/components/avo/sidebar/heading_component.rb
@@ -2,12 +2,14 @@
 
 class Avo::Sidebar::HeadingComponent < ViewComponent::Base
   attr_reader :collapsable
+  attr_reader :collapsed
   attr_reader :icon
   attr_reader :key
   attr_reader :label
 
-  def initialize(label: nil, icon: nil, collapsable: false, key: nil)
+  def initialize(label: nil, icon: nil, collapsable: false, collapsed: false, key: nil)
     @collapsable = collapsable
+    @collapsed = collapsed
     @icon = icon
     @key = key
     @label = label

--- a/app/components/avo/sidebar/section_component.html.erb
+++ b/app/components/avo/sidebar/section_component.html.erb
@@ -3,11 +3,11 @@
     data-controller="menu"
     data-menu-target="self"
     data-menu-key-param="<%= key %>"
-    data-menu-collapsed-param="<%= collapsed ? 'collapsed' : 'expanded' %>"
+    data-menu-default-collapsed-state="<%= collapsed ? 'collapsed' : 'expanded' %>"
   <% end %>
 >
-  <%= render Avo::Sidebar::HeadingComponent.new label: item.name, icon: helpers.svg(icon, class: 'h-5'), collapsable: item.collapsable, key: key %>
-  <div class="w-full space-y-1" data-menu-target="items">
+  <%= render Avo::Sidebar::HeadingComponent.new label: item.name, icon: helpers.svg(icon, class: "h-5"), collapsable: item.collapsable, collapsed: collapsed, key: key %>
+  <div class="w-full space-y-1 <%= 'hidden' if collapsed %>" data-menu-target="items">
     <% items.each do |item| %>
       <%= render Avo::Sidebar::ItemSwitcherComponent.new item: item %>
     <% end %>

--- a/app/javascript/avo.js
+++ b/app/javascript/avo.js
@@ -84,3 +84,16 @@ document.addEventListener('turbo:submit-end', () => document.body.classList.remo
 document.addEventListener('turbo:before-cache', () => {
   document.querySelectorAll('[data-turbo-remove-before-cache]').forEach((element) => element.remove())
 })
+
+window.Avo = window.Avo || { configuration: {} }
+
+window.Avo.menus = {
+  resetCollapsedState() {
+    Array.from(document.querySelectorAll('[data-menu-key-param]'))
+      .map((i) => i.getAttribute('data-menu-key-param'))
+      .filter(Boolean)
+      .forEach((key) => {
+        window.localStorage.removeItem(key)
+      })
+  },
+}

--- a/app/javascript/js/controllers/menu_controller.js
+++ b/app/javascript/js/controllers/menu_controller.js
@@ -1,31 +1,46 @@
 import { Controller } from '@hotwired/stimulus'
-import isNull from 'lodash/isNull'
 
 export default class extends Controller {
   static targets = ['svg', 'items', 'self'];
 
-  collapsed = false;
+  collapsed = true;
 
   get key() {
     return this.selfTarget.getAttribute('data-menu-key-param')
   }
 
-  defaultState() {
-    return this.selfTarget.getAttribute('data-menu-collapsed-param') === 'collapsed'
+  get defaultState() {
+    return this.selfTarget.getAttribute('data-menu-default-collapsed-state')
+  }
+
+  get userState() {
+    return window.localStorage.getItem(this.key)
+  }
+
+  set userState(payload) {
+    window.localStorage.setItem(this.key, payload)
+  }
+
+  get initiallyCollapsed() {
+    if (this.userState === 'collapsed' || this.defaultState === 'collapsed') return true
+    if (this.userState === 'expanded' || this.defaultState === 'expanded') return false
+
+    return false
   }
 
   connect() {
-    if (this.getState() === 'collapsed') {
+    if (this.initiallyCollapsed) {
       this.collapsed = true
       this.markCollapsed()
-    } else if (isNull(this.getState()) && this.defaultState()) {
-      this.collapsed = true
-      this.markCollapsed()
+    } else {
+      this.collapsed = false
+      this.markExpanded()
     }
   }
 
   triggerCollapse() {
     this.collapsed = !this.collapsed
+    this.userState = this.collapsed ? 'collapsed' : 'expanded'
 
     this.updateDom()
   }
@@ -41,20 +56,10 @@ export default class extends Controller {
   markCollapsed() {
     this.svgTarget.classList.add('rotate-90')
     this.itemsTarget.classList.add('hidden')
-    this.storeState('collapsed')
   }
 
   markExpanded() {
     this.svgTarget.classList.remove('rotate-90')
     this.itemsTarget.classList.remove('hidden')
-    this.storeState('expanded')
-  }
-
-  getState() {
-    return window.localStorage.getItem(this.key)
-  }
-
-  storeState(payload) {
-    window.localStorage.setItem(this.key, payload)
   }
 }

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -40,7 +40,7 @@ Avo.configure do |config|
         resource :comments
       end
 
-      group "Company", collapsable: true do
+      group "Company" do
         resource :projects
         resource :team
         resource :reviews


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This forces Avo to use the default state for collapsable menus. That means that you'll get more control and less jitter until the local storage values are retrieved.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

