### PR TITLE
fix: panel too tall

### DIFF
--- a/app/components/avo/panel_component.html.erb
+++ b/app/components/avo/panel_component.html.erb
@@ -25,8 +25,11 @@
   <% end %>
   <% if body? %>
     <div class="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:gap-4 w-full">
-      <div class="relative flex-1 <%= white_panel_classes %> <%= @body_classes %> <% if sidebar? %> w-2/3 overflow-auto <% else %> w-full <% end %>">
-        <%= body %>
+      <div class="relative flex-1 <% if sidebar? %> w-2/3 overflow-auto <% else %> w-full <% end %>">
+        <% # The body is wrapped inside another div in order to avoid long & tall panels next to sidebars when the sidebar taller. %>
+        <div class="relative <%= white_panel_classes %> <%= @body_classes %>">
+          <%= body %>
+        </div>
       </div>
       <% if sidebar? %>
         <div class="w-full sm:w-1/3 flex-shrink-0 h-full <%= white_panel_classes %>">

--- a/app/components/avo/views/resource_show_component.html.erb
+++ b/app/components/avo/views/resource_show_component.html.erb
@@ -1,4 +1,6 @@
 <%= content_tag :div,
+  # the overflow helps with long values
+  class: "overflow-auto",
   data: {
     'model-id': @resource.model.id,
     selected_resources_name: @resource.model_key,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where the panel has a tall, empty white area when the sidebar is taller.

### Before
![CleanShot 2022-10-21 at 19 00 41](https://user-images.githubusercontent.com/1334409/197239246-615186a1-7fe5-420b-b1fc-897e3374fd05.jpg)


### After
![CleanShot 2022-10-21 at 19 00 11](https://user-images.githubusercontent.com/1334409/197239135-46a85a18-a97b-4269-8f8e-1098517781d6.jpg)


# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works
