### PR TITLE
fix: date field format in mobile browsers

### DIFF
--- a/app/components/avo/fields/date_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_field/edit_component.html.erb
@@ -6,6 +6,7 @@
         'date-field-target': 'input',
         'first-day-of-week': @field.first_day_of_week,
         'picker-format': @field.picker_format,
+        'support-mobile': @field.support_mobile,
         'enable-time': false,
         format: @field.format,
         placeholder: @field.placeholder,

--- a/app/components/avo/fields/date_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_field/edit_component.html.erb
@@ -6,7 +6,7 @@
         'date-field-target': 'input',
         'first-day-of-week': @field.first_day_of_week,
         'picker-format': @field.picker_format,
-        'support-mobile': @field.support_mobile,
+        'disable-mobile': @field.disable_mobile,
         'enable-time': false,
         format: @field.format,
         placeholder: @field.placeholder,

--- a/app/components/avo/fields/date_time_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_time_field/edit_component.html.erb
@@ -6,6 +6,7 @@
         'date-field-target': 'input',
         'first-day-of-week': @field.first_day_of_week,
         'picker-format': @field.picker_format,
+        'support-mobile': @field.support_mobile,
         'enable-time': true,
         time24hr: @field.time_24hr,
         timezone: @field.timezone,

--- a/app/components/avo/fields/date_time_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_time_field/edit_component.html.erb
@@ -6,7 +6,7 @@
         'date-field-target': 'input',
         'first-day-of-week': @field.first_day_of_week,
         'picker-format': @field.picker_format,
-        'support-mobile': @field.support_mobile,
+        'disable-mobile': @field.disable_mobile,
         'enable-time': true,
         time24hr: @field.time_24hr,
         timezone: @field.timezone,

--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -28,7 +28,7 @@ export default class extends Controller {
     // Set the format of the displayed input field.
     options.altFormat = this.inputTarget.dataset.pickerFormat
 
-    // Support mobile browsers
+    // Disable native input in mobile browsers
     options.disableMobile = this.inputTarget.dataset.disableMobile
 
     // Set first day of the week.

--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -28,6 +28,9 @@ export default class extends Controller {
     // Set the format of the displayed input field.
     options.altFormat = this.inputTarget.dataset.pickerFormat
 
+    // Support mobile browsers
+    options.disableMobile = this.inputTarget.dataset.supportMobile
+
     // Set first day of the week.
     options.locale.firstDayOfWeek = this.inputTarget.dataset.firstDayOfWeek
 

--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -29,7 +29,7 @@ export default class extends Controller {
     options.altFormat = this.inputTarget.dataset.pickerFormat
 
     // Support mobile browsers
-    options.disableMobile = this.inputTarget.dataset.supportMobile
+    options.disableMobile = this.inputTarget.dataset.disableMobile
 
     // Set first day of the week.
     options.locale.firstDayOfWeek = this.inputTarget.dataset.firstDayOfWeek

--- a/lib/avo/fields/date_field.rb
+++ b/lib/avo/fields/date_field.rb
@@ -3,7 +3,7 @@ module Avo
     class DateField < TextField
       attr_reader :first_day_of_week
       attr_reader :picker_format
-      attr_reader :support_mobile
+      attr_reader :disable_mobile
       attr_reader :format
       attr_reader :relative
 
@@ -14,7 +14,7 @@ module Avo
         @picker_format = args[:picker_format].present? ? args[:picker_format] : "Y-m-d"
         @format = args[:format].present? ? args[:format] : :long
         @relative = args[:relative].present? ? args[:relative] : false
-        @support_mobile = args[:support_mobile].present? ? args[:support_mobile] : false
+        @disable_mobile = args[:disable_mobile].present? ? args[:disable_mobile] : false
       end
 
       def formatted_value

--- a/lib/avo/fields/date_field.rb
+++ b/lib/avo/fields/date_field.rb
@@ -3,6 +3,7 @@ module Avo
     class DateField < TextField
       attr_reader :first_day_of_week
       attr_reader :picker_format
+      attr_reader :support_mobile
       attr_reader :format
       attr_reader :relative
 
@@ -13,6 +14,7 @@ module Avo
         @picker_format = args[:picker_format].present? ? args[:picker_format] : "Y-m-d"
         @format = args[:format].present? ? args[:format] : :long
         @relative = args[:relative].present? ? args[:relative] : false
+        @support_mobile = args[:support_mobile].present? ? args[:support_mobile] : false
       end
 
       def formatted_value


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #975 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Configure a resource with date field
2. Specify a custom format for date and set `disable_mobile` to `true`
3. Go to new/edit page in web & mobile browsers

**Example:**
```ruby
field :date, as: :date, required: true, picker_format: 'd F, Y', format: '%d %B, %Y', default: Date.today, disable_mobile: true
```

**Output:**
<img width="393" alt="Date Field - Mobile - Fixed" src="https://user-images.githubusercontent.com/23002310/175897182-37f62bf0-14ef-4c0a-a9b3-61be30f5880a.png">

