### PR TITLE
fix: multiple resources per model brakes sidebar

### DIFF
--- a/lib/avo/menu/builder.rb
+++ b/lib/avo/menu/builder.rb
@@ -57,7 +57,7 @@ class Avo::Menu::Builder
   # Add all the resources
   def all_resources(**args)
     Avo::App.resources_for_navigation.each do |res|
-      resource res.model_class, **args
+      resource res.route_key, **args
     end
   end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1284

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Apply [this](https://github.com/avo-hq/avodemo/commit/d24681896c3a176152c361794ce0e233584cec8a) patch
1. Observe two different resources on the sidebar

Manual reviewer: please leave a comment with output from the test if that's the case.
