### PR TITLE
chore: don't crash Avo if SSL error raised

### DIFF
--- a/lib/avo/licensing/h_q.rb
+++ b/lib/avo/licensing/h_q.rb
@@ -121,6 +121,8 @@ module Avo
           cache_and_return_error "HTTP connection reset error.", exception.message
         rescue Errno::ECONNREFUSED => exception
           cache_and_return_error "HTTP connection refused error.", exception.message
+        rescue OpenSSL::SSL::SSLError => exception
+          cache_and_return_error "OpenSSL error.", exception.message
         rescue HTTParty::Error => exception
           cache_and_return_error "HTTP client error.", exception.message
         rescue Net::OpenTimeout => exception


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This gracefully catches SSL errors with avohq.io. Instead of crashing the app it keeps it still usable.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

