### PR TITLE
Removed unused parameter from `after_create_path`

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -415,7 +415,7 @@ module Avo
       if params[:via_relation_class].present? && params[:via_resource_id].present?
         parent_resource = ::Avo::App.get_resource_by_model_name params[:via_relation_class].safe_constantize
 
-        return resource_path(model: params[:via_relation_class].safe_constantize, resource: parent_resource, resource_id: params[:via_resource_id])
+        return resource_path(resource: parent_resource, resource_id: params[:via_resource_id])
       end
 
       redirect_path_from_resource_option(:after_create_path) || resource_path(model: @model, resource: @resource)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
AFAIK the `resource` parameter for `resource_path` is only used if the value is a model instance with an id attribute. Here it's a model class instead, so it'll be ignored and the `resource_id` parameter is used instead. I think it'd be simpler and easier to understand if this unnecessary parameter was removed?

Fixes # (issue)

This doesn't actually fix an issue, just cleans up the code a little

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Create a nested resource (eg. project comments in the demo app) and confirm that after creation you are redirected back to the show page for the parent resource (eg. project)

Manual reviewer: please leave a comment with output from the test if that's the case.
