### PR TITLE
fix: `as_avatar: :square` option doesn't work

### DIFF
--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -147,6 +147,9 @@ export default class extends Controller {
               case 'rounded':
                 classes = 'rounded'
                 break
+              case 'square':
+                classes = 'rounded-none'
+                break
             }
 
             children.push(


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #990

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Add `as_avatar: :square` option to image files
1. Click on 'Search' form

Manual reviewer: please leave a comment with output from the test if that's the case.
