### PR TITLE
Normalize and fixes missing locales

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,8 @@ group :development do
   gem "hotwire-livereload", "~> 1.1"
 
   gem "brakeman"
+
+  gem 'i18n-tasks', '~> 1.0.12'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -85,13 +85,12 @@ group :development do
   gem "hotwire-livereload", "~> 1.1"
 
   gem "brakeman"
-
-  gem 'i18n-tasks', '~> 1.0.12'
 end
 
 group :development, :test do
   gem "awesome_print"
   gem "faker", require: false
+  gem "i18n-tasks", "~> 1.0.12"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,13 @@ GEM
     aws-sigv4 (1.5.1)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.18)
+    better_html (2.0.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bindex (0.8.1)
     bootsnap (1.13.0)
       msgpack (~> 1.2)
@@ -189,6 +196,7 @@ GEM
     groupdate (6.1.0)
       activesupport (>= 5.2)
     hashdiff (1.0.1)
+    highline (2.0.3)
     hightop (0.3.0)
       activesupport (>= 5.2)
     hotwire-livereload (1.2.2)
@@ -200,6 +208,17 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.12)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      better_html (>= 1.0, < 3.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -249,6 +268,8 @@ GEM
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.8-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     pagy (5.10.1)
       activesupport
@@ -289,6 +310,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.5)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.1.6.1)
       actionpack (= 6.1.6.1)
       activesupport (= 6.1.6.1)
@@ -365,6 +389,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     sixarm_ruby_unaccent (1.2.0)
+    smart_properties (1.17.0)
     spring (4.0.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -378,6 +403,8 @@ GEM
     standard (1.16.0)
       rubocop (= 1.35.0)
       rubocop-performance (= 1.14.3)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     test-prof (1.0.10)
     thor (1.2.1)
     timeout (0.3.0)
@@ -452,6 +479,7 @@ DEPENDENCIES
   hotwire-livereload (~> 1.1)
   htmlbeautifier
   httparty
+  i18n-tasks (~> 1.0.12)
   image_processing (~> 1.12)
   iso
   jsbundling-rails

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -117,6 +117,7 @@ ignore_missing:
   - 'avo.field_translations.people'
   - 'avo.number_of_items'
   - 'avo.resource_translations.user'
+  - 'avo.x_items_more'
 
 # - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
 # - '{devise,simple_form}.*'

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -112,7 +112,13 @@ search:
 #   # deepl_version: "v2"
 
 ## Do not consider these keys missing:
-# ignore_missing:
+ignore_missing:
+  - 'avo.field_translations.file'
+  - 'avo.field_translations.people'
+  - 'avo.number_of_items'
+  - 'avo.resource_translations.user'
+  - 'avo.x_items_more'
+
 # - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
 # - '{devise,simple_form}.*'
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -117,7 +117,6 @@ ignore_missing:
   - 'avo.field_translations.people'
   - 'avo.number_of_items'
   - 'avo.resource_translations.user'
-  - 'avo.x_items_more'
 
 # - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
 # - '{devise,simple_form}.*'

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,153 @@
+# i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
+
+# The "main" locale.
+base_locale: en
+## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
+locales: [en, fr, nb, nn, pt-BR, ro, tr]
+## Reporting locale, default: en. Available: en, ru.
+# internal_locale: en
+
+# Read and write translations.
+data:
+  ## Translations are read from the file system. Supported format: YAML, JSON.
+  ## Provide a custom adapter:
+  # adapter: I18n::Tasks::Data::FileSystem
+
+  # Locale files or `File.find` patterns where translations are read from:
+  read:
+    ## Default:
+    # - config/locales/%{locale}.yml
+    ## More files:
+    - lib/generators/avo/templates/locales/**/*.%{locale}.yml
+
+  # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
+  # `i18n-tasks normalize -p` will force move the keys according to these rules
+  write:
+    ## For example, write devise and simple form keys to their respective files:
+    # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
+    ## Catch-all default:
+    # - config/locales/%{locale}.yml
+
+  # External locale data (e.g. gems).
+  # This data is not considered unused and is never written to.
+  external:
+    ## Example (replace %#= with %=):
+    # - "<%#= %x[bundle info vagrant --path].chomp %>/templates/locales/%{locale}.yml"
+
+  ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
+  # router: conservative_router
+
+  yaml:
+    write:
+      # do not wrap lines at 80 characters
+      line_width: -1
+
+  ## Pretty-print JSON:
+  # json:
+  #   write:
+  #     indent: '  '
+  #     space: ' '
+  #     object_nl: "\n"
+  #     array_nl: "\n"
+
+# Find translate calls
+search:
+  ## Paths or `File.find` patterns to search in:
+  # paths:
+  #  - app/
+
+  ## Root directories for relative keys resolution.
+  # relative_roots:
+  #   - app/controllers
+  #   - app/helpers
+  #   - app/mailers
+  #   - app/presenters
+  #   - app/views
+
+  ## Directories where method names which should not be part of a relative key resolution.
+  # By default, if a relative translation is used inside a method, the name of the method will be considered part of the resolved key.
+  # Directories listed here will not consider the name of the method part of the resolved key
+  #
+  # relative_exclude_method_name_paths:
+  #  -
+
+  ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
+  ##   *.jpg *.jpeg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less
+  ##   *.yml *.json *.zip *.tar.gz *.swf *.flv *.mp3 *.wav *.flac *.webm *.mp4 *.ogg *.opus *.webp *.map *.xlsx
+  exclude:
+    - app/assets/images
+    - app/assets/fonts
+    - app/assets/videos
+    - app/assets/builds
+
+  ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
+  ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
+  # only: ["*.rb", "*.html.slim"]
+
+  ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
+  # strict: true
+
+  ## Allows adding ast_matchers for finding translations using the AST-scanners
+  ## The available matchers are:
+  ## - RailsModelMatcher
+  ##     Matches ActiveRecord translations like
+  ##     User.human_attribute_name(:email) and User.model_name.human
+  ##
+  ## To implement your own, please see `I18n::Tasks::Scanners::AstMatchers::BaseMatcher`.
+  <%# I18n::Tasks.add_ast_matcher('I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher') %>
+
+  ## Multiple scanners can be used. Their results are merged.
+  ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.
+  ## See this example of a custom scanner: https://github.com/glebm/i18n-tasks/wiki/A-custom-scanner-example
+
+## Translation Services
+# translation:
+#   # Google Translate
+#   # Get an API key and set billing info at https://code.google.com/apis/console to use Google Translate
+#   google_translate_api_key: "AbC-dEf5"
+#   # DeepL Pro Translate
+#   # Get an API key and subscription at https://www.deepl.com/pro to use DeepL Pro
+#   deepl_api_key: "48E92789-57A3-466A-9959-1A1A1A1A1A1A"
+#   # deepl_host: "https://api.deepl.com"
+#   # deepl_version: "v2"
+
+## Do not consider these keys missing:
+# ignore_missing:
+# - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
+# - '{devise,simple_form}.*'
+
+## Consider these keys used:
+# ignore_unused:
+# - 'activerecord.attributes.*'
+# - '{devise,kaminari,will_paginate}.*'
+# - 'simple_form.{yes,no}'
+# - 'simple_form.{placeholders,hints,labels}.*'
+# - 'simple_form.{error_notification,required}.:'
+
+## Exclude these keys from the `i18n-tasks eq-base' report:
+# ignore_eq_base:
+#   all:
+#     - common.ok
+#   fr,es:
+#     - common.brand
+
+## Exclude these keys from the `i18n-tasks check-consistent-interpolations` report:
+# ignore_inconsistent_interpolations:
+# - 'activerecord.attributes.*'
+
+## Ignore these keys completely:
+# ignore:
+#  - kaminari.*
+
+## Sometimes, it isn't possible for i18n-tasks to match the key correctly,
+## e.g. in case of a relative key defined in a helper method.
+## In these cases you can use the built-in PatternMapper to map patterns to keys, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       only: %w(*.html.haml *.html.slim),
+#       patterns: [['= title\b', '.page_title']] %>
+#
+# The PatternMapper can also match key literals via a special %{key} interpolation, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       patterns: [['\bSpree\.t[( ]\s*%{key}', 'spree.%{key}']] %>

--- a/gemfiles/rails_6.0_ruby_3.0.3.gemfile
+++ b/gemfiles/rails_6.0_ruby_3.0.3.gemfile
@@ -58,6 +58,7 @@ end
 group :development, :test do
   gem "awesome_print"
   gem "faker", require: false
+  gem "i18n-tasks", "~> 1.0.12"
 end
 
 group :test do

--- a/gemfiles/rails_6.0_ruby_3.0.3.gemfile.lock
+++ b/gemfiles/rails_6.0_ruby_3.0.3.gemfile.lock
@@ -115,6 +115,13 @@ GEM
     aws-sigv4 (1.5.1)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.18)
+    better_html (2.0.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bindex (0.8.1)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
@@ -185,6 +192,7 @@ GEM
     groupdate (6.1.0)
       activesupport (>= 5.2)
     hashdiff (1.0.1)
+    highline (2.0.3)
     hightop (0.3.0)
       activesupport (>= 5.2)
     hotwire-livereload (1.2.0)
@@ -196,6 +204,17 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.12)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      better_html (>= 1.0, < 3.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -283,6 +302,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.5)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.5.1)
       actionpack (= 6.0.5.1)
       activesupport (= 6.0.5.1)
@@ -359,6 +381,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     sixarm_ruby_unaccent (1.2.0)
+    smart_properties (1.17.0)
     spring (4.0.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -372,6 +395,8 @@ GEM
     standard (1.13.0)
       rubocop (= 1.31.2)
       rubocop-performance (= 1.14.3)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     test-prof (1.0.9)
     thor (1.2.1)
     thread_safe (0.3.6)
@@ -446,6 +471,7 @@ DEPENDENCIES
   hotwire-livereload (~> 1.1)
   htmlbeautifier
   httparty
+  i18n-tasks (~> 1.0.12)
   image_processing (~> 1.12)
   iso
   jsbundling-rails
@@ -479,4 +505,4 @@ DEPENDENCIES
   zeitwerk (~> 2.3)
 
 BUNDLED WITH
-   2.3.5
+   2.3.23

--- a/gemfiles/rails_6.0_ruby_3.1.0.gemfile
+++ b/gemfiles/rails_6.0_ruby_3.1.0.gemfile
@@ -58,6 +58,7 @@ end
 group :development, :test do
   gem "awesome_print"
   gem "faker", require: false
+  gem "i18n-tasks", "~> 1.0.12"
 end
 
 group :test do

--- a/gemfiles/rails_6.0_ruby_3.1.0.gemfile.lock
+++ b/gemfiles/rails_6.0_ruby_3.1.0.gemfile.lock
@@ -115,6 +115,13 @@ GEM
     aws-sigv4 (1.5.1)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.18)
+    better_html (2.0.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bindex (0.8.1)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
@@ -185,6 +192,7 @@ GEM
     groupdate (6.1.0)
       activesupport (>= 5.2)
     hashdiff (1.0.1)
+    highline (2.0.3)
     hightop (0.3.0)
       activesupport (>= 5.2)
     hotwire-livereload (1.2.0)
@@ -196,6 +204,17 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.12)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      better_html (>= 1.0, < 3.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -283,6 +302,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.5)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.5.1)
       actionpack (= 6.0.5.1)
       activesupport (= 6.0.5.1)
