### PR TITLE
Use translations for polymorphic class names

### DIFF
--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -13,7 +13,7 @@
     data-association-class="<%= @field&.target_resource&.model_class || nil %>"
   >
     <%= edit_field_wrapper field: @field, index: @index, form: @form, resource: @resource, displayed_in_modal: @displayed_in_modal, help: @field.polymorphic_help || ''  do %>
-      <%= @form.select @field.type_input_foreign_key, @field.types.map { |type| [type.to_s.underscore.humanize, type.to_s] },
+      <%= @form.select @field.type_input_foreign_key, @field.types.map { |type| [::Avo::App.get_resource_by_model_name(type.to_s).name, type.to_s] },
       {
         value: @field.value,
         include_blank: @field.placeholder,
@@ -40,7 +40,7 @@
         data-belongs-to-field-target="type"
         data-type="<%= type %>"
       >
-        <%= edit_field_wrapper field: @field, index: @index, form: @form, resource: @resource, displayed_in_modal: @displayed_in_modal, label: type.to_s.underscore.humanize do %>
+        <%= edit_field_wrapper field: @field, index: @index, form: @form, resource: @resource, displayed_in_modal: @displayed_in_modal, label: ::Avo::App.get_resource_by_model_name(type.to_s).name do %>
           <% if @field.searchable %>
             <%= render Avo::Fields::BelongsToField::AutocompleteComponent.new form: @form,
               disabled: disabled,


### PR DESCRIPTION


# Description
Right now polymorphic belongs to fields use the class name
for the type. That isn't very user friendly and inconsistent with
other areas. Instead I've made it use translations to get the
human-readable model name that's used elsewhere in the app.

Fixes # (issue)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Find a resource form with a polymorphic belongs to association, eg. https://avodemo.herokuapp.com/avo/resources/reviews/new
2. Note that the types in the dropdown menu use the class name
3. Add a translation for that resource to `avo.en.yml` (or whichever language you're using) under `avo.resource_translations`
4. Restart the app and confirm that the values in the dropdown are now using the translation and not the class name

Manual reviewer: please leave a comment with output from the test if that's the case.
