### PR TITLE
Feature: `Time` field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ avo*.gem
 app/assets/builds
 
 TAGS
+brakeman_results.html

--- a/app/components/avo/fields/date_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_field/edit_component.html.erb
@@ -7,6 +7,8 @@
       date_field_picker_format_value: @field.picker_format,
       date_field_first_day_of_week_value: @field.first_day_of_week,
       date_field_disable_mobile_value: @field.disable_mobile,
+      date_field_field_type_value: "date",
+      date_field_picker_options_value: @field.picker_options,
   } do %>
     <%= datetime_field "fake_#{@field.id}", "fake",
       value: @field.edit_formatted_value,

--- a/app/components/avo/fields/date_field/index_component.html.erb
+++ b/app/components/avo/fields/date_field/index_component.html.erb
@@ -3,6 +3,7 @@
     controller: "date-field",
     date_field_view_value: @view,
     date_field_format_value: @field.format,
+    date_field_field_type_value: "date",
   } do %>
     <%= @field.formatted_value %>
   <% end %>

--- a/app/components/avo/fields/date_field/show_component.html.erb
+++ b/app/components/avo/fields/date_field/show_component.html.erb
@@ -3,6 +3,7 @@
     controller: "date-field",
     date_field_view_value: @view,
     date_field_format_value: @field.format,
+    date_field_field_type_value: "date",
   } do %>
     <%= @field.formatted_value %>
   <% end %>

--- a/app/components/avo/fields/date_time_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_time_field/edit_component.html.erb
@@ -8,6 +8,8 @@
       date_field_disable_mobile_value: @field.disable_mobile,
       date_field_time24_hr_value: @field.time_24hr,
       date_field_timezone_value: @field.timezone,
+      date_field_field_type_value: "dateTime",
+      date_field_picker_options_value: @field.picker_options,
   } do %>
     <%= datetime_field "fake_#{@field.id}", "fake",
       value: @field.edit_formatted_value,

--- a/app/components/avo/fields/date_time_field/index_component.html.erb
+++ b/app/components/avo/fields/date_time_field/index_component.html.erb
@@ -6,6 +6,7 @@
     date_field_format_value: @field.format,
     date_field_timezone_value: @field.timezone,
     date_field_picker_format_value: @field.picker_format,
+    date_field_field_type_value: "dateTime",
   } do %>
     <%= @field.formatted_value %>
   <% end %>

--- a/app/components/avo/fields/date_time_field/show_component.html.erb
+++ b/app/components/avo/fields/date_time_field/show_component.html.erb
@@ -6,6 +6,7 @@
     date_field_format_value: @field.format,
     date_field_timezone_value: @field.timezone,
     date_field_picker_format_value: @field.picker_format,
+    date_field_field_type_value: "dateTime",
   } do %>
     <%= @field.formatted_value %>
   <% end %>

--- a/app/components/avo/fields/time_field/edit_component.html.erb
+++ b/app/components/avo/fields/time_field/edit_component.html.erb
@@ -8,7 +8,9 @@
       date_field_time24_hr_value: @field.time_24hr,
       date_field_no_calendar_value: true,
       date_field_timezone_value: @field.timezone,
-      date_field_absolute_value: @field.absolute,
+      date_field_relative_value: @field.relative,
+      date_field_field_type_value: "time",
+      date_field_picker_options_value: @field.picker_options,
   } do %>
     <%= datetime_field "fake_#{@field.id}", "fake",
       value: @field.edit_formatted_value,

