### PR TITLE
feature: show actions on edit view

### DIFF
--- a/app/components/avo/actions_component.html.erb
+++ b/app/components/avo/actions_component.html.erb
@@ -4,6 +4,7 @@
   data-actions-picker-disabled-class="cursor-wait text-gray-500"
 >
   <%= a_button style: :outline,
+    type: :button,
     color: :primary,
     class: "focus:outline-none",
     icon: 'arrow-circle-right',
@@ -18,24 +19,14 @@
   >
     <div class="w-full space divide-y">
       <% @actions.each_with_index do |action, index| %>
-        <%
-          path = action_name == 'show' ?
-            "#{@resource.record_path}/actions/#{action.param_id}" :
-            "#{@resource.records_path}/actions/#{action.param_id}"
-          if action_name == 'show' || action.standalone
-            disabled = false
-          else
-            disabled = true
-          end
-        %>
-        <%= link_to path,
+        <%= link_to action_path(action.param_id),
           data: {
             'turbo-frame': 'actions_show',
             'action': 'click->actions-picker#visitAction',
             'actions-picker-target': action.standalone ? 'standaloneAction' : 'resourceAction',
-            'disabled': disabled,
+            'disabled': is_disabled?(action),
           },
-          class: "flex items-center px-4 py-3 w-full font-semibold text-sm #{disabled ? 'text-gray-500' : 'text-black hover:bg-blue-500 hover:text-white'}" do %>
+          class: "flex items-center px-4 py-3 w-full font-semibold text-sm #{is_disabled?(action) ? 'text-gray-500' : 'text-black hover:bg-blue-500 hover:text-white'}" do %>
           <%= svg 'play', class: 'h-5 mr-1 inline' %> <%= action.action_name %>
         <% end %>
       <% end %>

--- a/app/components/avo/actions_component.rb
+++ b/app/components/avo/actions_component.rb
@@ -3,12 +3,50 @@
 class Avo::ActionsComponent < ViewComponent::Base
   include Avo::ApplicationHelper
 
-  def initialize(actions: [], resource: nil)
+  def initialize(actions: [], resource: nil, view: nil)
     @actions = actions
     @resource = resource
+    @view = view
   end
 
   def render?
     @actions.present?
+  end
+
+  # When running an action for one record we should do it on a special path.
+  # We do that so we get the `model` param inside the action so we can prefill fields.
+  def action_path(id)
+    return many_records_path(id) unless @resource.has_model_id?
+
+    if on_record_page?
+      single_record_path id
+    else
+      many_records_path id
+    end
+  end
+
+  # How should the action be displayed by default
+  def is_disabled?(action)
+    return false if action.standalone
+
+    on_index_page?
+  end
+
+  private
+
+  def on_record_page?
+    @view.in?([:show, :edit, :new])
+  end
+
+  def on_index_page?
+    !on_record_page?
+  end
+
+  def single_record_path(id)
+    "#{@resource.record_path}/actions/#{id}"
+  end
+
+  def many_records_path(id)
+    "#{@resource.records_path}/actions/#{id}"
   end
 end

--- a/app/components/avo/views/resource_edit_component.html.erb
+++ b/app/components/avo/views/resource_edit_component.html.erb
@@ -2,6 +2,8 @@
   class: "space-y-12",
   data: {
     'model-id': @resource.model.id,
+    selected_resources_name: @resource.model_key,
+    selected_resources: [@resource.model.id],
     **@resource.stimulus_data_attributes
   } do %>
   <% @resource.panels.each do |resource_panel| %>
@@ -18,6 +20,7 @@
             icon: 'arrow-left' do %>
             <%= t('avo.cancel').capitalize %>
           <% end %>
+          <%= render Avo::ActionsComponent.new actions: @actions, resource: @resource, view: @view %>
           <% if can_see_the_save_button? %>
             <%= a_button color: :primary,
               style: :primary,

--- a/app/components/avo/views/resource_edit_component.rb
+++ b/app/components/avo/views/resource_edit_component.rb
@@ -6,9 +6,10 @@ class Avo::Views::ResourceEditComponent < Avo::ResourceComponent
 
   attr_reader :view
 
-  def initialize(resource: nil, model: nil, view: :edit)
+  def initialize(resource: nil, model: nil, actions: [], view: :edit)
     @resource = resource
     @model = model
+    @actions = actions
     @view = view
 
     split_panel_fields

--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -15,7 +15,7 @@
         <% end %>
       <% end %>
       <% if can_see_the_actions_button? %>
-        <%= render Avo::ActionsComponent.new actions: @actions, resource: @resource %>
+        <%= render Avo::ActionsComponent.new actions: @actions, resource: @resource, view: @view %>
       <% end %>
       <% if can_see_the_create_button? %>
         <%= a_link create_path,

