### PR TITLE
Fix rotation of move to top button

### DIFF
--- a/app/assets/svgs/download-solid-reversed.svg
+++ b/app/assets/svgs/download-solid-reversed.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" transform="rotate(-180)">
-  <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" />
+<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+  <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" transform="rotate(-180 10 10)" />
 </svg>


### PR DESCRIPTION
# Description

The 'Move record to top' button was not correctly oriented on Safari. Moving the `translate` parameter to the `path` element (and adjusting the origin accordingly) sorted this in both browsers.

<img width="208" alt="Screenshot 2022-05-19 at 12 23 07" src="https://user-images.githubusercontent.com/1191840/169176804-963958cb-20a9-40f8-aac6-d8cefa8f053b.png">

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps

Confirm that the icon is correctly oriented:

1. Visit `http://127.0.0.1:3030/admin/resources/course_links`