### PR TITLE
Fix Resource Search when Overriding Model

### DIFF
--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -34,7 +34,7 @@
       >
         <% if @resource.search_query.present? %>
           <div class="flex items-center px-4 w-64">
-            <%= render partial: 'avo/partials/resource_search', locals: {resource: @resource.model_name.collection} %>
+            <%= render partial: 'avo/partials/resource_search', locals: {resource: @resource.model_key} %>
           </div>
         <% else %>
           <%# Offset for the space-y-2 property when the search is missing %>


### PR DESCRIPTION
# Description
Use Resource's `model_key` when generating search url


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
Works locally with a namespaced model class, in addition to normal resources.

`self.model_class = SalesList::Organization`