### PR TITLE
fix: hard-coded policy action called on ResourceEditComponent

### DIFF
--- a/app/components/avo/views/resource_edit_component.rb
+++ b/app/components/avo/views/resource_edit_component.rb
@@ -32,7 +32,7 @@ class Avo::Views::ResourceEditComponent < Avo::ResourceComponent
   # The save button is dependent on the edit? policy method.
   # The update? method should be called only when the user clicks the Save button so the developer gets access to the params from the form.
   def can_see_the_save_button?
-    @resource.authorization.authorize_action :edit, raise_exception: false
+    @resource.authorization.authorize_action @view, raise_exception: false
   end
 
   private


### PR DESCRIPTION
# Description
Following the recent refactoring, a little authorization bug slipped through : the `can_see_the_save_button?` would call the `:edit` action, even on `:new` action. Therefore the `save` button would not appear despite correct authorization rules.