### PR TITLE
fix: key value field new->create view

### DIFF
--- a/app/components/avo/fields/common/key_value_component.html.erb
+++ b/app/components/avo/fields/common/key_value_component.html.erb
@@ -3,7 +3,7 @@
   data-key-value-target="controller"
   data-options="<%= @field.options.to_json %>"
   data-input-classes="<%= input_classes %>"
-  data-editable="<%= @view.in?([:edit, :create]) %>"
+  data-editable="<%= @view.in?([:edit, :new]) %>"
 >
   <div class="w-full flex flex-col">
     <div class="flex w-full">
@@ -14,7 +14,7 @@
         <div class="w-1/2 py-3 px-3 uppercase font-semibold text-xs text-white">
           <%= @field.value_label %>
         </div>
-        <% if @view.in?([:edit, :create]) %>
+        <% if @view.in?([:edit, :new]) %>
           <div class="flex items-center justify-center p-2 px-3 border-l border-gray-600">
             <a href="javascript:void(0);"
               title="<%= @field.action_text %>"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where the view used was `new` instead of `create` making the key value field inoperable in some scenarios.

https://discord.com/channels/740892036978442260/740893011994738751/992514007846105128

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

