### PR TITLE
fix: use resource name for url instead of model name

### DIFF
--- a/app/helpers/avo/url_helpers.rb
+++ b/app/helpers/avo/url_helpers.rb
@@ -12,10 +12,9 @@ module Avo
         end
       end
 
-      # Create the `route_key` from the model key so the namespaced models get the proper path (SomeModule::Post -> some_module_post).
-      # Add the `_index` suffix for the uncountable models so they get the correct path (`fish_index`)
-      route_key = resource.model_key
-      route_key << "_index" if resource.model_name.singular == resource.model_name.plural
+      route_key = resource.route_key
+      # Add the `_index` suffix for the uncountable names so they get the correct path (`fish_index`)
+      route_key << "_index" if resource.route_key == resource.singular_route_key
 
       avo.send :"resources_#{route_key}_path", **existing_params, **args
     end
@@ -33,19 +32,19 @@ module Avo
         id = resource_id
       end
 
-      avo.send :"resources_#{resource.singular_model_key}_path", id, **args
+      avo.send :"resources_#{resource.singular_route_key}_path", id, **args
     end
 
     def new_resource_path(model:, resource:, **args)
-      avo.send :"new_resources_#{resource.singular_model_key}_path", **args
+      avo.send :"new_resources_#{resource.singular_route_key}_path", **args
     end
 
     def edit_resource_path(model:, resource:, **args)
-      avo.send :"edit_resources_#{resource.singular_model_key}_path", model, **args
+      avo.send :"edit_resources_#{resource.singular_route_key}_path", model, **args
     end
 
     def resource_attach_path(resource, model_id, related_name, related_id = nil)
