### PR TITLE
Make the trix toolbar responsive

### DIFF
--- a/app/assets/stylesheets/css/fields/trix.css
+++ b/app/assets/stylesheets/css/fields/trix.css
@@ -15,3 +15,13 @@
 .trix-content ol {
   @apply list-decimal;
 }
+
+trix-toolbar {
+  .trix-button-row {
+    @apply flex-wrap gap-x-5;
+  }
+
+  .trix-button-group:not(:first-child) {
+    @apply ml-0;
+  }
+}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

By default trix toolbox does not wrap no matter what the size of the container is. That can be an issue when using a trix field in a smaller container like an action modal.

Here's trix in an action modal and on a resource form on 2.14.2 (see how the toolbar is wider than the container, which also hides the cancel and save buttons because they are aligned to the right):

![Screenshot 2022-09-08 at 13 33 57](https://user-images.githubusercontent.com/111963/189123515-493f4953-a7e1-4b3c-bf42-9a25f7259fb7.jpg)

![Screenshot 2022-09-08 at 13 35 13](https://user-images.githubusercontent.com/111963/189123504-349031a3-8aba-4522-b75b-49acfffd2416.jpg)

Here is the same action modal and form on this branch:

![Screenshot 2022-09-08 at 13 32 43](https://user-images.githubusercontent.com/111963/189123908-170eb4a8-c592-4631-b93d-80c0a1329789.jpg)

![Screenshot 2022-09-08 at 13 34 15](https://user-images.githubusercontent.com/111963/189123874-cb79e9ae-0875-409d-accf-c8204ba89f9d.jpg)

This is a known [issue with trix](https://github.com/basecamp/trix/issues/524) and there's no plan to fix it.

Fixes # (issue)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Add an action that has a trix field in it (`  field :content, as: :trix`)
2. Open the action in the browser and confirm that the trix toolbar and also the save cancel buttons are visible

Manual reviewer: please leave a comment with output from the test if that's the case.
