### PR TITLE
WIP Fix/toggle without search query

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -32,7 +32,7 @@ From the root directory you can run `bin/dev` and that will start a foreman proc
 
 ## Seeding the database for local development
 
-Run `AVO_ADMIN_PASSWORD=secret bin/rails db:seed` to seed the database with dummy data and create a user for yourself with the email `admin@avohq.io` and password `secret`.
+Run `AVO_ADMIN_PASSWORD=secret bin/rails db:seed` to seed the database with dummy data and create a user for yourself with the email `avo@avohq.io` and password `secret`.
 
 ## Using your fork from another project
 

--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -16,27 +16,25 @@
       <% end %>
     <% end %>
     <% c.body do %>
-      <% if @resource.search_query.present? || @filters.present? || available_view_types.count > 1 %>
-        <div class="flex flex-col xs:flex-row xs:justify-between space-y-2 xs:space-y-0 py-4"
-          data-selected-resources-name="<%= @resource.model_key %>"
-          data-selected-resources="[]"
-        >
-          <% if @resource.search_query.present? %>
-            <div class="flex items-center px-4 w-64">
-              <%= render partial: 'avo/partials/resource_search', locals: {resource: @resource.model_key} %>
-            </div>
-          <% else %>
-            <%# Offset for the space-y-2 property when the serach is missing %>
-            <div class="-mb-2"></div>
-          <% end %>
-          <% if @filters.present? || available_view_types.count > 1 %>
-            <div class="justify-self-end flex justify-start xs:justify-end items-center px-4 space-x-3">
-              <%= render Avo::FiltersComponent.new filters: @filters, resource: @resource %>
-              <%= render partial: 'avo/partials/view_toggle_button', locals: { available_view_types: available_view_types, view_type: view_type, turbo_frame: @turbo_frame } if available_view_types.count > 1 %>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
+      <div class="flex flex-col xs:flex-row xs:justify-between space-y-2 xs:space-y-0 py-4 <%= 'hidden' if @resource.search_query.nil? && @filters.empty? && available_view_types.count <= 1 %>"
+        data-selected-resources-name="<%= @resource.model_key %>"
+        data-selected-resources="[]"
+      >
+        <% if @resource.search_query.present? %>
+          <div class="flex items-center px-4 w-64">
+            <%= render partial: 'avo/partials/resource_search', locals: {resource: @resource.model_key} %>
+          </div>
+        <% else %>
+          <%# Offset for the space-y-2 property when the serach is missing %>
+          <div class="-mb-2"></div>
+        <% end %>
+        <% if @filters.present? || available_view_types.count > 1 %>
+          <div class="justify-self-end flex justify-start xs:justify-end items-center px-4 space-x-3">
+            <%= render Avo::FiltersComponent.new filters: @filters, resource: @resource %>
+            <%= render partial: 'avo/partials/view_toggle_button', locals: { available_view_types: available_view_types, view_type: view_type, turbo_frame: @turbo_frame } if available_view_types.count > 1 %>
+          </div>
+        <% end %>
+      </div>
       <% if view_type.to_sym == :table %>
         <% if @resources.present? %>
           <div class="w-full overflow-auto flex flex-col mt-0">

--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -34,7 +34,7 @@ module Avo
     private
 
     def action_params
-      params.permit(:resource_name, :action_id, fields: {})
+      params.permit(:authenticity_token, :resource_name, :action_id, fields: {})
     end
 
     def set_action


### PR DESCRIPTION
# Description
Fix the JS error when selecting a checkbox on an Index page that has no search query defined in the resource.

Fixes # [(861)](https://github.com/avo-hq/avo/issues/861)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [~] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
1. Load the dummy app.
2. Click on the "People" resource
3. Open the JS console.
4. Click any checkbox.
5. Ensure the JS console has no errors.
6. Ensure the `data-selected-resources` element is populated with IDs that were selected.