--- a/app/components/avo/fields/time_field/edit_component.html.erb
+++ b/app/components/avo/fields/time_field/edit_component.html.erb
@@ -1,0 +1,36 @@
+<%= field_wrapper **field_wrapper_args do %>
+  <%= content_tag :div, data: {
+      controller: "date-field",
+      date_field_view_value: @view,
+      date_field_enable_time_value: true,
+      date_field_picker_format_value: @field.picker_format,
+      date_field_disable_mobile_value: @field.disable_mobile,
+      date_field_time24_hr_value: @field.time_24hr,
+      date_field_no_calendar_value: true,
+  } do %>
+    <%= datetime_field "fake_#{@field.id}", "fake",
+      value: @field.edit_formatted_value,
+      class: classes("w-full"),
+      data: {
+        'date-field-target': 'fakeInput',
+        placeholder: @field.placeholder,
+        **@field.get_html(:data, view: view, element: :input)
+      },
+      disabled: @field.is_readonly?,
+      placeholder: @field.placeholder,
+      style: @field.get_html(:style, view: view, element: :input)
+    %>
+    <%= @form.text_field @field.id,
+      value: @field.edit_formatted_value,
+      class: classes("w-full hidden"),
+      data: {
+        'date-field-target': 'input',
+        placeholder: @field.placeholder,
+        **@field.get_html(:data, view: view, element: :input)
+      },
+      disabled: @field.is_readonly?,
+      placeholder: @field.placeholder,
+      style: @field.get_html(:style, view: view, element: :input)
+    %>
+  <% end %>
+<% end %>

--- a/app/components/avo/fields/time_field/edit_component.html.erb
+++ b/app/components/avo/fields/time_field/edit_component.html.erb
@@ -7,6 +7,8 @@
       date_field_disable_mobile_value: @field.disable_mobile,
       date_field_time24_hr_value: @field.time_24hr,
       date_field_no_calendar_value: true,
+      date_field_timezone_value: @field.timezone,
+      date_field_absolute_value: @field.absolute,
   } do %>
     <%= datetime_field "fake_#{@field.id}", "fake",
       value: @field.edit_formatted_value,

--- a/app/components/avo/fields/time_field/edit_component.rb
+++ b/app/components/avo/fields/time_field/edit_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Avo::Fields::TimeField::EditComponent < Avo::Fields::EditComponent
+end

--- a/app/components/avo/fields/time_field/index_component.html.erb
+++ b/app/components/avo/fields/time_field/index_component.html.erb
@@ -1,0 +1,12 @@
+<%= index_field_wrapper **field_wrapper_args do %>
+   <%= content_tag :div, data: {
+    controller: "date-field",
+    date_field_view_value: @view,
+    date_field_enable_time_value: true,
+    date_field_format_value: @field.format,
+    date_field_picker_format_value: @field.picker_format,
+    date_field_no_calendar_value: true,
+  } do %>
+    <%= @field.formatted_value %>
+  <% end %>
+<% end %>

--- a/app/components/avo/fields/time_field/index_component.html.erb
+++ b/app/components/avo/fields/time_field/index_component.html.erb
@@ -7,7 +7,8 @@
     date_field_timezone_value: @field.timezone,
     date_field_picker_format_value: @field.picker_format,
     date_field_no_calendar_value: true,
-    date_field_absolute_value: @field.absolute,
+    date_field_relative_value: @field.relative,
+    date_field_field_type_value: "time",
   } do %>
     <%= @field.formatted_value %>
   <% end %>

--- a/app/components/avo/fields/time_field/index_component.html.erb
+++ b/app/components/avo/fields/time_field/index_component.html.erb
@@ -4,8 +4,10 @@
     date_field_view_value: @view,
     date_field_enable_time_value: true,
     date_field_format_value: @field.format,
+    date_field_timezone_value: @field.timezone,
     date_field_picker_format_value: @field.picker_format,
     date_field_no_calendar_value: true,
+    date_field_absolute_value: @field.absolute,
   } do %>
     <%= @field.formatted_value %>
   <% end %>

--- a/app/components/avo/fields/time_field/index_component.rb
+++ b/app/components/avo/fields/time_field/index_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Avo::Fields::TimeField::IndexComponent < Avo::Fields::IndexComponent
+end

--- a/app/components/avo/fields/time_field/show_component.html.erb
+++ b/app/components/avo/fields/time_field/show_component.html.erb
@@ -1,0 +1,12 @@
+<%= field_wrapper **field_wrapper_args do %>
+  <%= content_tag :div, data: {
+    controller: "date-field",
+    date_field_view_value: @view,
+    date_field_enable_time_value: true,
+    date_field_format_value: @field.format,
+    date_field_picker_format_value: @field.picker_format,
+    date_field_no_calendar_value: true,
+  } do %>
+    <%= @field.formatted_value %>
+  <% end %>
+<% end %>

