### PR TITLE
feature: Callable readonly

### DIFF
--- a/app/components/avo/fields/belongs_to_field/edit_component.rb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.rb
@@ -8,7 +8,7 @@ class Avo::Fields::BelongsToField::EditComponent < Avo::Fields::EditComponent
   end
 
   def disabled
-    return true if @field.readonly
+    return true if @field.is_readonly?
 
     # When visiting the record through it's association we keep the field disabled by default
     # We make an exception when the user deliberately instructs Avo to allow detaching in this scenario

--- a/app/components/avo/fields/boolean_field/edit_component.html.erb
+++ b/app/components/avo/fields/boolean_field/edit_component.html.erb
@@ -4,7 +4,7 @@
       checked: @field.value,
       class: "text-lg h-4 w-4 #{@field.get_html(:classes, view: view, element: :input)}",
       data: @field.get_html(:data, view: view, element: :input),
-      disabled: @field.readonly,
+      disabled: @field.is_readonly?,
       style: @field.get_html(:style, view: view, element: :input)
     %>
   </div>

--- a/app/components/avo/fields/boolean_group_field/edit_component.html.erb
+++ b/app/components/avo/fields/boolean_group_field/edit_component.html.erb
@@ -20,7 +20,7 @@
           <%= check_box_tag "#{model_param_key}[#{@field.id}][]", id, checked, {
               class: "w-4 h-4 #{@field.get_html(:classes, view: view, element: :input)}",
               data: @field.get_html(:data, view: view, element: :input),
-              disabled: @field.readonly,
+              disabled: @field.is_readonly?,
               id: "#{model_param_key}_#{@field.id}_#{id}",
               style: @field.get_html(:style, view: view, element: :input)
             } %> <%= label %>

--- a/app/components/avo/fields/code_field/edit_component.html.erb
+++ b/app/components/avo/fields/code_field/edit_component.html.erb
@@ -8,12 +8,12 @@
         language: @field.language,
         theme: @field.theme,
         'tab-size': @field.tab_size,
-        'read-only': @field.readonly,
+        'read-only': @field.is_readonly?,
         'indent-with-tabs': @field.indent_with_tabs,
         'line-wrapping': @field.line_wrapping,
         **@field.get_html(:data, view: view, element: :input),
       },
-      disabled: @field.readonly,
+      disabled: @field.is_readonly?,
       placeholder: @field.placeholder,
       style: @field.get_html(:style, view: view, element: :input)
     %>

--- a/app/components/avo/fields/country_field/edit_component.html.erb
+++ b/app/components/avo/fields/country_field/edit_component.html.erb
@@ -8,7 +8,7 @@
     },
     class: classes("w-full"),
     data: @field.get_html(:data, view: view, element: :input),
-    disabled: @field.readonly,
+    disabled: @field.is_readonly?,
     style: @field.get_html(:style, view: view, element: :input),
     placeholder: @field.include_blank.present? ? nil : @field.placeholder
   %>

--- a/app/components/avo/fields/date_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_field/edit_component.html.erb
@@ -18,7 +18,7 @@
         relative: @field.relative,
         **@field.get_html(:data, view: view, element: :input)
       },
-      disabled: @field.readonly,
+      disabled: @field.is_readonly?,
       placeholder: @field.placeholder,
       style: @field.get_html(:style, view: view, element: :input)
     %>
@@ -31,7 +31,7 @@
         relative: @field.relative,
         **@field.get_html(:data, view: view, element: :input)
       },
-      disabled: @field.readonly,
+      disabled: @field.is_readonly?,
       placeholder: @field.placeholder,
       style: @field.get_html(:style, view: view, element: :input)
     %>

--- a/app/components/avo/fields/date_time_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_time_field/edit_component.html.erb
@@ -18,7 +18,7 @@
         relative: @field.relative,
         **@field.get_html(:data, view: view, element: :input)
       },
-      disabled: @field.readonly,
+      disabled: @field.is_readonly?,
       placeholder: @field.placeholder,
       style: @field.get_html(:style, view: view, element: :input)
     %>
