### PR TITLE
Removed safe_constantize where not needed

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -413,9 +413,9 @@ module Avo
     def after_create_path
       # If this is an associated record return to the association show page
       if params[:via_relation_class].present? && params[:via_resource_id].present?
-        parent_resource = ::Avo::App.get_resource_by_model_name params[:via_relation_class].safe_constantize
+        parent_resource = ::Avo::App.get_resource_by_model_name params[:via_relation_class]
 
-        return resource_path(model: params[:via_relation_class].safe_constantize, resource: parent_resource, resource_id: params[:via_resource_id])
+        return resource_path(model: params[:via_relation_class], resource: parent_resource, resource_id: params[:via_resource_id])
       end
 
       redirect_path_from_resource_option(:after_create_path) || resource_path(model: @model, resource: @resource)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

There are three places in BaseController where a request parameter is constantized. Even with safe_costantize this could lead to security issues. In two of these places I don’t think we need to constantize at all, so I’ve updated the code to not do it unnecessarily.

Fixes # (issue)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Check that when creating a nested resource (eg a project has many comments) the user is redirected back to the parent resource afterwards.

Manual reviewer: please leave a comment with output from the test if that's the case.
