### PR TITLE
Access resource.model in action visibility

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -75,9 +75,9 @@ module Avo
     end
 
     def show
-      set_actions
-
       @resource.hydrate(model: @model, view: :show, user: _current_user, params: params)
+      
+      set_actions
 
       @page_title = @resource.default_panel_name.to_s
 
@@ -302,14 +302,10 @@ module Avo
     end
 
     def set_actions
-      if params[:resource_id].present?
-        model = @resource.class.find_scope.find params[:resource_id]
-      end
-
       @actions = @resource
         .get_actions
         .map do |action|
-          action.new(model: model, resource: @resource, view: @view)
+          action.new(model: @model, resource: @resource, view: @view)
         end
         .select { |action| action.visible_in_view }
     end


### PR DESCRIPTION
Moving set actions after the resource is hydrated with the model allows access to the model in self.visible lambda via resource.

Also few of these lines seemed like unnecessary old code, model is available via `@model` instance variable.

# Description
Could not access the model in the visible lambda of action when determining whether an action should be shown on a particular page. With this you should be able to access it using `resource.model`.

# Checklist:

- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works