@@ -31,7 +31,7 @@
         relative: @field.relative,
         **@field.get_html(:data, view: view, element: :input)
       },
-      disabled: @field.readonly,
+      disabled: @field.is_readonly?,
       placeholder: @field.placeholder,
       style: @field.get_html(:style, view: view, element: :input)
     %>

--- a/app/components/avo/fields/external_image_field/edit_component.html.erb
+++ b/app/components/avo/fields/external_image_field/edit_component.html.erb
@@ -2,7 +2,7 @@
   <%= @form.text_field @field.id,
     class: classes("w-full"),
     data: @field.get_html(:data, view: view, element: :input),
-    disabled: @field.readonly,
+    disabled: @field.is_readonly?,
     placeholder: @field.placeholder,
     style: @field.get_html(:style, view: view, element: :input)
   %>

--- a/app/components/avo/fields/file_field/edit_component.html.erb
+++ b/app/components/avo/fields/file_field/edit_component.html.erb
@@ -10,7 +10,7 @@
       accept: @field.accept,
       data: @field.get_html(:data, view: view, element: :input),
       direct_upload: @field.direct_upload,
-      disabled: @field.readonly,
+      disabled: @field.is_readonly?,
       style: @field.get_html(:style, view: view, element: :input)
     %>
   <% end %>

--- a/app/components/avo/fields/files_field/edit_component.html.erb
+++ b/app/components/avo/fields/files_field/edit_component.html.erb
@@ -7,7 +7,7 @@
         accept: @field.accept,
         data: @field.get_html(:data, view: view, element: :input),
         direct_upload: @field.direct_upload,
-        disabled: @field.readonly,
+        disabled: @field.is_readonly?,
         multiple: true,
         style: @field.get_html(:style, view: view, element: :input)
       %>

--- a/app/components/avo/fields/has_one_field/show_component.html.erb
+++ b/app/components/avo/fields/has_one_field/show_component.html.erb
@@ -5,7 +5,7 @@
 <% else %>
   <%= render Avo::PanelComponent.new(title: @field.name) do |c| %>
     <% c.tools do %>
-      <% if !@field.readonly && can_attach? %>
+      <% if !@field.is_readonly? && can_attach? %>
         <%= a_link attach_path, icon: 'heroicons/outline/link', color: :primary, 'data-turbo-frame': 'attach_modal' do %>
           <%= t('avo.attach_item', item: @field.name.downcase) %>
         <% end %>

--- a/app/components/avo/fields/markdown_field/edit_component.html.erb
+++ b/app/components/avo/fields/markdown_field/edit_component.html.erb
@@ -7,7 +7,7 @@
         'simple-mde-target': 'element',
         'component-options': @field.options.to_json,
       },
-      disabled: @field.readonly,
+      disabled: @field.is_readonly?,
       placeholder: @field.placeholder,
       style: @field.get_html(:style, view: view, element: :input)
     %>

--- a/app/components/avo/fields/markdown_field/show_component.html.erb
+++ b/app/components/avo/fields/markdown_field/show_component.html.erb
@@ -3,7 +3,7 @@
     <%= text_area_tag @field.id, @field.value,
       class: helpers.input_classes('w-full js-has-simple-mde-editor'),
       placeholder: @field.placeholder,
-      disabled: @field.readonly,
+      disabled: @field.is_readonly?,
       'data-simple-mde-target': 'element',
       'data-component-options': @field.options.to_json,
       'data-view': :show %>

--- a/app/components/avo/fields/number_field/edit_component.html.erb
+++ b/app/components/avo/fields/number_field/edit_component.html.erb
@@ -2,7 +2,7 @@
   <%= @form.number_field @field.id,
     class: classes("w-full"),
     data: @field.get_html(:data, view: view, element: :input),
-    disabled: @field.readonly,
+    disabled: @field.is_readonly?,
     max: @field.max,
     min: @field.min,
     placeholder: @field.placeholder,

