### PR TITLE
Fixed rescue block in engine.rb

### DIFF
--- a/lib/avo/engine.rb
+++ b/lib/avo/engine.rb
@@ -71,7 +71,7 @@ module Avo
         begin
           Licensing::HQ.new.clear_response
         rescue => exception
-          puts "Failed to clear Avo HQ response: #{e.message}"
+          puts "Failed to clear Avo HQ response: #{exception.message}"
         end
       end
     end


### PR DESCRIPTION
# Description
There was a typo in `engine.rb` that prevented the license response `rescue` block to work properly. Currently, if a license error occurs (due to a bad license key for instance), CI fails with an `undefined method` error instead of logging the actual error. I guess staging and production environments are affected as well.