### PR TITLE
feature: allow custom fields in resource tools

### DIFF
--- a/app/components/avo/item_switcher_component.html.erb
+++ b/app/components/avo/item_switcher_component.html.erb
@@ -1,6 +1,6 @@
 <% if item.is_tool? %>
   <% if item&.partial.present? %>
-    <%= render item.partial, tool: item %>
+    <%= render item.partial, tool: item, form: @form %>
   <% end %>
 <% elsif item.is_panel? %>
   <%= render Avo::PanelComponent.new(title: item.name, description: item.description, index: index, view: view) do |c| %>

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -151,7 +151,7 @@ module Avo
       is_attach_action = params[model_param_key].blank? && params[:related_name].present? && params[:fields].present?
 
       unless is_attach_action
-        @model = @resource.fill_model(@model_to_fill, cast_nullable(model_params))
+        @model = @resource.fill_model(@model_to_fill, cast_nullable(model_params), extra_params: extra_params)
       end
     end
 

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -11,7 +11,7 @@ module Avo
     before_action :set_edit_title_and_breadcrumbs, only: [:edit, :update]
     before_action :fill_model, only: [:create, :update]
     # Don't run base authorizations for associations
-    before_action :authorize_base_action, if: -> {controller_name != "associations"}
+    before_action :authorize_base_action, if: -> { controller_name != "associations" }
 
     def index
       @page_title = @resource.plural_name.humanize

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -248,7 +248,11 @@ module Avo
     end
 
     def permitted_params
-      @resource.get_field_definitions.select(&:updatable).map(&:to_permitted_param)
+      @resource.get_field_definitions.select(&:updatable).map(&:to_permitted_param).concat extra_params
+    end
+
+    def extra_params
+      @resource.class.extra_params || []
     end
 
     def cast_nullable(params)

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -275,6 +275,9 @@ module Avo
       # Write the user configured extra params to the model
       if extra_params.present?
         extra_params.each do |param_id|
+          # if it's a nested array, use the key
+          param_id = param_id.first.first if param_id.is_a? Hash
+
           next unless @model.respond_to? "#{param_id}="
 
           param_value = params[param_id]

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -274,15 +274,8 @@ module Avo
 
       # Write the user configured extra params to the model
       if extra_params.present?
-        extra_params.each do |param_id|
-          # if it's a nested array, use the key
-          param_id = param_id.first.first if param_id.is_a? Hash
-
-          next unless model.respond_to? "#{param_id}="
-
-          param_value = params[param_id]
-          model.send("#{param_id}=", param_value)
-        end
+        # Let Rails fill in the rest of the params
+        model.assign_attributes params.permit(extra_params)
       end
 
       model

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -278,10 +278,10 @@ module Avo
           # if it's a nested array, use the key
           param_id = param_id.first.first if param_id.is_a? Hash
 
-          next unless @model.respond_to? "#{param_id}="
+          next unless model.respond_to? "#{param_id}="
 
           param_value = params[param_id]
-          @model.send("#{param_id}=", param_value)
+          model.send("#{param_id}=", param_value)
         end
       end
 

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -47,6 +47,7 @@ module Avo
     class_attribute :after_update_path, default: :show
     class_attribute :record_selector, default: true
     class_attribute :keep_filters_panel_open, default: false
+    class_attribute :extra_params
 
     class << self
       delegate :t, to: ::I18n
@@ -251,7 +252,7 @@ module Avo
       end
     end
 
-    def fill_model(model, params)
+    def fill_model(model, params, extra_params: [])
       # Map the received params to their actual fields
       fields_by_database_id = get_field_definitions
         .reject do |field|
@@ -262,12 +263,23 @@ module Avo
         end
         .to_h
 
+      # Write the field values
       params.each do |key, value|
         field = fields_by_database_id[key]
 
         next unless field.present?
 
         model = field.fill_field model, key, value, params
