### PR TITLE
fix: date value changed on direct submit

### DIFF
--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -117,7 +117,11 @@ export default class extends Controller {
 
     flatpickr(this.fakeInputTarget, options)
 
-    this.updateRealInput(this.parsedValue.setZone(this.displayTimezone).toISO())
+    if (this.enableTimeValue) {
+      this.updateRealInput(this.parsedValue.setZone(this.displayTimezone).toISO())
+    } else {
+      this.updateRealInput(universalTimestamp(this.initialValue))
+    }
   }
 
   onChange(selectedDates) {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1079

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Set your browser to a western timezone (San Francisco will do)
1. Go to a user
1. observe the date from the birthday field
2. go on the edit page
3. without filling in anything, hit submit
4. check that the birthday is the same

Manual reviewer: please leave a comment with output from the test if that's the case.
