### PR TITLE
fix: change belongs to target to turbo frame

### DIFF
--- a/app/components/avo/fields/belongs_to_field/show_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/show_component.html.erb
@@ -1,3 +1,3 @@
 <%= field_wrapper **field_wrapper_args do %>
-  <%= link_to @field.label, resource_view_path, target: @field.target %>
+  <%= link_to @field.label, resource_view_path, data: {turbo_frame: @field.target} %>
 <% end %>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue created in https://github.com/avo-hq/avo/pull/1242/files that changed the navigation from turbo to regular link.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

