### PR TITLE
fix: Long model names cause the navigation labels to overlap with the main content

### DIFF
--- a/app/components/avo/sidebar_component.html.erb
+++ b/app/components/avo/sidebar_component.html.erb
@@ -1,5 +1,5 @@
 <div
-  class="fixed z-[60] t-0 application-sidebar hidden lg:flex flex-1 border-r lg:border-none bg-none min-w-[16rem] h-[calc(100vh-4rem)] bg-gray-25 lg:bg-transparent <%= 'print:hidden' if Avo.configuration.hide_layout_when_printing %>"
+  class="fixed z-[60] t-0 application-sidebar md:max-w-[17rem] hidden lg:flex flex-1 border-r lg:border-none bg-none min-w-[16rem] h-[calc(100vh-4rem)] bg-gray-25 lg:bg-transparent <%= 'print:hidden' if Avo.configuration.hide_layout_when_printing %>"
   data-mobile-target="sidebar"
 >
   <div class="flex flex-col w-full h-full">

--- a/app/components/avo/sidebar_component.html.erb
+++ b/app/components/avo/sidebar_component.html.erb
@@ -1,5 +1,5 @@
 <div
-  class="fixed z-[60] t-0 application-sidebar md:max-w-[17rem] hidden lg:flex flex-1 border-r lg:border-none bg-none min-w-[16rem] h-[calc(100vh-4rem)] bg-gray-25 lg:bg-transparent <%= 'print:hidden' if Avo.configuration.hide_layout_when_printing %>"
+  class="fixed z-[60] t-0 application-sidebar w-64 hidden lg:flex flex-1 border-r lg:border-none bg-none h-[calc(100vh-4rem)] bg-gray-25 lg:bg-transparent <%= 'print:hidden' if Avo.configuration.hide_layout_when_printing %>"
   data-mobile-target="sidebar"
 >
   <div class="flex flex-col w-full h-full">


### PR DESCRIPTION
# Description
If a model name is long, it causes the sidebar to overlap with the main content of the page, setting a max width at medium fixes the issue.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
Create a resource with a long class name and the sidebar no longer overlaps.

Manual reviewer: please leave a comment with output from the test if that's the case.