### PR TITLE
fix: inverse of crashing association screen

### DIFF
--- a/lib/avo/concerns/has_fields.rb
+++ b/lib/avo/concerns/has_fields.rb
@@ -183,6 +183,7 @@ module Avo
               if field.is_a?(Avo::Fields::BelongsToField)
                 if field.respond_to?(:foreign_key) &&
                     reflection.inverse_of.present? &&
+                    reflection.inverse_of.respond_to?(:foreign_key) &&
                     reflection.inverse_of.foreign_key == field.foreign_key
                   is_valid = false
                 end
@@ -191,6 +192,7 @@ module Avo
                 if field.respond_to?(:foreign_key) &&
                     field.is_polymorphic? &&
                     reflection.respond_to?(:polymorphic?) &&
+                    reflection.inverse_of.respond_to?(:foreign_key) &&
                     reflection.inverse_of.foreign_key == field.reflection.foreign_key
                   is_valid = false
                 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/979

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add testes if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

