### PR TITLE
fix: broken search on back action

### DIFF
--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -193,7 +193,7 @@ export default class extends Controller {
       Mousetrap.bind(['command+k', 'ctrl+k'], () => this.showSearchPanel())
     }
 
-    autocomplete({
+    const { destroy } = autocomplete({
       container: this.autocompleteTarget,
       placeholder: this.translationKeys.placeholder,
       translations: {
@@ -215,6 +215,8 @@ export default class extends Controller {
           .then((data) => Object.keys(data).map((resourceName) => that.addSource(resourceName, data[resourceName])))
       },
     })
+
+    document.addEventListener('turbo:before-render', destroy)
 
     // When using search for belongs-to
     if (this.buttonTarget.dataset.shouldBeDisabled !== 'true') {

--- a/app/views/avo/partials/_global_search.html.erb
+++ b/app/views/avo/partials/_global_search.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="search" class="relative flex global-search rounded border border-gray-200 sm:min-w-[16rem]" data-turbo-remove-before-cache>
+<div data-controller="search" class="relative flex global-search rounded border border-gray-200 sm:min-w-[16rem]">
   <div class="flex-1 text-gray-500"
     data-search-target="autocomplete"
     data-search-resource="global"

--- a/app/views/avo/partials/_resource_search.html.erb
+++ b/app/views/avo/partials/_resource_search.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="search" class="resource-search flex items-center h-full w-full" data-turbo-remove-before-cache>
+<div data-controller="search" class="resource-search flex items-center h-full w-full">
   <div class="w-full"
     data-search-target="autocomplete"
     data-search-resource="<%= resource %>"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where when you click the browser back button, the search box is broken and unusable.

### Before
![CleanShot 2022-05-12 at 10 33 19](https://user-images.githubusercontent.com/1334409/168016716-44e2c75c-d76c-4f07-9c2d-cd6642ab1adb.gif)


### After
![CleanShot 2022-05-12 at 10 32 36](https://user-images.githubusercontent.com/1334409/168016585-5d1033f8-8f79-48af-ba3f-fd8d4322539c.gif)


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to the users page
3. click on a user
4. click on the browser back button
5. after each step, check that the search works

Manual reviewer: please leave a comment with output from the test if that's the case.
