### PR TITLE
feature: Custom path and message after create update and delete

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -20,6 +20,20 @@ Since v `1.20` (Jan 2022), we started to change the `model` name with `record` w
 
 Please fork Avo and create a descriptive branch for your feature or fix. We usually use the `feature/`, `chore/`, or `fix/` branch prefixes. This way, the PR gets automatically labeled.
 
+## Contributing with Pull Requests
+
+Thank you for considering to contribute to Avo. These are our recommendations to improve readability and interoperability when contributing with a PR:
+
+- the title should have the type (`feature`, `chore`, `fix`, `refactor`) followed by the sentence case of what it does (ex: `feature: scoped search for has many associations` or `fix: broken sidebar on desktop`).
+- the PR should be marked by the appropiate tag (`feature`, `chore`, `fix`, `refactor`)
+- if there's an issue open that could be fixed by this PR you can mark it by writing `Fixes ISSUE_URL` in the description so GitHub automates some actions (ex: `Fixes https://github.com/avo-hq/avo/issues/1008`). If there are more issues that could be fixed, add more lines.
+- please follow the steps on the `Checklist` and mark them as done with an `x` inside the brackets `[x]`
+- if there's something that we can test, please send us the instructions to do that in that PR description.
+- ask for help navigating the codebase. We love it when you do!
+- enjoy the process and the thing you are making, fixing, or improving.
+
+Thank you!
+
 ## Getting your local environment set up
 
 NOTE: We're using `docker-compose` to run Postgres. While we find this incredibly helpful, it's not a requirement, but you'll have to BYOD (Bring Your Own Database).

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -148,12 +148,12 @@ module Avo
 
       respond_to do |format|
         if saved
-          format.html { redirect_to after_create_path, notice: "#{@resource.name} #{t("avo.was_successfully_created")}." }
+          format.html { redirect_to after_create_path, notice: create_success_message}
         else
           add_breadcrumb @resource.plural_name.humanize, resources_path(resource: @resource)
           add_breadcrumb t("avo.new").humanize
           set_actions
-          flash.now[:error] = t "avo.you_missed_something_check_form"
+          flash.now[:error] = create_fail_message
           format.html { render :new, status: :unprocessable_entity }
         end
       end
@@ -170,10 +170,10 @@ module Avo
 
       respond_to do |format|
         if saved
-          format.html { redirect_to after_update_path, notice: "#{@resource.name} #{t("avo.was_successfully_updated")}." }
+          format.html { redirect_to after_update_path, notice: update_success_message }
         else
           set_actions
-          flash.now[:error] = t "avo.you_missed_something_check_form"
+          flash.now[:error] = update_fail_message
           format.html { render :edit, status: :unprocessable_entity }
         end
       end
@@ -182,11 +182,9 @@ module Avo
     def destroy
       respond_to do |format|
         if destroy_model
-          format.html { redirect_to params[:referrer] || resources_path(resource: @resource, turbo_frame: params[:turbo_frame], view_type: params[:view_type]), notice: t("avo.resource_destroyed", attachment_class: @attachment_class) }
+          format.html { redirect_to after_destroy_path, notice: destroy_success_message }
         else
-          error_message = @errors.present? ? @errors.first : t("avo.failed")
-
-          format.html { redirect_back fallback_location: params[:referrer] || resources_path(resource: @resource, turbo_frame: params[:turbo_frame], view_type: params[:view_type]), error: error_message }
+          format.html { redirect_back fallback_location: params[:referrer] || resources_path(resource: @resource, turbo_frame: params[:turbo_frame], view_type: params[:view_type]), error: destroy_fail_message }
         end
       end
     end
@@ -398,6 +396,14 @@ module Avo
       add_breadcrumb t("avo.edit").humanize
     end
 
+    def create_success_message
+      "#{@resource.name} #{t("avo.was_successfully_created")}."
+    end
+
+    def create_fail_message
+      t "avo.you_missed_something_check_form"
+    end
+
     def after_create_path
       # If this is an associated record return to the association show page
       if params[:via_relation_class].present? && params[:via_resource_id].present?
@@ -409,10 +415,30 @@ module Avo
       redirect_path_from_resource_option(:after_create_path) || resource_path(model: @model, resource: @resource)
     end
 
+    def update_success_message
+      "#{@resource.name} #{t("avo.was_successfully_updated")}."
+    end
+
+    def update_fail_message
+      t "avo.you_missed_something_check_form"
+    end
+
     def after_update_path
       return params[:referrer] if params[:referrer].present?
 
       redirect_path_from_resource_option(:after_update_path) || resource_path(model: @model, resource: @resource)
