### PR TITLE
Prevent filter buttons from overlapping filter popovers

### DIFF
--- a/app/components/avo/actions_component.html.erb
+++ b/app/components/avo/actions_component.html.erb
@@ -1,4 +1,4 @@
-<div class="relative flex flex-col w-full sm:w-auto z-40 js-actions-dropdown"
+<div class="relative flex flex-col w-full sm:w-auto js-actions-dropdown"
   data-controller="toggle-panel actions-picker"
   data-actions-picker-enabled-class="text-black hover:bg-primary-500 hover:text-white"
   data-actions-picker-disabled-class="cursor-wait text-gray-500"

--- a/app/components/avo/actions_component.html.erb
+++ b/app/components/avo/actions_component.html.erb
@@ -14,7 +14,7 @@
     <%= t 'avo.actions' %>
   <% end %>
   <div
-    class="absolute flex inset-auto xl:right-0 top-full bg-white w-full sm:w-auto sm:min-w-[300px] mt-2 z-20 shadow-modal rounded overflow-hidden hidden"
+    class="absolute flex inset-auto xl:right-0 top-full bg-white w-full sm:w-auto sm:min-w-[300px] mt-2 z-40 shadow-modal rounded overflow-hidden hidden"
     data-toggle-panel-target="panel"
   >
     <div class="w-full space divide-y">

--- a/app/components/avo/filters_component.html.erb
+++ b/app/components/avo/filters_component.html.erb
@@ -14,7 +14,7 @@
       <% end %>
     <% end %>
     <div
-      class="absolute block inset-auto sm:right-0 top-full bg-white min-w-[300px] mt-2 z-20 shadow-modal rounded divide-y divide-gray-300 <%= 'hidden' unless params[:keep_filters_panel_open] == '1' %>"
+      class="absolute block inset-auto sm:right-0 top-full bg-white min-w-[300px] mt-2 z-40 shadow-modal rounded divide-y divide-gray-300 <%= 'hidden' unless params[:keep_filters_panel_open] == '1' %>"
       data-toggle-panel-target="panel"
     >
       <% @filters.each do |filter| %>

--- a/app/components/avo/filters_component.html.erb
+++ b/app/components/avo/filters_component.html.erb
@@ -1,5 +1,5 @@
 <div data-controller="toggle-panel">
-  <div class="relative w-full flex justify-between z-30">
+  <div class="relative w-full flex justify-between">
     <%= a_button class: 'focus:outline-none',
       color: :primary,
       size: :sm,

--- a/app/components/avo/index/ordering/buttons_component.html.erb
+++ b/app/components/avo/index/ordering/buttons_component.html.erb
@@ -22,7 +22,7 @@
       %>
       <%= helpers.svg('switch-vertical', class: 'text-gray-400 h-6 hover:text-gray-600') %>
     <% end %>
-    <div class="flex hidden absolute max-w-xs bg-white rounded p-2 z-40" data-popover-target="content">
+    <div class="flex hidden absolute max-w-xs bg-white rounded p-2" data-popover-target="content">
       <%= render Avo::Index::Ordering::ButtonComponent.new resource: @resource, reflection: @reflection, direction: :higher, svg: 'arrow-up' %>
       <%= render Avo::Index::Ordering::ButtonComponent.new resource: @resource, reflection: @reflection, direction: :lower, svg: 'arrow-down' %>
       <%= render Avo::Index::Ordering::ButtonComponent.new resource: @resource, reflection: @reflection, direction: :to_top, svg: 'download-solid-reversed' %>

--- a/app/components/avo/sidebar_profile_component.html.erb
+++ b/app/components/avo/sidebar_profile_component.html.erb
@@ -22,7 +22,7 @@
         <%= helpers.svg 'three-dots', class: 'h-4' %>
       </a>
       <div
-        class="hidden absolute flex flex-col inset-auto right-0 -mt-12 bg-white rounded min-w-[200px] shadow-context -translate-y-full"
+        class="hidden absolute flex flex-col inset-auto right-0 -mt-12 bg-white rounded min-w-[200px] shadow-context -translate-y-full z-40"
         data-toggle-panel-target="panel"
       >
         <% if Avo::App.has_profile_menu? %>


### PR DESCRIPTION
# Description

Buttons and related action components should inherit the z-index from their wrapping elements. If need be, the popups they open are the ones that should have a high z-index.

In the same vein, panels are intended to "hover" above other elements, so they should have a higher z-index than most other elements.

As part of debugging this issue I mapped the following z-index uses:

* `z-20`: Dividers, tabs, 
* `z-30`: selectAllOverlay
* `z-40`: Popovers, dropdowns
* `z-50`: Modals, dialogs, Navbar

Fixes https://github.com/avo-hq/avo/issues/1217

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Manual review steps

1. Configure a resource to have multiple sub-resources that each have one or more filters.
2. Go to the resources show page.
3. Open the topmost filter and scroll down to the filter button below - it should not be visible through the open filter dropdown.

Manual reviewer: please leave a comment with output from the test if that's the case.
