### PR TITLE
feature: customize the model name of a resource

### DIFF
--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -26,6 +26,7 @@ module Avo
     class_attribute :search_query_help, default: ""
     class_attribute :includes, default: []
     class_attribute :model_class
+    class_attribute :model_name
     class_attribute :translation_key
     class_attribute :translation_enabled, default: false
     class_attribute :default_view_type, default: :table
@@ -293,6 +294,8 @@ module Avo
     end
 
     def name
+      return self.class.model_name if self.class.model_name.present?
+
       default = class_name_without_resource.titlecase
 
       return @name if @name.present?


### PR DESCRIPTION
# Description
This simple PR adds the ability to customize a resources name in the navigation links, page headers, breadcrumbs, etc by specifying the model_name in the resource class.  

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
In a Resource class, specify a model name, e.g.
self.model_name =  "Location Search"

This model name specified is then used for navigation links, page headers, breadcrumbs instead of the class name.