### PR TITLE
Fix sidebar default collapsed state

### DIFF
--- a/app/javascript/js/controllers/menu_controller.js
+++ b/app/javascript/js/controllers/menu_controller.js
@@ -22,8 +22,8 @@ export default class extends Controller {
   }
 
   get initiallyCollapsed() {
-    if (this.defaultState === 'collapsed') {
-      return this.userState === 'collapsed'
+    if (!this.userState) {
+      return this.defaultState === 'collapsed'
     }
 
     return this.userState === 'collapsed'


### PR DESCRIPTION
# Description
The deafault `collapsed` option for menu sections was not working. The default state is correctly set, but incorrectly read in the Stimulus controller, the bug was introduced in #941.

Basically, on the first load (and if the user never interacted with the collapse feature) the `this.userState` will return `null`, because there is no such key in the local storage. `this.userState === 'collapsed'` will always return false if the user never toggled the collapse feature, making the default option useless.

The fix is using the defaultState if userState is unefined/null.

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps

1. Create a section with  `collapsable: true, collapsed: true`
2. Delete local storage (clean cookies) to ensure there are no user preferences overriding the default
2. Check if the section appears collapsed. 
