### PR TITLE
Reset autocomplete container before set up

### DIFF
--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -73,6 +73,8 @@ export default class extends Controller {
       Mousetrap.bind(['command+k', 'ctrl+k'], () => this.showSearchPanel())
     }
 
+    this.autocompleteTarget.innerHTML = ""
+
     autocomplete({
       container: this.autocompleteTarget,
       placeholder: this.translationKeys.placeholder,

--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -73,7 +73,8 @@ export default class extends Controller {
       Mousetrap.bind(['command+k', 'ctrl+k'], () => this.showSearchPanel())
     }
 
-    this.autocompleteTarget.innerHTML = ""
+    // This line fixes a bug where the search box would be duplicated on back navigation.
+    this.autocompleteTarget.innerHTML = ''
 
     autocomplete({
       container: this.autocompleteTarget,


### PR DESCRIPTION
# Description
Algolia autocomplete.js creates duplicate search containers when navigating back to the page.

Fixes https://github.com/avo-hq/avo/issues/1331

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Open a resource index page with resource search. 
2. Navigate to an individual resource. 
3. Go back to the index page, by clicking on the browser back button. 
4. There should be one more `search box`.
5. Repeat from step 2 to step 4 and there will be as many search boxes as the number of times you did this.

Manual reviewer: please leave a comment with output from the test if that's the case.
