### PR TITLE
feature: enable decorators

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -153,4 +153,7 @@ gem 'acts-as-taggable-on', '~> 9.0'
 
 gem "bundler-integrity", "~> 1.0"
 
-gem 'erb-formatter'
+gem "erb-formatter"
+
+# Draper adds an object-oriented layer of presentation logic to your Rails application.
+gem "draper"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (6.1.4.6)
       activesupport (= 6.1.4.6)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (6.1.4.6)
       activemodel (= 6.1.4.6)
       activesupport (= 6.1.4.6)
@@ -166,6 +170,13 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    draper (4.0.2)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
+      ruby2_keywords
     dry-initializer (3.1.1)
     erb-formatter (0.3.0)
     erubi (1.10.0)
@@ -309,6 +320,8 @@ GEM
       ffi (~> 1.0)
     redis (4.6.0)
     regexp_parser (2.2.0)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -351,6 +364,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
@@ -442,6 +456,7 @@ DEPENDENCIES
   database_cleaner
   devise
   dotenv-rails
+  draper
   erb-formatter
   factory_bot_rails
   faker

--- a/app/components/avo/fields/belongs_to_field/index_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/index_component.html.erb
@@ -1,3 +1,3 @@
 <%= index_field_wrapper field: @field, resource: @resource do %>
-  <%= link_to @field.label, helpers.resource_path(model: @field.value, resource: @field.target_resource) %>
+  <%= link_to @field.field_label, helpers.resource_path(model: @field.value, resource: @field.target_resource) %>
 <% end %>

--- a/app/components/avo/fields/belongs_to_field/show_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/show_component.html.erb
@@ -1,3 +1,3 @@
 <%= show_field_wrapper field: @field, resource: @resource, index: @index do %>
-  <%= link_to @field.label, helpers.resource_path(model: @field.value, resource: @field.target_resource, via_resource_class: @resource.model_class, via_resource_id: @resource.model.id) %>
+  <%= link_to @field.field_label, helpers.resource_path(model: @field.value, resource: @field.target_resource, via_resource_class: @resource.model_class, via_resource_id: @resource.model.id) %>
 <% end %>

--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -50,7 +50,9 @@ module Avo
           query = Avo::Hosts::AssociationScopeHost.new(block: @field.attach_scope, query: query, parent: @model).handle
         end
 
-        @options = query.all.map do |model|
+        query = @attachment_resource.apply_decoration_to_collection query.all
+
+        @options = query.map do |model|
           [model.send(@attachment_resource.class.title), model.id]
         end
       end

--- a/gemfiles/rails_6.0_ruby_3.0.3.gemfile
+++ b/gemfiles/rails_6.0_ruby_3.0.3.gemfile
@@ -46,6 +46,7 @@ gem "acts_as_list"
 gem "acts-as-taggable-on", "~> 9.0"
 gem "bundler-integrity", "~> 1.0"
 gem "erb-formatter"
+gem "draper"
 
 group :development do
   gem "standard"

--- a/gemfiles/rails_6.0_ruby_3.0.3.gemfile.lock
+++ b/gemfiles/rails_6.0_ruby_3.0.3.gemfile.lock
@@ -68,6 +68,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (6.0.4.4)
       activesupport (= 6.0.4.4)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (6.0.4.4)
       activemodel (= 6.0.4.4)
       activesupport (= 6.0.4.4)
@@ -162,6 +166,13 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    draper (4.0.2)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
+      ruby2_keywords
     dry-initializer (3.1.1)
     erb-formatter (0.3.0)
     erubi (1.10.0)
@@ -303,6 +314,8 @@ GEM
       ffi (~> 1.0)
     redis (4.6.0)
     regexp_parser (2.2.0)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -345,6 +358,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
@@ -436,6 +450,7 @@ DEPENDENCIES
   database_cleaner
   devise
   dotenv-rails
+  draper
   erb-formatter
   factory_bot_rails
   faker
@@ -482,4 +497,4 @@ DEPENDENCIES
   zeitwerk (~> 2.3)
 
 BUNDLED WITH
-   2.3.5
+   2.3.12

--- a/gemfiles/rails_6.0_ruby_3.1.0.gemfile
+++ b/gemfiles/rails_6.0_ruby_3.1.0.gemfile
@@ -46,6 +46,7 @@ gem "acts_as_list"
 gem "acts-as-taggable-on", "~> 9.0"
 gem "bundler-integrity", "~> 1.0"
 gem "erb-formatter"
+gem "draper"
 
 group :development do
   gem "standard"

--- a/gemfiles/rails_6.0_ruby_3.1.0.gemfile.lock
+++ b/gemfiles/rails_6.0_ruby_3.1.0.gemfile.lock
@@ -68,6 +68,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (6.0.4.4)
       activesupport (= 6.0.4.4)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (6.0.4.4)
       activemodel (= 6.0.4.4)
       activesupport (= 6.0.4.4)
@@ -162,6 +166,13 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    draper (4.0.2)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
+      ruby2_keywords
     dry-initializer (3.1.1)
     erb-formatter (0.3.0)
     erubi (1.10.0)
@@ -303,6 +314,8 @@ GEM
       ffi (~> 1.0)
     redis (4.6.0)
     regexp_parser (2.2.0)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -345,6 +358,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
@@ -436,6 +450,7 @@ DEPENDENCIES
   database_cleaner
   devise
   dotenv-rails
+  draper
   erb-formatter
   factory_bot_rails
   faker
@@ -482,4 +497,4 @@ DEPENDENCIES
   zeitwerk (~> 2.3)
 
 BUNDLED WITH
-   2.3.5
+   2.3.12

