### PR TITLE
feature: expose global param in search

### DIFF
--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -65,6 +65,11 @@ export default class extends Controller {
 
     if (this.isGlobalSearch) {
       segments = [window.Avo.configuration.root_path, 'avo_api', 'search']
+
+      params = {
+        ...params,
+        global: true,
+      }
     }
 
     if (this.isBelongsToSearch) {

--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -55,7 +55,10 @@ export default class extends Controller {
   searchUrl(query) {
     const url = URI()
 
-    let params = { q: query }
+    let params = {
+      q: query,
+      global: false,
+    }
     let segments = [
       window.Avo.configuration.root_path,
       'avo_api',
@@ -66,10 +69,7 @@ export default class extends Controller {
     if (this.isGlobalSearch) {
       segments = [window.Avo.configuration.root_path, 'avo_api', 'search']
 
-      params = {
-        ...params,
-        global: true,
-      }
+      params.global = true
     }
 
     if (this.isBelongsToSearch) {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

We're now sending the `global` param in the search block so you can further customize the search query like so:

```ruby
class UserResource < Avo::BaseResource
  self.search_query = ->(params:) do
    if params[:global]
      scope.ransack(id_eq: params[:q], first_name_cont: params[:q], last_name_cont: params[:q], m: "or").result(distinct: false)
    else
      scope.ransack(first_name_cont: params[:q], last_name_cont: params[:q], bio_cont: params[:q], m: "or").result(distinct: false)
    end
  end
end
```

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

