### PR TITLE
fix: read-only trix field

### DIFF
--- a/app/components/avo/views/resource_edit_component.html.erb
+++ b/app/components/avo/views/resource_edit_component.html.erb
@@ -41,8 +41,8 @@
         <% c.body do %>
           <div class="divide-y">
             <% main_panel.items.each_with_index do |field, index| %>
-              <%= render field.hydrate(resource: @resource, model: @resource.model, user: @resource.user, view: view)
-                .component_for_view(view)
+              <%= render field.hydrate(resource: @resource, model: @resource.model, user: @resource.user, view: view_for(field))
+                .component_for_view(view_for field)
                 .new(field: field, resource: @resource, index: index, form: form)
               %>
             <% end %>

--- a/app/components/avo/views/resource_edit_component.rb
+++ b/app/components/avo/views/resource_edit_component.rb
@@ -65,4 +65,8 @@ class Avo::Views::ResourceEditComponent < Avo::ResourceComponent
       )
     end
   end
+
+  def view_for(field)
+    (field.is_a? Avo::Fields::TrixField) && field.is_readonly? ? :show : view
+  end
 end

--- a/app/components/avo/views/resource_edit_component.rb
+++ b/app/components/avo/views/resource_edit_component.rb
@@ -66,6 +66,7 @@ class Avo::Views::ResourceEditComponent < Avo::ResourceComponent
     end
   end
 
+  # Render :show view for read only trix fields
   def view_for(field)
     (field.is_a? Avo::Fields::TrixField) && field.is_readonly? ? :show : view
   end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1235

Rendering the show view for the field on the edit page:
![image](https://user-images.githubusercontent.com/69730720/190851258-f25e2251-e0c4-4c26-9faa-57cf020f5ca1.png)
![image](https://user-images.githubusercontent.com/69730720/190851266-126a6275-5dfe-42a1-9a9d-907f1a71890b.png)


# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works
