### PR TITLE
feature: pass record to association scope

### DIFF
--- a/app/components/avo/edit/field_wrapper_component.html.erb
+++ b/app/components/avo/edit/field_wrapper_component.html.erb
@@ -4,8 +4,8 @@
     <% if @model.present? and @model.errors.include? @field.id %>
       <div class="text-red-600 mt-2 text-sm"><%= @model.errors.full_messages_for(@field.id).to_sentence %></div>
     <% end %>
-    <% if @field.help %>
-      <div class="text-gray-600 mt-2 text-sm"><%== @field.help %></div>
+    <% if help.present? %>
+      <div class="text-gray-600 mt-2 text-sm"><%== help %></div>
     <% end %>
   </div>
 <% end %>

--- a/app/components/avo/edit/field_wrapper_component.rb
+++ b/app/components/avo/edit/field_wrapper_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::Edit::FieldWrapperComponent < ViewComponent::Base
-  def initialize(field: nil, dash_if_blank: true, full_width: false, displayed_in_modal: false, form: nil, resource: {}, label: nil, **args)
+  def initialize(field: nil, dash_if_blank: true, full_width: false, displayed_in_modal: false, form: nil, resource: {}, label: nil, help: nil, **args)
     @field = field
     @dash_if_blank = dash_if_blank
     @classes = args[:class].present? ? args[:class] : ""
@@ -12,5 +12,10 @@ class Avo::Edit::FieldWrapperComponent < ViewComponent::Base
     @model = resource.present? ? resource.model : nil
     @full_width = full_width
     @label = label
+    @help = help
+  end
+
+  def help
+    @help || @field.help
   end
 end

--- a/app/components/avo/fields/belongs_to_field/autocomplete_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/autocomplete_component.html.erb
@@ -4,6 +4,9 @@
     data-search-resource="<%= @model_key %>"
     data-translation-keys='{"no_item_found": "<%= I18n.translate 'avo.no_item_found' %>"}'
     data-via-association="belongs_to"
+    data-via-association-id="<%= @field.id %>"
+    data-via-reflection-id="<%= @field.model.id %>"
+    data-via-reflection-class="<%= @field.model.class.to_s %>"
   ></div>
   <div class="relative w-full" autocomplete="off">
     <%= @form.text_field @foreign_key,

--- a/app/components/avo/fields/belongs_to_field/autocomplete_component.rb
+++ b/app/components/avo/fields/belongs_to_field/autocomplete_component.rb
@@ -34,6 +34,10 @@ class Avo::Fields::BelongsToField::AutocompleteComponent < ViewComponent::Base
     result
   end
 
+  def reflection_class
+    has_polymorphic_association? ? polymorphic_class : @resource.model_class._reflections[@field.id.to_s].klass
+  end
+
   private
 
   def should_prefill?

--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -1,20 +1,19 @@
-<%
-  if is_polymorphic?
-
-  # Set the model keys so we can pass them over
-  model_keys = @field.types.map do |type|
-    resource = Avo::App.get_resource_by_model_name(type.to_s)
-    [type.to_s, resource.model_key]
-  end.to_h
-%>
-<div class="divide-y"
+<% if is_polymorphic? %>
+  <%
+    # Set the model keys so we can pass them over
+    model_keys = @field.types.map do |type|
+      resource = Avo::App.get_resource_by_model_name(type.to_s)
+      [type.to_s, resource.model_key]
+    end.to_h
+  %>
+  <div class="divide-y"
     data-controller="belongs-to-field"
     data-searchable="<%= @field.searchable %>"
     data-association="<%= @field.id %>"
     data-association-class="<%= @field&.target_resource&.model_class || nil %>"
   >
-  <%= edit_field_wrapper field: @field, index: @index, form: @form, resource: @resource, displayed_in_modal: @displayed_in_modal do %>
-    <%= @form.select @field.type_input_foreign_key, @field.types.map { |type| [type.to_s.underscore.humanize, type.to_s] },
+    <%= edit_field_wrapper field: @field, index: @index, form: @form, resource: @resource, displayed_in_modal: @displayed_in_modal, help: @field.polymorphic_help || ''  do %>
+      <%= @form.select @field.type_input_foreign_key, @field.types.map { |type| [type.to_s.underscore.humanize, type.to_s] },
       {
         value: @field.value,
         include_blank: @field.placeholder,
@@ -26,21 +25,21 @@
         'data-action': 'change->belongs-to-field#changeType'
       }
     %>
-    <%
+      <%
         # If the select field is disabled, no value will be sent. It's how HTML works.
         # Thus the extra hidden field to actually send the related id to the server.
         if disabled %>
