### PR TITLE
feature: live resources

### DIFF
--- a/app/components/avo/turbo_frame_wrapper_component.html.erb
+++ b/app/components/avo/turbo_frame_wrapper_component.html.erb
@@ -1,4 +1,4 @@
-<% if name.present? %><turbo-frame id="<%= name %>"><% end %>
+<% if name.present? %><turbo-frame id="<%= name %>" <%= "target=\"#{target}\"" if target.present? %>><% end %>
 <%
   # When rendering the frames the flashed content gets lost.
   # We're appending it back if it's a turbo_frame_request.

--- a/app/components/avo/turbo_frame_wrapper_component.rb
+++ b/app/components/avo/turbo_frame_wrapper_component.rb
@@ -2,8 +2,10 @@
 
 class Avo::TurboFrameWrapperComponent < ViewComponent::Base
   attr_reader :name
+  attr_reader :target
 
-  def initialize(name = nil)
+  def initialize(name = nil, target: nil)
     @name = name
+    @target = target
   end
 end

--- a/app/components/avo/views/resource_show_component.html.erb
+++ b/app/components/avo/views/resource_show_component.html.erb
@@ -1,4 +1,12 @@
-<div data-model-id="<%= @resource.model.id %>"
+  <%#= AvoChannel.broadcasting_for([@resource.class, @resource.model_id].join(":")) %>
+  <div>
+  <%# data-resource-view-value="<%#= @resource.view %" %>
+<div
+  data-controller="resource"
+  data-resource-channel-name-value="ResourceShowChannel"
+  data-resource-resource-name-value="<%= @resource.class %>"
+  data-resource-resource-id-value="<%= @resource.model_id %>"
+  data-model-id="<%= @resource.model.id %>"
   data-selected-resources-name="<%= @resource.model_key %>"
   data-selected-resources='["<%= @resource.model.id %>"]'
   class="space-y-8"
@@ -94,4 +102,5 @@
       </template>
     </turbo-stream>
   <% end %>
+</div>
 </div>

--- a/app/controllers/avo/home_controller.rb
+++ b/app/controllers/avo/home_controller.rb
@@ -12,6 +12,19 @@ module Avo
       end
     end
 
+    def hey
+      t = ResourceChannel.broadcast_to "bestd:1", body: "This Room is Best Room."
+      # puts ["in hey->", t].inspect
+      render plain: "ok"
+      # Turbo::StreamsChannel.broadcast_replace_to "resource:1:1", target: "hehe" do
+      #   'something'
+      # end
+
+        # render turbo_stream: turbo_stream.replace('hehe', 'hoho')
+        # format.html         { redirect_to messages_url }
+      # end
+    end
+
     def failed_to_load
     end
   end

--- a/app/helpers/avo/application_helper.rb
+++ b/app/helpers/avo/application_helper.rb
@@ -20,8 +20,8 @@ module Avo
       render Avo::EmptyStateComponent.new **args
     end
 
-    def turbo_frame_wrap(name, &block)
-      render Avo::TurboFrameWrapperComponent.new name do
+    def turbo_frame_wrap(name, **args, &block)
+      render Avo::TurboFrameWrapperComponent.new name, **args do
         capture(&block)
       end
     end

--- a/app/javascript/action_cable.js
+++ b/app/javascript/action_cable.js
@@ -1,0 +1,12 @@
+import { createConsumer } from '@rails/actioncable'
+
+// eslint-disable-next-line import/no-mutable-exports
+let consumer
+
+if (window.Avo.configuration.action_cable.enabled) {
+  consumer = createConsumer()
+
+  window.Avo.consumer = consumer
+}
+
+export default consumer

--- a/app/javascript/avo.js
+++ b/app/javascript/avo.js
@@ -13,18 +13,13 @@ import 'chartkick/chart.js/chart.esm'
 // Toastr alerts
 import './js/active-storage'
 import './js/controllers'
+import { reloadPage, restoreScrollTop } from './js/page_reloader'
 
 Rails.start()
 
 window.Turbolinks = Turbo
 
