### PR TITLE
feature: custom blank text on select filter

### DIFF
--- a/app/views/avo/base/_select_filter.html.erb
+++ b/app/views/avo/base/_select_filter.html.erb
@@ -4,9 +4,9 @@
   data-select-filter-keep-filters-panel-open-value="<%= @resource.keep_filters_panel_open %>"
 >
   <%= filter_wrapper name: filter.name do %>
-    <%= select_tag filter.id, options_for_select(filter.options.invert, filter.applied_or_default_value(@applied_filters)),
+    <%= select_tag filter.id, options_for_select(filter.options.except(:blank).invert, filter.applied_or_default_value(@applied_filters)),
       class: input_classes('w-full mb-0'),
-      include_blank: '—',
+      include_blank: filter.options[:blank] || '—',
       id: "avo_filters_#{filter.id.parameterize.underscore}",
       'data-filter-class': filter.class,
       'data-select-filter-target': 'selector',

--- a/app/views/avo/base/_select_filter.html.erb
+++ b/app/views/avo/base/_select_filter.html.erb
@@ -4,9 +4,9 @@
   data-select-filter-keep-filters-panel-open-value="<%= @resource.keep_filters_panel_open %>"
 >
   <%= filter_wrapper name: filter.name do %>
-    <%= select_tag filter.id, options_for_select(filter.options.except(:blank).invert, filter.applied_or_default_value(@applied_filters)),
+    <%= select_tag filter.id, options_for_select(filter.options.invert, filter.applied_or_default_value(@applied_filters)),
       class: input_classes('w-full mb-0'),
-      include_blank: filter.options[:blank] || '—',
+      include_blank: filter.class.empty_message || '—',
       id: "avo_filters_#{filter.id.parameterize.underscore}",
       'data-filter-class': filter.class,
       'data-select-filter-target': 'selector',

--- a/app/views/avo/base/_text_filter.html.erb
+++ b/app/views/avo/base/_text_filter.html.erb
@@ -7,6 +7,7 @@
     <%= text_field_tag filter.id, filter.applied_or_default_value(@applied_filters),
       class: input_classes('w-full mb-0'),
       id: "avo_filters_#{filter.id.parameterize.underscore}",
+      placeholder: filter.class.empty_message,
       'data-filter-class': filter.class.to_s,
       'data-text-filter-target': 'text',
       'data-action': 'keypress->text-filter#tryToSubmit'

--- a/spec/dummy/app/avo/filters/published_filter.rb
+++ b/spec/dummy/app/avo/filters/published_filter.rb
@@ -1,5 +1,6 @@
 class PublishedFilter < Avo::Filters::SelectFilter
   self.name = "Published status"
+  self.empty_message = "Published or unpublished"
 
   def apply(request, query, value)
     case value

--- a/spec/dummy/app/avo/filters/published_filter.rb
+++ b/spec/dummy/app/avo/filters/published_filter.rb
@@ -14,6 +14,7 @@ class PublishedFilter < Avo::Filters::SelectFilter
 
   def options
     {
+      blank: "Select status",
       published: "Published",
       unpublished: "Unpublished"
     }

--- a/spec/dummy/app/avo/filters/published_filter.rb
+++ b/spec/dummy/app/avo/filters/published_filter.rb
@@ -14,7 +14,6 @@ class PublishedFilter < Avo::Filters::SelectFilter
 
   def options
     {
-      blank: "Select status",
       published: "Published",
       unpublished: "Unpublished"
     }

--- a/spec/dummy/app/avo/filters/user_names_filter.rb
+++ b/spec/dummy/app/avo/filters/user_names_filter.rb
@@ -1,9 +1,10 @@
 class UserNamesFilter < Avo::Filters::TextFilter
-  self.name = 'User names filter'
-  self.button_label = 'Filter by user names'
+  self.name = "User names filter"
+  self.button_label = "Filter by user names"
+  self.empty_message = "Search by name"
 
   def apply(request, query, value)
-    query.where('LOWER(first_name) like ?', "%#{value}%").or(query.where('LOWER(last_name) like ?', "%#{value}%"))
+    query.where("LOWER(first_name) like ?", "%#{value}%").or(query.where("LOWER(last_name) like ?", "%#{value}%"))
   end
 
   # def default

--- a/spec/system/avo/filters/filters_spec.rb
+++ b/spec/system/avo/filters/filters_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "Filters", type: :system do
         open_filters_menu
 
         expect(page).to have_text "Published status"
