### PR TITLE
chore: add `avo_debug` param

### DIFF
--- a/app/components/avo/common_field_wrapper_component.html.erb
+++ b/app/components/avo/common_field_wrapper_component.html.erb
@@ -19,4 +19,8 @@
   <div class="flex-1 flex flex-row md:min-h-inherit py-2 <% unless @displayed_in_modal %> px-6 <% end %>">
     <%= content %>
   </div>
+  <% if params[:avo_debug].present? %>
+    <!-- Raw value: -->
+    <!-- <%== @field.value.inspect %> -->
+  <% end %>
 <% end %>

--- a/app/components/avo/index/field_wrapper_component.html.erb
+++ b/app/components/avo/index/field_wrapper_component.html.erb
@@ -17,4 +17,8 @@
       <%= content %>
     <% end %>
   <% end %>
+  <% if params[:avo_debug].present? %>
+    <!-- Raw value: -->
+    <!-- <%== @field.value.inspect %> -->
+  <% end %>
 <% end %>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update -qq && apt-get install -y yarn
 # Clean up APT when done.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN gem install bundler -v 2.2.32
+RUN gem install bundler -v 2.3.5
 
 ENV RAILS_ENV=production
 ENV NODE_ENV=production


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds the ability to debug the field value by appending `?avo_debug=1` to the URL. It works on the `Index` and `Show` views.

When doing that, the raw value of a field is displayed in an HTML comment.

![CleanShot 2022-07-26 at 10 52 24@2x](https://user-images.githubusercontent.com/1334409/180953263-fe8af359-219b-459c-9619-26ce2dea6834.jpg)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to `/admin/users?avo_debug=1`
2. Inspect a field value
3. See that the field value has a comment with the raw value

Manual reviewer: please leave a comment with output from the test if that's the case.
