### PR TITLE
fix: the panels overflow hides the filters popup

### DIFF
--- a/app/components/avo/panel_component.html.erb
+++ b/app/components/avo/panel_component.html.erb
@@ -25,7 +25,7 @@
   <% end %>
   <% if body? %>
     <div class="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:gap-4 w-full">
-      <div class="relative flex-1 overflow-auto <%= white_panel_classes %> <%= @body_classes %> <% if sidebar? %> w-2/3 <% end %>">
+      <div class="relative flex-1 <%= white_panel_classes %> <%= @body_classes %> <% if sidebar? %> w-2/3 overflow-auto <% else %> w-full <% end %>">
         <%= body %>
       </div>
       <% if sidebar? %>

--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -46,10 +46,8 @@
       </div>
       <% if view_type.to_sym == :table %>
         <% if @resources.present? %>
-          <div class="w-full overflow-auto flex flex-col mt-0 mac-styled-scrollbar">
-            <div class="relative flex-1 flex">
-              <%= render(Avo::Index::ResourceTableComponent.new(resources: @resources, resource: @resource, reflection: @reflection, parent_model: @parent_model, parent_resource: @parent_resource, pagy: @pagy, query: @query)) %>
-            </div>
+          <div class="w-full relative flex-1 flex mac-styled-scrollbar overflow-auto mt-0">
+            <%= render(Avo::Index::ResourceTableComponent.new(resources: @resources, resource: @resource, reflection: @reflection, parent_model: @parent_model, parent_resource: @parent_resource, pagy: @pagy, query: @query)) %>
           </div>
         <% else %>
           <%= helpers.empty_state resource_name: @resource.name.downcase.pluralize, related_name: params[:related_name], view_type: view_type, add_background: true %>

--- a/spec/features/avo/resource_controls_placement_spec.rb
+++ b/spec/features/avo/resource_controls_placement_spec.rb
@@ -14,8 +14,10 @@ RSpec.feature "ResourceControlsPlacement", type: :feature do
       Avo.configuration.resource_controls_placement = :left
       visit "/admin/resources/comments"
 
-      # XPath containing the index of the cell
-      expect(page).to have_xpath('/html/body/div/div/div[2]/div[3]/div/div/div[1]/div/div[2]/div/div[2]/div/div/table/tbody/tr[1]/td[1][@data-control="resource-controls"]')
+      within find("table") do
+        # XPath containing the index of the cell
+        expect(page).to have_xpath('tbody/tr[1]/td[1][@data-control="resource-controls"]')
+      end
     end
   end
 
@@ -24,8 +26,10 @@ RSpec.feature "ResourceControlsPlacement", type: :feature do
       Avo.configuration.resource_controls_placement = :right
       visit "/admin/resources/comments"
 
-      # XPath containing the index of the cell
-      expect(page).to have_xpath('/html/body/div/div/div[2]/div[3]/div/div/div[1]/div/div[2]/div/div[2]/div/div/table/tbody/tr[1]/td[6][@data-control="resource-controls"]')
+      within find("table") do
+        # XPath containing the index of the cell
+        expect(page).to have_xpath('tbody/tr[1]/td[6][@data-control="resource-controls"]')
+      end
     end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1334

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works