-      <%= @form.hidden_field @field.type_input_foreign_key %>
+        <%= @form.hidden_field @field.type_input_foreign_key %>
+      <% end %>
     <% end %>
-  <% end %>
-  <% @field.types.each do |type| %>
-    <div class="hidden"
+    <% @field.types.each do |type| %>
+      <div class="hidden"
         data-belongs-to-field-target="type"
         data-type="<%= type %>"
       >
-      <%= edit_field_wrapper field: @field, index: @index, form: @form, resource: @resource, displayed_in_modal: @displayed_in_modal, label: type.to_s.underscore.humanize do %>
-        <% if @field.searchable %>
-          <%= render Avo::Fields::BelongsToField::AutocompleteComponent.new form: @form,
+        <%= edit_field_wrapper field: @field, index: @index, form: @form, resource: @resource, displayed_in_modal: @displayed_in_modal, label: type.to_s.underscore.humanize do %>
+          <% if @field.searchable %>
+            <%= render Avo::Fields::BelongsToField::AutocompleteComponent.new form: @form,
             field: @field,
             type: type,
             model_key: model_keys[type.to_s],
@@ -49,8 +48,8 @@
             disabled: disabled,
             polymorphic_record: polymorphic_record
           %>
-        <% else %>
-          <%= @form.select @field.id_input_foreign_key,
+          <% else %>
+            <%= @form.select @field.id_input_foreign_key,
             options_for_select(@field.values_for_type(type), @resource.present? && @resource.model.present? ? @resource.model[@field.id_input_foreign_key] : nil),
             {
               value: @resource.model[@field.id_input_foreign_key].to_s,
@@ -61,17 +60,17 @@
               disabled: disabled
             }
           %>
-          <%
+            <%
             # If the select field is disabled, no value will be sent. It's how HTML works.
             # Thus the extra hidden field to actually send the related id to the server.
             if disabled %>
               <%= @form.hidden_field @field.id_input_foreign_key %>
             <% end %>
+          <% end %>
         <% end %>
-      <% end %>
-    </div>
-  <% end %>
-</div>
+      </div>
+    <% end %>
+  </div>
 <% else %>
   <%= edit_field_wrapper field: @field, index: @index, form: @form, resource: @resource, displayed_in_modal: @displayed_in_modal do %>
     <% if @field.searchable %>

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -90,7 +90,7 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
     if @reflection.present?
       args = {
         via_relation_class: reflection_model_class,
-        via_resource_id: @parent_model.id,
+        via_resource_id: @parent_model.id
       }
 
       if @reflection.is_a? ActiveRecord::Reflection::ThroughReflection
@@ -126,7 +126,12 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
   end
 
   def description
-    return if @reflection.present?
+    # If this is a has many association, the user can pass a description to be shown just for this association.
+    if @reflection.present?
+      return field.description if field.present? && field.description
+
+      return
+    end
 
     @resource.resource_description
   end

--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -21,7 +21,7 @@ module Avo
       @association_field = @parent_resource.get_field params[:related_name]
 
       if @association_field.present? && @association_field.scope.present?
-        @query = @query.instance_exec(&@association_field.scope)
+        @query = Avo::Hosts::AssociationScopeHost.new(block: @association_field.scope, query: @query, parent: @parent_model).handle
       end
 
       super
@@ -44,6 +44,11 @@ module Avo
 
       if @field.present? && !@field.searchable
         query = @authorization.apply_policy @attachment_class
+
+        # Add the association scope to the query scope
+        if @field.scope.present?
+          query = Avo::Hosts::AssociationScopeHost.new(block: @field.scope, query: query, parent: @model).handle
+        end
 
         @options = query.all.map do |model|
           [model.send(@attachment_resource.class.title), model.id]

--- a/app/helpers/avo/url_helpers.rb
+++ b/app/helpers/avo/url_helpers.rb
@@ -75,7 +75,7 @@ module Avo
       rescue
       end
 
-      avo.resources_associations_index_path(@parent_resource.model_class.model_name.route_key, @parent_resource.model.id, **existing_params, **args )
+      avo.resources_associations_index_path(@parent_resource.model_class.model_name.route_key, @parent_resource.model.id, **existing_params, **args)
     end
 
     def order_up_resource_path(model:, resource:, **args)