+    end
+
+    def destroy_success_message
+      t("avo.resource_destroyed", attachment_class: @attachment_class)
+    end
+
+    def destroy_fail_message
+      @errors.present? ? @errors.first : t("avo.failed")
+    end
+
+    def after_destroy_path
+      params[:referrer] || resources_path(resource: @resource, turbo_frame: params[:turbo_frame], view_type: params[:view_type])
     end
 
     def redirect_path_from_resource_option(action = :after_update_path)

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -146,6 +146,10 @@ module Avo
         end
       end
 
+      add_breadcrumb @resource.plural_name.humanize, resources_path(resource: @resource)
+      add_breadcrumb t("avo.new").humanize
+      set_actions
+
       if saved
         create_success_action
       else
@@ -161,6 +165,7 @@ module Avo
       # model gets instantiated and filled in the fill_model method
       saved = save_model
       @resource = @resource.hydrate(model: @model, view: :edit, user: _current_user)
+      set_actions
 
       if saved
         update_success_action
@@ -392,9 +397,6 @@ module Avo
 
     def create_fail_action
       respond_to do |format|
-        add_breadcrumb @resource.plural_name.humanize, resources_path(resource: @resource)
-        add_breadcrumb t("avo.new").humanize
-        set_actions
         flash.now[:error] = create_fail_message
         format.html { render :new, status: :unprocessable_entity }
       end
@@ -427,7 +429,6 @@ module Avo
 
     def update_fail_action
       respond_to do |format|
-        set_actions
         flash.now[:error] = update_fail_message
         format.html { render :edit, status: :unprocessable_entity }
       end

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -146,16 +146,10 @@ module Avo
         end
       end
 
-      respond_to do |format|
-        if saved
-          format.html { redirect_to after_create_path, notice: create_success_message}
-        else
-          add_breadcrumb @resource.plural_name.humanize, resources_path(resource: @resource)
-          add_breadcrumb t("avo.new").humanize
-          set_actions
-          flash.now[:error] = create_fail_message
-          format.html { render :new, status: :unprocessable_entity }
-        end
+      if saved
+        create_success_action
+      else
+        create_fail_action
       end
     end
 
@@ -168,24 +162,18 @@ module Avo
       saved = save_model
       @resource = @resource.hydrate(model: @model, view: :edit, user: _current_user)
 
-      respond_to do |format|
-        if saved
-          format.html { redirect_to after_update_path, notice: update_success_message }
-        else
-          set_actions
-          flash.now[:error] = update_fail_message
-          format.html { render :edit, status: :unprocessable_entity }
-        end
+      if saved
+        update_success_action
+      else
+        update_fail_action
       end
     end
 
     def destroy
-      respond_to do |format|
-        if destroy_model
-          format.html { redirect_to after_destroy_path, notice: destroy_success_message }
-        else
-          format.html { redirect_back fallback_location: params[:referrer] || resources_path(resource: @resource, turbo_frame: params[:turbo_frame], view_type: params[:view_type]), error: destroy_fail_message }
-        end
+      if destroy_model
+        destroy_success_action
+      else
+        destroy_fail_action
       end
     end
 
@@ -396,6 +384,22 @@ module Avo
       add_breadcrumb t("avo.edit").humanize
     end
 
+    def create_success_action
+      respond_to do |format|
+        format.html { redirect_to after_create_path, notice: create_success_message}
+      end
+    end
+
+    def create_fail_action
+      respond_to do |format|
+        add_breadcrumb @resource.plural_name.humanize, resources_path(resource: @resource)
+        add_breadcrumb t("avo.new").humanize
+        set_actions
+        flash.now[:error] = create_fail_message
+        format.html { render :new, status: :unprocessable_entity }
+      end
+    end
+
     def create_success_message
       "#{@resource.name} #{t("avo.was_successfully_created")}."
     end
@@ -415,6 +419,20 @@ module Avo
       redirect_path_from_resource_option(:after_create_path) || resource_path(model: @model, resource: @resource)
     end
 
+    def update_success_action
+      respond_to do |format|
+        format.html { redirect_to after_update_path, notice: update_success_message }
+      end
+    end
+
+    def update_fail_action
+      respond_to do |format|
+        set_actions
+        flash.now[:error] = update_fail_message
+        format.html { render :edit, status: :unprocessable_entity }
+      end
+    end
+
     def update_success_message
       "#{@resource.name} #{t("avo.was_successfully_updated")}."
     end
@@ -427,6 +445,18 @@ module Avo
       return params[:referrer] if params[:referrer].present?
 
       redirect_path_from_resource_option(:after_update_path) || resource_path(model: @model, resource: @resource)
+    end
+
+    def destroy_success_action
+      respond_to do |format|
+        format.html { redirect_to after_destroy_path, notice: destroy_success_message }
+      end
+    end
+
+    def destroy_fail_action
+      respond_to do |format|
+        format.html { redirect_back fallback_location: params[:referrer] || resources_path(resource: @resource, turbo_frame: params[:turbo_frame], view_type: params[:view_type]), error: destroy_fail_message }
+      end
     end
 
     def destroy_success_message