--- a/app/components/avo/fields/password_field/edit_component.html.erb
+++ b/app/components/avo/fields/password_field/edit_component.html.erb
@@ -2,7 +2,7 @@
   <%= @form.password_field @field.id,
     class: classes("w-full"),
     data: @field.get_html(:data, view: view, element: :input),
-    disabled: @field.readonly,
+    disabled: @field.is_readonly?,
     placeholder: @field.placeholder,
     style: @field.get_html(:style, view: view, element: :input)
     %>

--- a/app/components/avo/fields/progress_bar_field/edit_component.html.erb
+++ b/app/components/avo/fields/progress_bar_field/edit_component.html.erb
@@ -7,7 +7,7 @@
   <%= @form.range_field @field.id,
     class: "w-full #{@field.get_html(:classes, view: view, element: :input)}",
     data: @field.get_html(:data, view: view, element: :input),
-    disabled: @field.readonly,
+    disabled: @field.is_readonly?,
     max: @field.max,
     min: 0,
     placeholder: @field.placeholder,

--- a/app/components/avo/fields/select_field/edit_component.html.erb
+++ b/app/components/avo/fields/select_field/edit_component.html.erb
@@ -8,7 +8,7 @@
     },
     class: classes("w-full"),
     data: @field.get_html(:data, view: view, element: :input),
-    disabled: @field.readonly,
+    disabled: @field.is_readonly?,
     style: @field.get_html(:style, view: view, element: :input),
     value: @field.model.present? ? @field.model[@field.id] : @field.value,
     placeholder: @field.include_blank.present? ? nil : @field.placeholder

--- a/app/components/avo/fields/status_field/edit_component.html.erb
+++ b/app/components/avo/fields/status_field/edit_component.html.erb
@@ -2,7 +2,7 @@
   <%= @form.text_field @field.id,
     class: classes("w-full"),
     data: @field.get_html(:data, view: view, element: :input),
-    disabled: @field.readonly,
+    disabled: @field.is_readonly?,
     placeholder: @field.placeholder,
     style: @field.get_html(:style, view: view, element: :input),
     value: @resource.model.present? ? @resource.model[@field.id] : @field.value

--- a/app/components/avo/fields/tags_field/edit_component.html.erb
+++ b/app/components/avo/fields/tags_field/edit_component.html.erb
@@ -10,7 +10,7 @@
       data: {
         'tags-field-target': 'fakeInput',
       },
-      disabled: @field.readonly,
+      disabled: @field.is_readonly?,
       placeholder: @field.placeholder,
       style: @field.get_html(:style, view: view, element: :input),
       value: ''
@@ -26,7 +26,7 @@
         'delimiters': @field.delimiters,
         'close-on-select': @field.close_on_select ? 1 : 0,
       },
-      disabled: @field.readonly,
+      disabled: @field.is_readonly?,
       placeholder: @field.placeholder,
       style: @field.get_html(:style, view: view, element: :input),
       value: @field.field_value.to_json

--- a/app/components/avo/fields/text_field/edit_component.html.erb
+++ b/app/components/avo/fields/text_field/edit_component.html.erb
@@ -2,7 +2,7 @@
   <%= @form.text_field @field.id,
     class: classes("w-full"),
     data: @field.get_html(:data, view: view, element: :input),
-    disabled: @field.readonly,
+    disabled: @field.is_readonly?,
     placeholder: @field.placeholder,
     style: @field.get_html(:style, view: view, element: :input)
   %>

--- a/app/components/avo/fields/textarea_field/edit_component.html.erb
+++ b/app/components/avo/fields/textarea_field/edit_component.html.erb
@@ -2,7 +2,7 @@
   <%= @form.text_area @field.id,
     class: classes("w-full"),
     data: @field.get_html(:data, view: view, element: :input),
-    disabled: @field.readonly,
+    disabled: @field.is_readonly?,
     placeholder: @field.placeholder,
     rows: @field.rows,
     style: @field.get_html(:style, view: view, element: :input)