--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -68,8 +68,15 @@ export default class extends Controller {
     }
 
     if (this.isBelongsToSearch) {
-      // eslint-disable-next-line camelcase
-      params = { ...params, via_association: this.dataset.viaAssociation }
+      params = {
+        ...params,
+        // eslint-disable-next-line camelcase
+        via_association_id: this.dataset.viaAssociationId,
+        // eslint-disable-next-line camelcase
+        via_reflection_class: this.dataset.viaReflectionClass,
+        // eslint-disable-next-line camelcase
+        via_reflection_id: this.dataset.viaReflectionId,
+      }
     }
 
     return url.segment(segments).search(params).toString()

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -62,6 +62,8 @@ module Avo
       attr_reader :relation_method
       attr_reader :types # for Polymorphic associations
       attr_reader :allow_via_detaching
+      attr_reader :scope
+      attr_reader :polymorphic_help
 
       def initialize(id, **args, &block)
         args[:placeholder] ||= I18n.t("avo.choose_an_option")
@@ -73,6 +75,8 @@ module Avo
         @types = args[:types]
         @relation_method = id.to_s.parameterize.underscore
         @allow_via_detaching = args[:allow_via_detaching] == true
+        @scope = args[:scope]
+        @polymorphic_help = args[:polymorphic_help]
       end
 
       def searchable
@@ -111,7 +115,13 @@ module Avo
         resource = target_resource
         resource = App.get_resource_by_model_name model if model.present?
 
-        ::Avo::Services::AuthorizationService.apply_policy(user, resource.class.query_scope).all.map do |model|
+        query = Avo::Services::AuthorizationService.apply_policy(user, resource.class.query_scope)
+
+        if scope.present?
+          query = Avo::Hosts::AssociationScopeHost.new(block: scope, query: query, parent: get_model).handle
+        end
+
+        query.all.map do |model|
           [model.send(resource.class.title), model.id]
         end
       end

--- a/lib/avo/fields/has_base_field.rb
+++ b/lib/avo/fields/has_base_field.rb
@@ -3,6 +3,7 @@ module Avo
     class HasBaseField < BaseField
       attr_accessor :display
       attr_accessor :scope
+      attr_accessor :description
 
       def initialize(id, **args, &block)
         super(id, **args, &block)
@@ -10,6 +11,7 @@ module Avo
         @scope = args[:scope].present? ? args[:scope] : nil
         @display = args[:display].present? ? args[:display] : :show
         @searchable = args[:searchable] == true
+        @description = args[:description]
       end
 
       def searchable

--- a/lib/avo/hosts/association_scope_host.rb
+++ b/lib/avo/hosts/association_scope_host.rb
@@ -1,0 +1,8 @@
+module Avo
+  module Hosts
+    class AssociationScopeHost < BaseHost
+      option :parent
+      option :query
+    end
+  end
+end

--- a/lib/avo/services/authorization_service.rb
+++ b/lib/avo/services/authorization_service.rb
@@ -71,13 +71,13 @@ module Avo
           # If no action passed we should raise error if the user wants that.
           # If not, just allow it.
           if action.nil?
-            raise Pundit::NotDefinedError.new 'Policy method is missing' if Avo.configuration.raise_error_on_missing_policy
+            raise Pundit::NotDefinedError.new "Policy method is missing" if Avo.configuration.raise_error_on_missing_policy
 
             return true
           end
 
           # Add the question mark if it's missing
-          action = "#{action}?" unless action.end_with? '?'
+          action = "#{action}?" unless action.end_with? "?"
 
           authorize user, record, action, **args
         end
@@ -110,14 +110,12 @@ module Avo
         end
 
         def defined_methods(user, record, **args)
-          begin
-            Pundit.policy!(user, record).methods
-          rescue => error
-            if args[:raise_exception] == false
-              []
-            else
-              raise error
-            end
+          Pundit.policy!(user, record).methods
+        rescue => error
+          if args[:raise_exception] == false
+            []
+          else
+            raise error
           end
         end
       end

--- a/spec/dummy/app/avo/resources/comment_resource.rb
+++ b/spec/dummy/app/avo/resources/comment_resource.rb
@@ -13,6 +13,22 @@ class CommentResource < Avo::BaseResource
   field :body, as: :textarea
   field :tiny_name, as: :text, only_on: :index, as_description: true
 
