### PR TITLE
fix: broken download button for file fields

### DIFF
--- a/app/components/avo/fields/common/single_file_viewer_component.html.erb
+++ b/app/components/avo/fields/common/single_file_viewer_component.html.erb
@@ -21,8 +21,7 @@
     <div class="flex space-x-2">
       <div class="flex">
         <% if @resource.authorization.authorize_action(:download_attachments?, raise_exception: false) %>
-          <!-- <%= file.inspect %> -->
-          <%= a_link file.service_url(disposition: :attachment),
+          <%= a_link Rails.application.routes.url_helpers.rails_blob_path(file, only_path: true, disposition: :attachment),
             icon: 'heroicons/outline/download',
             color: :primary,
             download: true,

--- a/app/components/avo/fields/common/single_file_viewer_component.html.erb
+++ b/app/components/avo/fields/common/single_file_viewer_component.html.erb
@@ -21,7 +21,8 @@
     <div class="flex space-x-2">
       <div class="flex">
         <% if @resource.authorization.authorize_action(:download_attachments?, raise_exception: false) %>
-          <%= a_link file.url(disposition: :attachment),
+          <!-- <%= file.inspect %> -->
+          <%= a_link file.service_url(disposition: :attachment),
             icon: 'heroicons/outline/download',
             color: :primary,
             download: true,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1174
Fixes https://github.com/avo-hq/avo/issues/1187

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Use a cloud provider for active storage
2. Make sure you can upload and display files

Manual reviewer: please leave a comment with output from the test if that's the case.