--- a/gemfiles/rails_6.1_ruby_3.0.3.gemfile
+++ b/gemfiles/rails_6.1_ruby_3.0.3.gemfile
@@ -46,6 +46,7 @@ gem "acts_as_list"
 gem "acts-as-taggable-on", "~> 9.0"
 gem "bundler-integrity", "~> 1.0"
 gem "erb-formatter"
+gem "draper"
 
 group :development do
   gem "standard"

--- a/gemfiles/rails_6.1_ruby_3.0.3.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_3.0.3.gemfile.lock
@@ -70,6 +70,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (6.1.4.6)
       activesupport (= 6.1.4.6)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (6.1.4.6)
       activemodel (= 6.1.4.6)
       activesupport (= 6.1.4.6)
@@ -166,6 +170,13 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    draper (4.0.2)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
+      ruby2_keywords
     dry-initializer (3.1.1)
     erb-formatter (0.3.0)
     erubi (1.10.0)
@@ -307,6 +318,8 @@ GEM
       ffi (~> 1.0)
     redis (4.6.0)
     regexp_parser (2.2.0)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -349,6 +362,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
@@ -439,6 +453,7 @@ DEPENDENCIES
   database_cleaner
   devise
   dotenv-rails
+  draper
   erb-formatter
   factory_bot_rails
   faker
@@ -485,4 +500,4 @@ DEPENDENCIES
   zeitwerk (~> 2.3)
 
 BUNDLED WITH
-   2.3.5
+   2.3.12

--- a/gemfiles/rails_6.1_ruby_3.1.0.gemfile
+++ b/gemfiles/rails_6.1_ruby_3.1.0.gemfile
@@ -46,6 +46,7 @@ gem "acts_as_list"
 gem "acts-as-taggable-on", "~> 9.0"
 gem "bundler-integrity", "~> 1.0"
 gem "erb-formatter"
+gem "draper"
 
 group :development do
   gem "standard"

--- a/gemfiles/rails_6.1_ruby_3.1.0.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_3.1.0.gemfile.lock
@@ -70,6 +70,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (6.1.4.6)
       activesupport (= 6.1.4.6)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (6.1.4.6)
       activemodel (= 6.1.4.6)
       activesupport (= 6.1.4.6)
@@ -166,6 +170,13 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    draper (4.0.2)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
+      ruby2_keywords
     dry-initializer (3.1.1)
     erb-formatter (0.3.0)
     erubi (1.10.0)
@@ -307,6 +318,8 @@ GEM
       ffi (~> 1.0)
     redis (4.6.0)
     regexp_parser (2.2.0)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -349,6 +362,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
@@ -439,6 +453,7 @@ DEPENDENCIES
   database_cleaner
   devise
   dotenv-rails
+  draper
   erb-formatter
   factory_bot_rails
   faker
@@ -485,4 +500,4 @@ DEPENDENCIES
   zeitwerk (~> 2.3)
 
 BUNDLED WITH
-   2.3.5
+   2.3.12

--- a/gemfiles/rails_7.0_ruby_3.0.3.gemfile
+++ b/gemfiles/rails_7.0_ruby_3.0.3.gemfile
@@ -46,6 +46,7 @@ gem "acts_as_list"
 gem "acts-as-taggable-on", "~> 9.0"
 gem "bundler-integrity", "~> 1.0"
 gem "erb-formatter"
+gem "draper"
 
 group :development do
   gem "standard"

--- a/gemfiles/rails_7.0_ruby_3.0.3.gemfile.lock
+++ b/gemfiles/rails_7.0_ruby_3.0.3.gemfile.lock
@@ -77,6 +77,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (7.0.2.2)
       activesupport (= 7.0.2.2)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (7.0.2.2)
       activemodel (= 7.0.2.2)
       activesupport (= 7.0.2.2)
@@ -172,6 +176,13 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    draper (4.0.2)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
+      ruby2_keywords
     dry-initializer (3.1.1)
     erb-formatter (0.3.0)
     erubi (1.10.0)
@@ -321,6 +332,8 @@ GEM
       ffi (~> 1.0)
     redis (4.6.0)
     regexp_parser (2.2.0)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -363,6 +376,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
@@ -447,6 +461,7 @@ DEPENDENCIES
   database_cleaner
   devise
   dotenv-rails
+  draper
   erb-formatter
   factory_bot_rails
   faker
@@ -493,4 +508,4 @@ DEPENDENCIES
   zeitwerk (~> 2.3)
 
 BUNDLED WITH
-   2.3.5
+   2.3.12

--- a/gemfiles/rails_7.0_ruby_3.1.0.gemfile
+++ b/gemfiles/rails_7.0_ruby_3.1.0.gemfile
@@ -46,6 +46,7 @@ gem "acts_as_list"
 gem "acts-as-taggable-on", "~> 9.0"
 gem "bundler-integrity", "~> 1.0"
 gem "erb-formatter"
+gem "draper"
 
 group :development do
   gem "standard"

--- a/gemfiles/rails_7.0_ruby_3.1.0.gemfile.lock
+++ b/gemfiles/rails_7.0_ruby_3.1.0.gemfile.lock
@@ -77,6 +77,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (7.0.2.2)
       activesupport (= 7.0.2.2)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (7.0.2.2)
       activemodel (= 7.0.2.2)
       activesupport (= 7.0.2.2)
@@ -172,6 +176,13 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    draper (4.0.2)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
+      ruby2_keywords
     dry-initializer (3.1.1)
     erb-formatter (0.3.0)
     erubi (1.10.0)
@@ -321,6 +332,8 @@ GEM
       ffi (~> 1.0)
     redis (4.6.0)
     regexp_parser (2.2.0)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -363,6 +376,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