@@ -359,6 +381,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     sixarm_ruby_unaccent (1.2.0)
+    smart_properties (1.17.0)
     spring (4.0.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -372,6 +395,8 @@ GEM
     standard (1.13.0)
       rubocop (= 1.31.2)
       rubocop-performance (= 1.14.3)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     test-prof (1.0.9)
     thor (1.2.1)
     thread_safe (0.3.6)
@@ -446,6 +471,7 @@ DEPENDENCIES
   hotwire-livereload (~> 1.1)
   htmlbeautifier
   httparty
+  i18n-tasks (~> 1.0.12)
   image_processing (~> 1.12)
   iso
   jsbundling-rails
@@ -479,4 +505,4 @@ DEPENDENCIES
   zeitwerk (~> 2.3)
 
 BUNDLED WITH
-   2.3.5
+   2.3.23

--- a/gemfiles/rails_6.1_ruby_3.0.3.gemfile
+++ b/gemfiles/rails_6.1_ruby_3.0.3.gemfile
@@ -58,6 +58,7 @@ end
 group :development, :test do
   gem "awesome_print"
   gem "faker", require: false
+  gem "i18n-tasks", "~> 1.0.12"
 end
 
 group :test do

--- a/gemfiles/rails_6.1_ruby_3.0.3.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_3.0.3.gemfile.lock
@@ -119,6 +119,13 @@ GEM
     aws-sigv4 (1.5.1)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.18)
+    better_html (2.0.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bindex (0.8.1)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
@@ -189,6 +196,7 @@ GEM
     groupdate (6.1.0)
       activesupport (>= 5.2)
     hashdiff (1.0.1)
+    highline (2.0.3)
     hightop (0.3.0)
       activesupport (>= 5.2)
     hotwire-livereload (1.2.0)
@@ -200,6 +208,17 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.12)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      better_html (>= 1.0, < 3.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -287,6 +306,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.5)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.1.6.1)
       actionpack (= 6.1.6.1)
       activesupport (= 6.1.6.1)
@@ -363,6 +385,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     sixarm_ruby_unaccent (1.2.0)
+    smart_properties (1.17.0)
     spring (4.0.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -376,6 +399,8 @@ GEM
     standard (1.13.0)
       rubocop (= 1.31.2)
       rubocop-performance (= 1.14.3)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     test-prof (1.0.9)
     thor (1.2.1)
     timeout (0.3.0)
@@ -449,6 +474,7 @@ DEPENDENCIES
   hotwire-livereload (~> 1.1)
   htmlbeautifier
   httparty
+  i18n-tasks (~> 1.0.12)
   image_processing (~> 1.12)
   iso
   jsbundling-rails
@@ -482,4 +508,4 @@ DEPENDENCIES
   zeitwerk (~> 2.3)
 
 BUNDLED WITH
-   2.3.5
+   2.3.23

--- a/gemfiles/rails_6.1_ruby_3.1.0.gemfile
+++ b/gemfiles/rails_6.1_ruby_3.1.0.gemfile
@@ -58,6 +58,7 @@ end
 group :development, :test do
   gem "awesome_print"
   gem "faker", require: false
+  gem "i18n-tasks", "~> 1.0.12"
 end
 
 group :test do

--- a/gemfiles/rails_6.1_ruby_3.1.0.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_3.1.0.gemfile.lock
@@ -119,6 +119,13 @@ GEM
     aws-sigv4 (1.5.1)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.18)
+    better_html (2.0.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bindex (0.8.1)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
@@ -189,6 +196,7 @@ GEM
     groupdate (6.1.0)
       activesupport (>= 5.2)
     hashdiff (1.0.1)
+    highline (2.0.3)
     hightop (0.3.0)
       activesupport (>= 5.2)
     hotwire-livereload (1.2.0)
@@ -200,6 +208,17 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.12)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      better_html (>= 1.0, < 3.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -287,6 +306,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.5)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.1.6.1)
       actionpack (= 6.1.6.1)
       activesupport (= 6.1.6.1)
@@ -363,6 +385,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     sixarm_ruby_unaccent (1.2.0)
+    smart_properties (1.17.0)
     spring (4.0.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -376,6 +399,8 @@ GEM
     standard (1.13.0)
       rubocop (= 1.31.2)
       rubocop-performance (= 1.14.3)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     test-prof (1.0.9)
     thor (1.2.1)
     timeout (0.3.0)
@@ -449,6 +474,7 @@ DEPENDENCIES
   hotwire-livereload (~> 1.1)
   htmlbeautifier
   httparty
+  i18n-tasks (~> 1.0.12)
   image_processing (~> 1.12)
   iso
   jsbundling-rails
@@ -482,4 +508,4 @@ DEPENDENCIES
   zeitwerk (~> 2.3)
 
 BUNDLED WITH
-   2.3.5
+   2.3.23

--- a/gemfiles/rails_7.0_ruby_3.0.3.gemfile
+++ b/gemfiles/rails_7.0_ruby_3.0.3.gemfile
@@ -58,6 +58,7 @@ end
 group :development, :test do
   gem "awesome_print"
   gem "faker", require: false
+  gem "i18n-tasks", "~> 1.0.12"
 end
 
 group :test do

--- a/gemfiles/rails_7.0_ruby_3.0.3.gemfile.lock
+++ b/gemfiles/rails_7.0_ruby_3.0.3.gemfile.lock
@@ -125,6 +125,13 @@ GEM
     aws-sigv4 (1.5.1)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.18)
+    better_html (2.0.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bindex (0.8.1)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
@@ -195,6 +202,7 @@ GEM
     groupdate (6.1.0)
       activesupport (>= 5.2)
     hashdiff (1.0.1)
+    highline (2.0.3)
     hightop (0.3.0)
       activesupport (>= 5.2)
     hotwire-livereload (1.2.0)
@@ -206,6 +214,17 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.12)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      better_html (>= 1.0, < 3.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -300,6 +319,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.5)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.3.1)
       actionpack (= 7.0.3.1)
       activesupport (= 7.0.3.1)
@@ -377,6 +399,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     sixarm_ruby_unaccent (1.2.0)
+    smart_properties (1.17.0)
     spring (4.0.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -384,6 +407,8 @@ GEM
       rubocop (= 1.31.2)
       rubocop-performance (= 1.14.3)
     strscan (3.0.3)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     test-prof (1.0.9)
     thor (1.2.1)
     timeout (0.3.0)
@@ -457,6 +482,7 @@ DEPENDENCIES
   hotwire-livereload (~> 1.1)
   htmlbeautifier
   httparty
+  i18n-tasks (~> 1.0.12)
   image_processing (~> 1.12)
   iso
   jsbundling-rails
@@ -490,4 +516,4 @@ DEPENDENCIES
   zeitwerk (~> 2.3)
 
 BUNDLED WITH
-   2.3.5
+   2.3.23

--- a/gemfiles/rails_7.0_ruby_3.1.0.gemfile
+++ b/gemfiles/rails_7.0_ruby_3.1.0.gemfile
@@ -58,6 +58,7 @@ end
 group :development, :test do
   gem "awesome_print"
   gem "faker", require: false
+  gem "i18n-tasks", "~> 1.0.12"
 end
 
 group :test do

--- a/gemfiles/rails_7.0_ruby_3.1.0.gemfile.lock
+++ b/gemfiles/rails_7.0_ruby_3.1.0.gemfile.lock
@@ -125,6 +125,13 @@ GEM
     aws-sigv4 (1.5.1)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.18)
+    better_html (2.0.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bindex (0.8.1)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
@@ -195,6 +202,7 @@ GEM
     groupdate (6.1.0)
       activesupport (>= 5.2)
     hashdiff (1.0.1)
+    highline (2.0.3)
     hightop (0.3.0)
       activesupport (>= 5.2)
     hotwire-livereload (1.2.0)
@@ -206,6 +214,17 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.12)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      better_html (>= 1.0, < 3.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -300,6 +319,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.5)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.3.1)
       actionpack (= 7.0.3.1)
       activesupport (= 7.0.3.1)
