### PR TITLE
feature: Utilize required attribute in HTML to have browser-side requires

### DIFF
--- a/app/components/avo/fields/boolean_field/edit_component.html.erb
+++ b/app/components/avo/fields/boolean_field/edit_component.html.erb
@@ -5,6 +5,7 @@
       class: "text-lg h-4 w-4 #{@field.get_html(:classes, view: view, element: :input)}",
       data: @field.get_html(:data, view: view, element: :input),
       disabled: @field.readonly,
+      required: @field.is_required?,
       style: @field.get_html(:style, view: view, element: :input)
     %>
   </div>

--- a/app/components/avo/fields/boolean_group_field/edit_component.html.erb
+++ b/app/components/avo/fields/boolean_group_field/edit_component.html.erb
@@ -22,6 +22,7 @@
               data: @field.get_html(:data, view: view, element: :input),
               disabled: @field.readonly,
               id: "#{model_param_key}_#{@field.id}_#{id}",
+              required: @field.is_required?,
               style: @field.get_html(:style, view: view, element: :input)
             } %> <%= label %>
         </label>

--- a/app/components/avo/fields/code_field/edit_component.html.erb
+++ b/app/components/avo/fields/code_field/edit_component.html.erb
@@ -15,6 +15,7 @@
       },
       disabled: @field.readonly,
       placeholder: @field.placeholder,
+      required: @field.is_required?,
       style: @field.get_html(:style, view: view, element: :input)
     %>
   </div>

--- a/app/components/avo/fields/country_field/edit_component.html.erb
+++ b/app/components/avo/fields/country_field/edit_component.html.erb
@@ -9,7 +9,8 @@
     class: classes("w-full"),
     data: @field.get_html(:data, view: view, element: :input),
     disabled: @field.readonly,
-    style: @field.get_html(:style, view: view, element: :input),
-    placeholder: @field.include_blank.present? ? nil : @field.placeholder
+    placeholder: @field.include_blank.present? ? nil : @field.placeholder,
+    required: @field.is_required?,
+    style: @field.get_html(:style, view: view, element: :input)
   %>
 <% end %>

--- a/app/components/avo/fields/date_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_field/edit_component.html.erb
@@ -18,6 +18,7 @@
       },
       disabled: @field.readonly,
       placeholder: @field.placeholder,
+      required: @field.is_required?,
       style: @field.get_html(:style, view: view, element: :input)
     %>
     <%= @form.text_field @field.id,
@@ -30,6 +31,7 @@
       },
       disabled: @field.readonly,
       placeholder: @field.placeholder,
+      required: @field.is_required?,
       style: @field.get_html(:style, view: view, element: :input)
     %>
   <% end %>

--- a/app/components/avo/fields/date_time_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_time_field/edit_component.html.erb
@@ -19,6 +19,7 @@
       },
       disabled: @field.readonly,
       placeholder: @field.placeholder,
+      required: @field.is_required?,
       style: @field.get_html(:style, view: view, element: :input)
     %>
     <%= @form.text_field @field.id,
@@ -31,6 +32,7 @@
       },
       disabled: @field.readonly,
       placeholder: @field.placeholder,
+      required: @field.is_required?,
       style: @field.get_html(:style, view: view, element: :input)
     %>
   <% end %>

--- a/app/components/avo/fields/external_image_field/edit_component.html.erb
+++ b/app/components/avo/fields/external_image_field/edit_component.html.erb
@@ -4,6 +4,7 @@
     data: @field.get_html(:data, view: view, element: :input),
     disabled: @field.readonly,
     placeholder: @field.placeholder,
+    required: @field.is_required?,
     style: @field.get_html(:style, view: view, element: :input)
   %>
 <% end %>

--- a/app/components/avo/fields/file_field/edit_component.html.erb
+++ b/app/components/avo/fields/file_field/edit_component.html.erb
@@ -11,6 +11,7 @@
       data: @field.get_html(:data, view: view, element: :input),
       direct_upload: @field.direct_upload,
       disabled: @field.readonly,
+      required: @field.is_required?,
       style: @field.get_html(:style, view: view, element: :input)
     %>
   <% end %>

--- a/app/components/avo/fields/files_field/edit_component.html.erb
+++ b/app/components/avo/fields/files_field/edit_component.html.erb
@@ -9,6 +9,7 @@
         direct_upload: @field.direct_upload,
         disabled: @field.readonly,
         multiple: true,
