### PR TITLE
Renamed last forgotten spot in method renaming

### DIFF
--- a/app/components/avo/fields/belongs_to_field/show_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/show_component.html.erb
@@ -1,3 +1,3 @@
 <%= field_wrapper **field_wrapper_args do %>
-  <%= link_to @field.label, resource_view_path, target: @field.target %>
+  <%= link_to @field.label, resource_view_path, target: @field.target_resource %>
 <% end %>


### PR DESCRIPTION
## Description
Looks like in the process of renaming `Field#target` into `Field#resource_target`, a little spot has been forgotten, generating a 500 on `belongs_to` fields in Show pages.

![Screenshot_2022-10-10_at_19 09 15](https://user-images.githubusercontent.com/38864576/194920752-a3ea32a8-3b5d-44b2-b947-da561979d9b9.png)
