### PR TITLE
fix: date field wrongly subtracts time zone offsets

### DIFF
--- a/app/components/avo/fields/date_time_field/index_component.html.erb
+++ b/app/components/avo/fields/date_time_field/index_component.html.erb
@@ -2,6 +2,7 @@
    <%= content_tag :div, data: {
     controller: "date-field",
     date_field_view_value: @view,
+    date_field_enable_time_value: true,
     date_field_format_value: @field.format,
     date_field_timezone_value: @field.timezone,
     date_field_picker_format_value: @field.picker_format,

--- a/app/components/avo/fields/date_time_field/show_component.html.erb
+++ b/app/components/avo/fields/date_time_field/show_component.html.erb
@@ -2,6 +2,7 @@
   <%= content_tag :div, data: {
     controller: "date-field",
     date_field_view_value: @view,
+    date_field_enable_time_value: true,
     date_field_format_value: @field.format,
     date_field_timezone_value: @field.timezone,
     date_field_picker_format_value: @field.picker_format,

--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -68,7 +68,14 @@ export default class extends Controller {
 
   // Turns the value in the controller wrapper into the timezone of the browser
   initShow() {
-    this.context.element.innerText = this.parsedValue.setZone(this.displayTimezone).toFormat(this.formatValue)
+    let value = this.parsedValue
+
+    // Set the zone only if the type of field is date time.
+    if (this.enableTimeValue) {
+      value = value.setZone(this.displayTimezone)
+    }
+
+    this.context.element.innerText = value.toFormat(this.formatValue)
   }
 
   initEdit() {
@@ -99,10 +106,13 @@ export default class extends Controller {
 
     // enable timezone display
     if (this.enableTimeValue) {
+      console.log(1)
       options.defaultDate = this.parsedValue.setZone(this.displayTimezone).toISO()
 
       options.dateFormat = 'Y-m-d H:i:S'
     } else {
+      console.log(2)
+
       // Because the browser treats the date like a timestamp and updates it at 00:00 hour, when on a western timezone the date will be converted with one day offset.
       // Ex: 2022-01-30 will render as 2022-01-29 on an American timezone
       options.defaultDate = universalTimestamp(this.initialValue)

--- a/spec/dummy/app/avo/resources/project_resource.rb
+++ b/spec/dummy/app/avo/resources/project_resource.rb
@@ -18,11 +18,10 @@ class ProjectResource < Avo::BaseResource
     display_value: true,
     include_blank: false
   field :stage, as: :badge, options: {info: ["Discovery", "Idea"], success: "Done", warning: "On hold", danger: "Cancelled"}
-  # currency :budget, currency: 'EUR', locale: 'de-DE'
   field :country,
     as: :country,
     index_text_align: :left,
-    include_blank: 'No country'
+    include_blank: "No country"
   field :users_required, as: :number, min: 10, max: 1000000, step: 1, index_text_align: :right
   field :started_at, as: :date_time, name: "Started", time_24hr: true, relative: true, timezone: "EET", nullable: true
   field :description, as: :markdown, height: "350px"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1079

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add testes if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Set the birthday of a user to the 20th
1. set the browser timezone to `CST`
2. observer the date on index and show views is actually 20th, not 19th
3. checkt the time field to make sure it updates properly

Manual reviewer: please leave a comment with output from the test if that's the case.