+      end
+
+      # Write the user configured extra params to the model
+      if extra_params.present?
+        extra_params.each do |param_id|
+          next unless @model.respond_to? "#{param_id}="
+
+          param_value = params[param_id]
+          @model.send("#{param_id}=", param_value)
+        end
       end
 
       model

--- a/spec/dummy/app/avo/resources/fish_resource.rb
+++ b/spec/dummy/app/avo/resources/fish_resource.rb
@@ -5,8 +5,11 @@ class FishResource < Avo::BaseResource
     scope.ransack(id_eq: params[:q], name_cont: params[:q], m: "or").result(distinct: false)
   end
 
+  self.extra_params = [:fish_type, :something_else]
+
   field :id, as: :id
   field :name, as: :text, required: -> { view == :new }
+  field :type, as: :text, hide_on: :forms
 
   tool FishInformation, show_on: :edit
 

--- a/spec/dummy/app/avo/resources/fish_resource.rb
+++ b/spec/dummy/app/avo/resources/fish_resource.rb
@@ -10,7 +10,7 @@ class FishResource < Avo::BaseResource
   field :name, as: :text, required: -> { view == :new }
   field :type, as: :text, hide_on: :forms
 
-  tool FishInformation, show_on: :edit
+  tool FishInformation, show_on: :forms
 
   action DummyAction
 end

--- a/spec/dummy/app/avo/resources/fish_resource.rb
+++ b/spec/dummy/app/avo/resources/fish_resource.rb
@@ -4,8 +4,7 @@ class FishResource < Avo::BaseResource
   self.search_query = ->(params:) do
     scope.ransack(id_eq: params[:q], name_cont: params[:q], m: "or").result(distinct: false)
   end
-
-  self.extra_params = [:fish_type, :something_else]
+  self.extra_params = [:fish_type, :something_else, properties: []]
 
   field :id, as: :id
   field :name, as: :text, required: -> { view == :new }

--- a/spec/dummy/app/avo/resources/fish_resource.rb
+++ b/spec/dummy/app/avo/resources/fish_resource.rb
@@ -4,7 +4,7 @@ class FishResource < Avo::BaseResource
   self.search_query = ->(params:) do
     scope.ransack(id_eq: params[:q], name_cont: params[:q], m: "or").result(distinct: false)
   end
-  self.extra_params = [:fish_type, :something_else, properties: []]
+  self.extra_params = [:fish_type, :something_else, properties: [], information: [:name, :history]]
 
   field :id, as: :id
   field :name, as: :text, required: -> { view == :new }

--- a/spec/dummy/app/models/fish.rb
+++ b/spec/dummy/app/models/fish.rb
@@ -21,6 +21,11 @@ class Fish < ApplicationRecord
 
   def properties=(value)
     # properties should be an array
-    puts ["properties->", value].inspect
+    puts ["properties in the Fish model->", value].inspect
+  end
+
+  def information=(value)
+    # properties should be a hash
+    puts ["information in the Fish model->", value].inspect
   end
 end

--- a/spec/dummy/app/models/fish.rb
+++ b/spec/dummy/app/models/fish.rb
@@ -18,4 +18,9 @@ class Fish < ApplicationRecord
   def fish_type=(value)
     self.type = value
   end
+
+  def properties=(value)
+    # properties should be an array
+    puts ["properties->", value].inspect
+  end
 end

--- a/spec/dummy/app/models/fish.rb
+++ b/spec/dummy/app/models/fish.rb
@@ -9,4 +9,13 @@
 #
 class Fish < ApplicationRecord
   has_many :reviews, as: :reviewable
+  self.inheritance_column = nil
+
+  def fish_type
+    type
+  end
+
+  def fish_type=(value)
+    self.type = value
+  end
 end

--- a/spec/dummy/app/views/avo/resource_tools/_fish_information.html.erb
+++ b/spec/dummy/app/views/avo/resource_tools/_fish_information.html.erb
@@ -13,7 +13,7 @@
 
           <% if form.present? %>
             <%= form.label :fish_type  %>