-      helpers.avo.resources_associations_new_path(resource.singular_model_key, model_id, related_name)
+      helpers.avo.resources_associations_new_path(resource.singular_route_key, model_id, related_name)
     end
 
     def resource_detach_path(
@@ -79,7 +78,7 @@ module Avo
     end
 
     def order_up_resource_path(model:, resource:, **args)
-      avo.send :"order_up_resources_#{resource.singular_model_key}_path", model, **args
+      avo.send :"order_up_resources_#{resource.singular_route_key}_path", model, **args
     end
   end
 end

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -438,8 +438,8 @@ module Avo
       class_name_without_resource.underscore.pluralize
     end
 
-    def route_key
-      class_name_without_resource.underscore.singularize
+    def singular_route_key
+      route_key.underscore.singularize
     end
 
     # This is used as the model class ID

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -435,7 +435,11 @@ module Avo
     end
 
     def route_key
-      model_class.model_name.route_key
+      class_name_without_resource.underscore.pluralize
+    end
+
+    def singular_route_key
+      class_name_without_resource.underscore.singularize
     end
 
     # This is used as the model class ID

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -439,7 +439,7 @@ module Avo
     end
 
     def singular_route_key
-      route_key.underscore.singularize
+      route_key.singularize
     end
 
     # This is used as the model class ID

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -438,7 +438,7 @@ module Avo
       class_name_without_resource.underscore.pluralize
     end
 
-    def singular_route_key
+    def route_key
       class_name_without_resource.underscore.singularize
     end
 

--- a/lib/avo/dynamic_router.rb
+++ b/lib/avo/dynamic_router.rb
@@ -14,7 +14,7 @@ module Avo
         #   resource.model_class.present?
         # end
         .map do |resource|
-          router.resources resource.new.model_key
+          router.resources resource.new.route_key
         end
     end
   end

--- a/spec/dummy/app/avo/resources/membership_resource.rb
+++ b/spec/dummy/app/avo/resources/membership_resource.rb
@@ -1,4 +1,4 @@
-class TeamMembershipResource < Avo::BaseResource
+class MembershipResource < Avo::BaseResource
   self.title = :name
   self.includes = [:user, :team]
   self.visible_on_sidebar = false
@@ -6,9 +6,11 @@ class TeamMembershipResource < Avo::BaseResource
     scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
   end
   self.hide_from_global_search = true
+  self.model_class = ::TeamMembership
 
   field :id, as: :id
   field :id, as: :number, only_on: :edit
+
   field :level, as: :select, as_description: true, options: ->(**args) { {Beginner: :beginner, Intermediate: :intermediate, Advanced: :advanced, "#{args[:model].id}": "model_id", "#{args[:resource].name}": "resource_name", "#{args[:view]}": "view", "#{args[:field].id}": "field"} }, display_value: true, default: -> { Time.now.hour < 12 ? "advanced" : "beginner" }
 
   field :user, as: :belongs_to, searchable: false, attach_scope: -> {

--- a/spec/dummy/app/avo/resources/team_resource.rb
+++ b/spec/dummy/app/avo/resources/team_resource.rb
@@ -21,7 +21,6 @@ class TeamResource < Avo::BaseResource
     model.team_members.length
   end
 
-
   field :memberships,
     as: :has_many,
     searchable: true,

--- a/spec/dummy/app/avo/resources/team_resource.rb
+++ b/spec/dummy/app/avo/resources/team_resource.rb
@@ -21,12 +21,13 @@ class TeamResource < Avo::BaseResource
     model.team_members.length
   end
 
-  # field :memberships,
-  #   as: :has_many,
-  #   searchable: true,
-  #   attach_scope: -> do
-  #     query.where.not(user_id: parent.id).or(query.where(user_id: nil))
-  #   end
+
+  field :memberships,
+    as: :has_many,
+    searchable: true,
+    attach_scope: -> do
+      query.where.not(user_id: parent.id).or(query.where(user_id: nil))
+    end
 
   field :admin, as: :has_one
   field :team_members, as: :has_many, through: :memberships

--- a/spec/dummy/app/controllers/avo/memberships_controller.rb
+++ b/spec/dummy/app/controllers/avo/memberships_controller.rb
@@ -1,0 +1,2 @@
+class Avo::MembershipsController < Avo::ResourcesController
+end

--- a/spec/dummy/app/controllers/avo/team_memberships_controller.rb
+++ b/spec/dummy/app/controllers/avo/team_memberships_controller.rb
@@ -1,2 +1,0 @@
-class Avo::TeamMembershipsController < Avo::ResourcesController
-end

--- a/spec/features/avo/hidden_from_global_search_spec.rb
+++ b/spec/features/avo/hidden_from_global_search_spec.rb
@@ -19,13 +19,13 @@ RSpec.feature Avo::SearchController, type: :controller do
   describe "resource search" do
     it "does not return the ream membership" do
       get :show, params: {
-        resource_name: 'team_memberships'
+        resource_name: 'memberships'
       }
 
       expect(json.keys).not_to include "users"
-      expect(json.keys).to include "team memberships"
-      expect(json['team memberships']['count']).to eq 1
-      expect(json['team memberships']['results'].first['_id']).to eq team.memberships.first.id
+      expect(json.keys).to include "memberships"
+      expect(json['memberships']['count']).to eq 1
+      expect(json['memberships']['results'].first['_id']).to eq team.memberships.first.id
     end
   end
 end

--- a/spec/features/avo/multiple_names_model_spec.rb
+++ b/spec/features/avo/multiple_names_model_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "multiple names model", type: :feature do
   describe "creating a comment" do
     context "without a polymorphic association" do
       it "sets the right form_scope" do
-        visit "admin/resources/team_memberships/#{team_membership.id}/edit"
+        visit "admin/resources/memberships/#{team_membership.id}/edit"
 
         click_on "Save"
       end

--- a/spec/features/avo/resource_name_urls_spec.rb
+++ b/spec/features/avo/resource_name_urls_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.feature "ResourceNameUrls", type: :feature do
+  let!(:user) { create :user, first_name: 'John MMM' }
+  let!(:team) { create :team, name: 'Apple XXX' }
+  let!(:team_membership) { team.team_members << user }
+
+  it "loads the model configuration in the resource URL" do
+    visit "/admin/resources/memberships/#{team.memberships.first.id}"
+
+    expect(find_field_value_element(:user)).to have_text 'John MMM'
+    expect(find_field_value_element(:team)).to have_text 'Apple XXX'
+  end
+end

--- a/spec/features/avo/resources_hidden_from_sidebar_spec.rb
+++ b/spec/features/avo/resources_hidden_from_sidebar_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "ResourcesHiddenFromSidebar", type: :feature do
 
       expect(page.body).not_to have_text "Team memberships"
 
-      visit "/admin/resources/team_memberships"
+      visit "/admin/resources/memberships"
 
       expect(page.body).to have_text "Team memberships"
     end

--- a/spec/features/avo/resources_hidden_from_sidebar_spec.rb
+++ b/spec/features/avo/resources_hidden_from_sidebar_spec.rb
@@ -13,11 +13,11 @@ RSpec.feature "ResourcesHiddenFromSidebar", type: :feature do
     it "does not display the resource but can access it" do
       visit "/admin/resources/posts"
 
-      expect(page.body).not_to have_text "Team memberships"
+      expect(page.body).not_to have_text "Memberships"
 
       visit "/admin/resources/memberships"
 
-      expect(page.body).to have_text "Team memberships"
+      expect(page.body).to have_text "Memberships"
     end
   end
 end

--- a/spec/system/avo/default_field_spec.rb
+++ b/spec/system/avo/default_field_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "DefaultField", type: :system do
 
     context "create" do
       it "checks presence of default team membership level" do
-        visit "/admin/resources/team_memberships/new"
+        visit "/admin/resources/memberships/new"
         wait_for_loaded
 
         if Time.now.hour < 12
@@ -44,7 +44,7 @@ RSpec.describe "DefaultField", type: :system do
       end
 
       it "saves team membership and checks for default team membership level value" do
-        visit "/admin/resources/team_memberships/new"
+        visit "/admin/resources/memberships/new"
         wait_for_loaded
 
         expect(TeamMembership.count).to eql 0
@@ -55,7 +55,7 @@ RSpec.describe "DefaultField", type: :system do
         click_on "Save"
         wait_for_loaded
 
-        expect(current_path).to eql "/admin/resources/team_memberships/#{TeamMembership.last.id}"
+        expect(current_path).to eql "/admin/resources/memberships/#{TeamMembership.last.id}"
 
         if Time.now.hour < 12
           expect(find_field_element(:level)).to have_text "advanced"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/950
Fixes https://github.com/avo-hq/avo/discussions/846

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to the membership resource
2. Observe it's feeding off of the `TeamMembership` model but has the path `/memberships`, thus respecting the resource name not the model name.

Manual reviewer: please leave a comment with output from the test if that's the case.
