### PR TITLE
fix: use secret_key_base off the env variable

### DIFF
--- a/lib/avo/services/encryption_service.rb
+++ b/lib/avo/services/encryption_service.rb
@@ -18,7 +18,7 @@ module Avo
       def initialize(message:, purpose:)
         @message = message
         @purpose = purpose
-        @crypt = ActiveSupport::MessageEncryptor.new(Rails.application.secrets.secret_key_base[0..31])
+        @crypt = ActiveSupport::MessageEncryptor.new(encryption_key)
       end
 
       def encrypt
@@ -27,6 +27,20 @@ module Avo
 
       def decrypt
         crypt.decrypt_and_verify(message, purpose: purpose)
+      end
+
+      private
+
+      def encryption_key
+        secret_key_base[0..31]
+      rescue
+        # This will fail the decryption process.
+        # It's here only to keep Avo from crashing
+        SecureRandom.random_bytes(32)
+      end
+
+      def secret_key_base
+        Rails.application.secrets.secret_key_base || ENV['SECRET_KEY_BASE']
       end
     end
   end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue with older apps, or apps deployed on Heroku that use `ENV['SECRET_KEY_BASE']` instead of `Rails.application.secrets.secret_key_base` for our encryption needs.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to an index page that has more than one page and see it doesn't crash.

Manual reviewer: please leave a comment with output from the test if that's the case.