-            <%= form.text_field :fish_type, value: 'default type of pish', class: input_classes %>
+            <%= form.text_field :fish_type, value: 'default type of fish', class: input_classes %>
             <br>
 
             <%= form.label :properties  %>

--- a/spec/dummy/app/views/avo/resource_tools/_fish_information.html.erb
+++ b/spec/dummy/app/views/avo/resource_tools/_fish_information.html.erb
@@ -11,6 +11,11 @@
         <div class="space-y-4">
           <h3>Below there should be an image of this fish 🐠</h3>
 
+          <% if form.present? %>
+            <%= form.label :fish_type  %>
+            <%= form.text_field :fish_type, value: 'default type of fish', class: input_classes %>
+          <% end %>
+
           <p>
             The fish's name is <strong><%= @resource.model.name %></strong>. The ID of the record is <%= @resource.model.id %> and the tool's name is <strong><%= tool.class.to_s %></strong>.
           </p>

--- a/spec/dummy/app/views/avo/resource_tools/_fish_information.html.erb
+++ b/spec/dummy/app/views/avo/resource_tools/_fish_information.html.erb
@@ -12,13 +12,28 @@
           <h3>Below there should be an image of this fish 🐠</h3>
 
           <% if form.present? %>
-            <%= form.label :fish_type  %>
+            <%= form.label :fish_type %>
             <%= form.text_field :fish_type, value: 'default type of fish', class: input_classes %>
             <br>
 
-            <%= form.label :properties  %>
+            <%= form.label :properties %>
             <%= form.text_field :properties, multiple: true, value: 'property 1', class: input_classes %>
             <%= form.text_field :properties, multiple: true, value: 'property 2', class: input_classes %>
+            <br>
+
+            <% form.fields_for :information do |information_form| %>
+              <%= form.label :information_name %>
+              <%= information_form.text_field :name, value: 'information name', class: input_classes %>
+              <div class="text-gray-600 mt-2 text-sm">This is going to be passed to the model</div>
+              <br>
+              <%= form.label :information_history %>
+              <%= information_form.text_field :history, value: 'information history', class: input_classes %>
+              <div class="text-gray-600 mt-2 text-sm">This is going to be passed to the model</div>
+              <br>
+              <%= form.label :information_age %>
+              <%= information_form.text_field :age, value: 'information age', class: input_classes %>
+              <div class="text-gray-600 mt-2 text-sm">This is NOT going to be passed to the model</div>
+            <% end %>
           <% end %>
 
           <p>

--- a/spec/dummy/app/views/avo/resource_tools/_fish_information.html.erb
+++ b/spec/dummy/app/views/avo/resource_tools/_fish_information.html.erb
@@ -13,7 +13,12 @@
 
           <% if form.present? %>
             <%= form.label :fish_type  %>
-            <%= form.text_field :fish_type, value: 'default type of fish', class: input_classes %>
+            <%= form.text_field :fish_type, value: 'default type of pish', class: input_classes %>
+            <br>
+
+            <%= form.label :properties  %>
+            <%= form.text_field :properties, multiple: true, value: 'property 1', class: input_classes %>
+            <%= form.text_field :properties, multiple: true, value: 'property 2', class: input_classes %>
           <% end %>
 
           <p>

--- a/spec/dummy/db/migrate/20220727112241_add_type_to_fish.rb
+++ b/spec/dummy/db/migrate/20220727112241_add_type_to_fish.rb
@@ -1,0 +1,5 @@
+class AddTypeToFish < ActiveRecord::Migration[6.1]
+  def change
+    add_column :fish, :type, :string
+  end
+end

--- a/spec/dummy/db/migrate/20220727112241_add_type_to_fish.rb
+++ b/spec/dummy/db/migrate/20220727112241_add_type_to_fish.rb
@@ -1,4 +1,4 @@
-class AddTypeToFish < ActiveRecord::Migration[6.1]
+class AddTypeToFish < ActiveRecord::Migration[6.0]
   def change
     add_column :fish, :type, :string
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_05_172707) do
+ActiveRecord::Schema.define(version: 2022_07_27_112241) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 2022_07_05_172707) do
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "type"
   end
 
   create_table "people", force: :cascade do |t|

