### PR TITLE
Support `date` and `date_time` to clear the value

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -254,18 +254,19 @@ module Avo
     def cast_nullable(params)
       fields = @resource.get_field_definitions
 
-      nullable_fields = fields.filter do |field|
-        field.nullable
-      end
+      nullable_fields = fields
+        .filter do |field|
+          field.nullable
+        end
         .map do |field|
-        [field.id, field.null_values]
-      end
+          [field.id, field.null_values]
+        end
         .to_h
 
       params.each do |key, value|
-        nullable = nullable_fields[key.to_sym]
+        nullable_values = nullable_fields[key.to_sym]
 
-        if nullable.present? && value.in?(nullable)
+        if nullable_values.present? && value.in?(nullable_values)
           params[key] = nil
         end
       end

--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -106,13 +106,10 @@ export default class extends Controller {
 
     // enable timezone display
     if (this.enableTimeValue) {
-      console.log(1)
       options.defaultDate = this.parsedValue.setZone(this.displayTimezone).toISO()
 
       options.dateFormat = 'Y-m-d H:i:S'
     } else {
-      console.log(2)
-
       // Because the browser treats the date like a timestamp and updates it at 00:00 hour, when on a western timezone the date will be converted with one day offset.
       // Ex: 2022-01-30 will render as 2022-01-29 on an American timezone
       options.defaultDate = universalTimestamp(this.initialValue)
@@ -125,8 +122,9 @@ export default class extends Controller {
 
   onChange(selectedDates) {
     // No date has been selected
-    if (selectedDates.length == 0) {
-      this.updateRealInput("")
+    if (selectedDates.length === 0) {
+      this.updateRealInput('')
+
       return
     }
 

--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -124,6 +124,12 @@ export default class extends Controller {
   }
 
   onChange(selectedDates) {
+    // No date has been selected
+    if (selectedDates.length == 0) {
+      this.updateRealInput("")
+      return
+    }
+
     let time
     let args = {}
 

--- a/lib/avo/fields/date_time_field.rb
+++ b/lib/avo/fields/date_time_field.rb
@@ -28,8 +28,8 @@ module Avo
       end
 
       def fill_field(model, key, value, params)
-        if value.nil?
-          model[id] = nil
+        if value.in?(["", nil])
+          model[id] = value
 
           return model
         end


### PR DESCRIPTION
# Description
While updating the date/date_time picking implementation, we lost the ability to set the value to empty.

Previously, there was an avo date_field_controller.js exception that was raise that would bail out of the `onChange` when the input field was empty.

-  [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps

1. Utilize a `date` or `date_time` field
2. Manually clear the input field
3. Check it works :)


Manual reviewer: please leave a comment with output from the test if that's the case.