--- a/app/components/avo/views/resource_show_component.html.erb
+++ b/app/components/avo/views/resource_show_component.html.erb
@@ -22,7 +22,7 @@
                 } do %>
                 <%= t('avo.detach_item', item: title).capitalize %>
               <% end %>
-              <%= render Avo::ActionsComponent.new actions: @actions, resource: @resource %>
+              <%= render Avo::ActionsComponent.new actions: @actions, resource: @resource, view: @view %>
             <% end %>
             <% if can_see_the_edit_button? %>
               <%= a_link edit_path,
@@ -57,7 +57,7 @@
                 <%= t('avo.delete').capitalize %>
               <% end %>
             <% end %>
-            <%= render Avo::ActionsComponent.new actions: @actions, resource: @resource %>
+            <%= render Avo::ActionsComponent.new actions: @actions, resource: @resource, view: @view %>
             <% if @resource.authorization.authorize_action(:edit, raise_exception: false) %>
               <%= a_link edit_path,
                 color: :primary,

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -101,6 +101,8 @@ module Avo
       @model = @resource.model_class.new
       @resource = @resource.hydrate(model: @model, view: :new, user: _current_user)
 
+      set_actions
+
       @page_title = @resource.default_panel_name.to_s
 
       if params[:via_relation_class].present? && params[:via_resource_id].present?
@@ -161,6 +163,7 @@ module Avo
     end
 
     def edit
+      set_actions
     end
 
     def update

--- a/app/views/avo/base/edit.html.erb
+++ b/app/views/avo/base/edit.html.erb
@@ -1,2 +1,2 @@
-<%= render Avo::Views::ResourceEditComponent.new(resource: @resource, view: @view) %>
+<%= render Avo::Views::ResourceEditComponent.new(resource: @resource, view: @view, actions: @actions) %>
 

--- a/app/views/avo/base/new.html.erb
+++ b/app/views/avo/base/new.html.erb
@@ -1,1 +1,1 @@
-<%= render Avo::Views::ResourceEditComponent.new(resource: @resource, model: @model, view: @view) %>
+<%= render Avo::Views::ResourceEditComponent.new(resource: @resource, model: @model, view: @view, actions: @actions) %>

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -120,9 +120,14 @@ module Avo
     end
 
     def visible_in_view
-      return true unless visible.present?
+      # Run the visible block if available
+      return instance_exec(resource: self.class.resource, view: view, &visible) if visible.present?
 
-      instance_exec(resource: self.class.resource, view: view, &visible)
+      # Hide on the :new view by default
+      return false if view == :new
+
+      # Show on all other views
+      true
     end
 
     def param_id

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -5,6 +5,7 @@ module Avo
 
     include ActionView::Helpers::UrlHelper
     include Avo::Concerns::HasTools
+    include Avo::Concerns::HasModel
     include Avo::Concerns::HasFields
     include Avo::Concerns::HasStimulusControllers
 

--- a/lib/avo/concerns/has_model.rb
+++ b/lib/avo/concerns/has_model.rb
@@ -1,0 +1,11 @@
+module Avo
+  module Concerns
+    module HasModel
+      extend ActiveSupport::Concern
+
+      def has_model_id?
+        model.present? && model.id.present?
+      end
+    end
+  end
+end

--- a/spec/dummy/app/avo/actions/toggle_admin.rb
+++ b/spec/dummy/app/avo/actions/toggle_admin.rb
@@ -1,6 +1,11 @@
 class ToggleAdmin < Avo::BaseAction
   self.name = "Toggle admin"
   self.no_confirmation = true
+  self.visible = -> (resource:, view:) {
+    # puts ["view->", view].inspect
+    # view == :edit
+    view == :new
+  }
 
   def handle(**args)
     models, fields, current_user, resource = args.values_at(:models, :fields, :current_user, :resource)

--- a/spec/dummy/app/javascript/avo_custom.js
+++ b/spec/dummy/app/javascript/avo_custom.js
@@ -2,7 +2,6 @@ import { Application } from '@hotwired/stimulus'
 import CourseResourceController from './avo_custom/course_resource_controller'
 
 const application = Application.start()
-console.log('mer')
 
 // Configure Stimulus development experience
 application.debug = window?.localStorage.getItem('avo.debug')


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/977 and adds the actions on the `Edit` and `New` views.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to new user page
2. Check that the `ToggleAdmin` action is visible
3. No other actions will be visible on the `New` view
4. The rest of the actions will be visible on all the other views `Index`, `Edit`, `Show`

Manual reviewer: please leave a comment with output from the test if that's the case.