--- a/app/components/avo/fields/time_field/show_component.html.erb
+++ b/app/components/avo/fields/time_field/show_component.html.erb
@@ -7,7 +7,8 @@
     date_field_timezone_value: @field.timezone,
     date_field_picker_format_value: @field.picker_format,
     date_field_no_calendar_value: true,
-    date_field_absolute_value: @field.absolute,
+    date_field_relative_value: @field.relative,
+    date_field_field_type_value: "time",
   } do %>
     <%= @field.formatted_value %>
   <% end %>

--- a/app/components/avo/fields/time_field/show_component.html.erb
+++ b/app/components/avo/fields/time_field/show_component.html.erb
@@ -4,8 +4,10 @@
     date_field_view_value: @view,
     date_field_enable_time_value: true,
     date_field_format_value: @field.format,
+    date_field_timezone_value: @field.timezone,
     date_field_picker_format_value: @field.picker_format,
     date_field_no_calendar_value: true,
+    date_field_absolute_value: @field.absolute,
   } do %>
     <%= @field.formatted_value %>
   <% end %>

--- a/app/components/avo/fields/time_field/show_component.rb
+++ b/app/components/avo/fields/time_field/show_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Avo::Fields::TimeField::ShowComponent < Avo::Fields::ShowComponent
+end

--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -20,6 +20,7 @@ export default class extends Controller {
     time24Hr: Boolean,
     disableMobile: Boolean,
     noCalendar: Boolean,
+    absolute: Boolean,
   }
 
   flatpickrInstance;
