### PR TITLE
refactor: allow empty show_controls block

### DIFF
--- a/app/components/avo/views/resource_show_component.html.erb
+++ b/app/components/avo/views/resource_show_component.html.erb
@@ -36,6 +36,7 @@
                   tippy: control.title ? :tooltip : nil,
                   'resource-id': @resource.model.id,
                 } do %>
+                <%= control.label %>
               <% end %>
             <% end %>
           <% elsif control.actions_list? %>
@@ -90,7 +91,7 @@
                   data: {
                     confirm: "Are you sure you want to detach this #{title}."
                   } do %>
-                <%= t('avo.detach_item', item: title).capitalize %>
+                <%= control.label %>
               <% end %>
             <% end %>
           <% end %>

--- a/lib/avo/concerns/has_editable_controls.rb
+++ b/lib/avo/concerns/has_editable_controls.rb
@@ -24,7 +24,7 @@ module Avo
             resource: self,
             record: model,
             view: view
-          ).handle.items
+          ).handle&.items || []
         else
           []
         end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes a small issue where if you left the `show_controls` block empty, you would crash Avo.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works
