### PR TITLE
fix: allow tools to come before fields

### DIFF
--- a/lib/avo/concerns/has_fields.rb
+++ b/lib/avo/concerns/has_fields.rb
@@ -13,8 +13,6 @@ module Avo
       end
 
       class_methods do
-        delegate :tool, to: :items_holder
-
         # DSL methods
         def field(name, **args, &block)
           ensure_items_holder_initialized
@@ -32,6 +30,12 @@ module Avo
           ensure_items_holder_initialized
 
           self.items_holder.tabs Avo::TabGroupBuilder.parse_block(&block)
+        end
+
+        def tool(klass, **args)
+          ensure_items_holder_initialized
+
+          items_holder.tool klass, **args
         end
 
         def heading(body, **args)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes [this](https://discord.com/channels/740892036978442260/740893011994738751/1001527120503251094) issue
# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Got to a fish show page
2. observe the tool comes before the fields

Manual reviewer: please leave a comment with output from the test if that's the case.
