### PR TITLE
fix: ensure the right resource is used in resource_component

### DIFF
--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -54,7 +54,7 @@ class Avo::ResourceComponent < Avo::BaseComponent
 
     if @reflection.present?
       # Fetch the appropiate resource
-      reflection_resource = field.use_resource || field.resource
+      reflection_resource = field.resource
       # Fetch the model
       # Hydrate the resource with the model if we have one
       reflection_resource.hydrate(model: @parent_model) if @parent_model.present?

--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -54,7 +54,7 @@ class Avo::ResourceComponent < Avo::BaseComponent
 
     if @reflection.present?
       # Fetch the appropiate resource
-      reflection_resource = field.resource
+      reflection_resource = field.use_resource || field.resource
       # Fetch the model
       # Hydrate the resource with the model if we have one
       reflection_resource.hydrate(model: @parent_model) if @parent_model.present?

--- a/lib/avo/fields/has_base_field.rb
+++ b/lib/avo/fields/has_base_field.rb
@@ -30,7 +30,7 @@ module Avo
       end
 
       def resource
-        Avo::App.get_resource_by_model_name @model.class
+        @resource || Avo::App.get_resource_by_model_name(@model.class)
       end
 
       def turbo_frame


### PR DESCRIPTION
# Description
In the `has_base_field` class, the `resource` method resorts to the `Avo::App.get_resource_by_model_name` method, which picks whatever resource that would use the same base model, instead of the one calling the given field. Using `@resource` and falling back to this method solves this problem.

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
Note: although this bug appeared while trying a yet to be merged feature, I believe this is still a bug that should be fixed.

Here's the setup:
```ruby
class DocumentReviewResource < Avo::BaseResource
  self.model_class = Ticket
  self.authorization_policy = Avo::DocumentReviewPolicy

  field :unreviewed_documents, as: :has_many, use_resource: UnreviewedDocumentResource
end
```
```ruby
module Avo
  class DocumentReviewPolicy < BasePolicy
    def create_unreviewed_documents?
      false
    end

    def edit_unreviewed_documents?
      false
    end

    def detach_unreviewed_documents?
      false
    end

    def destroy_unreviewed_documents?
      false
    end
  end
end
```

Despite using this custom policy, actions would still be visible. Upon debugging, I saw that the resource specified when calling `field.resource` was not the one calling it, thus calling some random policy.
