### PR TITLE
Fix trix input name for resources with more than one word in their name

### DIFF
--- a/app/components/avo/fields/trix_field/edit_component.rb
+++ b/app/components/avo/fields/trix_field/edit_component.rb
@@ -2,6 +2,6 @@
 
 class Avo::Fields::TrixField::EditComponent < Avo::Fields::EditComponent
   def trix_id
-    "trix_#{@resource.name.underscore}_#{@field.id}"
+    "trix_#{@resource.class_name_without_resource.underscore}_#{@field.id}"
   end
 end


### PR DESCRIPTION
# Description

There's a bug in the trix field at the moment, where the `input` attribute of the `<trix-editor>` tag can include spaces whenever you have a resource with more than one word in it's name. If you have a resource named `MyPost` then `@resource.name` will be `My post`, `@resource.name.underscore` will be `my post` and therefore `trix_id` will be `trix_my post_foo` (if the field is named `foo`).

To fix this I've changed it to use the class name instead of the human readable name, then calling underscore on that.

Fixes # (issue)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

I couldn't figure out how to test this - the only place the trix field is tested right now is in a system spec and I couldn't see how to change the resource name there without causing a lot more changes. I think this could be tested easily in a unit test but it looks like no fields have unit tests so it wasn't clear how to test it that way either.

## Manual review steps

1. Create a resource with two words in it's name (eg `MyPost`)
1. Add a trix field to the resource (eg. `foo`)
1. Start avo and navigate to the edit page for that resource. 
1. Confirm that the input attribute of the trip field is `trix_my_post_foo` (not `trix_my post_foo`)

Manual reviewer: please leave a comment with output from the test if that's the case.
