### PR TITLE
fix: failed forms can't be resubmitted

### DIFF
--- a/app/components/avo/fields/tags_field/show_component.rb
+++ b/app/components/avo/fields/tags_field/show_component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# require_relative 'item_labels'
-
 class Avo::Fields::TagsField::ShowComponent < Avo::Fields::ShowComponent
   include Avo::Fields::Concerns::ItemLabels
 end

--- a/app/components/avo/tab_group_component.html.erb
+++ b/app/components/avo/tab_group_component.html.erb
@@ -25,7 +25,7 @@
       # On edit screens we want to load each tab because we wnst the DOM to have the fields present on form submission.
       # If you have a field which is in the second tab and it's required, the form submission will fail because the required field is not in view, and we don't want that.
       # We also want to load the current tab
-      should_lazy_load = if @view.to_s.in?(['edit', 'new'])
+      should_lazy_load = if @view.to_s.in?(['edit', 'new', 'update', 'create'])
         false
       else
         !is_current_tab

--- a/app/components/avo/tab_switcher_component.rb
+++ b/app/components/avo/tab_switcher_component.rb
@@ -30,11 +30,11 @@ class Avo::TabSwitcherComponent < Avo::BaseComponent
   end
 
   def is_edit?
-    @view == :edit
+    @view.in?([:edit, :update])
   end
 
   def is_new?
-    @view == :new
+    @view.in?([:new, :create])
   end
 
   def is_initial_load?

--- a/app/components/avo/views/resource_edit_component.rb
+++ b/app/components/avo/views/resource_edit_component.rb
@@ -42,7 +42,7 @@ class Avo::Views::ResourceEditComponent < Avo::ResourceComponent
   end
 
   def is_edit?
-    view == :edit
+    view.in?([:edit, :update])
   end
 
   def form_method

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -129,8 +129,7 @@ module Avo
         @reflection = @model._reflections[params[:via_relation]]
         # Figure out what kind of association does the record have with the parent record
 
-        # belongs_to
-        # has_many
+        # Fills in the required infor for belongs_to and has_many
         # Get the foreign key and set it to the id we received in the params
         if @reflection.is_a?(ActiveRecord::Reflection::BelongsToReflection) || @reflection.is_a?(ActiveRecord::Reflection::HasManyReflection)
           foreign_key = @reflection.foreign_key
@@ -138,12 +137,7 @@ module Avo
           @model.save
         end
 
-        # has_one
-        # has_one_through
-
-        # has_many_through
-        # has_and_belongs_to_many
-        # polymorphic
+        # For when working with has_one, has_one_through, has_many_through, has_and_belongs_to_many, polymorphic
         if @reflection.is_a? ActiveRecord::Reflection::ThroughReflection
           # find the record
           via_resource = ::Avo::App.get_resource_by_model_name params[:via_relation_class]

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -132,8 +132,7 @@ module Avo
         # Fills in the required infor for belongs_to and has_many
         # Get the foreign key and set it to the id we received in the params
         if @reflection.is_a?(ActiveRecord::Reflection::BelongsToReflection) || @reflection.is_a?(ActiveRecord::Reflection::HasManyReflection)
-          foreign_key = @reflection.foreign_key
-          @model.send("#{foreign_key}=", params[:via_resource_id])
+          @model.send("#{@reflection.foreign_key}=", params[:via_resource_id])
           @model.save
         end
 

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -115,7 +115,7 @@ module Avo
         add_breadcrumb via_resource.model_title, resource_path(model: via_model, resource: via_resource)
       end
 
-      add_breadcrumb @resource.plural_name.humanize
+      add_breadcrumb @resource.plural_name.humanize, resources_path(resource: @resource)
       add_breadcrumb t("avo.new").humanize
     end
 
@@ -157,6 +157,9 @@ module Avo
         if saved
           format.html { redirect_to after_create_path, notice: "#{@resource.name} #{t("avo.was_successfully_created")}." }
         else
+          add_breadcrumb @resource.plural_name.humanize, resources_path(resource: @resource)
+          add_breadcrumb t("avo.new").humanize
+          set_actions
           flash.now[:error] = t "avo.you_missed_something_check_form"
           format.html { render :new, status: :unprocessable_entity }
         end
@@ -176,6 +179,7 @@ module Avo
         if saved
           format.html { redirect_to after_update_path, notice: "#{@resource.name} #{t("avo.was_successfully_updated")}." }
         else
+          set_actions
           flash.now[:error] = t "avo.you_missed_something_check_form"
           format.html { render :edit, status: :unprocessable_entity }
         end

--- a/app/views/avo/associations/new.html.erb
+++ b/app/views/avo/associations/new.html.erb
@@ -13,6 +13,7 @@
       <div class="flex-1 flex items-center justify-center px-0 lg:px-8 text-lg mt-8 mb-12">
         <% if @field.searchable %>
           <%= render Avo::Fields::BelongsToField::AutocompleteComponent.new form: form,
+            classes: input_classes("w-full"),
             field: @field,
             model_key: @field.target_resource&.model_key,
             foreign_key: 'related_id',

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -160,7 +160,7 @@ module Avo
         final_value = @model.send(property) if (model_or_class(@model) == "model") && @model.respond_to?(property)
 
         # On new views and actions modals we need to prefill the fields
-        if (@view === :new) || @action.present?
+        if @view.in?([:new, :create]) || @action.present?
           if default.present?
             final_value = if default.respond_to?(:call)
               default.call


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where if you resubmitted a form (create or update), some data would be lost (actions, breadcrumbs, and some other state), and sometimes the edit screen would become the create screen.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works
