### PR TITLE
Remove max limit on tags field

### DIFF
--- a/app/javascript/js/controllers/fields/tags_field_controller.js
+++ b/app/javascript/js/controllers/fields/tags_field_controller.js
@@ -40,7 +40,6 @@ export default class extends BaseController {
       blacklist: this.disallowedItems,
       enforceWhitelist: this.enforceSuggestions,
       delimiters: this.delimiters.join('|'),
-      maxTags: 10,
       dropdown: {
         maxItems: 20,
         enabled: 0,


### PR DESCRIPTION
# Description

The tags field had a hardcoded limit of 10 tags - this meant that any extra tags were being removed in the UI. Saving the record would then remove these extra tags.

I couldn't see any specific reason for the tag limit. Perhaps it would be worthwhile allowing this limit to be defined in the UI? I'm not familiar with `acts_as_taggable_on` but if a limit can be defined there (or in a validation) we could try to use that?

I was using the tags field as a simpler way to add multiple associations though, so a limit wasn't desired. This was my field definition for reference (although for bonus confusion, the association is called 'tags' 😂):

```ruby
field :tag_ids,
  name: "Tags",
  as: :tags,
  hide_on: [:show, :index, :new],
  close_on_select: false,
  enforce_suggestions: true,
  suggestions: -> {
                  record
                    .system
                    .tags
                    .joins("INNER JOIN tag_categories ON tags.tag_category_id = tag_categories.id")
                    .select("tags.id AS value, tag_categories.name || ' > ' || tags.name AS label")
                    .reorder(:label)
                    .as_json(only: [:value, :label])
                }

```

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
Fire up the dummy app and try adding more than 10 tags. Will need to remove the suggestions list or disable 'enforce suggestions' in the post resource.