### PR TITLE
fix: search pagination unlimited

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -47,7 +47,7 @@ module Avo
       query =  Avo::Hosts::SearchScopeHost.new(
         block: resource.search_query,
         params: params,
-        scope: resource.class.scope
+        scope: resource.class.scope.limit(8)
       ).handle
 
       query = apply_scope(query) if should_apply_any_scope?


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes [this issue](https://discord.com/channels/740892036978442260/740893011994738751/1010185907992801291) where the search is not paginated and Avo tries to return all the results. This causes a crash when there are too many results.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works
