### PR TITLE
refactor: minor tab improvements

### DIFF
--- a/app/components/avo/tab_switcher_component.html.erb
+++ b/app/components/avo/tab_switcher_component.html.erb
@@ -20,13 +20,13 @@
     </div>
   </div>
 <% else %>
-  <div class="flex flex-wrap gap-2" data-target="tab-switcher" data-style="pills">
+  <div class="flex flex-wrap gap-2 bg-white p-2" data-target="tab-switcher" data-style="pills">
     <% visible_items.each do |tab| %>
       <%= a_link tab_path(tab),
       color: selected?(tab) ? :primary : :gray,
       style: selected?(tab) ? :outline : :text,
       size: :sm,
-      class: selected?(tab) ? "z-20" : "",
+      class: selected?(tab) ? "z-20 bg-primary-100" : "",
       title: tab.description,
       data: {
         tippy: tab.description.present? ? 'tooltip' : '',

--- a/app/javascript/js/controllers/actions_picker_controller.js
+++ b/app/javascript/js/controllers/actions_picker_controller.js
@@ -16,7 +16,6 @@ export default class extends Controller {
   }
 
   enableTarget() {
-    console.log('enableTarget')
     if (this.targetIsDisabled) {
       this.target.classList.remove(...this.disabledClasses)
       this.target.classList.add(...this.enabledClasses)
@@ -25,7 +24,6 @@ export default class extends Controller {
   }
 
   disableTarget() {
-    console.log('disableTarget')
     this.target.classList.remove(...this.enabledClasses)
     this.target.classList.add(...this.disabledClasses)
     this.target.dataset.disabled = true

--- a/app/javascript/js/controllers/actions_picker_controller.js
+++ b/app/javascript/js/controllers/actions_picker_controller.js
@@ -1,4 +1,3 @@
-import { AttributeObserver } from '@stimulus/mutation-observers'
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
@@ -12,7 +11,12 @@ export default class extends Controller {
     return this.target.dataset.disabled === 'true'
   }
 
+  get actionsShowTurboFrame() {
+    return document.querySelector('turbo-frame#actions_show')
+  }
+
   enableTarget() {
+    console.log('enableTarget')
     if (this.targetIsDisabled) {
       this.target.classList.remove(...this.disabledClasses)
       this.target.classList.add(...this.enabledClasses)
@@ -21,6 +25,7 @@ export default class extends Controller {
   }
 
   disableTarget() {
+    console.log('disableTarget')
     this.target.classList.remove(...this.enabledClasses)
     this.target.classList.add(...this.disabledClasses)
     this.target.dataset.disabled = true
@@ -36,13 +41,9 @@ export default class extends Controller {
     }
 
     this.disableTarget()
-
-    const observer = new AttributeObserver(document.querySelector('turbo-frame#actions_show'), 'busy', {
-      elementUnmatchedAttribute: () => {
-        this.enableTarget(this.target)
-        if (observer) observer.stop()
-      },
-    })
-    observer.start()
+    const that = this
+    setTimeout(() => {
+      this.actionsShowTurboFrame.loaded.then(() => that.enableTarget(that.target))
+    }, 1)
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@hotwired/turbo-rails": "^7.1.1",
     "@rails/activestorage": "^6.0.2-1",
     "@rails/ujs": "^6.1.0",
-    "@stimulus/mutation-observers": "^2.0.0",
     "@tailwindcss/forms": "^0.4.0",
     "@tailwindcss/jit": "^0.1.17",
     "@tailwindcss/typography": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,18 +324,6 @@
   resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.1.0.tgz#9a48df6511cb2b472c9f596c1f37dc0af022e751"
   integrity sha512-kQNKyM4ePAc4u9eR1c4OqrbAHH+3SJXt++8izIjeaZeg+P7yBtgoF/dogMD/JPPowNC74ACFpM/4op0Ggp/fPw==
 
-"@stimulus/multimap@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/multimap/-/multimap-2.0.0.tgz#420cfa096ed6538df4a91dbd2b2842c1779952b2"
-  integrity sha512-pMBCewkZCFVB3e5mEMoyO9+9aKzHDITmf3OnPun51YWxlcPdHcwbjqm1ylK63fsoduIE+RowBpFwFqd3poEz4w==
-
-"@stimulus/mutation-observers@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stimulus/mutation-observers/-/mutation-observers-2.0.0.tgz#3dbe37453bda47a6c795a90204ee8d77a799fb87"
-  integrity sha512-kx4VAJdPhIGBQKGIoUDC2tupEKorG3A+ckc2b1UiwInKTMAC1axOHU8ebcwhaJIxRqIrs8//4SJo9YAAOx6FEg==
-  dependencies:
-    "@stimulus/multimap" "^2.0.0"
-
 "@tailwindcss/forms@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.4.0.tgz#a46715e347a32d216a3973eb67473bd29ae3798e"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Changes:

- [x] tab height on change bug
- [ ] new design for tabbed pills
- [ ] refactor the `loaded` mechanics for tabs (from `busy` attribute to `loaded` promise)
- [ ] refactor the action modal `loaded` mechanics (from `busy` attribute to `loaded` promise)

Fixes a bug with tabs height and adds a new design to the tabbed pills.
We also take advantage of the new Turbo 7.2.0 `loaded` promise feature to better figure out when a tab frame has loaded.

![CleanShot 2022-10-09 at 21 58 25](https://user-images.githubusercontent.com/1334409/194774723-78082595-252c-4894-9f12-63420dd85326.gif)


# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

