### PR TITLE
return field name if field is has_one

### DIFF
--- a/app/components/avo/fields/has_one_field/show_component.html.erb
+++ b/app/components/avo/fields/has_one_field/show_component.html.erb
@@ -3,11 +3,11 @@
     <%= render(Avo::LoadingComponent.new(title: @field.name)) %>
   </turbo-frame>
 <% else %>
-  <%= render Avo::PanelComponent.new(title: @field.id.capitalize) do |c| %>
+  <%= render Avo::PanelComponent.new(title: @field.name) do |c| %>
     <% c.tools do %>
       <% if !@field.readonly && can_attach? %>
         <%= a_link attach_path, icon: 'heroicons/outline/link', color: :primary, 'data-turbo-frame': 'attach_modal' do %>
-          <%= t('avo.attach_item', item: @field.id).capitalize %>
+          <%= t('avo.attach_item', item: @field.name) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/avo/views/resource_show_component.html.erb
+++ b/app/components/avo/views/resource_show_component.html.erb
@@ -15,9 +15,9 @@
                 form_class: 'flex flex-col sm:flex-row sm:inline-flex',
                 style: :text,
                 data: {
-                  confirm: "Are you sure you want to detach this #{@reflection.name.to_s}."
+                  confirm: "Are you sure you want to detach this #{title}."
                 } do %>
-                <%= t('avo.detach_item', item: @reflection.name.to_s).capitalize %>
+                <%= t('avo.detach_item', item: title).capitalize %>
               <% end %>
               <%= render Avo::ActionsComponent.new actions: @actions, resource: @resource %>
             <% end %>

--- a/app/components/avo/views/resource_show_component.rb
+++ b/app/components/avo/views/resource_show_component.rb
@@ -15,6 +15,7 @@ class Avo::Views::ResourceShowComponent < Avo::ResourceComponent
 
   def title
     if @reflection.present?
+      return field.name if has_one_field?
       reflection_resource.name
     else
       @resource.panels.first[:name]
@@ -47,5 +48,9 @@ class Avo::Views::ResourceShowComponent < Avo::ResourceComponent
   # In development and test environments we shoudl show the invalid field errors
   def should_display_invalid_fields_errors?
     (Rails.env.development? || Rails.env.test?) && @resource.invalid_fields.present?
+  end
+
+  def has_one_field?
+    field.present? and field.class == Avo::Fields::HasOneField
   end
 end

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -48,7 +48,7 @@ class UserResource < Avo::BaseResource
     main_app.hey_url
   end
 
-  field :post, as: :has_one, translation_key: "avo.field_translations.people"
+  field :post, as: :has_one, translation_key: "avo.field_translations.people", name: "Main post"
   field :posts,
     as: :has_many,
     attach_scope: -> { query.where.not(user_id: parent.id).or(query.where(user_id: nil)) }

--- a/spec/system/avo/has_one_field_name_spec.rb
+++ b/spec/system/avo/has_one_field_name_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'HasOneFieldName', type: :system do
+  let!(:user) { create :user }
+  let!(:post) { create :post }
+
+  subject { visit url; page }
+
+  context 'show' do
+    let(:url) { "/admin/resources/users/#{user.id}" }
+
+    describe 'without a related user' do
+      it 'attaches a post' do
+        visit url
+        expect(page).to have_text 'Attach Main post'
+
+        click_on 'Attach Main post'
+        wait_for_loaded
+        expect(page).to have_text 'Choose post'
+
+        expect(page).to have_select "fields_related_id", selected: "Choose an option"
+        select post.name, from: "fields_related_id"
+
+        click_on 'Attach'
+        wait_for_loaded
+
+        expect(page).to have_text 'Post attached.'
+        expect(page).not_to have_text 'Choose post'
+        expect(page).to have_text post.name
+
+        expect(user.posts.pluck('id')).to include post.id
+      end
+    end
+  end
+end

--- a/spec/system/avo/has_one_field_name_spec.rb
+++ b/spec/system/avo/has_one_field_name_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe 'HasOneFieldName', type: :system do
   context 'show' do
     let(:url) { "/admin/resources/users/#{user.id}" }
 
-    describe 'without a related user' do
-      it 'attaches a post' do
+    describe 'without a related post' do
+      it 'attaches and detaches a post' do
         visit url
         expect(page).to have_text 'Attach Main post'
 
@@ -32,6 +32,19 @@ RSpec.describe 'HasOneFieldName', type: :system do
         expect(page).to have_text post.name
 
         expect(user.posts.pluck('id')).to include post.id
+
+        expect(page).to have_text 'Main post'
+        expect(page).to have_text 'Detach main post'
+
+        accept_alert do
+          click_on 'Detach main post'
+        end
+        wait_for_loaded
+
+        expect(page).to have_text 'Post detached.'
+        expect(page).not_to have_text 'Detach main post'
+        expect(page).to have_text 'Attach Main post'
+        expect(user.posts.pluck('id')).not_to include post.id
       end
     end
   end

--- a/spec/system/avo/has_one_field_name_spec.rb
+++ b/spec/system/avo/has_one_field_name_spec.rb
@@ -4,7 +4,10 @@ RSpec.describe 'HasOneFieldName', type: :system do
   let!(:user) { create :user }
   let!(:post) { create :post }
 
-  subject { visit url; page }
+  subject {
+    visit url
+    page 
+  }
 
   context 'show' do
     let(:url) { "/admin/resources/users/#{user.id}" }
@@ -18,8 +21,8 @@ RSpec.describe 'HasOneFieldName', type: :system do
         wait_for_loaded
         expect(page).to have_text 'Choose post'
 
-        expect(page).to have_select "fields_related_id", selected: "Choose an option"
-        select post.name, from: "fields_related_id"
+        expect(page).to have_select 'fields_related_id', selected: "Choose an option"
+        select post.name, from: 'fields_related_id'
 
         click_on 'Attach'
         wait_for_loaded


### PR DESCRIPTION
# Description
Has_one field now display the chosen name in resource file

Fixes # (issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
added name for has_one fields and check if appear on show page
