### PR TITLE
feature: protocol option for text field

### DIFF
--- a/app/components/avo/fields/text_field/index_component.html.erb
+++ b/app/components/avo/fields/text_field/index_component.html.erb
@@ -1,6 +1,8 @@
 <%= index_field_wrapper field: @field, resource: @resource do %>
   <% if @field.as_html %>
     <%== @field.value %>
+  <% elsif @field.protocol.present? %>
+    <%= link_to @field.value, "#{@field.protocol}:#{@field.value}" %>
   <% else %>
     <%= link_to_if @field.link_to_resource, @field.value, resource_path %>
   <% end %>

--- a/app/components/avo/fields/text_field/show_component.html.erb
+++ b/app/components/avo/fields/text_field/show_component.html.erb
@@ -1,6 +1,8 @@
 <%= show_field_wrapper field: @field, resource: @resource, index: @index do %>
   <% if @field.as_html %>
     <%== @field.value %>
+  <% elsif @field.protocol.present? %>
+    <%= link_to @field.value, "#{@field.protocol}:#{@field.value}" %>
   <% else %>
     <%= @field.value %>
   <% end %>

--- a/lib/avo/fields/text_field.rb
+++ b/lib/avo/fields/text_field.rb
@@ -3,12 +3,14 @@ module Avo
     class TextField < BaseField
       attr_reader :link_to_resource
       attr_reader :as_html
+      attr_reader :protocol
 
       def initialize(id, **args, &block)
         super(id, **args, &block)
 
-        @link_to_resource = args[:link_to_resource].present? ? args[:link_to_resource] : false
-        @as_html = args[:as_html].present? ? args[:as_html] : false
+        add_boolean_prop args, :link_to_resource
+        add_boolean_prop args, :as_html
+        add_string_prop args, :protocol
       end
     end
   end

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -21,7 +21,7 @@ class UserResource < Avo::BaseResource
   heading "User Information"
   field :first_name, as: :text, required: true, placeholder: "John"
   field :last_name, as: :text, required: true, placeholder: "Doe"
-  field :email, as: :text, name: "User Email", required: true
+  field :email, as: :text, name: "User Email", required: true, protocol: :mailto
   field :active, as: :boolean, name: "Is active", show_on: :show
   field :cv, as: :file, name: "CV"
   field :is_admin?, as: :boolean, name: "Is admin", only_on: :index


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds the `protocol` option to the text field.

`field :email, as: :email, protocol: :mailto` to create a mailto link. Same for `tel` links.

![CleanShot 2022-07-23 at 00 34 30](https://user-images.githubusercontent.com/1334409/180571746-9f08fe58-0f07-4dc7-9ccb-890f7b0a93c3.gif)


# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to a user index page
2. Click a user's email
3. observe the browser opening a new window to compose an email
4. do the same on show

Manual reviewer: please leave a comment with output from the test if that's the case.