-let scrollTop = null
-Mousetrap.bind('r r r', () => {
-  // Cpture scroll position
-  scrollTop = document.scrollingElement.scrollTop
-
-  Turbo.visit(window.location.href, { action: 'replace' })
-})
+Mousetrap.bind('r r r', reloadPage)
 
 function isMac() {
   const isMac = window.navigator.userAgent.indexOf('Mac OS X')
@@ -58,13 +53,15 @@ document.addEventListener('turbo:load', () => {
   initTippy()
   isMac()
 
+  console.log(1, restoreScrollTop())
+
   // Restore scroll position after r r r turbo reload
-  if (scrollTop) {
-    setTimeout(() => {
-      document.scrollingElement.scrollTo(0, scrollTop)
-      scrollTop = 0
-    }, 50)
-  }
+  // if (scrollTop) {
+  //   setTimeout(() => {
+  //     document.scrollingElement.scrollTo(0, scrollTop)
+  //     scrollTop = 0
+  //   }, 50)
+  // }
 })
 
 document.addEventListener('turbo:frame-load', () => {
@@ -82,10 +79,15 @@ document.addEventListener('turbo:visit', () => document.body.classList.add('turb
 document.addEventListener('turbo:submit-start', () => document.body.classList.add('turbo-loading'))
 document.addEventListener('turbo:submit-end', () => document.body.classList.remove('turbo-loading'))
 document.addEventListener('turbo:before-cache', () => {
-  document.querySelectorAll('[data-turbo-remove-before-cache]').forEach((element) => element.remove())
+  document
+    .querySelectorAll('[data-turbo-remove-before-cache]')
+    .forEach((element) => element.remove())
 })
 
 window.Avo = window.Avo || { configuration: {} }
+
+// eslint-disable-next-line import/first
+import './action_cable'
 
 window.Avo.menus = {
   resetCollapsedState() {
@@ -97,3 +99,8 @@ window.Avo.menus = {
       })
   },
 }
+
+// // app/javascript/channels/appearance_channel.js
+// import consumer from "./consumer"
+
+// consumer.subscriptions.create({ channel: "AppearanceChannel" })

--- a/app/javascript/js/controllers.js
+++ b/app/javascript/js/controllers.js
@@ -20,6 +20,7 @@ import MobileController from './controllers/mobile_controller'
 import ModalController from './controllers/modal_controller'
 import MultipleSelectFilterController from './controllers/multiple_select_filter_controller'
 import PerPageController from './controllers/per_page_controller'
+import ResourceController from './controllers/resource_controller'
 import SearchController from './controllers/search_controller'
 import SelectController from './controllers/select_controller'
 import SelectFilterController from './controllers/select_filter_controller'
@@ -45,6 +46,7 @@ application.register('mobile', MobileController)
 application.register('modal', ModalController)
 application.register('multiple-select-filter', MultipleSelectFilterController)
 application.register('per-page', PerPageController)
+application.register('resource', ResourceController)
 application.register('search', SearchController)
 application.register('select', SelectController)
 application.register('select-filter', SelectFilterController)

--- a/app/javascript/js/controllers/resource_controller.js
+++ b/app/javascript/js/controllers/resource_controller.js
@@ -1,0 +1,111 @@
+/* eslint-disable camelcase */
+import { Controller } from '@hotwired/stimulus'
+import URI from 'urijs'
+// import { reloadPage } from '../page_reloader'
+
+export default class extends Controller {
+  // static targets = ['element']
+  static values = {
+    resourceName: String,
+    resourceId: String,
+    view: String,
+    channelName: String,
+  }
+
+  get consumer() {
+    return window.Avo.consumer
+  }
+
+  connect() {
+    console.log('resource_controller', this.context.element, this.resourceNameValue, this.consumer, this.viewValue)
+    if (this.consumer) {
+      this.listen()
+    }
+  }
+
+  listen() {
+    const vm = this
+    this.consumer.subscriptions.create(
+      {
+        channel: this.channelNameValue,
+        resource_name: this.resourceNameValue,
+        resource_id: this.resourceIdValue,
+      },
+      {
+        received(data) {
+          // console.log('received->', data)
+          const { action } = data
+          if (action === 'reload') {
+            console.log('reloadingg->', this)
+            vm.reloadPage()
+          }
+        // this.appendLine(data)
+        },
+      },
+    )
+    // this.consumer.subscriptions.create(
+    //   {
+    //     channel: 'AvoChannel',
+    //     resource_name: this.resourceNameValue,
+    //     resource_id: this.resourceIdValue,
+    //   },
+    //   {
+    //     received(data) {
+    //       console.log('received->', data)
+    //       const { action } = data
+    //       if (action === 'reload') {
+    //         console.log('reloadingg->')
+    //       }
+    //     // this.appendLine(data)
+    //     },
+    //   },
+    // )
+  }
+
+  // We can't wrap the resource show component in a turbo frame because it will hijack the links inside to only feel this frame
+  // So we try to trick it.
+  // We'll create a turbo-frame element with this url as the src.
+  // This will trigger a reload and the record will be refreshed.
+  // In the last step we'll reverse the process.
+  reloadPage() {
+    // create a new turbo-frame element
+    const frame = this.element.parentElement
+
+    const frameId = 'resource_show'
+
+    const src = URI(window.location.href).search({ turbo_frame: frameId })
+    const frameSrc = src.toString()
+
+    frame.id = frameId
+    frame.src = frameSrc
+    // frame.src = 'window.location.href?#{}'
+    // console.log('this->', src, src.toString())
+
+    // add an empty element inside
+    const span = document.createElement('span')
+
+    // add the empty element in the frame
+    frame.appendChild(span)
+
+    // add the frame before the resource show component
+    this.element.parentElement.insertBefore(frame, this.element)
+
+    // replace the dummy element with the contents of the component
+    span.replaceWith(this.element)
+
+    // revert the changes and remove the turbo-frame
+
+    function frameRenderCallback(e) {
+      console.log('e->', e, e.srcElement.id, e.srcElement.src)
+      if (e.srcElement.id === frameId && e.srcElement.src === frameSrc) {
+        console.log('it is')
+        frame.parentElement.insertBefore(frame, this.element)
+      }
+      document.removeEventListener('turbo:frame-render', frameRenderCallback)
+    }
+    document.addEventListener('turbo:frame-render', frameRenderCallback)
+    // frame.remove()
+
+    // console.log('this.element->', this.element, frame)
+  }
+}

--- a/app/javascript/js/page_reloader.js
+++ b/app/javascript/js/page_reloader.js
@@ -1,0 +1,28 @@
+import { Turbo } from '@hotwired/turbo-rails'
+
+window.scrollTop ||= null
+
+const restoreScrollTop = () => {
+  // document.addEventListener('turbo:load', () => {
+  console.log('scrollTop->', window.scrollTop)
+  // Restore scroll position after r r r turbo reload
+  if (window.scrollTop) {
+    setTimeout(() => {
+      console.log('window.scrollTop in settimeout->', window.scrollTop)
+      document.scrollingElement.scrollTo(0, 100)
+      // window.scrollTop = null
+    }, 50)
+  }
+  // })
+}
+
+const reloadPage = () => {
+  console.log('reloadPage->', window.scrollTop)
+  // Cpture scroll position
+  window.scrollTop = document.scrollingElement.scrollTop
+  console.log('reloadPage2->', window.scrollTop)
+
+  Turbo.visit(window.location.href, { action: 'replace' })
+}
+
+export { reloadPage, restoreScrollTop }

--- a/app/views/avo/base/show.html.erb
+++ b/app/views/avo/base/show.html.erb
@@ -1,3 +1,6 @@
+<%#= turbo_frame_wrap(params[:turbo_frame] || 'resource_show', target: "_top") do %>
 <%= turbo_frame_wrap(params[:turbo_frame]) do %>
+  <turbo-frame>
   <%= render Avo::Views::ResourceShowComponent.new(resource: @resource, reflection: @reflection, actions: @actions) %>
+  </turbo-frame>
 <% end %>

--- a/app/views/avo/partials/_javascript.html.erb
+++ b/app/views/avo/partials/_javascript.html.erb
@@ -2,5 +2,8 @@
   window.Avo = window.Avo || { configuration: {} }
   Avo.configuration.timezone = '<%= Avo.configuration.timezone %>'
   Avo.configuration.root_path = '<%= Avo::App.root_path %>'
+  Avo.configuration.action_cable = {
+    enabled: <%= Avo.configuration.action_cable[:enabled] %>
+  }
   Avo.configuration.search_debounce = '<%= Avo.configuration.search_debounce %>'
 <% end %>

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -97,6 +97,25 @@ module Avo
 
         ordering.dig(:actions) || {}
       end
+
+      def reload_resource(id: nil)
+        puts ["reload_resource->"].inspect
+        if id.present?
+          # , self, id, ResourceShowChannel.broadcasting_for([self, id].join(":"))
+          # tag = ResourceShowChannel.broadcasting_for [:resource, self, id].join(":")
+          # tag = [:resource, self, id].join(":")
+          tag = [self, id].join(":")
+          puts ["tag->", tag].inspect
+          # AvoChannel.broadcast_to "#{self.to_s}:#{id}", action: :reload
+          ResourceShowChannel.broadcast_to tag, action: :reload, params: {
+            foo: 'bar'
+          }
+        end
+      end
+    end
+
+    def turbo_tag
+      "resource:#{self.class}:#{model_id}"
     end
 
     def initialize

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -32,6 +32,7 @@ module Avo
     attr_accessor :buttons_on_form_footers
     attr_accessor :main_menu
     attr_accessor :profile_menu
+    attr_accessor :action_cable
 
     def initialize
       @root_path = "/avo"
@@ -76,6 +77,9 @@ module Avo
       @buttons_on_form_footers = false
       @main_menu = nil
       @profile_menu = nil
+      @action_cable = {
+        enabled: false
+      }
     end
 
     def locale_tag

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@hotwired/stimulus": "^3.0.1",
     "@hotwired/turbo-rails": "^7.1.1",
+    "@rails/actioncable": "^7.0.2-4",
     "@rails/activestorage": "^6.0.2-1",
     "@rails/ujs": "^6.1.0",
     "@stimulus/mutation-observers": "^2.0.0",

--- a/spec/dummy/app/channels/application_cable/connection.rb
+++ b/spec/dummy/app/channels/application_cable/connection.rb
@@ -1,4 +1,19 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    protected
+
+    def find_verified_user
+      if (current_user = env["warden"].user(:user))
+        current_user
+      else
+        reject_unauthorized_connection
+      end
+    end
   end
 end

--- a/spec/dummy/app/channels/avo_channel.rb
+++ b/spec/dummy/app/channels/avo_channel.rb
@@ -1,0 +1,7 @@
+class AvoChannel < ApplicationCable::Channel
+  def subscribed
+    # puts ["self->", "#{params[:id]}:#{current_user.id}"].inspect
+    # stream_from "avo:#{params[:resource_name]}:#{params[:resource_id]}"
+    stream_from "avo"
+  end
+end

--- a/spec/dummy/app/channels/resource_show_channel.rb
+++ b/spec/dummy/app/channels/resource_show_channel.rb
@@ -1,0 +1,11 @@
+class ResourceShowChannel < ApplicationCable::Channel
+  def subscribed
+    # puts ["self->", "#{params[:id]}:#{current_user.id}"].inspect
+    # stream_from "avo:#{params[:resource_name]}:#{params[:resource_id]}"
+    tag = "resource_show:#{params[:resource_name]}:#{params[:resource_id]}"
+    puts ["tag subscribed->", tag].inspect
+    stream_from tag
+    # stream_from "resource:#{params[]}"
+    # stream_from "ResourceShow"
+  end
+end

--- a/spec/dummy/app/controllers/home_controller.rb
+++ b/spec/dummy/app/controllers/home_controller.rb
@@ -1,4 +1,10 @@
 class HomeController < ApplicationController
   def index
   end
+
+  def trigger_course_update
+    CourseResource.reload_resource id: 280
+
+    render plain: :ok
+  end
 end

--- a/spec/dummy/config/cable.yml
+++ b/spec/dummy/config/cable.yml
@@ -1,5 +1,6 @@
 development:
-  adapter: async
+  adapter: redis
+  url: redis://localhost:6379/1
 
 test:
   adapter: test

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -69,4 +69,14 @@ Avo.configure do |config|
   config.profile_menu = -> {
     link "Profile", path: "/profile", icon: "user-circle"
   }
+
+  config.action_cable = {
+    enabled: true
+  }
 end
+
+# Course.after_save_commit do
+#   puts ["dynamic after save commit->"].inspect
+#   # Avo::App.
+#   ResourceChannel.broadcast_to "1", action: :reload
+# end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
   get "hey", to: "home#index"
+  get "trigger_course_update", to: "home#trigger_course_update"
 
   authenticate :user, ->(user) { user.is_admin? } do
     scope :admin do

--- a/yarn.lock
+++ b/yarn.lock
@@ -312,6 +312,11 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.2.tgz#69a6d999f4087e0537dd38fe0963db1f4305d650"
   integrity sha512-G26maXW1Kx0LxQdmNNuNjQlRO/QlXNr3QfuwKiOKb5FZQGYe2OwtHTGXBAjSoiu4dW36XYMT/+L1Wo1Yov4ZXA==
 
+"@rails/actioncable@^7.0.2-4":
+  version "7.0.2-4"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.2-4.tgz#24a31bde761ee7652b2567d267699c17c7e725a6"
+  integrity sha512-EPTZ0U/KBlaJKPAyLuvPBSZMojyHVgCqwMDkwTfm4TDPyp5f0hTBsOsolQxqeOJmoTafK+7pJi7hO9eCjBEhTA==
+
 "@rails/activestorage@^6.0.2-1":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-6.0.3.tgz#401d2a28ecb7167cdb5e830ffddaa17c308c31aa"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/discussions/466

I got action cable working and a channel to send events through. At first, I thought I would be able to use Turbo frames, but I'm not sure that's possible in an easy manner. My initial strategy was to wrap the `ResourceShow` component in a `turbo-frame` and trigger an update through a dumb stimulus controller when a web-sockets event came in. 

That's not so easy because when you wrap something in a turbo-frame, all the links inside are "hijacked" to run as turbo. 
For all the content that comes back from those links, turbo looks for the same frame that the `ResourceShow` component is wrapped in. 
We can force all of our links and add the `target="_top"` attribute (although that's not pleasant and prone to human error), but there are going link from custom pieces of content (custom fields, and tools).

Now I am trying to dynamically wrap the component in a turbo-frame, trigger a reload and remove the frame on each websockets event. It's kinda hacky, but it could do the job.

We're open to suggestions on this one.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Description...

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