-        expect(page).to have_select "published status", selected: empty_dash, options: [empty_dash, "Published", "Unpublished"]
+        expect(page).to have_select "published status", selected: "Published or unpublished", options: ["Published or unpublished", "Published", "Unpublished"]
         expect(page).to have_text "Published post"
         expect(page).to have_text "Unpublished post"
         expect(page).to have_button("Reset filters", disabled: true)
@@ -162,7 +162,7 @@ RSpec.describe "Filters", type: :system do
 
         expect(page).to have_text "Published post"
         expect(page).not_to have_text "Unpublished post"
-        expect(page).to have_select "avo_filters_published_status", selected: "Published", options: [empty_dash, "Published", "Unpublished"]
+        expect(page).to have_select "avo_filters_published_status", selected: "Published", options: ["Published or unpublished", "Published", "Unpublished"]
         expect(current_url).to include "filters="
         expect(page).to have_link("Reset filters")
       end
@@ -177,17 +177,17 @@ RSpec.describe "Filters", type: :system do
 
         expect(page).to have_text "Published post"
         expect(page).not_to have_text "Unpublished post"
-        expect(page).to have_select "avo_filters_published_status", selected: "Published", options: [empty_dash, "Published", "Unpublished"]
+        expect(page).to have_select "avo_filters_published_status", selected: "Published", options: ["Published or unpublished", "Published", "Unpublished"]
         expect(current_url).to include "filters="
         expect(page).to have_link("Reset filters")
 
-        select empty_dash, from: "avo_filters_published_status"
+        select "Published or unpublished", from: "avo_filters_published_status"
         wait_for_loaded
         open_filters_menu
 
         expect(page).to have_text "Published post"
         expect(page).to have_text "Unpublished post"
-        expect(page).to have_select "avo_filters_published_status", selected: empty_dash, options: [empty_dash, "Published", "Unpublished"]
+        expect(page).to have_select "avo_filters_published_status", selected: "Published or unpublished", options: ["Published or unpublished", "Published", "Unpublished"]
         expect(current_url).not_to include "filters="
         expect(page).to have_button("Reset filters", disabled: true)
 
@@ -197,7 +197,7 @@ RSpec.describe "Filters", type: :system do
 
         expect(page).not_to have_text "Published post"
         expect(page).to have_text "Unpublished post"
-        expect(page).to have_select "avo_filters_published_status", selected: "Unpublished", options: [empty_dash, "Published", "Unpublished"]
+        expect(page).to have_select "avo_filters_published_status", selected: "Unpublished", options: ["Published or unpublished", "Published", "Unpublished"]
         expect(current_url).to include "filters="
         expect(page).to have_link("Reset filters")
 
@@ -206,7 +206,7 @@ RSpec.describe "Filters", type: :system do
         open_filters_menu
 
         expect(page).to have_text "Published status"
-        expect(page).to have_select "avo_filters_published_status", selected: empty_dash, options: [empty_dash, "Published", "Unpublished"]
+        expect(page).to have_select "avo_filters_published_status", selected: "Published or unpublished", options: ["Published or unpublished", "Published", "Unpublished"]
         expect(page).to have_text "Published post"
         expect(page).to have_text "Unpublished post"
         expect(page).to have_button("Reset filters", disabled: true)
@@ -279,19 +279,19 @@ RSpec.describe "Filters", type: :system do
     let(:url) { "/admin/resources/teams?view_type=table" }
 
     context "without default value" do
-      it 'displays the filter' do
+      it "displays the filter" do
         visit url
         open_filters_menu
 
         expect(page).to have_text "Name filter"
       end
 
-      it 'filters by name' do
+      it "filters by name" do
         visit url
         expect(page).to have_text("Displaying 2 item")
 
         open_filters_menu
-        fill_in 'avo_filters_name_filter', with: 'With Members'
+        fill_in "avo_filters_name_filter", with: "With Members"
         click_on "Filter by name"
         wait_for_loaded
         expect(page).to have_text("Displaying 1 item")


### PR DESCRIPTION
# Description
Now it's possible to customize the default blank text on a select filter using the option `blank: "custom text"` or let it by default ( "-" )

# Checklist:

- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
1. Go to file `published_filter.rb` and add  `blank: "Select status"` to `def options{ ... }`
2. Go to `/admin/resources/posts` open filters and confirm if blank changed
![image](https://user-images.githubusercontent.com/69730720/170859816-6dd79cbc-bcf0-4b91-80f6-f32d47a51298.png)