+        required: @field.is_required?,
         style: @field.get_html(:style, view: view, element: :input)
       %>
     </div>

--- a/app/components/avo/fields/markdown_field/edit_component.html.erb
+++ b/app/components/avo/fields/markdown_field/edit_component.html.erb
@@ -9,6 +9,7 @@
       },
       disabled: @field.readonly,
       placeholder: @field.placeholder,
+      required: @field.is_required?,
       style: @field.get_html(:style, view: view, element: :input)
     %>
   </div>

--- a/app/components/avo/fields/markdown_field/show_component.html.erb
+++ b/app/components/avo/fields/markdown_field/show_component.html.erb
@@ -6,6 +6,7 @@
       disabled: @field.readonly,
       'data-simple-mde-target': 'element',
       'data-component-options': @field.options.to_json,
-      'data-view': :show %>
+      'data-view': :show,
+      required: @field.is_required? %>
   </div>
 <% end %>

--- a/app/components/avo/fields/number_field/edit_component.html.erb
+++ b/app/components/avo/fields/number_field/edit_component.html.erb
@@ -6,6 +6,7 @@
     max: @field.max,
     min: @field.min,
     placeholder: @field.placeholder,
+    required: @field.is_required?,
     step: @field.step,
     style: @field.get_html(:style, view: view, element: :input)
   %>

--- a/app/components/avo/fields/password_field/edit_component.html.erb
+++ b/app/components/avo/fields/password_field/edit_component.html.erb
@@ -4,6 +4,7 @@
     data: @field.get_html(:data, view: view, element: :input),
     disabled: @field.readonly,
     placeholder: @field.placeholder,
+    required: @field.is_required?,
     style: @field.get_html(:style, view: view, element: :input)
     %>
 <% end %>

--- a/app/components/avo/fields/progress_bar_field/edit_component.html.erb
+++ b/app/components/avo/fields/progress_bar_field/edit_component.html.erb
@@ -11,6 +11,7 @@
     max: @field.max,
     min: 0,
     placeholder: @field.placeholder,
+    required: @field.is_required?,
     step: @field.step,
     style: @field.get_html(:style, view: view, element: :input)
   %>

--- a/app/components/avo/fields/select_field/edit_component.html.erb
+++ b/app/components/avo/fields/select_field/edit_component.html.erb
@@ -9,8 +9,9 @@
     class: classes("w-full"),
     data: @field.get_html(:data, view: view, element: :input),
     disabled: @field.readonly,
+    placeholder: @field.include_blank.present? ? nil : @field.placeholder,
+    required: @field.is_required?,
     style: @field.get_html(:style, view: view, element: :input),
-    value: @field.model.present? ? @field.model[@field.id] : @field.value,
-    placeholder: @field.include_blank.present? ? nil : @field.placeholder
+    value: @field.model.present? ? @field.model[@field.id] : @field.value
   %>
 <% end %>

--- a/app/components/avo/fields/status_field/edit_component.html.erb
+++ b/app/components/avo/fields/status_field/edit_component.html.erb
@@ -4,6 +4,7 @@
     data: @field.get_html(:data, view: view, element: :input),
     disabled: @field.readonly,
     placeholder: @field.placeholder,
+    required: @field.is_required?,
     style: @field.get_html(:style, view: view, element: :input),
     value: @resource.model.present? ? @resource.model[@field.id] : @field.value
   %>

--- a/app/components/avo/fields/tags_field/edit_component.html.erb
+++ b/app/components/avo/fields/tags_field/edit_component.html.erb
@@ -12,6 +12,7 @@
       },
       disabled: @field.readonly,
       placeholder: @field.placeholder,
+      required: @field.is_required?,
       style: @field.get_html(:style, view: view, element: :input),
       value: ''
     %>
@@ -28,6 +29,7 @@
       },
       disabled: @field.readonly,
       placeholder: @field.placeholder,
+      required: @field.is_required?,
       style: @field.get_html(:style, view: view, element: :input),
       value: @field.field_value.to_json
     %>

--- a/app/components/avo/fields/text_field/edit_component.html.erb
+++ b/app/components/avo/fields/text_field/edit_component.html.erb
@@ -4,6 +4,7 @@
     data: @field.get_html(:data, view: view, element: :input),
     disabled: @field.readonly,
     placeholder: @field.placeholder,
+    required: @field.is_required?,
     style: @field.get_html(:style, view: view, element: :input)
   %>
 <% end %>

