### PR TITLE
feature: attach_scope for associations

### DIFF
--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -46,8 +46,8 @@ module Avo
         query = @authorization.apply_policy @attachment_class
 
         # Add the association scope to the query scope
-        if @field.scope.present?
-          query = Avo::Hosts::AssociationScopeHost.new(block: @field.scope, query: query, parent: @model).handle
+        if @field.attach_scope.present?
+          query = Avo::Hosts::AssociationScopeHost.new(block: @field.attach_scope, query: query, parent: @model).handle
         end
 
         @options = query.all.map do |model|

--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -51,12 +51,12 @@ module Avo
         # Fetch the field
         field = belongs_to_field
 
-        if field.scope.present?
+        if field.attach_scope.present?
           # Fetch the parent
           parent = params[:via_reflection_class].safe_constantize.find params[:via_reflection_id]
 
           # Add to the query
-          query = Avo::Hosts::AssociationScopeHost.new(block: belongs_to_field.scope, query: query, parent: parent).handle
+          query = Avo::Hosts::AssociationScopeHost.new(block: belongs_to_field.attach_scope, query: query, parent: parent).handle
         end
       end
 

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -62,7 +62,7 @@ module Avo
       attr_reader :relation_method
       attr_reader :types # for Polymorphic associations
       attr_reader :allow_via_detaching
-      attr_reader :scope
+      attr_reader :attach_scope
       attr_reader :polymorphic_help
 
       def initialize(id, **args, &block)
@@ -75,7 +75,7 @@ module Avo
         @types = args[:types]
         @relation_method = id.to_s.parameterize.underscore
         @allow_via_detaching = args[:allow_via_detaching] == true
-        @scope = args[:scope]
+        @attach_scope = args[:attach_scope]
         @polymorphic_help = args[:polymorphic_help]
       end
 

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -117,8 +117,8 @@ module Avo
 
         query = Avo::Services::AuthorizationService.apply_policy(user, resource.class.query_scope)
 
-        if scope.present?
-          query = Avo::Hosts::AssociationScopeHost.new(block: scope, query: query, parent: get_model).handle
+        if attach_scope.present?
+          query = Avo::Hosts::AssociationScopeHost.new(block: attach_scope, query: query, parent: get_model).handle
         end
 
         query.all.map do |model|

--- a/lib/avo/fields/has_base_field.rb
+++ b/lib/avo/fields/has_base_field.rb
@@ -3,12 +3,14 @@ module Avo
     class HasBaseField < BaseField
       attr_accessor :display
       attr_accessor :scope
+      attr_accessor :attach_scope
       attr_accessor :description
 
       def initialize(id, **args, &block)
         super(id, **args, &block)
 
         @scope = args[:scope].present? ? args[:scope] : nil
+        @attach_scope = args[:attach_scope].present? ? args[:attach_scope] : nil
         @display = args[:display].present? ? args[:display] : :show
         @searchable = args[:searchable] == true
         @description = args[:description]

--- a/spec/dummy/app/avo/resources/post_resource.rb
+++ b/spec/dummy/app/avo/resources/post_resource.rb
@@ -4,7 +4,7 @@ class PostResource < Avo::BaseResource
     scope.ransack(id_eq: params[:q], name_cont: params[:q], body_cont: params[:q], m: "or").result(distinct: false)
   end
   self.search_query_help = "- search by id, name or body"
-  self.includes = [:user, cover_photo_attachment: :blob, audio_attachment: :blob]
+  self.includes = [:user]
   self.default_view_type = :grid
 
   field :id, as: :id

--- a/spec/dummy/app/avo/resources/review_resource.rb
+++ b/spec/dummy/app/avo/resources/review_resource.rb
@@ -13,22 +13,27 @@ class ReviewResource < Avo::BaseResource
     ""
   end
 
-  field :user, as: :belongs_to, searchable: true, allow_via_detaching: true, scope: -> do
-    # For the parent record with ID 1 we'll apply this rule.
-    # This is for testing purposes only. Just to show that it's possbile.
-    if parent.present? && parent.id == 1
-      query.admins
-    else
-      query
+  field :user,
+    as: :belongs_to,
+    searchable: true,
+    allow_via_detaching: true,
+    help: "For the review with the ID of 1 only admin users will be displayed.",
+    attach_scope: -> do
+      # For the parent record with ID 1 we'll apply this rule.
+      # This is for testing purposes only. Just to show that it's possbile.
+      if parent.present? && parent.id == 1
+        query.admins
+      else
+        query
+      end
     end
-  end, help: "For the review with the ID of 1 only admin users will be displayed."
   field :reviewable,
     as: :belongs_to,
     polymorphic_as: :reviewable,
     types: [::Fish, ::Post, ::Project, ::Team],
     searchable: true,
     allow_via_detaching: true,
-    scope: -> do
+    attach_scope: -> do
       # For the parent record with ID 1 we'll apply this rule.
       # This is for testing purposes only. Just to show that it's possbile.
       if parent.present? && parent.id == 1

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -49,7 +49,9 @@ class UserResource < Avo::BaseResource
   end
 
   field :post, as: :has_one, translation_key: "avo.field_translations.people"
-  field :posts, as: :has_many
+  field :posts,
+    as: :has_many,
+    attach_scope: -> { query.where.not(user_id: parent.id).or(query.where(user_id: nil)) }
   field :teams, as: :has_and_belongs_to_many
   field :people, as: :has_many, translation_key: "avo.field_translations.people"
   field :spouses, as: :has_many # STI has_many resource

--- a/spec/dummy/app/models/project.rb
+++ b/spec/dummy/app/models/project.rb
@@ -17,7 +17,7 @@
 #  progress       :integer
 #
 class Project < ApplicationRecord
-  enum stage: {'Discovery': "discovery", 'Idea': "idea", 'Done': "done", 'On hold': "on hold", 'Cancelled': "cancelled"}
+  enum stage: {Discovery: "discovery", Idea: "idea", Done: "done", 'On hold': "on hold", Cancelled: "cancelled"}
 
   validates :name, presence: true
   validates :users_required, numericality: {greater_than: 9, less_than: 1000000}

--- a/spec/features/avo/has_many_attach_scope_spec.rb
+++ b/spec/features/avo/has_many_attach_scope_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.feature "HasManyAttachScopes", type: :feature do
+  let!(:user) { create :user }
+  let!(:post) { create :post, user_id: user.id}
+  let!(:post_2) { create :post}
+
+  it "filters out the current selection" do
+    visit "/admin/resources/users/#{user.id}/posts/new"
+
+    expect(page).to have_select "fields[related_id]", options: ["Choose an option", post_2.name]
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR introduces a new scope for the association attach screen. It also changes the `belongs_to` option from `scope` to `attach_scope`.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to a user
2. Click on attach post
3. attach one post
4. attach another
5. check that the initial post is not present in the list anymore

Manual reviewer: please leave a comment with output from the test if that's the case.