-  field :user, as: :belongs_to
-  field :commentable, as: :belongs_to, polymorphic_as: :commentable, types: [::Post, ::Project]
+  field :user, as: :belongs_to, scope: -> do
+    # For the parent record with ID 1 we'll apply this rule.
+    # This is for testing purposes only. Just to show that it's possbile.
+    if parent.present? && parent.id == 1 && params[:like].present?
+      query.where("lower(first_name) like ?", "%#{params[:like]}%")
+    else
+      query
+    end
+  end
+  field :commentable, as: :belongs_to, polymorphic_as: :commentable, types: [::Post, ::Project], scope: -> do
+    # For the parent record with ID 1 we'll apply this rule.
+    # This is for testing purposes only. Just to show that it's possbile.
+    if parent.present? && parent.id == 1 && params[:like].present?
+      query.where("lower(name) like ?", "%#{params[:like]}%")
+    else
+      query
+    end
+  end
 end

--- a/spec/dummy/app/avo/resources/comment_resource.rb
+++ b/spec/dummy/app/avo/resources/comment_resource.rb
@@ -13,22 +13,6 @@ class CommentResource < Avo::BaseResource
   field :body, as: :textarea
   field :tiny_name, as: :text, only_on: :index, as_description: true
 
-  field :user, as: :belongs_to, scope: -> do
-    # For the parent record with ID 1 we'll apply this rule.
-    # This is for testing purposes only. Just to show that it's possbile.
-    if parent.present? && parent.id == 1 && params[:like].present?
-      query.where("lower(first_name) like ?", "%#{params[:like]}%")
-    else
-      query
-    end
-  end
-  field :commentable, as: :belongs_to, polymorphic_as: :commentable, types: [::Post, ::Project], scope: -> do
-    # For the parent record with ID 1 we'll apply this rule.
-    # This is for testing purposes only. Just to show that it's possbile.
-    if parent.present? && parent.id == 1 && params[:like].present?
-      query.where("lower(name) like ?", "%#{params[:like]}%")
-    else
-      query
-    end
-  end
+  field :user, as: :belongs_to
+  field :commentable, as: :belongs_to, polymorphic_as: :commentable, types: [::Post, ::Project]
 end

--- a/spec/dummy/app/avo/resources/review_resource.rb
+++ b/spec/dummy/app/avo/resources/review_resource.rb
@@ -13,6 +13,30 @@ class ReviewResource < Avo::BaseResource
     ""
   end
 
-  field :user, as: :belongs_to, searchable: true, allow_via_detaching: true
-  field :reviewable, as: :belongs_to, polymorphic_as: :reviewable, types: [::Fish, ::Post, ::Project, ::Team], searchable: true, allow_via_detaching: true
+  field :user, as: :belongs_to, searchable: true, allow_via_detaching: true, scope: -> do
+    # For the parent record with ID 1 we'll apply this rule.
+    # This is for testing purposes only. Just to show that it's possbile.
+    if parent.present? && parent.id == 1
+      query.admins
+    else
+      query
+    end
+  end, help: "For the review with the ID of 1 only admin users will be displayed."
+  field :reviewable,
+    as: :belongs_to,
+    polymorphic_as: :reviewable,
+    types: [::Fish, ::Post, ::Project, ::Team],
+    searchable: true,
+    allow_via_detaching: true,
+    scope: -> do
+      # For the parent record with ID 1 we'll apply this rule.
+      # This is for testing purposes only. Just to show that it's possbile.
+      if parent.present? && parent.id == 1
+        query.where("lower(name) like ?", "%#{params[:like]}%")
+      else
+        query
+      end
+    end,
+    polymorphic_help: "Select the polymorphic type",
+    help: "For the review with the ID of 1 the scope is modified. Please check the code under <code>review_resource.rb</code>"
 end

--- a/spec/dummy/app/avo/resources/review_resource.rb
+++ b/spec/dummy/app/avo/resources/review_resource.rb
@@ -32,7 +32,7 @@ class ReviewResource < Avo::BaseResource
       # For the parent record with ID 1 we'll apply this rule.
       # This is for testing purposes only. Just to show that it's possbile.
       if parent.present? && parent.id == 1
-        query.where("lower(name) like ?", "%#{params[:like]}%")
+        query.where("lower(name) like ?", "%#{parent.body[0].downcase}%")
       else
         query
       end

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -53,7 +53,10 @@ class UserResource < Avo::BaseResource
   field :teams, as: :has_and_belongs_to_many
   field :people, as: :has_many, translation_key: "avo.field_translations.people"
   field :spouses, as: :has_many # STI has_many resource
-  field :comments, as: :has_many, scope: -> { query.starts_with parent.first_name[0].downcase }, description: "The comments listed in the attach modal all start with the name of the parent user."
+  field :comments,
+    as: :has_many,
+    scope: -> { query.starts_with parent.first_name[0].downcase },
+    description: "The comments listed in the attach modal all start with the name of the parent user."
   field :projects, as: :has_and_belongs_to_many
 
   grid do

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -53,7 +53,7 @@ class UserResource < Avo::BaseResource
   field :teams, as: :has_and_belongs_to_many
   field :people, as: :has_many, translation_key: "avo.field_translations.people"
   field :spouses, as: :has_many # STI has_many resource
