### PR TITLE
chore: alert developer about missing model

### DIFF
--- a/app/views/avo/partials/_custom_tools_alert.html.erb
+++ b/app/views/avo/partials/_custom_tools_alert.html.erb
@@ -5,13 +5,27 @@
     </a>
   </div>
 <% end %>
-
 <% if Avo::App.error_messages.present? %>
-  <% Avo::App.error_messages.each do |message| %>
-    <div class="w-full inset-auto bottom-0 z-50 mb-4 opacity-75 hover:opacity-100 transition-opacity duration-150">
-      <a href="https://avohq.io/pricing" target="_blank" class="rounded bg-orange-700 text-white py-2 px-4 text-sm block items-center flex leading-tight">
-        <%= svg "exclamation", class: "h-6 inline mr-2 text-bold flex-shrink-0 mr-1" %> <%= message %>
-      </a>
-    </div>
+  <% Avo::App.error_messages.each do |error| %>
+    <% if error.is_a? Hash %>
+      <%
+        url, message, target = error.values_at :url, :message, :target
+      %>
+      <div class="w-full inset-auto bottom-0 z-50 mb-4 opacity-75 hover:opacity-100 transition-opacity duration-150">
+        <a href="<%= url %>" target="<%= target %>" class="rounded bg-orange-700 text-white py-2 px-4 text-sm items-center flex leading-tight space-x-2">
+          <%= svg "exclamation", class: "h-6 inline mr-2 text-bold flex-shrink-0 mr-1" %>
+          <div>
+            <%= simple_format message %>
+          </div>
+        </a>
+      </div>
+    <% elsif error.is_a? String %>
+      <div class="w-full inset-auto bottom-0 z-50 mb-4 opacity-75 hover:opacity-100 transition-opacity duration-150">
+        <div class="rounded bg-orange-700 text-white py-2 px-4 text-sm items-center flex leading-tight space-x-2">
+          <%= svg "exclamation", class: "h-6 inline mr-2 text-bold flex-shrink-0 mr-1" %>
+          <div><%= simple_format error %></div>
+        </div>
+      </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/spec/features/avo/resource_missing_model_spec.rb
+++ b/spec/features/avo/resource_missing_model_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'rails/generators'
 
 RSpec.feature "ResourceMissingModels", type: :feature do
   before :all do

--- a/spec/features/avo/resource_missing_model_spec.rb
+++ b/spec/features/avo/resource_missing_model_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.feature "ResourceMissingModels", type: :feature do
+  before :all do
+    Rails::Generators.invoke('avo:resource', ['bad'], {destination_root: Rails.root})
+  end
+
+  after :all do
+    files = %w(spec/dummy/app/avo/resources/bad_resource.rb spec/dummy/app/controllers/avo/bads_controller.rb)
+    files.each do |path|
+      File.delete(path) if File.exist?(path)
+    end
+  end
+
+  it "tests" do
+    visit '/admin/dashboards/dashy'
+
+    click_on "Sales"
+    expect(page).to have_text "BadResource does not have a valid model assigned. It failed to find the Bad model."
+    expect(page).to have_text "Please create that model or assign one using self.model_class = YOUR_MODEL"
+    expect(page).to have_link href: "https://docs.avohq.io/2.0/resources.html#custom-model-class"
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where Avo would crash if the developer generated a resource without a valid model.

<img width="778" alt="CleanShot 2022-06-15 at 23 47 11@2x" src="https://user-images.githubusercontent.com/1334409/173924033-daed9c6c-f620-4c2a-85ad-70a1c0221542.png">


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Run `rails g avo:resource bad`
2. Go to Avo. Maybe refresh the page once if it doesn't show up
3. Notice the error message like in the screenshot 👆

Manual reviewer: please leave a comment with output from the test if that's the case.
