### PR TITLE
Remove debug Profile link from sidebar component

### DIFF
--- a/app/components/avo/sidebar_profile_component.html.erb
+++ b/app/components/avo/sidebar_profile_component.html.erb
@@ -34,9 +34,6 @@
             <% end %>
           </div>
         <% end %>
-        <% if Rails.env.development? %>
-          <%= render Avo::ProfileItemComponent.new label: 'Debug', path: "#{root_path}avo_private/debug", icon: 'heroicons/outline/receipt-refund', title: 'Menu item visible only in development.' %>
-        <% end %>
         <%# Example link below %>
         <%#= render Avo::ProfileItemComponent.new label: 'Profile', path: '/profile', icon: 'user-circle' %>
         <%= button_to helpers.main_app.send(destroy_user_session_path),


### PR DESCRIPTION
# Description
Fixes issue when rendering the sidebar component due to the fact that the `root_path` helper is unavailable

Fixes # (issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Boot a test app, ensure that the root avo page loads.

Manual reviewer: please leave a comment with output from the test if that's the case.