@@ -377,6 +399,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     sixarm_ruby_unaccent (1.2.0)
+    smart_properties (1.17.0)
     spring (4.0.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -384,6 +407,8 @@ GEM
       rubocop (= 1.31.2)
       rubocop-performance (= 1.14.3)
     strscan (3.0.3)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     test-prof (1.0.9)
     thor (1.2.1)
     timeout (0.3.0)
@@ -457,6 +482,7 @@ DEPENDENCIES
   hotwire-livereload (~> 1.1)
   htmlbeautifier
   httparty
+  i18n-tasks (~> 1.0.12)
   image_processing (~> 1.12)
   iso
   jsbundling-rails
@@ -490,4 +516,4 @@ DEPENDENCIES
   zeitwerk (~> 2.3)
 
 BUNDLED WITH
-   2.3.5
+   2.3.23

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -1,118 +1,119 @@
+---
 en:
   avo:
-    dashboard: 'Dashboard'
-    dashboards: 'Dashboards'
-    choose_a_country: 'Choose a country'
-    choose_an_option: 'Choose an option'
-    are_you_sure_you_want_to_run_this_option: 'Are you sure you want to run this action?'
-    are_you_sure_detach_item: 'Are you sure you want to detach this %{item}.'
-    run: 'Run'
-    cancel: 'Cancel'
-    action_ran_successfully: 'Action ran successfully!'
-    details: "details"
-    unauthorized: 'Unauthorized'
-    attachment_class_attached: '%{attachment_class} attached.'
-    attachment_class_detached: '%{attachment_class} detached.'
-    resource_updated: 'Record updated'
-    resource_created: 'Record created'
-    resource_destroyed: 'Record destroyed'
-    switch_to_view: "Switch to %{view_type} view"
-    click_to_reveal_filters: "Click to reveal filters"
-    attachment_destroyed: 'Attachment destroyed'
-    failed_to_find_attachment: 'Failed to find attachment'
-    you_missed_something_check_form: 'You might have missed something. Please check the form.'
-    remove_selection: 'Remove selection'
-    select_item: 'Select item'
-    select_all: 'Select all'
-    select_all_matching: 'Select all matching'
-    undo: undo
-    delete_file: 'Delete file'
-    delete: 'delete'
-    delete_item: 'Delete %{item}'
-    download_item: 'Download %{item}'
-    download_file: 'Download file'
-    download: 'Download'
-    view: 'View'
-    view_item: 'view %{item}'
-    edit: 'edit'
-    edit_item: 'edit %{item}'
-    detach_item: 'detach %{item}'
-    number_of_items:
-      zero: 'no %{item}'
-      one: 'one %{item}'
-      other: '%{count} %{item}'
-    x_items_more:
-      zero: 'no more items'
-      one: 'one more item'
-      other: '%{count} more items'
-    are_you_sure: 'Are you sure?'
-    filters: 'Filters'
-    per_page: 'Per page'
-    more: 'More'
-    attach: 'Attach'
-    save: 'Save'
-    attach_and_attach_another: 'Attach & Attach another'
-    hide_content: 'Hide content'
-    show_content: 'Show content'
-    no_related_item_found: 'No related %{item} found'
-    no_item_found: 'No %{item} found'
-    loading: 'Loading'
-    confirm: 'Confirm'
-    actions: 'Actions'
-    resources: 'Resources'
-    oops_nothing_found: 'Oops! Nothing found...'
-    type_to_search: 'Type to search.'
-    and_x_other_resources: 'and %{count} other resources'
-    go_back: 'Go back'
-    home: 'Home'
-    new: 'new'
-    attach_item: 'Attach %{item}'
-    choose_item: 'Choose %{item}'
-    create_new_item: 'Create new %{item}'
-    table_view: 'Table view'
-    grid_view: 'Grid view'
-    next_page: 'Next page'
-    prev_page: 'Previous page'
-    list_is_empty: 'List is empty'
+    action_ran_successfully: Action ran successfully!
+    actions: Actions
+    and_x_other_resources: and %{count} other resources
+    are_you_sure: Are you sure?
+    are_you_sure_detach_item: Are you sure you want to detach this %{item}.
+    are_you_sure_you_want_to_run_this_option: Are you sure you want to run this action?
+    attach: Attach
+    attach_and_attach_another: Attach & Attach another
+    attach_item: Attach %{item}
+    attachment_class_attached: "%{attachment_class} attached."
+    attachment_class_detached: "%{attachment_class} detached."
+    attachment_destroyed: Attachment destroyed
+    cancel: Cancel
+    choose_a_country: Choose a country
+    choose_an_option: Choose an option
+    choose_item: Choose %{item}
+    clear_value: Clear value
+    click_to_reveal_filters: Click to reveal filters
+    confirm: Confirm
+    create_new_item: Create new %{item}
+    dashboard: Dashboard
+    dashboards: Dashboards
+    delete: delete
+    delete_file: Delete file
+    delete_item: Delete %{item}
+    detach_item: detach %{item}
+    details: details
+    download: Download
+    download_file: Download file
+    download_item: Download %{item}
+    edit: edit
+    edit_item: edit %{item}
+    empty_dashboard_message: Add cards to this dashboard
+    failed: Failed
+    failed_to_find_attachment: Failed to find attachment
+    failed_to_load: Failed to load
     field_translations:
       file:
-        zero: 'files'
-        one: 'file'
-        other: 'files'
+        one: file
+        other: files
+        zero: files
       people:
-        zero: 'peeps'
-        one: 'peep'
-        other: 'peeps'
-    resource_translations:
-      user:
-        zero: 'users'
-        one: 'user'
-        other: 'users'
-    reset_filters: 'Reset filters'
-    not_authorized: 'You are not authorized to perform this action.'
-    search:
-      placeholder: 'Search'
-      cancel_button: 'Cancel'
-    sign_out: 'Sign out'
-    failed: 'Failed'
-    failed_to_load: 'Failed to load'
+        one: peep
+        other: peeps
+        zero: peeps
+    filters: Filters
+    go_back: Go back
+    grid_view: Grid view
+    hide_content: Hide content
+    home: Home
     key_value_field:
-      key: 'Key'
-      value: 'Value'
-      add_row: 'Add row'
-      delete_row: 'Delete row'
-    was_successfully_created: 'was successfully created'
-    was_successfully_updated: 'was successfully updated'
-    clear_value: "Clear value"
-    tools: Tools
+      add_row: Add row
+      delete_row: Delete row
+      key: Key
+      value: Value
+    list_is_empty: List is empty
+    loading: Loading
+    more: More
+    new: new
+    next_page: Next page
+    no_cards_present: No cards present
+    no_item_found: No %{item} found
+    no_options_available: No options available
+    no_related_item_found: No related %{item} found
+    not_authorized: You are not authorized to perform this action.
+    number_of_items:
+      one: one %{item}
+      other: "%{count} %{item}"
+      zero: no %{item}
+    oops_nothing_found: Oops! Nothing found...
     order:
-      reorder_record: Reorder record
       higher: Move record higher
       lower: Move record lower
-      to_top: Move record to top
+      reorder_record: Reorder record
       to_bottom: Move record to bottom
-    empty_dashboard_message: Add cards to this dashboard
-    no_cards_present: No cards present
-    no_options_available: No options available
+      to_top: Move record to top
+    per_page: Per page
+    prev_page: Previous page
+    remove_selection: Remove selection
+    reset_filters: Reset filters
+    resource_created: Record created
+    resource_destroyed: Record destroyed
+    resource_translations:
+      user:
+        one: user
+        other: users
+        zero: users
+    resource_updated: Record updated
+    resources: Resources
+    run: Run
+    save: Save
+    search:
+      cancel_button: Cancel
+      placeholder: Search
+    select_all: Select all
+    select_all_matching: Select all matching
+    select_item: Select item
+    show_content: Show content
+    sign_out: Sign out
+    switch_to_view: Switch to %{view_type} view
+    table_view: Table view
+    tools: Tools
+    type_to_search: Type to search.
+    unauthorized: Unauthorized
+    undo: undo
+    view: View
+    view_item: view %{item}
+    was_successfully_created: was successfully created
+    was_successfully_updated: was successfully updated
+    x_items_more:
+      one: one more item
+      other: "%{count} more items"
+      zero: no more items
     x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> records selected on this page from a total of <span class="font-bold text-gray-700">%{count}</span>
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> records selected from all pages
+    you_missed_something_check_form: You might have missed something. Please check the form.

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -1,119 +1,119 @@
+---
 fr:
   avo:
-    dashboard: 'Tableau de bord'
-    dashboards: 'Tableaux de bord'
-    choose_a_country: 'Sélectionnez un pays'
-    choose_an_option: 'Sélectionnez une option'
-    are_you_sure_you_want_to_run_this_option: 'Etes-vous sûr de vouloir exécuter cette action ?'
-    are_you_sure_detach_item: 'Êtes-vous sûr de vouloir détacher %{item}.'
-    run: 'Exécuter'
-    cancel: 'Annuler'
-    action_ran_successfully: "L'action s'est exécutée avec succès !"
-    details: "détails"
-    unauthorized: 'Non autorisé'
-    attachment_class_attached: '%{attachment_class} attaché.'
-    attachment_class_detached: '%{attachment_class} détaché.'
-    resource_updated: 'Ressource mise à jour'
-    resource_created: 'Ressource créee'
-    resource_destroyed: 'Ressource détruite'
-    switch_to_view: "Passez à la vue %{view_type}"
-    click_to_reveal_filters: "Cliquez pour révéler les filtres"
-    attachment_destroyed: 'Pièce jointe détruite'
-    failed_to_find_attachment: 'Impossible de trouver la pièce jointe'
-    you_missed_something_check_form: 'Vous avez peut-être oublié quelque chose. Veuillez vérifier le formulaire'
-    remove_selection: 'Supprimer la sélection'
-    select_item: 'Sélectionnez un élément'
-    select_all: 'Sélectionner tout sur la page'
-    select_all_matching: 'Sélectionner toutes les correspondances'
-    undo: annuler
-    delete_file: 'Supprimer le fichier'
-    delete: 'supprimer'
-    delete_item: 'Supprimer %{item}'
-    download_item: 'Télécharger %{item}'
-    download_file: 'Télécharger le fichier'
-    download: 'Télécharger'
-    view: 'Vue'
-    view_item: 'voir %{item}'
-    edit: 'éditer'
-    edit_item: 'éditer %{item}'
-    detach_item: 'détacher %{item}'
-    number_of_items:
-      zero: 'aucun %{item}'
-      one: 'un %{item}'
-      other: '%{count} %{item}'
-    x_items_more:
-      zero: 'aucun élément supplémentaire'
-      one: 'un élément de plus'
-      other: '%{count} éléments en plus'
-    are_you_sure: 'Êtes-vous sûr ?'
-    filters: 'Filtres'
-    per_page: 'Par page'
-    more: 'Plus'
-    attach: 'Attacher'
-    cancel: 'Annuler'
-    save: 'Enregistrer'
-    attach_and_attach_another: 'joindre et joindre un autre'
-    hide_content: 'Cacher le contenu'
-    show_content: 'Afficher le contenu'
-    no_related_item_found: "Aucun %{item} apparenté n'a été trouvé"
-    no_item_found: 'Aucun %{item} trouvé'
-    loading: 'Chargement'
-    confirm: 'Confirmer'
-    actions: 'Actions'
-    resources: 'Ressources'
-    oops_nothing_found: "Oups ! Rien n'a été trouvé..."
-    type_to_search: 'Type à rechercher.'
-    and_x_other_resources: 'et %{count} autres ressources'
-    go_back: 'Retourner en arrière'
-    home: 'Accueil'
-    new: 'Nouveau'
-    attach_item: 'Attacher %{item}'
-    choose_item: 'Choisir %{item}'
-    create_new_item: 'Créer un nouveau %{item}'
-    table_view: 'Vue table'
-    grid_view: 'Vue grille'
-    next_page: 'Page suivante'
-    prev_page: 'Page précédente'
-    list_is_empty: 'La liste est vide'
+    action_ran_successfully: L'action s'est exécutée avec succès !
+    actions: Actions
+    and_x_other_resources: et %{count} autres ressources
+    are_you_sure: Êtes-vous sûr ?
+    are_you_sure_detach_item: Êtes-vous sûr de vouloir détacher %{item}.
+    are_you_sure_you_want_to_run_this_option: Etes-vous sûr de vouloir exécuter cette action ?
+    attach: Attacher
+    attach_and_attach_another: joindre et joindre un autre
+    attach_item: Attacher %{item}
+    attachment_class_attached: "%{attachment_class} attaché."
+    attachment_class_detached: "%{attachment_class} détaché."
+    attachment_destroyed: Pièce jointe détruite
+    cancel: Annuler
+    choose_a_country: Sélectionnez un pays
+    choose_an_option: Sélectionnez une option
+    choose_item: Choisir %{item}
+    clear_value: Effacer la valeur
+    click_to_reveal_filters: Cliquez pour révéler les filtres
+    confirm: Confirmer
+    create_new_item: Créer un nouveau %{item}
+    dashboard: Tableau de bord
+    dashboards: Tableaux de bord
+    delete: supprimer
+    delete_file: Supprimer le fichier
+    delete_item: Supprimer %{item}
+    detach_item: détacher %{item}
+    details: détails
+    download: Télécharger
+    download_file: Télécharger le fichier
+    download_item: Télécharger %{item}
+    edit: éditer
+    edit_item: éditer %{item}
+    empty_dashboard_message: Ajouter des cartes à ce tableau de bord
+    failed: Échec
+    failed_to_find_attachment: Impossible de trouver la pièce jointe
+    failed_to_load: Impossible de charger
     field_translations:
       file:
-        zero: 'fichier'
-        one: 'fichier'
-        other: 'fichiers'
+        one: fichier
+        other: fichiers
+        zero: fichier
       people:
-        zero: 'personne'
-        one: 'personne'
-        other: 'personnes'
-    resource_translations:
-      user:
-        zero: 'utilisateur'
-        one: 'utilisateurs'
-        other: 'utilisateurs'
-    reset_filters: 'Réinitialiser les filtres'
-    not_authorized: "Vous n'êtes pas autorisé à effectuer cette action."
-    search:
-      placeholder: 'Rechercher'
-      cancel_button: 'Annuler'
-    sign_out: 'Se déconnecter'
-    failed: 'Échec'
-    failed_to_load: 'Impossible de charger'
+        one: personne
+        other: personnes
+        zero: personne
+    filters: Filtres
+    go_back: Retourner en arrière
+    grid_view: Vue grille
+    hide_content: Cacher le contenu
+    home: Accueil
     key_value_field:
-      key: 'Clé'
-      value: 'Valeur'
-      add_row: 'Ajouter une ligne'
-      delete_row: 'Supprimer une ligne'
-    was_successfully_created: 'a été créé avec succès'
-    was_successfully_updated: 'a été mis à jour avec succès'
-    clear_value: "Effacer la valeur"
-    tools: Outils
+      add_row: Ajouter une ligne
+      delete_row: Supprimer une ligne
+      key: Clé
+      value: Valeur
+    list_is_empty: La liste est vide
+    loading: Chargement
+    more: Plus
+    new: Nouveau
+    next_page: Page suivante
+    no_cards_present: Aucune carte présente
+    no_item_found: Aucun %{item} trouvé
+    no_options_available: Aucune option disponible
+    no_related_item_found: Aucun %{item} apparenté n'a été trouvé
+    not_authorized: Vous n'êtes pas autorisé à effectuer cette action.
+    number_of_items:
+      one: un %{item}
+      other: "%{count} %{item}"
+      zero: aucun %{item}
+    oops_nothing_found: Oups ! Rien n'a été trouvé...
     order:
-      reorder_record: Réorganiser
       higher: Déplacer plus haut
       lower: Déplacer plus bas
-      to_top: Déplacer tout en haut
+      reorder_record: Réorganiser
       to_bottom: Déplacer tout en bas
-    empty_dashboard_message: Ajouter des cartes à ce tableau de bord
-    no_cards_present: Aucune carte présente
-    no_options_available: Aucune option disponible
+      to_top: Déplacer tout en haut
+    per_page: Par page
+    prev_page: Page précédente
+    remove_selection: Supprimer la sélection
+    reset_filters: Réinitialiser les filtres
+    resource_created: Ressource créee
+    resource_destroyed: Ressource détruite
+    resource_translations:
+      user:
+        one: utilisateurs
+        other: utilisateurs
+        zero: utilisateur
+    resource_updated: Ressource mise à jour
+    resources: Ressources
+    run: Exécuter
+    save: Enregistrer
+    search:
+      cancel_button: Annuler
+      placeholder: Rechercher
+    select_all: Sélectionner tout sur la page
+    select_all_matching: Sélectionner toutes les correspondances
+    select_item: Sélectionnez un élément
+    show_content: Afficher le contenu
+    sign_out: Se déconnecter
+    switch_to_view: Passez à la vue %{view_type}
+    table_view: Vue table
+    tools: Outils
+    type_to_search: Type à rechercher.
+    unauthorized: Non autorisé
+    undo: annuler
+    view: Vue
+    view_item: voir %{item}
+    was_successfully_created: a été créé avec succès
+    was_successfully_updated: a été mis à jour avec succès
+    x_items_more:
+      one: un élément de plus
+      other: "%{count} éléments en plus"
+      zero: aucun élément supplémentaire
     x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> enregistrements sélectionnés sur cette page sur un total de <span class="font-bold text-gray-700">%{count}</span>
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> enregistrements sélectionnés dans toutes les pages
+    you_missed_something_check_form: Vous avez peut-être oublié quelque chose. Veuillez vérifier le formulaire

--- a/lib/generators/avo/templates/locales/avo.nb.yml
+++ b/lib/generators/avo/templates/locales/avo.nb.yml
@@ -1,118 +1,119 @@
+---
 nb:
   avo:
-    dashboard: 'Dashboard'
-    dashboards: 'Dashboards'
-    choose_a_country: 'Velg et land'
-    choose_an_option: 'Velg et alternativ'
-    are_you_sure_you_want_to_run_this_option: 'Er du sikker?'
-    are_you_sure_detach_item: 'Er du sikker på at du vil koble fra %{item}.'
-    run: 'Kjør'
-    cancel: 'Avslutt'
-    action_ran_successfully: 'Suksess!'
-    details: "detaljer"
-    unauthorized: 'Ikke autorisert'
-    attachment_class_attached: '%{attachment_class} lagt til.'
-    attachment_class_detached: '%{attachment_class} fjernet.'
-    resource_updated: 'Ressurs oppdatert'
-    resource_created: 'Ressurs generert'
-    resource_destroyed: 'Ressurs slettet'
-    switch_to_view: "Bytt til %{view_type} vis"
-    click_to_reveal_filters: "Vis filter"
-    attachment_destroyed: 'Vedlett slettet'
-    failed_to_find_attachment: 'Fant ikke vedlegg'
-    you_missed_something_check_form: 'Her mangler du noe. Vennligst sjekk skjemaet.'
-    remove_selection: 'Fjern valg'
-    select_item: 'Velg'
-    select_all: 'Velg alle'
-    select_all_matching: 'Velg alle samsvarende'
-    undo: angre
-    delete_file: 'Slett fil'
-    delete: 'slett'
-    delete_item: 'Slett %{item}'
-    download_item: 'Last ned %{item}'
-    download_file: 'Last ned fil'
-    download: 'Last ned'
-    view: 'Vis'
-    view_item: 'vis %{item}'
-    edit: 'endre'
-    edit_item: 'endre %{item}'
-    detach_item: 'koble fra %{item}'
-    number_of_items:
-      zero: 'ingen %{item}'
-      one: 'en %{item}'
-      other: '%{count} %{item}'
-    x_items_more:
-      zero: 'ingen flere elementer'
-      one: 'ett element til'
-      other: '%{count} flere elementer'
-    are_you_sure: 'Er du sikker?'
-    filters: 'Filter'
-    per_page: 'Per side'
-    more: 'Mer'
-    attach: 'Legg til'
-    save: 'Lagre'
-    attach_and_attach_another: 'Legg til & Legg til ny'
-    hide_content: 'Skjul innhold'
-    show_content: 'Vis innhold'
-    no_related_item_found: 'Ingen relaterte %{item} funnet'
-    no_item_found: 'Ingen %{item} funnet'
-    loading: 'Laster'
-    confirm: 'Bekreft'
-    actions: 'Handlinger'
-    resources: 'Ressurser'
-    oops_nothing_found: 'Oops! Ingen ting funnet...'
-    type_to_search: 'Søk.'
-    and_x_other_resources: 'og %{count} andre ressurser'
-    go_back: 'Gå tilbake'
-    home: 'Hjem'
-    new: 'ny'
-    attach_item: 'Legg til %{item}'
-    choose_item: 'Velge %{item}'
-    create_new_item: 'Lag ny %{item}'
-    table_view: 'Tabell visning'
-    grid_view: 'Grid visning'
-    next_page: 'Neste side'
-    prev_page: 'Forrige side'
-    list_is_empty: 'Listen er tom'
+    action_ran_successfully: Suksess!
+    actions: Handlinger
+    and_x_other_resources: og %{count} andre ressurser
+    are_you_sure: Er du sikker?
+    are_you_sure_detach_item: Er du sikker på at du vil koble fra %{item}.
+    are_you_sure_you_want_to_run_this_option: Er du sikker?
+    attach: Legg til
+    attach_and_attach_another: Legg til & Legg til ny
+    attach_item: Legg til %{item}
+    attachment_class_attached: "%{attachment_class} lagt til."
+    attachment_class_detached: "%{attachment_class} fjernet."
+    attachment_destroyed: Vedlett slettet
+    cancel: Avslutt
+    choose_a_country: Velg et land
+    choose_an_option: Velg et alternativ
+    choose_item: Velge %{item}
+    clear_value: Nullstill verdi
+    click_to_reveal_filters: Vis filter
+    confirm: Bekreft
+    create_new_item: Lag ny %{item}
+    dashboard: Dashboard
+    dashboards: Dashboards
+    delete: slett
+    delete_file: Slett fil
+    delete_item: Slett %{item}
+    detach_item: koble fra %{item}
+    details: detaljer
+    download: Last ned
+    download_file: Last ned fil
+    download_item: Last ned %{item}
+    edit: endre
+    edit_item: endre %{item}
+    empty_dashboard_message: Legg til kort i dette dashbordet
+    failed: Feilet
+    failed_to_find_attachment: Fant ikke vedlegg
+    failed_to_load: Lasting feilet
     field_translations:
       file:
-        zero: 'filer'
-        one: 'fil'
-        other: 'filer'
+        one: fil
+        other: filer
+        zero: filer
       people:
-        zero: 'personer'
-        one: 'person'
-        other: 'personer'
+        one: person
+        other: personer
+        zero: personer
+    filters: Filter
+    go_back: Gå tilbake
+    grid_view: Grid visning
+    hide_content: Skjul innhold
+    home: Hjem
+    key_value_field:
+      add_row: Legg til rad
+      delete_row: Slett rad
+      key: Nøkkel
+      value: Verdi
+    list_is_empty: Listen er tom
+    loading: Laster
+    more: Mer
+    new: ny
+    next_page: Neste side
+    no_cards_present: Ingen kort til stede
+    no_item_found: Ingen %{item} funnet
+    no_options_available: Ingen tilgjengelige alternativer
+    no_related_item_found: Ingen relaterte %{item} funnet
+    not_authorized: Du er ikke autorisert til å gjøre denne handlingen.
+    number_of_items:
+      one: en %{item}
+      other: "%{count} %{item}"
+      zero: ingen %{item}
+    oops_nothing_found: Oops! Ingen ting funnet...
+    order:
+      higher: Flytt elementet høyere
+      lower: Flytt elementet lavere
+      reorder_record: Sorter elementer
+      to_bottom: Flytt elementet til bunnen
+      to_top: Flytt elementet til toppen
+    per_page: Per side
+    prev_page: Forrige side
+    remove_selection: Fjern valg
+    reset_filters: Nullstill filter
+    resource_created: Ressurs generert
+    resource_destroyed: Ressurs slettet
     resource_translations:
       user:
-        zero: 'brukere'
-        one: 'bruker'
-        other: 'brukere'
-    reset_filters: 'Nullstill filter'
-    not_authorized: 'Du er ikke autorisert til å gjøre denne handlingen.'
+        one: bruker
+        other: brukere
+        zero: brukere
+    resource_updated: Ressurs oppdatert
+    resources: Ressurser
+    run: Kjør
+    save: Lagre
     search:
-      placeholder: 'Søk'
-      cancel_button: 'Avbryt'
-    sign_out: 'Logg ut'
-    failed: 'Feilet'
-    failed_to_load: 'Lasting feilet'
-    key_value_field:
-      key: 'Nøkkel'
-      value: 'Verdi'
-      add_row: 'Legg til rad'
-      delete_row: 'Slett rad'
-    was_successfully_created: 'ble opprettet'
-    was_successfully_updated: 'ble oppdatert'
-    clear_value: 'Nullstill verdi'
-    tools: 'Redskapene'
-    order:
-      reorder_record: 'Sorter elementer'
-      higher: 'Flytt elementet høyere'
-      lower: 'Flytt elementet lavere'
-      to_top: 'Flytt elementet til toppen'
-      to_bottom: 'Flytt elementet til bunnen'
-    empty_dashboard_message: 'Legg til kort i dette dashbordet'
-    no_cards_present: 'Ingen kort til stede'
-    no_options_available: 'Ingen tilgjengelige alternativer'
-    x_records_selected_from_a_total_of_x_html: '<span class="font-bold text-gray-700">%{selected}</span> poster valgt på denne siden fra totalt <span class="font-bold text-gray-700">%{count}</span>'
-    x_records_selected_from_all_pages_html: '<span class="font-bold text-gray-700">%{count}</span> poster valgt fra alle sider'
+      cancel_button: Avbryt
+      placeholder: Søk
+    select_all: Velg alle
+    select_all_matching: Velg alle samsvarende
+    select_item: Velg
+    show_content: Vis innhold
+    sign_out: Logg ut
+    switch_to_view: Bytt til %{view_type} vis
+    table_view: Tabell visning
+    tools: Redskapene
+    type_to_search: Søk.
+    unauthorized: Ikke autorisert
+    undo: angre
+    view: Vis
+    view_item: vis %{item}
+    was_successfully_created: ble opprettet
+    was_successfully_updated: ble oppdatert
+    x_items_more:
+      one: ett element til
+      other: "%{count} flere elementer"
+      zero: ingen flere elementer
+    x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> poster valgt på denne siden fra totalt <span class="font-bold text-gray-700">%{count}</span>
+    x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> poster valgt fra alle sider
+    you_missed_something_check_form: Her mangler du noe. Vennligst sjekk skjemaet.

--- a/lib/generators/avo/templates/locales/avo.nn.yml
+++ b/lib/generators/avo/templates/locales/avo.nn.yml
@@ -1,118 +1,119 @@
+---
 nn:
   avo:
-    dashboard: 'Dashboard'
-    dashboards: 'Dashboards'
-    choose_a_country: 'Vel eit land'
-    choose_an_option: 'Vel eit alternativ'
-    are_you_sure_you_want_to_run_this_option: 'Er du sikker?'
-    are_you_sure_detach_item: 'Er du sikker på at du vil koble frå %{item}.'
-    run: 'Køyr'
-    cancel: 'Avslutt'
-    action_ran_successfully: 'Suksess!'
-    details: "detaljar"
-    unauthorized: 'Ikkje autorisert'
-    attachment_class_attached: '%{attachment_class} lagt til.'
-    attachment_class_detached: '%{attachment_class} fjerna.'
-    resource_updated: 'Ressurs oppdatert'
-    resource_created: 'Ressurs generert'
-    resource_destroyed: 'Ressurs sletta'
-    switch_to_view: "Bytt til %{view_type} vis"
-    click_to_reveal_filters: "Vis filter"
-    attachment_destroyed: 'Vedlegg sletta'
-    failed_to_find_attachment: 'Fann ikkje vedlegg'
-    you_missed_something_check_form: 'Her manglar du noko. Ver venleg og sjekk skjemaet.'
-    remove_selection: 'Fjern val'
-    select_item: 'Vel'
-    select_all: 'Vel alle'
-    select_all_matching: 'Vel alle samsvarende'
-    undo: angre
-    delete_file: 'Slett fil'
-    delete: 'slett'
-    delete_item: 'Slett %{item}'
-    download_item: 'Last ned %{item}'
-    download_file: 'Last ned fil'
-    download: 'Last ned'
-    view: 'Vis'
-    view_item: 'vis %{item}'
-    edit: 'endre'
-    edit_item: 'endre %{item}'
-    detach_item: 'koble frå %{item}'
-    number_of_items:
-      zero: 'ingen %{item}'
-      one: 'en %{item}'
-      other: '%{count} %{item}'
-    x_items_more:
-      zero: 'ingen fleire element'
-      one: 'ett element til'
-      other: '%{count} fleire element'
-    are_you_sure: 'Er du sikker?'
-    filters: 'Filter'
-    per_page: 'Per side'
-    more: 'Meir'
-    attach: 'Legg til'
-    save: 'Lagre'
-    attach_and_attach_another: 'Legg til & Legg til ny'
-    hide_content: 'Skjul innhald'
-    show_content: 'Vis innhald'
-    no_related_item_found: 'Fann ingen relaterte %{item}'
-    no_item_found: 'Fann ingen %{item}'
-    loading: 'Lastar'
-    confirm: 'Stadfest'
-    actions: 'Handlingar'
-    resources: 'Ressursar'
-    oops_nothing_found: 'Oops! Fann ikkje noko...'
-    type_to_search: 'Søk.'
-    and_x_other_resources: 'og %{count} andre ressurar'
-    go_back: 'Gå tilbake'
-    home: 'Heim'
-    new: 'ny'
-    attach_item: 'Legg til %{item}'
-    choose_item: 'Vel %{item}'
-    create_new_item: 'Lag ny %{item}'
-    table_view: 'Tabellvisning'
-    grid_view: 'Gridvisning'
-    next_page: 'Neste side'
-    prev_page: 'Forrige side'
-    list_is_empty: 'Listen er tom'
+    action_ran_successfully: Suksess!
+    actions: Handlingar
+    and_x_other_resources: og %{count} andre ressurar
+    are_you_sure: Er du sikker?
+    are_you_sure_detach_item: Er du sikker på at du vil koble frå %{item}.
+    are_you_sure_you_want_to_run_this_option: Er du sikker?
+    attach: Legg til
+    attach_and_attach_another: Legg til & Legg til ny
+    attach_item: Legg til %{item}
+    attachment_class_attached: "%{attachment_class} lagt til."
+    attachment_class_detached: "%{attachment_class} fjerna."
+    attachment_destroyed: Vedlegg sletta
+    cancel: Avslutt
+    choose_a_country: Vel eit land
+    choose_an_option: Vel eit alternativ
+    choose_item: Vel %{item}
+    clear_value: Nullstill verdi
+    click_to_reveal_filters: Vis filter
+    confirm: Stadfest
+    create_new_item: Lag ny %{item}
+    dashboard: Dashboard
+    dashboards: Dashboards
+    delete: slett
+    delete_file: Slett fil
+    delete_item: Slett %{item}
+    detach_item: koble frå %{item}
+    details: detaljar
+    download: Last ned
+    download_file: Last ned fil
+    download_item: Last ned %{item}
+    edit: endre
+    edit_item: endre %{item}
+    empty_dashboard_message: Legg til kort i dette dashbordet
+    failed: Feila
+    failed_to_find_attachment: Fann ikkje vedlegg
+    failed_to_load: Lasting feila
     field_translations:
       file:
-        zero: 'filer'
-        one: 'fil'
-        other: 'filer'
+        one: fil
+        other: filer
+        zero: filer
       people:
-        zero: 'personar'
-        one: 'person'
-        other: 'personar'
+        one: person
+        other: personar
+        zero: personar
+    filters: Filter
+    go_back: Gå tilbake
+    grid_view: Gridvisning
+    hide_content: Skjul innhald
+    home: Heim
+    key_value_field:
+      add_row: Legg til rad
+      delete_row: Slett rad
+      key: Nøkkel
+      value: Verdi
+    list_is_empty: Listen er tom
+    loading: Lastar
+    more: Meir
+    new: ny
+    next_page: Neste side
+    no_cards_present: Ingen kort til stades
+    no_item_found: Fann ingen %{item}
+    no_options_available: Ingen tilgjengelege alternativ
+    no_related_item_found: Fann ingen relaterte %{item}
+    not_authorized: Du er ikkje autorisert til å gjere denne handlinga.
+    number_of_items:
+      one: en %{item}
+      other: "%{count} %{item}"
+      zero: ingen %{item}
+    oops_nothing_found: Oops! Fann ikkje noko...
+    order:
+      higher: Flytt elementet opp
+      lower: Flytt elementet ned
+      reorder_record: Sorter element
+      to_bottom: Flytt elementet til bunnen
+      to_top: Flytt elementet til toppen
+    per_page: Per side
+    prev_page: Forrige side
+    remove_selection: Fjern val
+    reset_filters: Nullstill filter
+    resource_created: Ressurs generert
+    resource_destroyed: Ressurs sletta
     resource_translations:
       user:
-        zero: 'brukarar'
-        one: 'bruker'
-        other: 'brukarar'
-    reset_filters: 'Nullstill filter'
-    not_authorized: 'Du er ikkje autorisert til å gjere denne handlinga.'
+        one: bruker
+        other: brukarar
+        zero: brukarar
+    resource_updated: Ressurs oppdatert
+    resources: Ressursar
+    run: Køyr
+    save: Lagre
     search:
-      placeholder: 'Søk'
-      cancel_button: 'Avbryt'
-    sign_out: 'Logg ut'
-    failed: 'Feila'
-    failed_to_load: 'Lasting feila'
-    key_value_field:
-      key: 'Nøkkel'
-      value: 'Verdi'
-      add_row: 'Legg til rad'
-      delete_row: 'Slett rad'
-    was_successfully_created: 'vart oppretta'
-    was_successfully_updated: 'vart oppdatert'
-    clear_value: 'Nullstill verdi'
-    tools: 'Reiskapane'
-    order:
-      reorder_record: 'Sorter element'
-      higher: 'Flytt elementet opp'
-      lower: 'Flytt elementet ned'
-      to_top: 'Flytt elementet til toppen'
-      to_bottom: 'Flytt elementet til bunnen'
-    empty_dashboard_message: 'Legg til kort i dette dashbordet'
-    no_cards_present: 'Ingen kort til stades'
-    no_options_available: 'Ingen tilgjengelege alternativ'
-    x_records_selected_from_a_total_of_x_html: '<span class="font-bold text-gray-700">%{selected}</span> valde postar på denne sida av totalt <span class="font-bold text-gray-700">%{count}</span>'
-    x_records_selected_from_all_pages_html: '<span class="font-bold text-gray-700">%{count}</span> valde postar frå alle sider'
+      cancel_button: Avbryt
+      placeholder: Søk
+    select_all: Vel alle
+    select_all_matching: Vel alle samsvarende
+    select_item: Vel
+    show_content: Vis innhald
+    sign_out: Logg ut
+    switch_to_view: Bytt til %{view_type} vis
+    table_view: Tabellvisning
+    tools: Reiskapane
+    type_to_search: Søk.
+    unauthorized: Ikkje autorisert
+    undo: angre
+    view: Vis
+    view_item: vis %{item}
+    was_successfully_created: vart oppretta
+    was_successfully_updated: vart oppdatert
+    x_items_more:
+      one: ett element til
+      other: "%{count} fleire element"
+      zero: ingen fleire element
+    x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> valde postar på denne sida av totalt <span class="font-bold text-gray-700">%{count}</span>
+    x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> valde postar frå alle sider
+    you_missed_something_check_form: Her manglar du noko. Ver venleg og sjekk skjemaet.

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -1,94 +1,95 @@
+---
 pt-BR:
   avo:
-    dashboard: 'Painel'
-    dashboards: 'Painéis'
-    choose_a_country: 'Escolha um país'
-    choose_an_option: 'Escolha uma opção'
-    are_you_sure_you_want_to_run_this_option: 'Você tem certeza que deseja executar esta ação?'
-    are_you_sure_detach_item: 'Você tem certeza que deseja separar este %{item}.'
-    run: 'Executar'
-    cancel: 'Cancelar'
-    action_ran_successfully: 'Ação executada com sucesso!'
-    details: "detalhe"
-    unauthorized: 'Não autorizado'
-    attachment_class_attached: '%{attachment_class} anexado.'
-    attachment_class_detached: '%{attachment_class} separado.'
-    resource_updated: 'Recurso atualizado'
-    resource_created: 'Recurso criado'
-    resource_destroyed: 'Recurso destruído'
-    switch_to_view: "Alterar para visão %{view_type}"
-    click_to_reveal_filters: "Clique para revelar os filtros"
-    attachment_destroyed: 'Anexo destruído'
-    failed_to_find_attachment: 'Falhou ao achar anexo'
-    you_missed_something_check_form: 'Você pode ter esquecido algo. Por favor, cheque o formulário.'
-    remove_selection: 'Remover seleção'
-    select_item: 'Selecionar item'
-    select_all: 'Selecionar tudo'
-    select_all_matching: 'Selecione todas as correspondências'
-    undo: desfazer
-    delete_file: 'Deletar arquivo'
-    delete: 'deletar'
-    delete_item: 'Deletar %{item}'
-    download_item: 'Baixar %{item}'
-    download_file: 'Baixar arquivo'
-    download: 'Baixar'
-    view: 'Visualizar'
-    view_item: 'visualizar %{item}'
-    edit: 'editar'
-    edit_item: 'editar %{item}'
-    detach_item: 'separar %{item}'
-    number_of_items:
-      zero: 'sem %{item}'
-      one: 'um %{item}'
-      other: '%{count} %{item}'
-    are_you_sure: 'Você tem certeza?'
-    filters: 'Filtros'
-    per_page: 'Por página'
-    more: 'Mais'
-    attach: 'Anexar'
-    save: 'Salvar'
-    attach_and_attach_another: 'Anexar & anexar outro'
-    hide_content: 'Esconder conteúdo'
-    show_content: 'Mostrar conteúdo'
-    no_related_item_found: 'Nenhum %{item} relacionado encontrado'
-    no_item_found: 'Nenhum %{item} encontrado'
-    loading: 'Carregando'
-    confirm: 'Confirmar'
-    actions: 'Ações'
-    resources: 'Recursos'
-    oops_nothing_found: 'Oops! Nada encontrado...'
-    type_to_search: 'Digite para buscar.'
-    and_x_other_resources: 'e %{count} outros recursos'
-    go_back: 'Voltar'
-    home: 'Início'
-    new: 'novo'
-    attach_item: 'Anexar %{item}'
-    choose_item: 'Escolher %{item}'
-    create_new_item: 'Criar novo %{item}'
-    table_view: 'Visualização em tabela'
-    grid_view: 'Visualização em grade'
-    next_page: 'Próxima página'
-    prev_page: 'Página anterior'
-    list_is_empty: 'Lista vazia'
+    action_ran_successfully: Ação executada com sucesso!
+    actions: Ações
+    and_x_other_resources: e %{count} outros recursos
+    are_you_sure: Você tem certeza?
+    are_you_sure_detach_item: Você tem certeza que deseja separar este %{item}.
+    are_you_sure_you_want_to_run_this_option: Você tem certeza que deseja executar esta ação?
+    attach: Anexar
+    attach_and_attach_another: Anexar & anexar outro
+    attach_item: Anexar %{item}
+    attachment_class_attached: "%{attachment_class} anexado."
+    attachment_class_detached: "%{attachment_class} separado."
+    attachment_destroyed: Anexo destruído
+    cancel: Cancelar
+    choose_a_country: Escolha um país
+    choose_an_option: Escolha uma opção
+    choose_item: Escolher %{item}
+    click_to_reveal_filters: Clique para revelar os filtros
+    confirm: Confirmar
+    create_new_item: Criar novo %{item}
+    dashboard: Painel
+    dashboards: Painéis
+    delete: deletar
+    delete_file: Deletar arquivo
+    delete_item: Deletar %{item}
+    detach_item: separar %{item}
+    details: detalhe
+    download: Baixar
+    download_file: Baixar arquivo
+    download_item: Baixar %{item}
+    edit: editar
+    edit_item: editar %{item}
+    empty_dashboard_message: Adicionar cartões a este painel
+    failed_to_find_attachment: Falhou ao achar anexo
     field_translations:
       file:
-        zero: 'arquivos'
-        one: 'arquivo'
-        other: 'arquivos'
+        one: arquivo
+        other: arquivos
+        zero: arquivos
+    filters: Filtros
+    go_back: Voltar
+    grid_view: Visualização em grade
+    hide_content: Esconder conteúdo
+    home: Início
+    list_is_empty: Lista vazia
+    loading: Carregando
+    more: Mais
+    new: novo
+    next_page: Próxima página
+    no_cards_present: Nenhum cartão presente
+    no_item_found: Nenhum %{item} encontrado
+    no_options_available: Nenhuma opção disponível
+    no_related_item_found: Nenhum %{item} relacionado encontrado
+    not_authorized: Você não está autorizado à executar essa ação.
+    number_of_items:
+      one: um %{item}
+      other: "%{count} %{item}"
+      zero: sem %{item}
+    oops_nothing_found: Oops! Nada encontrado...
+    per_page: Por página
+    prev_page: Página anterior
+    remove_selection: Remover seleção
+    reset_filters: Limpar filtros
+    resource_created: Recurso criado
+    resource_destroyed: Recurso destruído
     resource_translations:
       user:
-        zero: 'usuários'
-        one: 'usuário'
-        other: 'usuários'
-    reset_filters: 'Limpar filtros'
-    not_authorized: 'Você não está autorizado à executar essa ação.'
+        one: usuário
+        other: usuários
+        zero: usuários
+    resource_updated: Recurso atualizado
+    resources: Recursos
+    run: Executar
+    save: Salvar
     search:
-      placeholder: 'Procurar'
-      cancel_button: 'Cancelar'
-    sign_out: 'sair'
+      cancel_button: Cancelar
+      placeholder: Procurar
+    select_all: Selecionar tudo
+    select_all_matching: Selecione todas as correspondências
+    select_item: Selecionar item
+    show_content: Mostrar conteúdo
+    sign_out: sair
+    switch_to_view: Alterar para visão %{view_type}
+    table_view: Visualização em tabela
     tools: Ferramentas
-    empty_dashboard_message: Adicionar cartões a este painel
-    no_cards_present: Nenhum cartão presente
-    no_options_available: Nenhuma opção disponível
+    type_to_search: Digite para buscar.
+    unauthorized: Não autorizado
+    undo: desfazer
+    view: Visualizar
+    view_item: visualizar %{item}
     x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> registros selecionados nesta página de um total de <span class="font-bold text-gray-700">%{count}</span>
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> registros selecionados de todas as páginas
+    you_missed_something_check_form: Você pode ter esquecido algo. Por favor, cheque o formulário.

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -17,6 +17,7 @@ pt-BR:
     choose_a_country: Escolha um país
     choose_an_option: Escolha uma opção
     choose_item: Escolher %{item}
+    clear_value: Limpar valor
     click_to_reveal_filters: Clique para revelar os filtros
     confirm: Confirmar
     create_new_item: Criar novo %{item}
@@ -33,17 +34,28 @@ pt-BR:
     edit: editar
     edit_item: editar %{item}
     empty_dashboard_message: Adicionar cartões a este painel
+    failed: Falhou
     failed_to_find_attachment: Falhou ao achar anexo
+    failed_to_load: Falha ao carregar
     field_translations:
       file:
         one: arquivo
         other: arquivos
         zero: arquivos
+      people:
+        one: pessoa
+        other: pessoas
+        zero: ninguém
     filters: Filtros
     go_back: Voltar
     grid_view: Visualização em grade
     hide_content: Esconder conteúdo
     home: Início
+    key_value_field:
+      add_row: Adicionar linha
+      delete_row: Remover linha
+      key: Chave
+      value: Valor
     list_is_empty: Lista vazia
     loading: Carregando
     more: Mais
@@ -59,6 +71,12 @@ pt-BR:
       other: "%{count} %{item}"
       zero: sem %{item}
     oops_nothing_found: Oops! Nada encontrado...
+    order:
+      higher: Mover registro um para cima
+      lower: Mover registro um para baixo
+      reorder_record: Reordenar registro
+      to_bottom: Mover registro para baixo
+      to_top: Mover registro para cima
     per_page: Por página
     prev_page: Página anterior
     remove_selection: Remover seleção
@@ -90,6 +108,12 @@ pt-BR:
     undo: desfazer
     view: Visualizar
     view_item: visualizar %{item}
+    was_successfully_created: foi criado com sucesso
+    was_successfully_updated: foi atualizado com sucesso
+    x_items_more:
+      one: mais um item
+      other: "%{count} mais items"
+      zero: mais nenhum item
     x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> registros selecionados nesta página de um total de <span class="font-bold text-gray-700">%{count}</span>
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> registros selecionados de todas as páginas
     you_missed_something_check_form: Você pode ter esquecido algo. Por favor, cheque o formulário.

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -17,7 +17,8 @@ ro:
     choose_a_country: Alege o tara
     choose_an_option: Alege o optiune
     choose_item: Alege %{item}
-    clear_value: Valoare clară
+
+    clear_value: Sterge valoarea
     click_to_reveal_filters: Faceți clic pentru a afișa filtrele
     confirm: Confirm
     create_new_item: Creeaza %{item}
@@ -29,7 +30,7 @@ ro:
     detach_item: detaseaza %{item}
     details: detalii
     download: Descarca
-    download_file: Descărcare fișier
+    download_file: Descărcă fișier
     download_item: Descarca %{item}
     edit: modifica
     edit_item: modifica %{item}
@@ -75,8 +76,8 @@ ro:
       higher: Mutați înregistrarea mai sus
       lower: Mutați înregistrarea mai jos
       reorder_record: Reordonați înregistrarea
-      to_bottom: Mutați înregistrarea în jos
-      to_top: Mutați înregistrarea sus
+      to_bottom: Mutați înregistrarea jos de tot
+      to_top: Mutați înregistrarea sus de tot
     per_page: Pe pagina
     prev_page: Pagina anterioara
     remove_selection: Sterge selectia
@@ -113,7 +114,7 @@ ro:
     x_items_more:
       one: încă un articol
       other: "%{count} mai multe articole"
-      zero: nu mai multe articole
+      zero: zero articole
     x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> selectate dintr-un total de <span class="font-bold text-gray-700">%{count}</span>
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> selectate din toate paginile
     you_missed_something_check_form: S-ar putea să fi omis ceva. Vă rugăm să verificați formularul.

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -17,7 +17,6 @@ ro:
     choose_a_country: Alege o tara
     choose_an_option: Alege o optiune
     choose_item: Alege %{item}
-
     clear_value: Sterge valoarea
     click_to_reveal_filters: Faceți clic pentru a afișa filtrele
     confirm: Confirm

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -5,16 +5,20 @@ ro:
     actions: Actiuni
     and_x_other_resources: plus alte %{count} resources
     are_you_sure: Esti sigur?
+    are_you_sure_detach_item: Sigur vrei să detașezi asta %{item}.
     are_you_sure_you_want_to_run_this_option: Esti sigur ca vrei sa rulezi aceasta actiune?
     attach: Ataseaza
     attach_and_attach_another: Ataseaza si ataseaza inca unul
     attach_item: Anexeaza %{item}
     attachment_class_attached: "%{attachment_class} anexat."
     attachment_class_detached: "%{attachment_class} separat."
+    attachment_destroyed: Atașamentul a fost distrus
     cancel: Anuleaza
     choose_a_country: Alege o tara
     choose_an_option: Alege o optiune
     choose_item: Alege %{item}
+    clear_value: Valoare clară
+    click_to_reveal_filters: Faceți clic pentru a afișa filtrele
     confirm: Confirm
     create_new_item: Creeaza %{item}
     dashboard: Panou de control
@@ -25,15 +29,23 @@ ro:
     detach_item: detaseaza %{item}
     details: detalii
     download: Descarca
+    download_file: Descărcare fișier
     download_item: Descarca %{item}
     edit: modifica
     edit_item: modifica %{item}
     empty_dashboard_message: Adauga carduri in acest dashboard
+    failed: A eșuat
+    failed_to_find_attachment: Atașamentul nu a fost găsit
+    failed_to_load: Incarcarea a esuat
     field_translations:
       file:
         one: fisier
         other: fisiere
         zero: fisiere
+      people:
+        one: peep
+        other: peeps
+        zero: peeps
     filters: Filtre
     go_back: Inapoi
     grid_view: Vezi sub forma de grid
@@ -47,19 +59,28 @@ ro:
     list_is_empty: Lista este goala
     loading: Se incarca
     more: Mai multe
+    new: nou
     next_page: Pagina urmatoare
     no_cards_present: Niciun card disponibil
     no_item_found: Nu s-au gasit %{item}
     no_options_available: Nicio optiune disponibila
     no_related_item_found: Nu s-au gasit %{item} asociate
+    not_authorized: Nu sunteți autorizat să efectuați această acțiune.
     number_of_items:
       one: un %{item}
       other: "%{count} %{item}"
       zero: 0 %{item}
     oops_nothing_found: Oups! Nu am gasit rezultate...
+    order:
+      higher: Mutați înregistrarea mai sus
+      lower: Mutați înregistrarea mai jos
+      reorder_record: Reordonați înregistrarea
+      to_bottom: Mutați înregistrarea în jos
+      to_top: Mutați înregistrarea sus
     per_page: Pe pagina
     prev_page: Pagina anterioara
     remove_selection: Sterge selectia
+    reset_filters: Resetați filtrele
     resource_created: Resursa creata
     resource_destroyed: Resursa stearsa
     resource_translations:
@@ -79,6 +100,7 @@ ro:
     select_item: Selecteaza record
     show_content: Arata continutul
     sign_out: Delogare
+    switch_to_view: Comutați la vizualizarea %{view_type}
     table_view: Vezi sub forma de tabel
     tools: Instrumente
     type_to_search: Cauta aici...
@@ -88,5 +110,10 @@ ro:
     view_item: vezi %{item}
     was_successfully_created: a fost creat
     was_successfully_updated: a fost actualizat
+    x_items_more:
+      one: încă un articol
+      other: "%{count} mai multe articole"
+      zero: nu mai multe articole
     x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> selectate dintr-un total de <span class="font-bold text-gray-700">%{count}</span>
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> selectate din toate paginile
+    you_missed_something_check_form: S-ar putea să fi omis ceva. Vă rugăm să verificați formularul.

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -1,91 +1,92 @@
+---
 ro:
   avo:
-    dashboard: 'Panou de control'
-    dashboards: 'Panouri de control'
-    choose_a_country: 'Alege o tara'
-    choose_an_option: 'Alege o optiune'
-    are_you_sure_you_want_to_run_this_option: 'Esti sigur ca vrei sa rulezi aceasta actiune?'
-    run: 'Ruleaza'
-    cancel: 'Anuleaza'
-    action_ran_successfully: 'Actiunea a rulat cu succes!'
-    details: "detalii"
-    unauthorized: 'Neautorizat'
-    attachment_class_attached: '%{attachment_class} anexat.'
-    attachment_class_detached: '%{attachment_class} separat.'
-    resource_updated: 'Resursa actualizata'
-    resource_created: 'Resursa creata'
-    resource_destroyed: 'Resursa stearsa'
-    remove_selection: 'Sterge selectia'
-    select_item: 'Selecteaza record'
-    select_all: 'Selecteaza totul'
-    select_all_matching: 'Selecteaza toate care se potrivesc'
-    undo: Anuleaza
-    delete_file: 'Sterge fisierul'
-    delete: 'sterge'
-    delete_item: 'Sterge %{item}'
-    download_item: 'Descarca %{item}'
-    download: 'Descarca'
-    view: 'vezi'
-    view_item: 'vezi %{item}'
-    edit: 'modifica'
-    edit_item: 'modifica %{item}'
-    detach_item: 'detaseaza %{item}'
-    number_of_items:
-      zero: '0 %{item}'
-      one: 'un %{item}'
-      other: '%{count} %{item}'
-    are_you_sure: 'Esti sigur?'
-    filters: 'Filtre'
-    per_page: 'Pe pagina'
-    more: 'Mai multe'
-    attach: 'Ataseaza'
-    save: 'Salveaza'
-    attach_and_attach_another: 'Ataseaza si ataseaza inca unul'
-    hide_content: 'Ascunde continutul'
-    show_content: 'Arata continutul'
-    no_related_item_found: 'Nu s-au gasit %{item} asociate'
-    no_item_found: 'Nu s-au gasit %{item}'
-    loading: 'Se incarca'
-    confirm: 'Confirm'
-    actions: 'Actiuni'
-    resources: 'Resurse'
-    oops_nothing_found: 'Oups! Nu am gasit rezultate...'
-    type_to_search: 'Cauta aici...'
-    and_x_other_resources: 'plus alte %{count} resources'
-    go_back: 'Inapoi'
-    home: 'Acasa'
-    attach_item: 'Anexeaza %{item}'
-    choose_item: 'Alege %{item}'
-    create_new_item: 'Creeaza %{item}'
-    table_view: 'Vezi sub forma de tabel'
-    grid_view: 'Vezi sub forma de grid'
-    next_page: 'Pagina urmatoare'
-    prev_page: 'Pagina anterioara'
-    list_is_empty: 'Lista este goala'
+    action_ran_successfully: Actiunea a rulat cu succes!
+    actions: Actiuni
+    and_x_other_resources: plus alte %{count} resources
+    are_you_sure: Esti sigur?
+    are_you_sure_you_want_to_run_this_option: Esti sigur ca vrei sa rulezi aceasta actiune?
+    attach: Ataseaza
+    attach_and_attach_another: Ataseaza si ataseaza inca unul
+    attach_item: Anexeaza %{item}
+    attachment_class_attached: "%{attachment_class} anexat."
+    attachment_class_detached: "%{attachment_class} separat."
+    cancel: Anuleaza
+    choose_a_country: Alege o tara
+    choose_an_option: Alege o optiune
+    choose_item: Alege %{item}
+    confirm: Confirm
+    create_new_item: Creeaza %{item}
+    dashboard: Panou de control
+    dashboards: Panouri de control
+    delete: sterge
+    delete_file: Sterge fisierul
+    delete_item: Sterge %{item}
+    detach_item: detaseaza %{item}
+    details: detalii
+    download: Descarca
+    download_item: Descarca %{item}
+    edit: modifica
+    edit_item: modifica %{item}
+    empty_dashboard_message: Adauga carduri in acest dashboard
     field_translations:
       file:
-        zero: 'fisiere'
-        one: 'fisier'
-        other: 'fisiere'
+        one: fisier
+        other: fisiere
+        zero: fisiere
+    filters: Filtre
+    go_back: Inapoi
+    grid_view: Vezi sub forma de grid
+    hide_content: Ascunde continutul
+    home: Acasa
+    key_value_field:
+      add_row: Adauga rand
+      delete_row: Sterge rand
+      key: Cheie
+      value: Valoare
+    list_is_empty: Lista este goala
+    loading: Se incarca
+    more: Mai multe
+    next_page: Pagina urmatoare
+    no_cards_present: Niciun card disponibil
+    no_item_found: Nu s-au gasit %{item}
+    no_options_available: Nicio optiune disponibila
+    no_related_item_found: Nu s-au gasit %{item} asociate
+    number_of_items:
+      one: un %{item}
+      other: "%{count} %{item}"
+      zero: 0 %{item}
+    oops_nothing_found: Oups! Nu am gasit rezultate...
+    per_page: Pe pagina
+    prev_page: Pagina anterioara
+    remove_selection: Sterge selectia
+    resource_created: Resursa creata
+    resource_destroyed: Resursa stearsa
     resource_translations:
       user:
-        zero: 'utilizatori'
-        one: 'utilizator'
-        other: 'utilizatori'
+        one: utilizator
+        other: utilizatori
+        zero: utilizatori
+    resource_updated: Resursa actualizata
+    resources: Resurse
+    run: Ruleaza
+    save: Salveaza
     search:
-      placeholder: 'Cauta'
-      cancel_button: 'Anulare'
-    sign_out: 'Delogare'
-    key_value_field:
-      key: 'Cheie'
-      value: 'Valoare'
-      add_row: 'Adauga rand'
-      delete_row: 'Sterge rand'
-    was_successfully_created: 'a fost creat'
-    was_successfully_updated: 'a fost actualizat'
+      cancel_button: Anulare
+      placeholder: Cauta
+    select_all: Selecteaza totul
+    select_all_matching: Selecteaza toate care se potrivesc
+    select_item: Selecteaza record
+    show_content: Arata continutul
+    sign_out: Delogare
+    table_view: Vezi sub forma de tabel
     tools: Instrumente
-    empty_dashboard_message: Adauga carduri in acest dashboard
-    no_cards_present: Niciun card disponibil
-    no_options_available: Nicio optiune disponibila
+    type_to_search: Cauta aici...
+    unauthorized: Neautorizat
+    undo: Anuleaza
+    view: vezi
+    view_item: vezi %{item}
+    was_successfully_created: a fost creat
+    was_successfully_updated: a fost actualizat
     x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> selectate dintr-un total de <span class="font-bold text-gray-700">%{count}</span>
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> selectate din toate paginile

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -64,7 +64,7 @@ tr:
     no_cards_present: Kart yok
     no_item_found: Hiç %{item} bulunamadı
     no_options_available: Seçenek yok
-    no_related_item_found: İlişkili öğe bulunamadı
+    no_related_item_found: İlişkili %{item} bulunamadı
     not_authorized: Bu eylemi gerçekleştirme yetkiniz yok.
     number_of_items:
       one: bir %{item}

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -1,119 +1,119 @@
+---
 tr:
   avo:
-    dashboard: 'Yönetim Paneli'
-    dashboards: 'Yönetim Panelleri'
-    choose_a_country: 'Bir ülke seç'
-    choose_an_option: 'Bir seçenek seç'
-    are_you_sure_you_want_to_run_this_option: 'Bu işlemi gerçekleştirmek istediğinize emin misiniz?'
-    are_you_sure_detach_item: '%{item} öğesini ayırmak istediğinizden emin misiniz?'
-    run: 'Başlat'
-    cancel: 'İptal et'
-    action_ran_successfully: 'Eylem başarıyla gerçekleşti!'
-    details: "detaylar"
-    unauthorized: 'Yetkisiz'
-    attachment_class_attached: '%{attachment_class} ilişkilendirildi.'
-    attachment_class_detached: '%{attachment_class} ilişkisi kesildi.'
-    resource_updated: 'Kayıt güncellendi'
-    resource_created: 'Kayıt oluşturuldu'
-    resource_destroyed: 'Kayıt silindi'
-    switch_to_view: "%{view_type} görünümüne kay"
-    click_to_reveal_filters: "Filtreleri ortaya çıkarmak için tıklayın"
-    attachment_destroyed: 'Ek silindi'
-    failed_to_find_attachment: 'Ek bulunamadı'
-    you_missed_something_check_form: 'Bir şeyleri kaçırmış olabilirsiniz. Lütfen formu kontrol edin.'
-    remove_selection: 'Seçimi sil'
-    select_item: 'Öğe seç'
-    select_all: 'Tümünü seç'
-    select_all_matching: 'Tüm eşleşenleri seç'
-    undo: geri al
-    delete_file: 'Dosyayı sil'
-    delete: 'sil'
-    delete_item: '%{item} öğresini sil'
-    download_item: '%{item} öğesini indir'
-    download_file: 'Dosya indir'
-    download: 'İndir'
-    view: 'Görünüm'
-    view_item: '%{item} öğresini görüntüle'
-    edit: 'düzenle'
-    edit_item: '%{item} öğesini düzenle'
-    detach_item: '%{item} öğesinin ilişkisini kes'
-    number_of_items:
-      zero: 'sıfır %{item}'
-      one: 'bir %{item}'
-      other: '%{count} %{item}'
-    x_items_more:
-      zero: 'daha fazla öğe yok'
-      one: 'bir öğe daha'
-      other: '%{count} öğe daha'
-    are_you_sure: 'Emin misiniz?'
-    filters: 'Filtreler'
-    per_page: 'Sayfa başına'
-    more: 'Daha fazla'
-    attach: 'İlişkilendir'
-    cancel: 'İptal et'
-    save: 'Kaydet'
-    attach_and_attach_another: 'İlişkilendir & Bir başka daha İlişkilendir'
-    hide_content: 'İçeriği gizle'
-    show_content: 'İçeriği göster'
-    no_related_item_found: 'İlişkili öğe bulunamadı'
-    no_item_found: 'Hiç %{item} bulunamadı'
-    loading: 'Yükleniyor'
-    confirm: 'Onayla'
-    actions: 'Aksiyonlar'
-    resources: 'Kaynaklar'
-    oops_nothing_found: 'Hata! Hiçbir şey bulunamadı'
-    type_to_search: 'Aramak için yazın.'
-    and_x_other_resources: 've %{count} diğer kaynak'
-    go_back: 'Geri dön'
-    home: 'Anasayfa'
-    new: 'yeni'
-    attach_item: '%{item} öğesini ilişkilendir'
-    choose_item: '%{item} seçin'
-    create_new_item: 'Yeni bir %{item} oluşturun'
-    table_view: 'Tablo görünümü'
-    grid_view: 'Grid görünümü'
-    next_page: 'Sonraki sayfa'
-    prev_page: 'Önceki sayfa'
-    list_is_empty: 'Boş liste'
+    action_ran_successfully: Eylem başarıyla gerçekleşti!
+    actions: Aksiyonlar
+    and_x_other_resources: ve %{count} diğer kaynak
+    are_you_sure: Emin misiniz?
+    are_you_sure_detach_item: "%{item} öğesini ayırmak istediğinizden emin misiniz?"
+    are_you_sure_you_want_to_run_this_option: Bu işlemi gerçekleştirmek istediğinize emin misiniz?
+    attach: İlişkilendir
+    attach_and_attach_another: İlişkilendir & Bir başka daha İlişkilendir
+    attach_item: "%{item} öğesini ilişkilendir"
+    attachment_class_attached: "%{attachment_class} ilişkilendirildi."
+    attachment_class_detached: "%{attachment_class} ilişkisi kesildi."
+    attachment_destroyed: Ek silindi
+    cancel: İptal et
+    choose_a_country: Bir ülke seç
+    choose_an_option: Bir seçenek seç
+    choose_item: "%{item} seçin"
+    clear_value: Değeri temizle
+    click_to_reveal_filters: Filtreleri ortaya çıkarmak için tıklayın
+    confirm: Onayla
+    create_new_item: Yeni bir %{item} oluşturun
+    dashboard: Yönetim Paneli
+    dashboards: Yönetim Panelleri
+    delete: sil
+    delete_file: Dosyayı sil
+    delete_item: "%{item} öğresini sil"
+    detach_item: "%{item} öğesinin ilişkisini kes"
+    details: detaylar
+    download: İndir
+    download_file: Dosya indir
+    download_item: "%{item} öğesini indir"
+    edit: düzenle
+    edit_item: "%{item} öğesini düzenle"
+    empty_dashboard_message: Kartları yönetim paneline ekle
+    failed: Başarısız
+    failed_to_find_attachment: Ek bulunamadı
+    failed_to_load: Yüklenemedi
     field_translations:
       file:
-        zero: 'dosya'
-        one: 'dosya'
-        other: 'dosya'
+        one: dosya
+        other: dosya
+        zero: dosya
       people:
-        zero: 'kişi'
-        one: 'kişi'
-        other: 'kişi'
-    resource_translations:
-      user:
-        zero: 'kullanıcı'
-        one: 'kullanıcı'
-        other: 'kullanıcı'
-    reset_filters: 'Filtreleri sıfırla'
-    not_authorized: 'Bu eylemi gerçekleştirme yetkiniz yok.'
-    search:
-      placeholder: 'Ara'
-      cancel_button: 'İptal et'
-    sign_out: 'Çıkış yap'
-    failed: 'Başarısız'
-    failed_to_load: 'Yüklenemedi'
+        one: kişi
+        other: kişi
+        zero: kişi
+    filters: Filtreler
+    go_back: Geri dön
+    grid_view: Grid görünümü
+    hide_content: İçeriği gizle
+    home: Anasayfa
     key_value_field:
-      key: 'Anahtar'
-      value: 'Değer'
-      add_row: 'Satır ekle'
-      delete_row: 'Satır sil'
-    was_successfully_created: 'başarıyla oluşturuldu'
-    was_successfully_updated: 'başarıyla güncellendi'
-    clear_value: "Değeri temizle"
-    tools: Araçlar
+      add_row: Satır ekle
+      delete_row: Satır sil
+      key: Anahtar
+      value: Değer
+    list_is_empty: Boş liste
+    loading: Yükleniyor
+    more: Daha fazla
+    new: yeni
+    next_page: Sonraki sayfa
+    no_cards_present: Kart yok
+    no_item_found: Hiç %{item} bulunamadı
+    no_options_available: Seçenek yok
+    no_related_item_found: İlişkili öğe bulunamadı
+    not_authorized: Bu eylemi gerçekleştirme yetkiniz yok.
+    number_of_items:
+      one: bir %{item}
+      other: "%{count} %{item}"
+      zero: sıfır %{item}
+    oops_nothing_found: Hata! Hiçbir şey bulunamadı
     order:
-      reorder_record: Kaydı yeniden sırala
       higher: Kaydı yüksekten sırala
       lower: Kaydı düşükten sırala
-      to_top: Kaydı en üste taşı
+      reorder_record: Kaydı yeniden sırala
       to_bottom: Kaydı en alta taşı
-    empty_dashboard_message: Kartları yönetim paneline ekle
-    no_cards_present: Kart yok
-    no_options_available: Seçenek yok
+      to_top: Kaydı en üste taşı
+    per_page: Sayfa başına
+    prev_page: Önceki sayfa
+    remove_selection: Seçimi sil
+    reset_filters: Filtreleri sıfırla
+    resource_created: Kayıt oluşturuldu
+    resource_destroyed: Kayıt silindi
+    resource_translations:
+      user:
+        one: kullanıcı
+        other: kullanıcı
+        zero: kullanıcı
+    resource_updated: Kayıt güncellendi
+    resources: Kaynaklar
+    run: Başlat
+    save: Kaydet
+    search:
+      cancel_button: İptal et
+      placeholder: Ara
+    select_all: Tümünü seç
+    select_all_matching: Tüm eşleşenleri seç
+    select_item: Öğe seç
+    show_content: İçeriği göster
+    sign_out: Çıkış yap
+    switch_to_view: "%{view_type} görünümüne kay"
+    table_view: Tablo görünümü
+    tools: Araçlar
+    type_to_search: Aramak için yazın.
+    unauthorized: Yetkisiz
+    undo: geri al
+    view: Görünüm
+    view_item: "%{item} öğresini görüntüle"
+    was_successfully_created: başarıyla oluşturuldu
+    was_successfully_updated: başarıyla güncellendi
+    x_items_more:
+      one: bir öğe daha
+      other: "%{count} öğe daha"
+      zero: daha fazla öğe yok
     x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> bu sayfada seçilen toplam kayıtlar <span class="font-bold text-gray-700">%{count}</span>
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> tüm sayfalardan seçilen kayıtlar
+    you_missed_something_check_form: Bir şeyleri kaçırmış olabilirsiniz. Lütfen formu kontrol edin.

--- a/spec/system/i18n_spec.rb
+++ b/spec/system/i18n_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'i18n/tasks'
+
+RSpec.describe I18n do
+  let(:i18n) { I18n::Tasks::BaseTask.new }
+  let(:missing_keys) { i18n.missing_keys }
+  let(:unused_keys) { i18n.unused_keys }
+  let(:inconsistent_interpolations) { i18n.inconsistent_interpolations }
+
+  it 'does not have missing keys' do
+    expect(missing_keys).to be_empty,
+                            "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+  end
+
+  it 'does not have unused keys' do
+    expect(unused_keys).to be_empty,
+                           "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+  end
+
+  it 'files are normalized' do
+    non_normalized = i18n.non_normalized_paths
+    error_message = "The following files need to be normalized:\n" \
+                    "#{non_normalized.map { |path| "  #{path}" }.join("\n")}\n" \
+                    "Please run `i18n-tasks normalize' to fix"
+    expect(non_normalized).to be_empty, error_message
+  end
+
+  it 'does not have inconsistent interpolations' do
+    error_message = "#{inconsistent_interpolations.leaves.count} i18n keys have inconsistent interpolations.\n" \
+                    "Run `i18n-tasks check-consistent-interpolations' to show them"
+    expect(inconsistent_interpolations).to be_empty, error_message
+  end
+end

--- a/spec/system/i18n_spec.rb
+++ b/spec/system/i18n_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe I18n do
                             "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
   end
 
-  it 'does not have unused keys' do
-    expect(unused_keys).to be_empty,
-                           "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
-  end
+  # it 'does not have unused keys' do
+  #   expect(unused_keys).to be_empty,
+  #                          "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+  # end
 
   it 'files are normalized' do
     non_normalized = i18n.non_normalized_paths


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
The goal in this issue is normalize and fixes some missing locales, for this i have done the following tasks:
- Install i18n-tasks gem and configure for avo
- Normalize locale files
- Fixes inconsistent interpolations for tr locale
- Adds missing keys for pt-BR (my main language) and ro (I used google translate for that)
- Adds specs for no more missing keys

In this PR i do not fixes any opened issues, but we talk a little bit for this change is this PR #1216
*OBS*: I have not checked for unused translations, because there are a lot, i thinks this should be done in another PR.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. I run i-18n-tasks and correct one by one.
2. Print for missing keys for pt-BR and ro locale
![Screenshot_85](https://user-images.githubusercontent.com/43936240/195647905-71f6700a-bf3e-4ad4-8f18-39b4783457a2.png)