@@ -447,6 +461,7 @@ DEPENDENCIES
   database_cleaner
   devise
   dotenv-rails
+  draper
   erb-formatter
   factory_bot_rails
   faker
@@ -493,4 +508,4 @@ DEPENDENCIES
   zeitwerk (~> 2.3)
 
 BUNDLED WITH
-   2.3.5
+   2.3.12

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -39,6 +39,8 @@ module Avo
     class_attribute :unscoped_queries_on_index, default: false
     class_attribute :resolve_query_scope
     class_attribute :resolve_find_scope
+    class_attribute :decorate_record
+    class_attribute :decorate_collection
     class_attribute :ordering
     class_attribute :hide_from_global_search, default: false
     class_attribute :after_create_path, default: :show
@@ -114,12 +116,22 @@ module Avo
       @params = params if params.present?
 
       if model.present?
-        @model = model
+        @model = apply_decoration_to_record model
 
         hydrate_model_with_default_values if @view == :new
       end
 
       self
+    end
+
+    # Used by external entities
+    def apply_decoration_to_record(record)
+      Avo::Services::DecoratorService.decorate_record(decoration: decorate_record, record: record, view: @view)
+    end
+
+    # Used by external entities
+    def apply_decoration_to_collection(collection)
+      Avo::Services::DecoratorService.decorate_collection(decoration: decorate_collection, collection: collection, view: @view)
     end
 
     def get_field_definitions
@@ -525,5 +537,7 @@ module Avo
     def ordering_host(**args)
       Avo::Hosts::Ordering.new resource: self, options: self.class.ordering, **args
     end
+
+    # def decorate_model
   end
 end

--- a/lib/avo/fields/has_base_field.rb
+++ b/lib/avo/fields/has_base_field.rb
@@ -30,7 +30,14 @@ module Avo
       end
 
       def resource
-        Avo::App.get_resource_by_model_name value(decorated: false).class
+        field_value = value(decorated: false)
+        record = if field_value.class.to_s.downcase.include? 'collectionproxy'
+          field_value.first
+        else
+          field_value
+        end
+
+        Avo::App.get_resource_by_model_name record.class
       end
 
       def turbo_frame

--- a/lib/avo/fields/has_base_field.rb
+++ b/lib/avo/fields/has_base_field.rb
@@ -16,12 +16,21 @@ module Avo
         @description = args[:description]
       end
 
+      def value(decorated: true)
+        val = super()
+
+        return val if val.nil?
+        return val if decorated == false
+
+        resource.apply_decoration_to_record(val)
+      end
+
       def searchable
         @searchable && ::Avo::App.license.has_with_trial(:searchable_associations)
       end
 
       def resource
-        Avo::App.get_resource_by_model_name @model.class
+        Avo::App.get_resource_by_model_name value(decorated: false).class
       end
 
       def turbo_frame

--- a/lib/avo/fields/has_one_field.rb
+++ b/lib/avo/fields/has_one_field.rb
@@ -17,9 +17,6 @@ module Avo
         value.send(target_resource.title)
       end
 
-      def resource
-        Avo::App.get_resource_by_model_name @model.class
-      end
 
       def frame_url
         "#{@resource.record_path}/#{id}/#{value.id}?turbo_frame=#{turbo_frame}"

--- a/lib/avo/hosts/view_collection_host.rb
+++ b/lib/avo/hosts/view_collection_host.rb
@@ -1,0 +1,8 @@
+module Avo
+  module Hosts
+    class ViewCollectionHost < BaseHost
+      option :view
+      option :collection
+    end
+  end
+end

--- a/lib/avo/services/decorator_service.rb
+++ b/lib/avo/services/decorator_service.rb
@@ -1,0 +1,19 @@
+module Avo
+  module Services
+    class DecoratorService
+      class << self
+        def decorate_record(record:, decoration:, **args)
+          return record if decoration.blank?
+
+          Avo::Hosts::ViewRecordHost.new(block: decoration, record: record, **args).handle
+        end
+
+        def decorate_collection(collection:, decoration:, **args)
+          return collection if decoration.blank?
+
+          Avo::Hosts::ViewCollectionHost.new(block: decoration, collection: collection, **args).handle
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/app/avo/resources/post_resource.rb
+++ b/spec/dummy/app/avo/resources/post_resource.rb
@@ -14,7 +14,9 @@ class PostResource < Avo::BaseResource
   end
 
   field :id, as: :id
-  field :decorated_name, as: :text, required: true, sortable: true, name: :Name
+  field :decorated_name, as: :text, required: true, sortable: true, name: :Name, hide_on: :forms
+  # keep this so forms won't try to update the decorated name property that doesn't really exist
+  field :name, as: :text, required: true, sortable: true, name: :Name, show_on: :forms
   field :body, as: :trix, placeholder: "Enter text", always_show: false, attachment_key: :attachments, hide_attachment_url: true, hide_attachment_filename: true, hide_attachment_filesize: true
   field :tags,
     as: :tags,

--- a/spec/dummy/app/avo/resources/post_resource.rb
+++ b/spec/dummy/app/avo/resources/post_resource.rb
@@ -1,14 +1,20 @@
 class PostResource < Avo::BaseResource
-  self.title = :name
+  self.title = :decorated_name
   self.search_query = ->(params:) do
     scope.ransack(id_eq: params[:q], name_cont: params[:q], body_cont: params[:q], m: "or").result(distinct: false)
   end
   self.search_query_help = "- search by id, name or body"
   self.includes = [:user]
   self.default_view_type = :grid
