### PR TITLE
chore: add generators dir to zetwerk ignore

### DIFF
--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -3,6 +3,7 @@ require_relative "avo/version"
 require_relative "avo/engine" if defined?(Rails)
 
 loader = Zeitwerk::Loader.for_gem
+loader.ignore("#{__dir__}/generators")
 loader.setup
 
 module Avo


### PR DESCRIPTION
# Description

Fixes #1034

Related PR for v2.x: https://github.com/avo-hq/avo/pull/963/files

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


I tested this by adding this to my Rails app `Gemfile`:

```rb
gem 'avo', path: '../../gems/avo'
```

And made sure there's no Zeitwerk warning after running `bundle exec rails console`