### PR TITLE
fix: locale configuration broken

### DIFF
--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -295,7 +295,7 @@ module Avo
       I18n.with_locale(locale, &action)
     end
 
-    # Enable the user to change the default locale wiht the `?set_locale=pt-BR` param
+    # Enable the user to change the default locale with the `?set_locale=pt-BR` param
     def set_default_locale
       locale = params[:set_locale] || I18n.default_locale
 

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -11,10 +11,11 @@ module Avo
     include Avo::UrlHelpers
 
     protect_from_forgery with: :exception
+    around_action :set_avo_locale
+    around_action :set_force_locale, if: -> { params[:force_locale].present? }
+    before_action :set_default_locale, if: -> { params[:set_locale].present? }
     before_action :init_app
     before_action :check_avo_license
-    before_action :set_default_locale
-    around_action :set_force_locale, if: -> { params[:force_locale].present? }
     before_action :set_authorization
     before_action :_authenticate!
     before_action :set_container_classes
@@ -288,10 +289,17 @@ module Avo
       @resource.form_scope
     end
 
-    def set_default_locale
-      I18n.locale = params[:set_locale] || I18n.default_locale
+    # Sets the locale set in avo.rb initializer
+    def set_avo_locale(&action)
+      locale = Avo.configuration.locale || I18n.default_locale
+      I18n.with_locale(locale, &action)
+    end
 
-      I18n.default_locale = I18n.locale
+    # Enable the user to change the default locale wiht the `?set_locale=pt-BR` param
+    def set_default_locale
+      locale = params[:set_locale] || I18n.default_locale
+
+      I18n.default_locale = locale
     end
 
     # Temporary set the locale and reverting at the end of the request.

--- a/lib/avo/app.rb
+++ b/lib/avo/app.rb
@@ -20,8 +20,6 @@ module Avo
       def boot
         init_fields
 
-        I18n.locale = Avo.configuration.language_code
-
         if Rails.cache.instance_of?(ActiveSupport::Cache::NullStore)
           self.cache_store ||= ActiveSupport::Cache::MemoryStore.new
         else

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -40,7 +40,7 @@ module Avo
       @per_page = 24
       @per_page_steps = [12, 24, 48, 72]
       @via_per_page = 8
-      @locale = "en-US"
+      @locale = nil
       @currency = "USD"
       @default_view_type = :table
       @license = "community"
@@ -76,16 +76,6 @@ module Avo
       @buttons_on_form_footers = false
       @main_menu = nil
       @profile_menu = nil
-    end
-
-    def locale_tag
-      ::ISO::Tag.new(locale)
-    end
-
-    def language_code
-      locale_tag.language.code
-    rescue
-      "en"
     end
 
     def current_user_method(&block)

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -18,8 +18,19 @@ module AvoDummy
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
-    # Used to test root_path_without_url helper
+
+    # Use this to test root_path_without_url helper
+    # ---
     # config.relative_url_root = '/development/internal-api'
+    # ---
+
+
+    # Use this to test the locale configuration
+    # ---
+    # config.i18n.available_locales = [:fr, :en, :ro]
+    # config.i18n.default_locale = :fr
+    # ---
+
 
     config.action_view.form_with_generates_remote_forms = false
   end

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -2,7 +2,6 @@ Avo.configure do |config|
   config.root_path = "/admin"
   config.app_name = "Avocadelicious"
   config.license = "pro"
-  config.locale = "en-US"
   config.license_key = ENV["AVO_LICENSE_KEY"]
   config.current_user_method = :current_user
   config.id_links_to_resource = true


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1022

[Docs](https://docs.avohq.io/2.0/localization.html#setting-the-locale)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add testes if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. De-comment the locale testing helpers in application.rb
2. Load Avo
3. Observe it uses `fr` locale
4. add the `force_locale=ro` param
5. Observe it uses the to locale
6. Navigate to another page
7. Observe it still uses `ro` and the param is still present
8. Remove the param
9. Observe it switched back to `fr`
10. Use the `set_locale=ro` param
11. Observe it uses the to param
12. Navigate to another page
13. Observe it uses to and the param is gone

Manual reviewer: please leave a comment with output from the test if that's the case.