+  self.decorate_record = -> do
+    record.decorate
+  end
+  self.decorate_collection = -> do
+    collection.decorate
+  end
 
   field :id, as: :id
-  field :name, as: :text, required: true, sortable: true
+  field :decorated_name, as: :text, required: true, sortable: true, name: :Name
   field :body, as: :trix, placeholder: "Enter text", always_show: false, attachment_key: :attachments, hide_attachment_url: true, hide_attachment_filename: true, hide_attachment_filesize: true
   field :tags,
     as: :tags,
@@ -39,11 +45,7 @@ class PostResource < Avo::BaseResource
   grid do
     cover :cover_photo, as: :file, is_image: true, link_to_resource: true
     title :name, as: :text, required: true, link_to_resource: true
-    body :excerpt, as: :text do |model|
-      ActionView::Base.full_sanitizer.sanitize(model.body).truncate 130
-    rescue
-      ""
-    end
+    body :excerpt, as: :text
   end
 
   filter FeaturedFilter

--- a/spec/dummy/app/avo/resources/review_resource.rb
+++ b/spec/dummy/app/avo/resources/review_resource.rb
@@ -32,10 +32,15 @@ class ReviewResource < Avo::BaseResource
     polymorphic_as: :reviewable,
     types: [::Fish, ::Post, ::Project, ::Team],
     searchable: true,