--- a/app/components/avo/fields/trix_field/edit_component.html.erb
+++ b/app/components/avo/fields/trix_field/edit_component.html.erb
@@ -24,7 +24,7 @@
     <%= @form.text_area @field.id,
       class: classes("w-full hidden"),
       data: @field.get_html(:data, view: view, element: :input),
-      disabled: @field.readonly,
+      disabled: @field.is_readonly?,
       id: trix_id,
       placeholder: @field.placeholder,
       style: @field.get_html(:style, view: view, element: :input)

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -13,6 +13,7 @@ module Avo
       include Avo::Concerns::HandlesFieldArgs
       include Avo::Concerns::HasHTMLAttributes
       include Avo::Fields::Concerns::IsRequired
+      include Avo::Fields::Concerns::IsReadonly
 
       delegate :view_context, to: ::Avo::App
       delegate :simple_format, :content_tag, to: :view_context

--- a/lib/avo/fields/concerns/is_readonly.rb
+++ b/lib/avo/fields/concerns/is_readonly.rb
@@ -1,0 +1,17 @@
+module Avo
+  module Fields
+    module Concerns
+      module IsReadonly
+        extend ActiveSupport::Concern
+
+        def is_readonly?
+          if readonly.respond_to? :call
+            Avo::Hosts::ViewRecordHost.new(block: readonly, record: model, view: view).handle
+          else
+            readonly
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/avo/templates/field/components/edit_component.html.erb.tt
+++ b/lib/generators/avo/templates/field/components/edit_component.html.erb.tt
@@ -2,5 +2,5 @@
   <%%= @form.text_field @field.id,
     class: classes("w-full"),
     placeholder: @field.placeholder,
-    disabled: @field.readonly %>
+    disabled: @field.is_readonly? %>
 <%% end %>

--- a/spec/dummy/app/avo/resources/fish_resource.rb
+++ b/spec/dummy/app/avo/resources/fish_resource.rb
@@ -7,6 +7,7 @@ class FishResource < Avo::BaseResource
   self.extra_params = [:fish_type, :something_else, properties: [], information: [:name, :history]]
 
   field :id, as: :id
+  field :id, as: :number, only_on: :forms, readonly: -> { view != :new }
   field :name, as: :text, required: -> { view == :new }
   field :type, as: :text, hide_on: :forms
 

--- a/spec/dummy/app/components/avo/fields/color_picker_field/edit_component.html.erb
+++ b/spec/dummy/app/components/avo/fields/color_picker_field/edit_component.html.erb
@@ -2,6 +2,6 @@
   <%= @form.color_field @field.id,
     class: helpers.input_classes('w-full py-0', has_error: @field.model_errors.include?(@field.id)).gsub('py-2', ''),
     placeholder: @field.placeholder,
-    disabled: @field.readonly
+    disabled: @field.is_readonly?
   %>
 <% end %>

--- a/spec/features/avo/readonly_takes_a_block_spec.rb
+++ b/spec/features/avo/readonly_takes_a_block_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature "ReadonlyTakesABlock", type: :feature do
+  context "new" do
+    it "is readonly" do
+      visit "/admin/resources/fish/new"
+
+      expect(page).to have_field 'fish[id]', disabled: false
+    end
+  end
+
+  context "edit" do
+    let(:fish) { create :fish }
+
+    it "is readonly" do
+      visit "/admin/resources/fish/#{fish.id}/edit"
+
+      expect(page).to have_field 'fish[id]', disabled: true
+    end
+  end
+end

--- a/spec/features/avo/required_takes_a_block_spec.rb
+++ b/spec/features/avo/required_takes_a_block_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature "RequiredTakesABlocks", type: :feature do
+RSpec.feature "RequiredTakesABlock", type: :feature do
   context "new" do
     it "is required" do
       visit "/admin/resources/fish/new"


### PR DESCRIPTION
# Description
This adds support for making the `readonly` field take a proc, just like required (implemented in https://github.com/avo-hq/avo/pull/955)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


With support from @ncsmith24