### PR TITLE
Allow long button groups to wrap

### DIFF
--- a/app/assets/stylesheets/css/buttons.css
+++ b/app/assets/stylesheets/css/buttons.css
@@ -1,5 +1,5 @@
 .button-group {
-  @apply flex;
+  @apply flex flex-wrap gap-y-1;
 
   .button-component {
     @apply -mr-px;


### PR DESCRIPTION
# Description
I have a lot of tabs for one of my resources. At the moment the buttons do not wrap around, they overflow out of the container and beyond the page. By adding flex-wrap to the button group, it wraps and wraps around to create two rows of buttons instead,

Fixes # (issue)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Create a resource with lots of tabs
2. View the page in the app
3. Confirm that the tabs wrap and are all visible

Manual reviewer: please leave a comment with output from the test if that's the case.
