### PR TITLE
fix: heading can't be the first item in your resource

### DIFF
--- a/lib/avo/concerns/has_fields.rb
+++ b/lib/avo/concerns/has_fields.rb
@@ -39,6 +39,8 @@ module Avo
         end
 
         def heading(body, **args)
+          ensure_items_holder_initialized
+
           self.items_holder.heading body, **args
         end
         # END DSL methods

--- a/lib/avo/concerns/has_fields.rb
+++ b/lib/avo/concerns/has_fields.rb
@@ -17,19 +17,19 @@ module Avo
         def field(name, **args, &block)
           ensure_items_holder_initialized
 
-          self.items_holder.field name, **args, &block
+          items_holder.field name, **args, &block
         end
 
         def panel(name = nil, **args, &block)
           ensure_items_holder_initialized
 
-          self.items_holder.panel name, **args, &block
+          items_holder.panel name, **args, &block
         end
 
         def tabs(&block)
           ensure_items_holder_initialized
 
-          self.items_holder.tabs Avo::TabGroupBuilder.parse_block(&block)
+          items_holder.tabs Avo::TabGroupBuilder.parse_block(&block)
         end
 
         def tool(klass, **args)
@@ -41,27 +41,27 @@ module Avo
         def heading(body, **args)
           ensure_items_holder_initialized
 
-          self.items_holder.heading body, **args
+          items_holder.heading body, **args
         end
         # END DSL methods
 
         def items
-          if self.items_holder.present?
-            self.items_holder.items
+          if items_holder.present?
+            items_holder.items
           else
             []
           end
         end
 
         def tools
-          self.tools_holder
+          tools_holder
         end
 
         # Dives deep into panels and tabs to fetch all the fields for a resource.
         def fields(only_root: false)
           fields = []
 
-          self.items.each do |item|
+          items.each do |item|
             next if item.nil?
 
             unless only_root
@@ -78,7 +78,6 @@ module Avo
               end
             end
 
-
             if item.is_field?
               fields << item
             end
@@ -88,7 +87,7 @@ module Avo
         end
 
         def tab_groups
-          self.items.select do |item|
+          items.select do |item|
             item.instance_of? Avo::TabGroup
           end
         end

--- a/lib/avo/hosts/base_host.rb
+++ b/lib/avo/hosts/base_host.rb
@@ -1,6 +1,6 @@
 require "dry-initializer"
 
-# This object holds some data tha is usually needed to compute blocks around the app.
+# This object holds some data that is usually needed to compute blocks around the app.
 module Avo
   module Hosts
     class BaseHost
@@ -10,6 +10,7 @@ module Avo
       option :params, default: proc { Avo::App.params }
       option :view_context, default: proc { Avo::App.view_context }
       option :current_user, default: proc { Avo::App.current_user }
+      # This is optional because we might instantiate the `Host` first and later hydrate it with a block.
       option :block, optional: true
 
       delegate :authorize, to: Avo::Services::AuthorizationService


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1123

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Configure a resource to have a `heading` as the first item in the DSL
1. Observe the show page loads

Manual reviewer: please leave a comment with output from the test if that's the case.