--- a/spec/features/avo/custom_fields_in_resource_tools_spec.rb
+++ b/spec/features/avo/custom_fields_in_resource_tools_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.feature "CustomFieldsInResourceTools", type: :feature do
+  let(:fish) { create :fish, name: :Salmon }
+
+  describe "fish information" do
+    it "sends the params to the model" do
+      visit avo.edit_resources_fish_path fish
+
+      expect(page).to have_text "Below there should be an image of this fish 🐠"
+
+      fill_in "fish[fish_type]", with: "Fishy type"
+
+      properties_fields = find_all('input[name="fish[properties][]"]')
+      properties_fields.first.set("Fishy property 1")
+      properties_fields.last.set("Fishy property 2")
+
+      find('input[name="fish[information][name]"]').set("Fishy name")
+      find('input[name="fish[information][history]"]').set("Fishy history")
+      find('input[name="fish[information][age]"]').set("Fishy age")
+
+      expect(properties_fields.count).to be 2
+      expect_any_instance_of(Fish).to receive("fish_type=").with("Fishy type")
+      expect_any_instance_of(Fish).to receive("properties=").with(["Fishy property 1", "Fishy property 2"])
+      expect_any_instance_of(Fish).to receive("information=").with({name: "Fishy name", history: "Fishy history"})
+
+      click_on "Save"
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

[Docs](https://docs.avohq.io/2.0/resource-tools.html#add-custom-fields-on-forms)

The idea behind this implementation is that you can add a resource tool to your new/edit screen and add the fields you need there. 
You'll have access to the `form` object. 
In your resource file, you must specify the `extra_params` option, so Rails knows to permit those params in the controller and fill them into the model.
Next, in your model file, you create the setters to take the values passed by the user and use them as you need it.

In our example `fish.rb` we just write to a different `type` field in the DB just to show that the value reaches that point, but you can do whatever you need. You may need to add some nested data and will send the data as an array and you would create your nested attributes or associations.

Use Avo version `2.11.2.pre.2` to test this out (add `gem 'avo', '2.11.2.pre.2'` to your `Gemfile`)
https://rubygems.org/gems/avo/versions/2.11.2.pre.2

1. Add fields to your resource tool
https://github.com/avo-hq/avo/pull/1107/files#diff-b618e6775e9b8655b6fcfdec518b6449164c10db11d4be8b46f87b05bdb8e032R14-R23
2. Extra params example
https://github.com/avo-hq/avo/pull/1107/files#diff-b0f12779958c73ed930aa4145294724986277dbe629a29f47044e225d822c922R7
3. Model setters
https://github.com/avo-hq/avo/pull/1107/files#diff-687e1a96dbb6472660a69f4eff70ca03782ccb59868291748bd3bae98dd6d08eR18
https://github.com/avo-hq/avo/pull/1107/files#diff-687e1a96dbb6472660a69f4eff70ca03782ccb59868291748bd3bae98dd6d08eR22

### How to use

1. On your resource add the fields you want to add with `self.extra_params = [:fish_type, :something_else]`
2. In your resource tool add the fields to the `form`. See `_fish_information.html.erb` how it adds the `fish_type` field.
3. On your model add the setter method where you capture the value and do with it as you please. 

![CleanShot 2022-07-27 at 15 01 24](https://user-images.githubusercontent.com/1334409/181242034-652dcc7f-6137-471f-a4a4-3b4c149f5fe3.gif)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works



## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go and edit a fish
2. write something in the fields from the resource tool
3. Click save
4. Observe that the information filled in `fish_type`, `properties`, `information.name`, and `information.history` gets forwarded to the appropriate methods.

Manual reviewer: please leave a comment with output from the test if that's the case.
