### PR TITLE
fix: add html attributes to grid items

### DIFF
--- a/app/components/avo/index/grid_item_component.html.erb
+++ b/app/components/avo/index/grid_item_component.html.erb
@@ -2,7 +2,7 @@
   class="relative bg-white rounded shadow-modal flex flex-col group"
   <%== item_selector_init @resource %>
 >
-  <div class="relative w-full pb-3/4 rounded-t overflow-hidden">
+  <%= content_tag :div, class: "relative w-full pb-3/4 rounded-t overflow-hidden #{cover.get_html(:classes, view: :index, element: :wrapper)}", style: cover.get_html(:style, view: :index, element: :wrapper) do %>
     <% if @resource.record_selector %>
       <%== item_selector_input floating: true, size: :lg %>
     <% end %>
@@ -27,18 +27,18 @@
     <% else %>
       <%= render Avo::Index::GridCoverEmptyStateComponent.new %>
     <% end %>
-  </div>
-  <div class="grid grid-cols-1 place-content-between p-4 h-full">
+  <% end %>
+  <%= content_tag :div, class: "grid grid-cols-1 place-content-between p-4 h-full" do %>
     <div class="mb-4 h-full flex flex-col space-between">
-      <div class="grid font-semibold leading-tight text-lg mb-2">
+      <%= content_tag :div, class: "grid font-semibold leading-tight text-lg mb-2 #{title.get_html(:classes, view: :index, element: :wrapper)}", style: title.get_html(:style, view: :index, element: :wrapper) do %>
         <%= link_to_if title.link_to_resource, title.value, resource_view_path if title.present? %>
-      </div>
-      <div class="text-sm break-words text-gray-500">
+      <% end %>
+      <%= content_tag :div, class: "text-sm break-words text-gray-500 #{body.get_html(:classes, view: :index, element: :wrapper)}", style: body.get_html(:style, view: :index, element: :wrapper) do %>
         <%= body.value if body.present? %>
-      </div>
+      <% end %>
     </div>
     <div class="w-full place-self-end">
       <%= render(Avo::Index::ResourceControlsComponent.new(resource: @resource, reflection: @reflection, parent_model: @parent_model, parent_resource: @parent_resource, view_type: :grid)) %>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/app/components/avo/index/grid_item_component.html.erb
+++ b/app/components/avo/index/grid_item_component.html.erb
@@ -2,7 +2,7 @@
   class="relative bg-white rounded shadow-modal flex flex-col group"
   <%== item_selector_init @resource %>
 >
-  <%= content_tag :div, class: "relative w-full pb-3/4 rounded-t overflow-hidden #{cover.get_html(:classes, view: :index, element: :wrapper)}", style: cover.get_html(:style, view: :index, element: :wrapper) do %>
+  <%= content_tag :div, class: "relative w-full pb-3/4 rounded-t overflow-hidden #{cover.present? ? cover.get_html(:classes, view: :index, element: :wrapper) : ""}", style: cover.present? ? cover.get_html(:style, view: :index, element: :wrapper) : "" do %>
     <% if @resource.record_selector %>
       <%== item_selector_input floating: true, size: :lg %>
     <% end %>
@@ -30,11 +30,15 @@
   <% end %>
   <%= content_tag :div, class: "grid grid-cols-1 place-content-between p-4 h-full" do %>
     <div class="mb-4 h-full flex flex-col space-between">
-      <%= content_tag :div, class: "grid font-semibold leading-tight text-lg mb-2 #{title.get_html(:classes, view: :index, element: :wrapper)}", style: title.get_html(:style, view: :index, element: :wrapper) do %>
-        <%= link_to_if title.link_to_resource, title.value, resource_view_path if title.present? %>
+      <% if title.present? %>
+        <%= content_tag :div, class: "grid font-semibold leading-tight text-lg mb-2 #{title.get_html(:classes, view: :index, element: :wrapper)}", style: title.get_html(:style, view: :index, element: :wrapper) do %>
+          <%= link_to_if title.link_to_resource, title.value, resource_view_path %>
+        <% end %>
       <% end %>
-      <%= content_tag :div, class: "text-sm break-words text-gray-500 #{body.get_html(:classes, view: :index, element: :wrapper)}", style: body.get_html(:style, view: :index, element: :wrapper) do %>
-        <%= body.value if body.present? %>
+      <% if body.present? %>
+        <%= content_tag :div, class: "text-sm break-words text-gray-500 #{body.get_html(:classes, view: :index, element: :wrapper)}", style: body.get_html(:style, view: :index, element: :wrapper) do %>
+          <%= body.value %>
+        <% end %>
       <% end %>
     </div>
     <div class="w-full place-self-end">

--- a/spec/dummy/app/avo/resources/product_resource.rb
+++ b/spec/dummy/app/avo/resources/product_resource.rb
@@ -11,7 +11,13 @@ class ProductResource < Avo::BaseResource
   field :category, as: :select, enum: ::Product.categories
 
   grid do
-    cover :image, as: :file, is_image: true, link_to_resource: true
+    cover :image, as: :file, is_image: true, link_to_resource: true, html: {
+      index: {
+        wrapper: {
+          style: 'background: pink;'
+        }
+      }
+    }
     title :title, as: :text
     body :description, as: :textarea, format_using: ->(value) {
       simple_format value

--- a/spec/features/avo/generators/locales_generator_spec.rb
+++ b/spec/features/avo/generators/locales_generator_spec.rb
@@ -3,7 +3,7 @@ require "rails/generators"
 
 RSpec.feature "locales generator", type: :feature do
   it "generates the files" do
-    locales = %w[en fr nb-NO pt-BR ro]
+    locales = %w[en fr nn nb pt-BR ro tr]
 
     files = locales.map do |locale|
       Rails.root.join("config", "locales", "avo.#{locale}.yml").to_s

--- a/spec/features/avo/ordering_spec.rb
+++ b/spec/features/avo/ordering_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Ordering", type: :system do
+RSpec.describe "Ordering", type: :feature do
   let!(:course) { create :course }
   let!(:links) { create_list :course_link, 4, course: course }
   let(:default_order) { links.map(&:id) }

--- a/spec/support/wait_for_loaded.rb
+++ b/spec/support/wait_for_loaded.rb
@@ -56,7 +56,7 @@ def wait_for_element_missing(identifier = ".element", time = Capybara.default_ma
     if page.present?
       break if page.has_no_css?(identifier, wait: time)
     else
-      sleep 0.01
+      sleep 0.05
     end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1268

![CleanShot 2022-09-30 at 17 20 36](https://user-images.githubusercontent.com/1334409/193290608-ad484b0f-80e1-4cd6-b40f-8d966188f4c6.jpg)


# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to products
1. use the grid mode
2. Observer the pink background for cover photos

Manual reviewer: please leave a comment with output from the test if that's the case.
