### PR TITLE
fix: sidebar menu collapsed state

### DIFF
--- a/app/javascript/js/controllers/menu_controller.js
+++ b/app/javascript/js/controllers/menu_controller.js
@@ -22,10 +22,11 @@ export default class extends Controller {
   }
 
   get initiallyCollapsed() {
-    if (this.userState === 'collapsed' || this.defaultState === 'collapsed') return true
-    if (this.userState === 'expanded' || this.defaultState === 'expanded') return false
+    if (this.defaultState === 'collapsed') {
+      return this.userState === 'collapsed'
+    }
 
-    return false
+    return this.userState === 'collapsed'
   }
 
   connect() {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/939

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Add a menu item that is collapsed
2. go and expand it
3. refresh the page
4. observe it remains expanded

Manual reviewer: please leave a comment with output from the test if that's the case.

![CleanShot 2022-06-03 at 19 05 24](https://user-images.githubusercontent.com/1334409/171903345-5f7b3413-041b-47f3-ba13-8549aa90b0a0.gif)