-  field :comments, as: :has_many, scope: -> { starts_with :a }
+  field :comments, as: :has_many, scope: -> { query.starts_with parent.first_name[0].downcase }, description: "The comments listed in the attach modal all start with the name of the parent user."
   field :projects, as: :has_and_belongs_to_many
 
   grid do

--- a/spec/features/avo/belongs_to_spec.rb
+++ b/spec/features/avo/belongs_to_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature "belongs_to", type: :feature do
   end
 
   describe "hidden columns if current association" do
-    let!(:user) { create :user }
+    let!(:user) { create :user, first_name: "Alicia" }
     let!(:comment) { create :comment, body: "a comment", user: user }
 
     it "hides the User column" do

--- a/spec/features/avo/has_many_field_spec.rb
+++ b/spec/features/avo/has_many_field_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "HasManyField", type: :feature do
-  let!(:user) { create :user }
+  let!(:user) { create :user, first_name: "Alicia" }
 
   subject do
     visit url

--- a/spec/features/avo/record_passed_to_scope_spec.rb
+++ b/spec/features/avo/record_passed_to_scope_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.feature Avo::SearchController, type: :controller do
   let!(:user) { create :user }
   let!(:admin) { create :user, roles: {admin: true} }
-  let!(:team) { create :team, name: "Ruby" }
-  let!(:java_team) { create :team, name: "Java" }
-  let!(:review) { create :review, id: 1, user: user, reviewable: team }
+  let!(:team) { create :team, name: "Hershey" }
+  let!(:java_team) { create :team, name: "Snickers" }
+  let!(:review) { create :review, body: "Hello", id: 1, user: user, reviewable: team }
 
   it "returns only the admins" do
     get :show, params: {
@@ -19,17 +19,16 @@ RSpec.feature Avo::SearchController, type: :controller do
     expect(json["users"]["results"].first["_id"]).to eq admin.id
   end
 
-  it "returns only the ones requested in the query" do
+  it "returns only the team that starts with the letter H" do
     get :show, params: {
       resource_name: "teams",
       via_association_id: "reviewable",
       via_reflection_class: "Review",
-      via_reflection_id: 1,
-      like: "ru"
+      via_reflection_id: 1
     }
 
     expect(json["teams"]["results"].count).to eq 1
     expect(json["teams"]["results"].first["_id"]).to eq team.id
-    expect(json["teams"]["results"].first["_label"]).to eq 'Ruby'
+    expect(json["teams"]["results"].first["_label"]).to eq "Hershey"
   end
 end

--- a/spec/features/avo/record_passed_to_scope_spec.rb
+++ b/spec/features/avo/record_passed_to_scope_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.feature Avo::SearchController, type: :controller do
+  let!(:user) { create :user }
+  let!(:admin) { create :user, roles: {admin: true} }
+  let!(:team) { create :team, name: "Ruby" }
+  let!(:java_team) { create :team, name: "Java" }
+  let!(:review) { create :review, id: 1, user: user, reviewable: team }
+
+  it "returns only the admins" do
+    get :show, params: {
+      resource_name: "users",
+      via_association_id: "user",
+      via_reflection_class: "Review",
+      via_reflection_id: 1
+    }
+
+    expect(json["users"]["results"].count).to eq 1
+    expect(json["users"]["results"].first["_id"]).to eq admin.id
+  end
+
+  it "returns only the ones requested in the query" do
+    get :show, params: {
+      resource_name: "teams",
+      via_association_id: "reviewable",
+      via_reflection_class: "Review",
+      via_reflection_id: 1,
+      like: "ru"
+    }
+
+    expect(json["teams"]["results"].count).to eq 1
+    expect(json["teams"]["results"].first["_id"]).to eq team.id
+    expect(json["teams"]["results"].first["_label"]).to eq 'Ruby'
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This empowers the scope for associations by providing access to the `parent` record.

[Docs](https://docs.avohq.io/2.0/associations.html#add-scopes-to-associations)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to the review with the id of 1
2. update the body to start with the letter A
3. create a team that contains the letter A
4. create a team that doesn't contain the letter A
5. go back to that review (1)
6. search for teams
7. only the team that contains the letter A should show up in the search

Manual reviewer: please leave a comment with output from the test if that's the case.
