### PR TITLE
fix: don't open filters after filters reset + f5

### DIFF
--- a/app/helpers/avo/url_helpers.rb
+++ b/app/helpers/avo/url_helpers.rb
@@ -7,7 +7,7 @@ module Avo
       if keep_query_params
         begin
           existing_params =
-            Addressable::URI.parse(request.fullpath).query_values.symbolize_keys
+            Addressable::URI.parse(request.fullpath).query_values.symbolize_keys.except(:keep_filters_panel_open)
         rescue
         end
       end


### PR DESCRIPTION
# Description
Excluding :keep_filters_panel_open param when reset filters make user able to reset the page or navigate throw table pages without having filters page open on every move

# Checklist:

- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
Go to courses page, play around with filters, press reset filters and then f5. Filters page should not open
