### PR TITLE
refactor: white-panel-classes helper global

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,5 +19,5 @@ jobs:
           stale-pr-message: 'This PR has been marked as stale because there was no activity for the past 15 days.'
           close-issue-message: 'Closing this because there was no activity for the past 15 days. Feel free to reopen if new information pops up ✌️'
           close-pr-message: 'Closing this because there was no activity for the past 15 days. Feel free to reopen if new information pops up ✌️'
-          exempt-issue-labels: Stale exempt, Good first issue, Help wanted, bug, RFC
-          exempt-pr-labels: Stale exempt, Good first issue, Help wanted, bug, RFC
+          exempt-issue-labels: Stale exempt, Good first issue, Help wanted, bug, RFC, Task
+          exempt-pr-labels: Stale exempt, Good first issue, Help wanted, bug, RFC, Task

--- a/app/components/avo/panel_component.html.erb
+++ b/app/components/avo/panel_component.html.erb
@@ -25,10 +25,8 @@
   <% end %>
   <% if body? %>
     <div class="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:gap-4 w-full">
-      <div class="flex-1 overflow-auto <% if sidebar? %> w-2/3 <% end %>">
-        <div class="relative <%= white_panel_classes %> <%= @body_classes %>">
-          <%= body %>
-        </div>
+      <div class="relative flex-1 overflow-auto <%= white_panel_classes %> <%= @body_classes %> <% if sidebar? %> w-2/3 <% end %>">
+        <%= body %>
       </div>
       <% if sidebar? %>
         <div class="w-full sm:w-1/3 flex-shrink-0 h-full <%= white_panel_classes %>">

--- a/app/components/avo/panel_component.rb
+++ b/app/components/avo/panel_component.rb
@@ -5,6 +5,8 @@ class Avo::PanelComponent < ViewComponent::Base
   attr_reader :name
   attr_reader :classes
 
+  delegate :white_panel_classes, to: :helpers
+
   renders_one :tools
   renders_one :body
   renders_one :sidebar
@@ -25,10 +27,6 @@ class Avo::PanelComponent < ViewComponent::Base
   end
 
   private
-
-  def white_panel_classes
-    "bg-white rounded shadow"
-  end
 
   def data_attributes
     @data.merge({"panel-index": @index})

--- a/app/components/avo/tab_switcher_component.html.erb
+++ b/app/components/avo/tab_switcher_component.html.erb
@@ -20,7 +20,7 @@
     </div>
   </div>
 <% else %>
-  <div class="flex flex-wrap gap-2 bg-white p-2" data-target="tab-switcher" data-style="pills">
+  <div class="flex flex-wrap gap-2 p-2 <%= white_panel_classes %>" data-target="tab-switcher" data-style="pills">
     <% visible_items.each do |tab| %>
       <%= a_link tab_path(tab),
       color: selected?(tab) ? :primary : :gray,

--- a/app/components/avo/tab_switcher_component.rb
+++ b/app/components/avo/tab_switcher_component.rb
@@ -11,6 +11,8 @@ class Avo::TabSwitcherComponent < Avo::BaseComponent
   attr_reader :view
   attr_reader :style
 
+  delegate :white_panel_classes, to: :helpers
+
   def initialize(resource:, group:, current_tab:, active_tab_name:, view:, style:)
     @active_tab_name = active_tab_name
     @resource = resource

--- a/app/helpers/avo/application_helper.rb
+++ b/app/helpers/avo/application_helper.rb
@@ -89,6 +89,10 @@ module Avo
       classes
     end
 
+    def white_panel_classes
+      "bg-white rounded shadow-md"
+    end
+
     def get_model_class(model)
       if model.instance_of?(Class)
         model

--- a/spec/features/avo/resource_controls_placement_spec.rb
+++ b/spec/features/avo/resource_controls_placement_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "ResourceControlsPlacement", type: :feature do
       visit "/admin/resources/comments"
 
       # XPath containing the index of the cell
-      expect(page).to have_xpath('/html/body/div/div/div[2]/div[3]/div/div/div[1]/div/div[2]/div/div/div[2]/div/div/table/tbody/tr[1]/td[1][@data-control="resource-controls"]')
+      expect(page).to have_xpath('/html/body/div/div/div[2]/div[3]/div/div/div[1]/div/div[2]/div/div[2]/div/div/table/tbody/tr[1]/td[1][@data-control="resource-controls"]')
     end
   end
 
@@ -25,7 +25,7 @@ RSpec.feature "ResourceControlsPlacement", type: :feature do
       visit "/admin/resources/comments"
 
       # XPath containing the index of the cell
-      expect(page).to have_xpath('/html/body/div/div/div[2]/div[3]/div/div/div[1]/div/div[2]/div/div/div[2]/div/div/table/tbody/tr[1]/td[6][@data-control="resource-controls"]')
+      expect(page).to have_xpath('/html/body/div/div/div[2]/div[3]/div/div/div[1]/div/div[2]/div/div[2]/div/div/table/tbody/tr[1]/td[6][@data-control="resource-controls"]')
     end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where the overflow value was set to `auto` and the shadows are not visible. We also add those style to the tab switcher component.


### Before
![CleanShot 2022-10-18 at 12 44 34](https://user-images.githubusercontent.com/1334409/196396374-0fd4eda4-bf7b-4d9d-b7e4-653a57c51a02.jpg)

### After
![CleanShot 2022-10-18 at 12 44 49](https://user-images.githubusercontent.com/1334409/196396405-53fdc086-0bfe-4d02-8bb1-4604d1c70774.jpg)


# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works