-    allow_via_detaching: true, html: {
-      data: {
-        'resource-edit-target': 'emailField',
-        action: 'input->resource-edit#emailUpdate'
+    allow_via_detaching: true,
+    html: {
+      edit: {
+        input: {
+          data: {
+            'resource-edit-target': 'emailField',
+            action: 'input->resource-edit#emailUpdate'
+          }
+        }
       }
     },
     attach_scope: -> do

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -25,9 +25,8 @@ class UserResource < Avo::BaseResource
   field :id, as: :id, link_to_resource: true
   field :email, as: :gravatar, link_to_resource: true, as_avatar: :circle
   heading "User Information"
-  field :name, as: :text, only_on: :index
-  # field :first_name, as: :text, required: true, placeholder: "John"
-  # field :last_name, as: :text, required: true, placeholder: "Doe"
+  field :first_name, as: :text, required: true, placeholder: "John"
+  field :last_name, as: :text, required: true, placeholder: "Doe"
   field :email, as: :text, name: "User Email", required: true
   field :active, as: :boolean, name: "Is active", show_on: :show
   field :cv, as: :file, name: "CV"

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -13,14 +13,21 @@ class UserResource < Avo::BaseResource
   self.resolve_find_scope = ->(model_class:) do
     model_class.friendly
   end
+  self.decorate_record = -> do
+    UserDecorator.decorate record
+  end
+  self.decorate_collection = -> do
+    UserDecorator.decorate_collection collection
+  end
   self.includes = [:posts, :post]
   self.devise_password_optional = true
 
   field :id, as: :id, link_to_resource: true
   field :email, as: :gravatar, link_to_resource: true, as_avatar: :circle
   heading "User Information"
-  field :first_name, as: :text, required: true, placeholder: "John"
-  field :last_name, as: :text, required: true, placeholder: "Doe"
+  field :name, as: :text, only_on: :index
+  # field :first_name, as: :text, required: true, placeholder: "John"
+  # field :last_name, as: :text, required: true, placeholder: "Doe"
   field :email, as: :text, name: "User Email", required: true
   field :active, as: :boolean, name: "Is active", show_on: :show
   field :cv, as: :file, name: "CV"

--- a/spec/dummy/app/decorators/post_decorator.rb
+++ b/spec/dummy/app/decorators/post_decorator.rb
@@ -1,0 +1,12 @@
+class PostDecorator < Draper::Decorator
+  delegate_all
+
+  # This is here to test the decorator in different scenarios
+  def decorated_name
+    name
+  end
+
+  def excerpt
+    ActionView::Base.full_sanitizer.sanitize(body).truncate 130
+  end
+end

--- a/spec/dummy/app/decorators/user_decorator.rb
+++ b/spec/dummy/app/decorators/user_decorator.rb
@@ -1,0 +1,7 @@
+class UserDecorator < Draper::Decorator
+  delegate_all
+
+  def name
+    "#{first_name} #{last_name}"
+  end
+end

--- a/spec/dummy/app/decorators/user_decorator.rb
+++ b/spec/dummy/app/decorators/user_decorator.rb
@@ -4,4 +4,9 @@ class UserDecorator < Draper::Decorator
   def name
     "#{first_name} #{last_name}"
   end
+
+  # Returning the same thing just to test out the decoration functionality
+  def first_name
+    object.first_name
+  end
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -40,7 +40,7 @@ class User < ApplicationRecord
 
   has_one_attached :cv
 
-  friendly_id :name, use: :slugged
+  friendly_id :slug_candidates, use: :slugged
 
   scope :active, -> { where active: true }
   scope :admins, -> { where "(roles->>'admin')::boolean is true" }
@@ -68,5 +68,16 @@ class User < ApplicationRecord
 
   def avo_title
     is_admin? ? "Admin" : "Member"
+  end
+
+  # Friendly id
+  def slug_candidates
+    [
+      [:first_name, :last_name]
+    ]
+  end
+
+  def should_generate_new_friendly_id?
+    first_name_changed? || last_name_changed? || super
   end
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -50,10 +50,6 @@ class User < ApplicationRecord
     roles.present? && roles["admin"].present?
   end
 
-  def name
-    "#{first_name} #{last_name}"
-  end
-
   def notify(text)
     # notify about text
   end

--- a/spec/features/avo/belongs_to_polymorphic_spec.rb
+++ b/spec/features/avo/belongs_to_polymorphic_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "belongs_to", type: :system do
 
             click_on "Create new comment"
             fill_in "comment_body", with: "Sample comment"
-            select user.name, from: "comment_user_id"
+            select user.decorate.name, from: "comment_user_id"
             click_on "Save"
 
             wait_for_loaded
@@ -41,7 +41,7 @@ RSpec.feature "belongs_to", type: :system do
             return_to_comment_page
 
             expect(find_field_value_element("body")).to have_text "Sample comment"
-            expect(find_field_value_element("user")).to have_link user.name, href: "/admin/resources/users/#{user.slug}?via_resource_class=Comment&via_resource_id=#{Comment.last.id}"
+            expect(find_field_value_element("user")).to have_link user.decorate.name, href: "/admin/resources/users/#{user.slug}?via_resource_class=Comment&via_resource_id=#{Comment.last.id}"
             expect(find_field_value_element("commentable")).to have_text empty_dash
           end
         end
@@ -214,7 +214,7 @@ RSpec.feature "belongs_to", type: :system do
           click_on comment.id.to_s
 
           expect(find_field_value_element("body")).to have_text "hey there"
-          expect(find_field_value_element("user")).to have_link user.name, href: "/admin/resources/users/#{user.slug}?via_resource_class=Comment&via_resource_id=#{comment.id}"
+          expect(find_field_value_element("user")).to have_link user.decorate.name, href: "/admin/resources/users/#{user.slug}?via_resource_class=Comment&via_resource_id=#{comment.id}"
           expect(find_field_value_element("commentable")).to have_link project.name, href: "/admin/resources/projects/#{project.id}?via_resource_class=Comment&via_resource_id=#{comment.id}"
 
           click_on "Edit"

--- a/spec/features/avo/belongs_to_polymorphic_spec.rb
+++ b/spec/features/avo/belongs_to_polymorphic_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "belongs_to", type: :system do
 
               fill_in "comment_body", with: "Sample comment"
               select "Post", from: "comment_commentable_type"
-              select post.name, from: "comment_commentable_id"
+              select post.decorate.name, from: "comment_commentable_id"
               click_on "Save"
               wait_for_loaded
 
@@ -68,18 +68,18 @@ RSpec.feature "belongs_to", type: :system do
               expect(current_path).to eq "/admin/resources/comments/#{comment.id}"
 
               expect(find_field_value_element("body")).to have_text "Sample comment"
-              expect(page).to have_link post.name, href: "/admin/resources/posts/#{post.id}?via_resource_class=Comment&via_resource_id=#{Comment.last.id}"
+              expect(page).to have_link post.decorate.name, href: "/admin/resources/posts/#{post.id}?via_resource_class=Comment&via_resource_id=#{Comment.last.id}"
 
               click_on "Edit"
 
               expect(page).to have_select "comment_commentable_type", options: ["Choose an option", "Post", "Project"], selected: "Post"
-              expect(page).to have_select "comment_commentable_id", options: ["Choose an option", post.name, second_post.name, *other_posts.map(&:name)], selected: post.name
+              expect(page).to have_select "comment_commentable_id", options: ["Choose an option", post.decorate.name, second_post.decorate.name, *other_posts.map(&:name)], selected: post.decorate.name
 
               # Switch between types and check that values are kept for each one.
               select "Project", from: "comment_commentable_type"
               expect(page).to have_select "comment_commentable_id", options: ["Choose an option", project.name], selected: "Choose an option"
               select "Post", from: "comment_commentable_type"
-              expect(page).to have_select "comment_commentable_id", options: ["Choose an option", post.name, second_post.name, *other_posts.map(&:name)], selected: post.name
+              expect(page).to have_select "comment_commentable_id", options: ["Choose an option", post.decorate.name, second_post.decorate.name, *other_posts.map(&:name)], selected: post.decorate.name
 
               # Switch to Project, select one and save
               select "Project", from: "comment_commentable_type"
@@ -152,14 +152,14 @@ RSpec.feature "belongs_to", type: :system do
               expect(page).to have_select "comment_commentable_id", options: ["Choose an option", project.name], selected: project.name
 
               select "Post", from: "comment_commentable_type"
-              select post.name, from: "comment_commentable_id"
+              select post.decorate.name, from: "comment_commentable_id"
               click_on "Save"
 
               wait_for_loaded
 
               return_to_comment_page
 
-              expect(find_field_value_element("commentable")).to have_text post.name
+              expect(find_field_value_element("commentable")).to have_text post.decorate.name
             end
           end
         end
@@ -282,7 +282,7 @@ RSpec.feature "belongs_to", type: :system do
 
           expect(review.reviewable).to eq post
           expect(page).to have_text("Review was successfully created.").once
-          expect(find_field_value_element("reviewable")).to have_text post.name
+          expect(find_field_value_element("reviewable")).to have_text post.decorate.name
         end
       end
 
@@ -305,9 +305,9 @@ RSpec.feature "belongs_to", type: :system do
           it "changes the reviewable item" do
             visit "/admin/resources/reviews/#{review.id}/edit"
 
-            expect(page).to have_field "review_reviewable_id", with: post.name
+            expect(page).to have_field "review_reviewable_id", with: post.decorate.name
             expect(page).to have_select "review_reviewable_type", selected: "Post", options: ["Choose an option", "Fish", "Post", "Project", "Team"]
-            expect(page).to have_field type: "text", name: "review[reviewable_id]", with: post.name
+            expect(page).to have_field type: "text", name: "review[reviewable_id]", with: post.decorate.name
             expect(page).to have_field type: "hidden", name: "review[reviewable_id]", with: post.id, visible: false
 
             fill_in "review_body", with: "Avo rules!"
@@ -325,7 +325,7 @@ RSpec.feature "belongs_to", type: :system do
             wait_for_search_to_dissapear
             sleep 0.2
 
-            expect(page).to have_field type: "text", name: "review[reviewable_id]", with: second_post.name
+            expect(page).to have_field type: "text", name: "review[reviewable_id]", with: second_post.decorate.name
             expect(page).to have_field type: "hidden", name: "review[reviewable_id]", with: second_post.id, visible: false
 
             click_on "Save"
@@ -342,9 +342,9 @@ RSpec.feature "belongs_to", type: :system do
         it "nullifies the reviewable item" do
           visit "/admin/resources/reviews/#{review.id}/edit"
 
-          expect(page).to have_field "review_reviewable_id", with: post.name
+          expect(page).to have_field "review_reviewable_id", with: post.decorate.name
           expect(page).to have_select "review_reviewable_type", selected: "Post", options: ["Choose an option", "Fish", "Post", "Project", "Team"]
-          expect(page).to have_field type: "text", name: "review[reviewable_id]", with: post.name
+          expect(page).to have_field type: "text", name: "review[reviewable_id]", with: post.decorate.name
           expect(page).to have_field type: "hidden", name: "review[reviewable_id]", with: post.id, visible: false
 
           fill_in "review_body", with: "Avo rules!"
@@ -363,9 +363,9 @@ RSpec.feature "belongs_to", type: :system do
         it "toggles the reviewable item" do
           visit "/admin/resources/reviews/#{review.id}/edit"
 
-          expect(page).to have_field "review_reviewable_id", with: post.name
+          expect(page).to have_field "review_reviewable_id", with: post.decorate.name
           expect(page).to have_select "review_reviewable_type", selected: "Post", options: ["Choose an option", "Fish", "Post", "Project", "Team"]
-          expect(page).to have_field type: "text", name: "review[reviewable_id]", with: post.name
+          expect(page).to have_field type: "text", name: "review[reviewable_id]", with: post.decorate.name
           expect(page).to have_field type: "hidden", name: "review[reviewable_id]", with: post.id, visible: false
 
           # Change reviewable to Team and check for empty inputs
@@ -398,7 +398,7 @@ RSpec.feature "belongs_to", type: :system do
           # Change reviewable to Post and check for inputs filled with the post details
           select "Post", from: "review_reviewable_type"
 
-          expect(page).to have_field type: "text", name: "review[reviewable_id]", with: post.name
+          expect(page).to have_field type: "text", name: "review[reviewable_id]", with: post.decorate.name
           expect(page).to have_field type: "hidden", name: "review[reviewable_id]", with: post.id, visible: false
 
           # Change reviewable to Team and check for inputs filled with the team details
@@ -419,9 +419,9 @@ RSpec.feature "belongs_to", type: :system do
         it "nullifies the reviewable type" do
           visit "/admin/resources/reviews/#{review.id}/edit"
 
-          expect(page).to have_field "review_reviewable_id", with: post.name
+          expect(page).to have_field "review_reviewable_id", with: post.decorate.name
           expect(page).to have_select "review_reviewable_type", selected: "Post", options: ["Choose an option", "Fish", "Post", "Project", "Team"]
-          expect(page).to have_field type: "text", name: "review[reviewable_id]", with: post.name
+          expect(page).to have_field type: "text", name: "review[reviewable_id]", with: post.decorate.name
           expect(page).to have_field type: "hidden", name: "review[reviewable_id]", with: post.id, visible: false
 
           select "Choose an option", from: "review_reviewable_type"

--- a/spec/features/avo/belongs_to_spec.rb
+++ b/spec/features/avo/belongs_to_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "belongs_to", type: :feature do
     describe "with a related user" do
       let!(:post) { create :post, user: admin }
 
-      it { is_expected.to have_text admin.name }
+      it { is_expected.to have_text decorated_admin.name }
     end
 
     describe "without a related user" do
@@ -39,7 +39,7 @@ RSpec.feature "belongs_to", type: :feature do
     describe "with user attached" do
       let!(:post) { create :post, user: admin }
 
-      it { is_expected.to have_link admin.name, href: "/admin/resources/users/#{admin.slug}?via_resource_class=Post&via_resource_id=#{post.id}" }
+      it { is_expected.to have_link decorated_admin.name, href: "/admin/resources/users/#{admin.slug}?via_resource_class=Post&via_resource_id=#{post.id}" }
     end
 
     describe "without user attached" do
@@ -55,18 +55,18 @@ RSpec.feature "belongs_to", type: :feature do
     describe "without user attached" do
       let!(:post) { create :post, user: nil }
 
-      it { is_expected.to have_select "post_user_id", selected: nil, options: [empty_dash, admin.name] }
+      it { is_expected.to have_select "post_user_id", selected: nil, options: [empty_dash, decorated_admin.name] }
 
       it "changes the user" do
         visit url
-        expect(page).to have_select "post_user_id", selected: nil, options: [empty_dash, admin.name]
+        expect(page).to have_select "post_user_id", selected: nil, options: [empty_dash, decorated_admin.name]
 
-        select admin.name, from: "post_user_id"
+        select decorated_admin.name, from: "post_user_id"
 
         click_on "Save"
 
         expect(current_path).to eql "/admin/resources/posts/#{post.id}"
-        expect(page).to have_link admin.name, href: "/admin/resources/users/#{admin.slug}?via_resource_class=Post&via_resource_id=#{post.id}"
+        expect(page).to have_link decorated_admin.name, href: "/admin/resources/users/#{admin.slug}?via_resource_class=Post&via_resource_id=#{post.id}"
       end
     end
 
@@ -74,11 +74,11 @@ RSpec.feature "belongs_to", type: :feature do
       let!(:post) { create :post, user: admin }
       let!(:second_user) { create :user }
 
-      it { is_expected.to have_select "post_user_id", selected: admin.name }
+      it { is_expected.to have_select "post_user_id", selected: decorated_admin.name }
 
       it "changes the user" do
         visit url
-        expect(page).to have_select "post_user_id", selected: admin.name
+        expect(page).to have_select "post_user_id", selected: decorated_admin.name
 
         select second_user.decorate.name, from: "post_user_id"
 
@@ -90,7 +90,7 @@ RSpec.feature "belongs_to", type: :feature do
 
       it "nullifies the user" do
         visit url
-        expect(page).to have_select "post_user_id", selected: admin.name
+        expect(page).to have_select "post_user_id", selected: decorated_admin.name
 
         select empty_dash, from: "post_user_id"
 
@@ -105,7 +105,7 @@ RSpec.feature "belongs_to", type: :feature do
   context "new" do
     let(:url) { "/admin/resources/posts/new?via_relation=user&via_relation_class=User&via_resource_id=#{admin.id}" }
 
-    it { is_expected.to have_select "post_user_id", selected: admin.name, options: [empty_dash, admin.name], disabled: true }
+    it { is_expected.to have_select "post_user_id", selected: decorated_admin.name, options: [empty_dash, decorated_admin.name], disabled: true }
   end
 
   describe "hidden columns if current association" do

--- a/spec/features/avo/belongs_to_spec.rb
+++ b/spec/features/avo/belongs_to_spec.rb
@@ -80,12 +80,12 @@ RSpec.feature "belongs_to", type: :feature do
         visit url
         expect(page).to have_select "post_user_id", selected: admin.name
 
-        select second_user.name, from: "post_user_id"
+        select second_user.decorate.name, from: "post_user_id"
 
         click_on "Save"
 
         expect(current_path).to eql "/admin/resources/posts/#{post.id}"
-        expect(page).to have_link second_user.name, href: "/admin/resources/users/#{second_user.slug}?via_resource_class=Post&via_resource_id=#{post.id}"
+        expect(page).to have_link second_user.decorate.name, href: "/admin/resources/users/#{second_user.slug}?via_resource_class=Post&via_resource_id=#{post.id}"
       end
 
       it "nullifies the user" do
@@ -121,7 +121,7 @@ RSpec.feature "belongs_to", type: :feature do
       expect(find("thead")).not_to have_text "User"
       expect(page).to have_text comment.id
       expect(page).to have_text "a comment"
-      expect(page).not_to have_text user.name
+      expect(page).not_to have_text user.decorate.name
     end
   end
 
@@ -139,7 +139,7 @@ RSpec.feature "belongs_to", type: :feature do
       expect(find("thead")).not_to have_text "Commentable"
       expect(page).to have_text comment.id
       expect(page).to have_text "a comment"
-      expect(page).to have_text user.name
+      expect(page).to have_text user.decorate.name
       expect(page).not_to have_text project.name
     end
   end
@@ -158,7 +158,7 @@ RSpec.feature "belongs_to", type: :feature do
       expect(find("thead")).not_to have_text "Reviewable"
       expect(page).to have_text review.id
       expect(page).to have_text "a review"
-      expect(page).to have_text user.name
+      expect(page).to have_text user.decorate.name
       expect(page).not_to have_text team.name
     end
   end

--- a/spec/features/avo/has_many_field_spec.rb
+++ b/spec/features/avo/has_many_field_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "HasManyField", type: :feature do
         click_on "Create new post"
 
         expect(page).to have_current_path "/admin/resources/posts/new?via_relation=user&via_relation_class=User&via_resource_id=#{user.id}"
-        expect(page).to have_select "post_user_id", selected: user.name, disabled: true
+        expect(page).to have_select "post_user_id", selected: user.decorate.name, disabled: true
 
         fill_in "post_name", with: "New post name"
 

--- a/spec/features/avo/has_many_field_spec.rb
+++ b/spec/features/avo/has_many_field_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature "HasManyField", type: :feature do
         }.to change(Post, :count).by(-1)
 
         expect(page).to have_current_path url
-        expect(page).not_to have_text post.name
+        expect(page).not_to have_text post.decorate.name
       end
 
       it "detaches a post" do
@@ -103,7 +103,7 @@ RSpec.feature "HasManyField", type: :feature do
         }.to change(user.posts, :count).by(-1)
 
         expect(page).to have_current_path url
