### PR TITLE
Make sure null appears as "" in key value fields

### DIFF
--- a/app/javascript/js/controllers/fields/key_value_controller.js
+++ b/app/javascript/js/controllers/fields/key_value_controller.js
@@ -111,13 +111,14 @@ export default class extends Controller {
 
   inputField(id = 'key', index, key, value) {
     const inputValue = id === 'key' ? key : value
+
     return `<input
   class="${this.options.inputClasses} focus:bg-gray-100 !rounded-none border-gray-600 border-r border-l-0 border-b-0 border-t-0 focus:border-gray-300 w-1/2 focus:outline-none outline-none key-value-input-${id}"
   data-action="input->key-value#${id}FieldUpdated"
   placeholder="${this.options[`${id}_label`]}"
   data-index="${index}"
   ${this[`${id}InputDisabled`] ? "disabled='disabled'" : ''}
-  value="${typeof(inputValue) === 'undefined' || inputValue === null ? '' : inputValue}"
+  value="${typeof inputValue === 'undefined' || inputValue === null ? '' : inputValue}"
 />`
   }
 

--- a/app/javascript/js/controllers/fields/key_value_controller.js
+++ b/app/javascript/js/controllers/fields/key_value_controller.js
@@ -110,13 +110,14 @@ export default class extends Controller {
   }
 
   inputField(id = 'key', index, key, value) {
+    const inputValue = id === 'key' ? key : value
     return `<input
   class="${this.options.inputClasses} focus:bg-gray-100 !rounded-none border-gray-600 border-r border-l-0 border-b-0 border-t-0 focus:border-gray-300 w-1/2 focus:outline-none outline-none key-value-input-${id}"
   data-action="input->key-value#${id}FieldUpdated"
   placeholder="${this.options[`${id}_label`]}"
   data-index="${index}"
   ${this[`${id}InputDisabled`] ? "disabled='disabled'" : ''}
-  value="${id === 'key' ? key : value}"
+  value="${typeof(inputValue) === 'undefined' || inputValue === null ? '' : inputValue}"
 />`
   }
 

--- a/spec/system/avo/key_value_field/key_value_field_spec.rb
+++ b/spec/system/avo/key_value_field/key_value_field_spec.rb
@@ -283,4 +283,49 @@ RSpec.describe "KeyValueFields", type: :system do
       end
     end
   end
+
+  describe "with null values" do
+    let!(:meta_data) { {'foo' => nil, nil => 'bar'} }
+    let!(:project) { create :project, meta: meta_data }
+
+    context "show" do
+      it "does not show null keys or values" do
+        visit "/admin/resources/projects/#{project.id}"
+        wait_for_loaded
+
+        meta_element = find_field_element("meta")
+
+        keys = page.all('input[placeholder="Meta key"][disabled="disabled"]')
+        values = page.all('input[placeholder="Meta value"][disabled="disabled"]')
+
+        expect(keys[0].value).to eq "foo"
+        expect(values[0].value).to eq ""
+
+        expect(keys[1].value).to eq ""
+        expect(values[1].value).to eq "bar"
+      end
+    end
+
+    context "edit" do
+      let!(:project) { create :project, meta: meta_data }
+
+      it "has the projects meta label, table header, table rows (2), buttons" do
+        visit "/admin/resources/projects/#{project.id}/edit"
+        wait_for_loaded
+
+        meta_element = find_field_element("meta")
+
+        expect(meta_element).to have_text "META"
+
+        keys = page.all('input[placeholder="Meta key"]')
+        values = page.all('input[placeholder="Meta value"]')
+
+        expect(keys[0].value).to eq "foo"
+        expect(values[0].value).to eq ""
+
+        expect(keys[1].value).to eq ""
+        expect(values[1].value).to eq "bar"
+      end
+    end
+  end
 end

--- a/spec/system/avo/key_value_field/key_value_field_spec.rb
+++ b/spec/system/avo/key_value_field/key_value_field_spec.rb
@@ -293,7 +293,6 @@ RSpec.describe "KeyValueFields", type: :system do
         visit "/admin/resources/projects/#{project.id}"
         wait_for_loaded
 
-        meta_element = find_field_element("meta")
 
         keys = page.all('input[placeholder="Meta key"][disabled="disabled"]')
         values = page.all('input[placeholder="Meta value"][disabled="disabled"]')


### PR DESCRIPTION


# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Right now null values in a key value field appear as "null", but I'd expect them to appear
as "".

Fixes # (issue)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Find a resource with a key value field
1. Using the rails console, find a record for this resource and add a new key-value entry with a null value to the field
1. Edit this resource in avo
1. The new key-value entry should have a blank value, rather than "null"

Manual reviewer: please leave a comment with output from the test if that's the case.
