### PR TITLE
chore: add generators dir to zetwerk ignore

### DIFF
--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -7,6 +7,7 @@ loader.inflector.inflect(
   "html" => "HTML",
   "has_html_attributes" => "HasHTMLAttributes"
 )
+loader.ignore("#{__dir__}/generators")
 loader.setup
 
 #                                      .//*,,.....,,*/(*


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes this issue

<img width="679" alt="CleanShot 2022-06-15 at 19 56 29@2x" src="https://user-images.githubusercontent.com/1334409/173883480-4c61b0f5-1376-4135-b762-12aac407ad8b.png">


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