--- a/spec/dummy/app/controllers/avo/courses_controller.rb
+++ b/spec/dummy/app/controllers/avo/courses_controller.rb
@@ -3,6 +3,30 @@ class Avo::CoursesController < Avo::ResourcesController
     render json: get_cities(params[:country])
   end
 
+  def after_destroy_path
+    Avo::Engine.routes.url_helpers.new_resources_course_path
+  end
+
+  def create_success_message
+    "#{@model.class.name} created!"
+  end
+
+  def create_fail_message
+    "#{@model.class.name} not created!"
+  end
+
+  def update_success_message
+    "#{@model.class.name} updated!"
+  end
+
+  def update_fail_message
+    "#{@model.class.name} not updated!"
+  end
+
+  def destroy_success_message
+    "#{@model.class.name} destroyed for ever!"
+  end
+
   private
 
   def get_cities(country)

--- a/spec/dummy/app/models/course.rb
+++ b/spec/dummy/app/models/course.rb
@@ -13,6 +13,8 @@
 class Course < ApplicationRecord
   has_many :links, -> { order(position: :asc) }, class_name: "Course::Link", inverse_of: :course
 
+  validates :name, presence: true
+
   def has_skills
     true
   end

--- a/spec/features/avo/exposed_methods_base_controller_spec.rb
+++ b/spec/features/avo/exposed_methods_base_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "ExposedMethodsBaseController", type: :feature do
       fill_in "course_name", with: "Great Course"
       save_and_wait_for_loaded
 
-      expect(current_path).to eq "/admin/resources/courses/1"
+      expect(current_path).to eq "/admin/resources/courses/#{Course.last.id}"
       expect(page).to have_text "Course created!"
     end
 

--- a/spec/features/avo/exposed_methods_base_controller_spec.rb
+++ b/spec/features/avo/exposed_methods_base_controller_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.feature "ExposedMethodsBaseController", type: :feature do
+  describe "message" do
+
+    let(:new_course_url) { "/admin/resources/courses/new" }
+
+    it "create_fail_message" do
+      visit new_course_url
+
+      save_and_wait_for_loaded
+
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_text "Course not created!"
+    end
+
+    it "create_success_message" do
+      visit new_course_url
+
+      fill_in "course_name", with: "Great Course"
+      save_and_wait_for_loaded
+
+      expect(current_path).to eq "/admin/resources/courses/1"
+      expect(page).to have_text "Course created!"
+    end
+
+    let(:course) { create :course }
+    let(:edit_course_url) { "/admin/resources/courses/#{course.id}/edit" }
+
+    it "update_fail_message" do
+      visit edit_course_url
+
+      fill_in "course_name", with: ""
+      save_and_wait_for_loaded
+
+      expect(page).to have_http_status(:unprocessable_entity)
+      expect(page).to have_text "Course not updated!"
+      expect(page).to have_text "Validation failed: Name can't be blank"
+    end
+
+    let(:course_url) { "/admin/resources/courses/#{course.id}" }
+
+    it "update_success_message" do
+      visit edit_course_url
+
+      fill_in "course_name", with: "Guitar Course"
+      save_and_wait_for_loaded
+
+      expect(current_path).to eq course_url
+      expect(page).to have_text "Course updated!"
+    end
+
+    it "after_destroy_path && destroy_success_message" do
+      visit course_url
+
+      click_on "Delete"
+      wait_for_loaded
+
+      expect(current_path).to eq new_course_url
+      expect(page).to have_text "Course destroyed for ever!"
+    end
+  end
+end
+
+def save_and_wait_for_loaded
+  click_on "Save"
+  wait_for_loaded
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Besides `after_create_path` and `after_update_path` it's possible now to override the method `after_destroy_path`. This three methods gives the path to redirect after the create, update and destroy succeed.

It's also possible to customize the messages for each action (create, update and destroy) success or fail by overriding:
- Create
        Success  ->    `create_success_message`
        Error      ->    `create_fail_message`
- Update
        Success  ->    `update_success_message`
        Error      ->    `update_fail_message`
- Destroy
        Success  ->    `destroy_success_message`
        Error      ->    `destroy_fail_message`

Now it's possible to override completely the response of each **C**r**UD** action both on success and failure:
- Create
        Success  ->    `create_success_action`
        Error      ->    `create_fail_action`
- Update
        Success  ->    `update_success_action`
        Error      ->    `update_fail_action`
- Destroy
        Success  ->    `destroy_success_action`
        Error      ->    `destroy_fail_action`

Fixes https://github.com/avo-hq/avo/issues/1008

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works