--- a/app/components/avo/fields/textarea_field/edit_component.html.erb
+++ b/app/components/avo/fields/textarea_field/edit_component.html.erb
@@ -4,6 +4,7 @@
     data: @field.get_html(:data, view: view, element: :input),
     disabled: @field.readonly,
     placeholder: @field.placeholder,
+    required: @field.is_required?,
     rows: @field.rows,
     style: @field.get_html(:style, view: view, element: :input)
   %>

--- a/app/components/avo/fields/trix_field/edit_component.html.erb
+++ b/app/components/avo/fields/trix_field/edit_component.html.erb
@@ -27,6 +27,7 @@
       disabled: @field.readonly,
       id: trix_id,
       placeholder: @field.placeholder,
+      required: @field.is_required?,
       style: @field.get_html(:style, view: view, element: :input)
     %>
   </div>

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -25,7 +25,7 @@ class UserResource < Avo::BaseResource
   field :active, as: :boolean, name: "Is active", show_on: :show
   field :cv, as: :file, name: "CV"
   field :is_admin?, as: :boolean, name: "Is admin", only_on: :index
-  field :roles, as: :boolean_group, options: {admin: "Administrator", manager: "Manager", writer: "Writer"}
+  field :roles, as: :boolean_group, options: {admin: "Administrator", manager: "Manager", writer: "Writer"}, only_on: :index
   field :roles, as: :text, hide_on: :all, as_description: true do |model, resource, view, field|
     "This user has the following roles: #{model.roles.select { |key, value| value }.keys.join(", ")}"
   end
@@ -56,6 +56,21 @@ class UserResource < Avo::BaseResource
   end
 
   tabs do
+    field :fish, as: :has_one
+    field :teams, as: :has_and_belongs_to_many
+    field :people,
+      as: :has_many,
+      show_on: :edit,
+      translation_key: "avo.field_translations.people"
+    field :spouses, as: :has_many # STI has_many resource
+    field :projects, as: :has_and_belongs_to_many
+
+    tab "Roles", description: "This tab is here just to hide the Birthday tab on the edit screen" do
+      panel do
+        field :roles, as: :boolean_group, options: {admin: "Administrator", manager: "Manager", writer: "Writer"}
+      end
+    end
+
     tab "Birthday", description: "hey you", hide_on: :show do
       panel do
         field :birthday,
@@ -67,15 +82,6 @@ class UserResource < Avo::BaseResource
           required: true
       end
     end
-
-    field :fish, as: :has_one
-    field :teams, as: :has_and_belongs_to_many
-    field :people,
-      as: :has_many,
-      show_on: :edit,
-      translation_key: "avo.field_translations.people"
-    field :spouses, as: :has_many # STI has_many resource
-    field :projects, as: :has_and_belongs_to_many
   end
 
   tabs do

--- a/spec/features/avo/required_takes_a_block_spec.rb
+++ b/spec/features/avo/required_takes_a_block_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "RequiredTakesABlocks", type: :feature do
       visit "/admin/resources/fish/new"
 
       expect(page).to have_selector ".text-red-600.ml-1"
+      expect(page).to have_required_field "fish[name]"
     end
   end
 
@@ -16,6 +17,7 @@ RSpec.feature "RequiredTakesABlocks", type: :feature do
       visit "/admin/resources/fish/#{fish.id}/edit"
 
       expect(page).not_to have_selector ".text-red-600.ml-1"
+      expect(page).not_to have_required_field("fish[name]")
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,6 +48,7 @@ Avo::App.boot
 
 require "support/download_helpers"
 require "support/request_helpers"
+require "support/field_matchers"
 
 Capybara.register_driver :chrome_headless do |app|
   Capybara::Selenium::Driver.new app,

--- a/spec/support/field_matchers.rb
+++ b/spec/support/field_matchers.rb
@@ -1,0 +1,6 @@
+RSpec::Matchers.define :have_required_field do |expected|
+  match do |page|
+    expect(page).to have_field(expected)
+    expect(find_field(expected)[:required]).to eq("required")
+  end
+end


### PR DESCRIPTION
# Description
Use the HTML attribute of `required` and sync it up with the `required` status on the field so that the client-side knows it's required therefore disallowing the browser to submit the form.

This also adds a custom matcher for `have_required_field` and cleans up the alphabetical ordering of some keys in the HTML.

With support from @ncsmith24

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works
