### PR TITLE
Made sure the init script builds assets

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -28,6 +28,11 @@ app_root do
   header 'Preparing the database'
   run! 'bin/rails db:setup'
 
+  header 'Building assets'
+  run! 'yarn build:js'
+  run! 'yarn build:custom-js'
+  run! 'yarn build:css'
+
   if use_docker == 'y'
     header 'Stopping the Docker image'
     run! 'docker-compose stop'


### PR DESCRIPTION


# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

System specs won't run unless assets are compiled
(if you try, you get a lot of errors about missing
assets).

I've added commands to the init script to build
assets in the same way as the github actions test
workflow does, and this allows tests to run (after
running the init script).

Fixes # (issue)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Check out main branch in a new directory
1. Run `bin/init`
3. Run `bundle exec rspec --fail-fast spec/system`
4. Look for errors due to missing assets
5. Switch to this branch
6. Run `bin/init`
3. Run `bundle exec rspec --fail-fast spec/system`
4. There should be no errors
Manual reviewer: please leave a comment with output from the test if that's the case.