@@ -91,8 +92,8 @@ export default class extends Controller {
   initShow() {
     let value = this.parsedValue
 
-    // Set the zone only if the type of field is date time.
-    if (this.enableTimeValue && !this.noCalendarValue) {
+    // Set the zone only if the type of field is date time or relative time.
+    if (this.enableTimeValue && !this.absoluteValue) {
       value = value.setZone(this.displayTimezone)
     }
 
@@ -110,7 +111,8 @@ export default class extends Controller {
       },
       altInput: true,
       onChange: this.onChange.bind(this),
-      noCalendar: false
+      noCalendar: false,
+      absolute: true,
     }
 
     // Set the format of the displayed input field.
@@ -129,8 +131,11 @@ export default class extends Controller {
     // Hide calendar and only keep time picker.
     options.noCalendar = this.noCalendarValue
 
-    // enable timezone display
-    if (this.enableTimeValue && !this.noCalendarValue) {
+    // Enable absolute time if needed.
+    options.absolute = this.absoluteValue
+
+    // Enable timezone display
+    if (this.enableTimeValue && !this.absoluteValue) {
       options.defaultDate = this.parsedValue.setZone(this.displayTimezone).toISO()
 
       options.dateFormat = 'Y-m-d H:i:S'
@@ -142,7 +147,7 @@ export default class extends Controller {
 
     this.flatpickrInstance = flatpickr(this.fakeInputTarget, options)
 
-    if (this.enableTimeValue && !this.noCalendarValue) {
+    if (this.enableTimeValue && !this.absoluteValue) {
       this.updateRealInput(this.parsedValue.setZone(this.displayTimezone).toISO())
     } else {
       this.updateRealInput(universalTimestamp(this.initialValue))
@@ -166,7 +171,7 @@ export default class extends Controller {
       args = { keepLocalTime: false }
     }
 
-    if (this.enableTimeValue && !this.noCalendarValue) {
+    if (this.enableTimeValue && !this.absoluteValue) {
       time = DateTime.fromISO(selectedDates[0].toISOString()).setZone('UTC', args)
     } else {
       time = DateTime.fromISO(selectedDates[0].toISOString()).setZone('UTC', { keepLocalTime: true })

--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -136,18 +136,25 @@ export default class extends Controller {
     // Hide calendar and only keep time picker.
     options.noCalendar = this.noCalendarValue
 
-    // Enable timezone display
-    if (this.enableTimeValue && this.relativeValue) {
-      options.defaultDate = this.parsedValue.setZone(this.displayTimezone).toISO()
+    if (this.initialValue) {
+      // Enable timezone display
+      if (this.enableTimeValue && this.relativeValue) {
+        options.defaultDate = this.parsedValue.setZone(this.displayTimezone).toISO()
 
-      options.dateFormat = 'Y-m-d H:i:S'
-    } else {
-      // Because the browser treats the date like a timestamp and updates it at 00:00 hour, when on a western timezone the date will be converted with one day offset.
-      // Ex: 2022-01-30 will render as 2022-01-29 on an American timezone
-      options.defaultDate = universalTimestamp(this.initialValue)
+        options.dateFormat = 'Y-m-d H:i:S'
+      } else {
+        // Because the browser treats the date like a timestamp and updates it at 00:00 hour, when on a western timezone the date will be converted with one day offset.
+        // Ex: 2022-01-30 will render as 2022-01-29 on an American timezone
+        options.defaultDate = universalTimestamp(this.initialValue)
+      }
     }
 
     this.flatpickrInstance = flatpickr(this.fakeInputTarget, options)
+
+    // Don't try to parse the value if the input is empty.
+    if (!this.initialValue) {
+      return
+    }
 
     let value
     switch (this.fieldTypeValue) {

--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -19,6 +19,7 @@ export default class extends Controller {
     firstDayOfWeek: Number,
     time24Hr: Boolean,
     disableMobile: Boolean,
+    noCalendar: Boolean,
   }
 
   flatpickrInstance;
@@ -91,7 +92,7 @@ export default class extends Controller {
     let value = this.parsedValue
 
     // Set the zone only if the type of field is date time.
-    if (this.enableTimeValue) {
+    if (this.enableTimeValue && !this.noCalendarValue) {
       value = value.setZone(this.displayTimezone)
     }
 
@@ -109,6 +110,7 @@ export default class extends Controller {
       },
       altInput: true,
       onChange: this.onChange.bind(this),
+      noCalendar: false
     }
 
     // Set the format of the displayed input field.
@@ -124,8 +126,11 @@ export default class extends Controller {
     options.enableTime = this.enableTimeValue
     options.enableSeconds = this.enableTimeValue
 
+    // Hide calendar and only keep time picker.
+    options.noCalendar = this.noCalendarValue
+
     // enable timezone display
-    if (this.enableTimeValue) {
+    if (this.enableTimeValue && !this.noCalendarValue) {
       options.defaultDate = this.parsedValue.setZone(this.displayTimezone).toISO()
 
       options.dateFormat = 'Y-m-d H:i:S'
@@ -137,7 +142,7 @@ export default class extends Controller {
 
     this.flatpickrInstance = flatpickr(this.fakeInputTarget, options)
 
-    if (this.enableTimeValue) {
+    if (this.enableTimeValue && !this.noCalendarValue) {
       this.updateRealInput(this.parsedValue.setZone(this.displayTimezone).toISO())
     } else {
       this.updateRealInput(universalTimestamp(this.initialValue))
@@ -161,7 +166,7 @@ export default class extends Controller {
       args = { keepLocalTime: false }
     }
 
-    if (this.enableTimeValue) {
+    if (this.enableTimeValue && !this.noCalendarValue) {
       time = DateTime.fromISO(selectedDates[0].toISOString()).setZone('UTC', args)
     } else {
       time = DateTime.fromISO(selectedDates[0].toISOString()).setZone('UTC', { keepLocalTime: true })

--- a/db/factories.rb
+++ b/db/factories.rb
@@ -69,6 +69,7 @@ FactoryBot.define do
     skills { [Faker::Educator.subject, Faker::Educator.subject, Faker::Educator.subject, Faker::Educator.subject, Faker::Educator.subject] }
     country { Course.countries.sample }
     city { Course.cities.stringify_keys[country].sample }
+    starting_at { Time.now }
   end
 
   factory :course_link, class: "Course::Link" do

--- a/lib/avo/concerns/handles_field_args.rb
+++ b/lib/avo/concerns/handles_field_args.rb
@@ -28,6 +28,10 @@ module Avo
         add_prop_from_args args, name: name, default: default, type: :array
       end
 
+      def add_object_prop(args, name, default = {})
+        add_prop_from_args args, name: name, default: default, type: :object
+      end
+
       def add_string_prop(args, name, default = nil)
         add_prop_from_args args, name: name, default: default, type: :string
       end

--- a/lib/avo/fields/date_field.rb
+++ b/lib/avo/fields/date_field.rb
@@ -5,6 +5,7 @@ module Avo
       attr_reader :picker_format
       attr_reader :disable_mobile
       attr_reader :format
+      attr_reader :picker_options
 
       def initialize(id, **args, &block)
         super(id, **args, &block)
@@ -13,6 +14,7 @@ module Avo
         add_string_prop args, :picker_format, "Y-m-d"
         add_string_prop args, :format, "yyyy-LL-dd"
         add_boolean_prop args, :disable_mobile
+        add_object_prop args, :picker_options
       end
 
       def formatted_value

--- a/lib/avo/fields/time_field.rb
+++ b/lib/avo/fields/time_field.rb
@@ -4,6 +4,8 @@ module Avo
       attr_reader :format
       attr_reader :picker_format
       attr_reader :time_24hr
+      attr_reader :timezone
+      attr_reader :absolute
 
       def initialize(id, **args, &block)
         super(id, **args, &block)
@@ -11,18 +13,43 @@ module Avo
         add_boolean_prop args, :time_24hr
         add_string_prop args, :picker_format, "H:i:S"
         add_string_prop args, :format, "TT"
+        add_string_prop args, :timezone
+        add_string_prop args, :absolute
       end
 
       def formatted_value
         return nil if value.nil?
 
-        value.to_time.iso8601
+        value.utc.to_time.iso8601
+
       end
 
       def edit_formatted_value
         return nil if value.nil?
 
-        value.iso8601
+        value.utc.iso8601
+      end
+
+      def fill_field(model, key, value, params)
+        if value.in?(["", nil])
+          model[id] = value
+
+          return model
+        end
+
+        return model if value.blank?
+
+        model[id] = utc_time(value)
+
+        model
+      end
+
+      def utc_time(value)
+        if timezone.present?
+          ActiveSupport::TimeZone.new(timezone).local_to_utc(Time.parse(value))
+        else
+          value
+        end
       end
     end
   end

--- a/lib/avo/fields/time_field.rb
+++ b/lib/avo/fields/time_field.rb
@@ -1,0 +1,29 @@
+module Avo
+  module Fields
+    class TimeField < DateField
+      attr_reader :format
+      attr_reader :picker_format
+      attr_reader :time_24hr
+
+      def initialize(id, **args, &block)
+        super(id, **args, &block)
+
+        add_boolean_prop args, :time_24hr
+        add_string_prop args, :picker_format, "H:i:S"
+        add_string_prop args, :format, "TT"
+      end
+
+      def formatted_value
+        return nil if value.nil?
+
+        value.to_time.iso8601
+      end
+
+      def edit_formatted_value
+        return nil if value.nil?
+
+        value.iso8601
+      end
+    end
+  end
+end

--- a/lib/avo/fields/time_field.rb
+++ b/lib/avo/fields/time_field.rb
@@ -5,7 +5,7 @@ module Avo
       attr_reader :picker_format
       attr_reader :time_24hr
       attr_reader :timezone
-      attr_reader :absolute
+      attr_reader :relative
 
       def initialize(id, **args, &block)
         super(id, **args, &block)
@@ -14,14 +14,13 @@ module Avo
         add_string_prop args, :picker_format, "H:i:S"
         add_string_prop args, :format, "TT"
         add_string_prop args, :timezone
-        add_string_prop args, :absolute
+        add_boolean_prop args, :relative, true
       end
 
       def formatted_value
         return nil if value.nil?
 
         value.utc.to_time.iso8601
-
       end
 
       def edit_formatted_value

--- a/spec/dummy/app/avo/resources/course_resource.rb
+++ b/spec/dummy/app/avo/resources/course_resource.rb
@@ -50,7 +50,8 @@ class CourseResource < Avo::BaseResource
 
   field :starting_at, as: :time,
     picker_format: "H:i",
-    format: "HH:mm"
+    format: "HH:mm",
+    absolute: true
 
   field :country,
     as: :select,

--- a/spec/dummy/app/avo/resources/course_resource.rb
+++ b/spec/dummy/app/avo/resources/course_resource.rb
@@ -51,7 +51,12 @@ class CourseResource < Avo::BaseResource
   field :starting_at, as: :time,
     picker_format: "H:i",
     format: "HH:mm",
-    absolute: true
+    picker_options: {
+      hourIncrement: 1,
+      minuteIncrement: 1,
+      secondsIncrement: 1
+    },
+    relative: true
 
   field :country,
     as: :select,

--- a/spec/dummy/app/avo/resources/course_resource.rb
+++ b/spec/dummy/app/avo/resources/course_resource.rb
@@ -47,6 +47,11 @@ class CourseResource < Avo::BaseResource
       end
     end
   end
+
+  field :starting_at, as: :time,
+    picker_format: "H:i",
+    format: "HH:mm"
+
   field :country,
     as: :select,
     options: Course.countries.map { |country| [country, country] }.prepend(["-", nil]).to_h,

--- a/spec/dummy/app/models/course.rb
+++ b/spec/dummy/app/models/course.rb
@@ -2,13 +2,14 @@
 #
 # Table name: courses
 #
-#  id         :bigint           not null, primary key
-#  name       :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  skills     :text             default([]), is an Array
-#  country    :string
-#  city       :string
+#  id           :bigint           not null, primary key
+#  name         :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  skills       :text             default([]), is an Array
+#  country      :string
+#  city         :string
+#  starting_at  :date_time
 #
 class Course < ApplicationRecord
   has_many :links, -> { order(position: :asc) }, class_name: "Course::Link", inverse_of: :course

--- a/spec/dummy/db/migrate/20221011150126_add_starting_at_to_courses.rb
+++ b/spec/dummy/db/migrate/20221011150126_add_starting_at_to_courses.rb
@@ -1,5 +1,5 @@
 class AddStartingAtToCourses < ActiveRecord::Migration[6.0]
   def change
-    add_column :courses, :starting_at, :datetime
+    add_column :courses, :starting_at, :time
   end
 end

--- a/spec/dummy/db/migrate/20221011150126_add_starting_at_to_courses.rb
+++ b/spec/dummy/db/migrate/20221011150126_add_starting_at_to_courses.rb
@@ -1,0 +1,5 @@
+class AddStartingAtToCourses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :courses, :starting_at, :datetime
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_20_091039) do
+ActiveRecord::Schema.define(version: 2022_10_11_150126) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 2022_09_20_091039) do
     t.text "skills", default: [], array: true
     t.string "country"
     t.string "city"
+    t.datetime "starting_at"
   end
 
   create_table "fish", force: :cascade do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 2022_10_11_150126) do
     t.text "skills", default: [], array: true
     t.string "country"
     t.string "city"
-    t.datetime "starting_at"
+    t.time "starting_at"
   end
 
   create_table "fish", force: :cascade do |t|

--- a/spec/system/avo/time_field_spec.rb
+++ b/spec/system/avo/time_field_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "Time field", type: :system do
+  let!(:course) { create :course, starting_at: Time.new(2022, 10, 18, 16, 30, 0) }
+
+  describe "time field" do
+    context "index" do
+      it "formats the time" do
+        visit "/admin/resources/courses"
+        expect(field_element_by_resource_id("starting_at", course.id).text).to eq "16:30"
+      end
+    end
+
+    context "show" do
+      it "formats the time" do
+        visit "/admin/resources/courses/#{course.id}"
+
+        expect(find_field_value_element("starting_at").text).to eq "16:30"
+      end
+    end
+
+    context "edit" do
+      it "sets the proper time" do
+        visit "/admin/resources/courses/#{course.id}/edit"
+
+        wait_for_turbo_frame_id "avo-tabgroup-2-avo-tab-starting-at"
+
+        expect(find('[data-field-id="starting_at"] [data-controller="date-field"] input[type="hidden"]', visible: false).value).to eq "16:30:00"
+        expect(find('[data-field-id="starting_at"] [data-controller="date-field"] input[type="text"]').value).to eq "16:30"
+
+        click_on "Save"
+        wait_for_loaded
+
+        expect(find_field_value_element("starting_at").text).to eq "16:30"
+      end
+    end
+  end
+end

--- a/spec/system/avo/time_field_spec.rb
+++ b/spec/system/avo/time_field_spec.rb
@@ -20,18 +20,34 @@ RSpec.describe "Time field", type: :system do
     end
 
     context "edit" do
-      it "sets the proper time" do
+      it "keeps the proper time" do
         visit "/admin/resources/courses/#{course.id}/edit"
 
-        wait_for_turbo_frame_id "avo-tabgroup-2-avo-tab-starting-at"
-
-        expect(find('[data-field-id="starting_at"] [data-controller="date-field"] input[type="hidden"]', visible: false).value).to eq "16:30:00"
+        expect(find('[data-field-id="starting_at"] [data-controller="date-field"] input[name="course[starting_at]"]', visible: false).value).to eq "16:30:00"
         expect(find('[data-field-id="starting_at"] [data-controller="date-field"] input[type="text"]').value).to eq "16:30"
 
         click_on "Save"
         wait_for_loaded
 
         expect(find_field_value_element("starting_at").text).to eq "16:30"
+      end
+
+      it "sets the proper time" do
+        visit "/admin/resources/courses/#{course.id}/edit"
+
+        expect(find('[data-field-id="starting_at"] [data-controller="date-field"] input[name="course[starting_at]"]', visible: false).value).to eq "16:30:00"
+        expect(find('[data-field-id="starting_at"] [data-controller="date-field"] input[type="text"]').value).to eq "16:30"
+
+        find('[data-field-id="starting_at"] [data-controller="date-field"] input[type="text"]').click
+        sleep 0.1
+        find(".numInput.flatpickr-hour").set "17"
+        find('[data-target="title"]').click
+        sleep 0.3
+
+        click_on "Save"
+        wait_for_loaded
+
+        expect(find_field_value_element("starting_at").text).to eq "17:30"
       end
     end
   end


### PR DESCRIPTION
# Description
In this PR I added a new field called `Time` which works with the [Time Picker](https://flatpickr.js.org/examples/#:~:text=2016%2D10%2D20-,Time%20Picker,-%23) part of flatpickr to add a time to a resource. The field is similar to the `DateTime` field, but it doesn't show the calendar, only the time.

By default it looks like this 👇 
<img width="1524" alt="Screenshot 2022-10-12 at 12 11 31" src="https://user-images.githubusercontent.com/28513469/195322120-1ae2eea6-4fb3-4d7e-bf55-642a82427144.png">

You can also add some options to the field to show a different format (for example to not show the seconds, or to have a 24-hour time picker) 👇 
<img width="1524" alt="Screenshot 2022-10-12 at 12 12 19" src="https://user-images.githubusercontent.com/28513469/195322342-79f991a5-17f5-486d-bf9c-f403c1f3f910.png">

It looks like this on mobile 👇 
<img width="398" alt="Screenshot 2022-10-12 at 12 56 11" src="https://user-images.githubusercontent.com/28513469/195325139-e4a38335-9652-4ed6-8f3a-fffa749a6025.png">

Other than the `DateTime` field, this new field doesn't convert the time to the time of the browser, but instead leaves it to how it was created. So when a course starts at 6pm it will also say so if I am in a different timezone (I simulated this by changing my browser's timezone) 👇 
<img width="1440" alt="Screenshot 2022-10-12 at 20 56 03" src="https://user-images.githubusercontent.com/28513469/195322966-e4027ac6-ad93-444a-9b0a-ae4a73adeeaf.png">

I also added the `starting_at` attribute to the Course Factory and added some system tests. Let me know if I should any more.

Fixes #1289

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs) -> updated here avo-hq/docs#48
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. You can test this by going to a course resource (`/admin/resources/courses`) and adding and editing the time in the field `starting at`
