### PR TITLE
feature: add ability to make use of belongs_to associations in actions

### DIFF
--- a/app/components/avo/fields/belongs_to_field/autocomplete_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/autocomplete_component.html.erb
@@ -4,15 +4,25 @@
     data-search-resource="<%= @model_key %>"
     data-translation-keys='{"no_item_found": "<%= I18n.translate 'avo.no_item_found' %>"}'
     data-via-association="belongs_to"
-    data-via-association-id="<%= @field.id %>"
-    data-via-reflection-id="<%= @field.model.id %>"
-    data-via-reflection-class="<%= @field.model.class.to_s %>"
-    data-via-parent-resource-id="<%= params[:via_resource_id] %>"
-    data-via-parent-resource-class="<%= params[:via_relation_class] %>"
+
+    <% if @field.actionable? %>
+      data-via-association-id="<%= @field.relation_method %>"
+      data-via-reflection-id="<%= @field.actionable_id %>"
+      data-via-reflection-class="<%= @resource.params[:resource_name].singularize.camelize %>"
+      data-via-parent-resource-id="<%= @field.actionable_class.primary_key %>"
+      data-via-parent-resource-class="<%= @field.actionable_class.to_s %>"
+    <% else %>
+      data-via-association-id="<%= @field.id %>"
+      data-via-reflection-id="<%= @field.model.id %>"
+      data-via-reflection-class="<%= @field.model.class.to_s %>"
+      data-via-parent-resource-id="<%= params[:via_resource_id] %>"
+      data-via-parent-resource-class="<%= params[:via_relation_class] %>"
+    <% end %>
+
     data-via-relation="<%= params[:via_relation] %>"
   ></div>
   <div class="relative w-full" autocomplete="off">
-    <%= @form.text_field @foreign_key,
+    <%= @form.text_field @field.actionable ? @field.relation_method : @foreign_key,
       class: classes,
       # This instructs the search_controller if it should enable/disabled this field when the user switches polymorphic associations
       # It should not enable the field if the record is being created through an association
@@ -37,7 +47,7 @@
       </button>
     <% end %>
   </div>
-  <%= @form.hidden_field @foreign_key,
+  <%= @form.hidden_field @field.actionable ? @field.relation_method : @foreign_key,
     value: field_value,
     data: {
       'search-target': 'hiddenId clearValue',

--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -84,7 +84,7 @@
       <%= render Avo::Fields::BelongsToField::AutocompleteComponent.new form: @form,
         field: @field,
         model_key: @field.target_resource&.model_key,
-        foreign_key: @field.id_input_foreign_key,
+        foreign_key: @field.actionable ? @field.relation_method : @field.id_input_foreign_key,
         resource: @resource,
         disabled: disabled,
         classes: classes("w-full"),
@@ -92,7 +92,7 @@
         style: @field.get_html(:style, view: view, element: :input)
       %>
     <% else %>
-      <%= @form.select @field.id_input_foreign_key, @field.options,
+      <%= @form.select @field.actionable ? @field.relation_method : @field.id_input_foreign_key, @field.options,
         {
           include_blank: @field.placeholder,
           value: @field.value
@@ -108,7 +108,7 @@
         # If the select field is disabled, no value will be sent. It's how HTML works.
         # Thus the extra hidden field to actually send the related id to the server.
         if disabled %>
-        <%= @form.hidden_field @field.id_input_foreign_key %>
+        <%= @form.hidden_field @field.actionable ? @field.relation_method : @field.id_input_foreign_key %>
       <% end %>
     <% end %>
   <% end %>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Feature: Add ability to utilize `belongs_to` associations in Avo Actions

# Checklist:
- [X] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [-] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
1. Add an action to an Avo resource
2. Add a belongs_to field to the Avo resource
3. Set the belongs_to field as `actionable: true` and `actionable_class: ParentClass` 
4. `handle` the `fields['reflection_name']` that occurs as a result
5. ???
6. Profit

If you need me to write the specs and documentation, I will, just let me know. I wanted to get this out to you sooner rather than later, though, so that you can review my approach.

Manual reviewer: please leave a comment with output from the test if that's the case.