-        expect(page).not_to have_text post.name
+        expect(page).not_to have_text post.decorate.name
       end
     end
   end

--- a/spec/support/shared_contexts.rb
+++ b/spec/support/shared_contexts.rb
@@ -1,3 +1,4 @@
 shared_context "has_admin_user" do
   let(:admin) { create :user, roles: {admin: true} }
+  let(:decorated_admin) { UserDecorator.decorate admin }
 end

--- a/spec/system/avo/has_and_belongs_to_many_field_spec.rb
+++ b/spec/system/avo/has_and_belongs_to_many_field_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "HasAndBelongsToManyField", type: :system do
         expect(page).to have_text "Choose user"
         expect(page).to have_select "fields_related_id", selected: "Choose an option"
 
-        select user.name, from: "fields_related_id"
+        select user.decorate.name, from: "fields_related_id"
 
         expect {
           within '[aria-modal="true"]' do
@@ -51,7 +51,7 @@ RSpec.describe "HasAndBelongsToManyField", type: :system do
         expect(page).to have_text "Choose user"
         expect(page).to have_select "fields_related_id", selected: "Choose an option"
 
-        select user.name, from: "fields_related_id"
+        select user.decorate.name, from: "fields_related_id"
 
         expect {
           click_on "Cancel"
@@ -73,7 +73,7 @@ RSpec.describe "HasAndBelongsToManyField", type: :system do
       #   expect(page).to have_text 'Choose user'
       #   expect(page).to have_select 'fields_related_id', selected: 'Choose an option'
 
-      #   select user.name, from: 'fields_related_id'
+      #   select user.decorate.name, from: 'fields_related_id'
 
       #   expect {
       #     click_on 'Attach & Attach another'
@@ -83,7 +83,7 @@ RSpec.describe "HasAndBelongsToManyField", type: :system do
       #   expect(page).to have_text 'Choose user'
       #   expect(page).to have_select 'fields_related_id', selected: 'Choose an option'
 
-      #   select user.name, from: 'fields_related_id'
+      #   select user.decorate.name, from: 'fields_related_id'
 
       #   expect {
       #     click_on 'Attach'

--- a/spec/system/avo/has_many_spec.rb
+++ b/spec/system/avo/has_many_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "HasManyField", type: :system do
 
           row = find("[data-resource-name='comments'][data-resource-id='#{comment.id}']")
 
-          expect(row.find('[data-field-id="user"]').text).to eq user.name
+          expect(row.find('[data-field-id="user"]').text).to eq user.decorate.name
         end
       end
     end
@@ -31,7 +31,7 @@ RSpec.feature "HasManyField", type: :system do
 
           row = find("[data-resource-name='reviews'][data-resource-id='#{review.id}']")
 
-          expect(row.find('[data-field-id="user"]').text).to eq user.name
+          expect(row.find('[data-field-id="user"]').text).to eq user.decorate.name
         end
       end
     end

--- a/spec/system/avo/has_one_field_name_spec.rb
+++ b/spec/system/avo/has_one_field_name_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'HasOneFieldName', type: :system do
 
   subject {
     visit url
-    page 
+    page
   }
 
   context 'show' do
@@ -22,14 +22,14 @@ RSpec.describe 'HasOneFieldName', type: :system do
         expect(page).to have_text 'Choose post'
 
         expect(page).to have_select 'fields_related_id', selected: "Choose an option"
-        select post.name, from: 'fields_related_id'
+        select post.decorate.name, from: 'fields_related_id'
 
         click_on 'Attach'
         wait_for_loaded
 
         expect(page).to have_text 'Post attached.'
         expect(page).not_to have_text 'Choose post'
-        expect(page).to have_text post.name
+        expect(page).to have_text post.decorate.name
 
         expect(user.posts.pluck('id')).to include post.id
 

--- a/spec/system/avo/has_one_field_spec.rb
+++ b/spec/system/avo/has_one_field_spec.rb
@@ -11,7 +11,7 @@
 #     describe 'with a related user' do
 #       let!(:team) { create :team, admin: user }
 
-#       it { is_expected.to have_text user.name }
+#       it { is_expected.to have_text user.decorate.name }
 #     end
 
 #     describe 'without a related user' do
@@ -36,7 +36,7 @@
 #     describe 'with user attached' do
 #       let!(:team) { create :team, admin: user }
 
-#       it { is_expected.to have_link user.name, href: "/admin/resources/users/#{user.id}" }
+#       it { is_expected.to have_link user.decorate.name, href: "/admin/resources/users/#{user.id}" }
 #     end
 
 #     describe 'without user attached' do
@@ -58,13 +58,13 @@
 #         visit url
 #         expect(page).to have_select 'admin', selected: 'Choose an option'
 
-#         select user.name, from: 'admin'
+#         select user.decorate.name, from: 'admin'
 
 #         click_on 'Save'
 #         wait_for_loaded
 
 #         expect(current_path).to eql "/admin/resources/teams/#{team.id}"
-#         expect(page).to have_link user.name, href: "/admin/resources/users/#{user.id}"
+#         expect(page).to have_link user.decorate.name, href: "/admin/resources/users/#{user.id}"
 #       end
 #     end
 
@@ -72,24 +72,24 @@
 #       let!(:team) { create :team, admin: user }
 #       let!(:second_user) { create :user }
 
-#       it { is_expected.to have_select 'admin', selected: user.name }
+#       it { is_expected.to have_select 'admin', selected: user.decorate.name }
 
 #       it 'changes the user' do
 #         visit url
-#         expect(page).to have_select 'admin', selected: user.name
+#         expect(page).to have_select 'admin', selected: user.decorate.name
 
-#         select second_user.name, from: 'admin'
+#         select second_user.decorate.name, from: 'admin'
 
 #         click_on 'Save'
 #         wait_for_loaded
 
 #         expect(current_path).to eql "/admin/resources/teams/#{team.id}"
-#         expect(page).to have_link second_user.name, href: "/admin/resources/users/#{second_user.id}"
+#         expect(page).to have_link second_user.decorate.name, href: "/admin/resources/users/#{second_user.id}"
 #       end
 
 #       it 'nullifies the user' do
 #         visit url
-#         expect(page).to have_select 'admin', selected: user.name
+#         expect(page).to have_select 'admin', selected: user.decorate.name
 
 #         select 'Choose an option', from: 'admin'
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds the ability to assign decorators to resources.

```ruby
  self.decorate_record = -> do
    UserDecorator.decorate record
  end
  self.decorate_collection = -> do
    UserDecorator.decorate_collection collection
  end
```

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
