### PR TITLE
fix: action fileds default option broken

### DIFF
--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -12,7 +12,10 @@ module Avo
     before_action :set_action, only: [:show, :handle]
 
     def show
-      @resource.hydrate(model: @model, view: :show, user: _current_user, params: params)
+      # Se the view to :new so the default value gets prefilled
+      @view = :new
+
+      @resource.hydrate(model: @model, view: @view, user: _current_user, params: params)
       @model = ActionModel.new @action.get_attributes_for_action
     end
 
@@ -48,17 +51,15 @@ module Avo
     end
 
     def set_action
-      @action = action_class.new(model: @model, resource: @resource, user: _current_user, view: :edit)
+      @action = action_class.new(model: @model, resource: @resource, user: _current_user, view: @view)
     end
 
     def action_class
       klass_name = params[:action_id].gsub("avo_actions_", "").camelize
 
-      valid_klass = Avo::BaseAction.descendants.find do |action|
+      Avo::BaseAction.descendants.find do |action|
         action.to_s == klass_name
       end
-
-      valid_klass
     end
 
     def respond(response)

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -27,7 +27,7 @@
           <% @action.get_fields.each_with_index do |field, index| %>
             <%= render field
               .hydrate(resource: @resource, model: @resource.model, user: @resource.user, view: @view)
-              .component_for_view(:edit)
+              .component_for_view(@view)
               .new(field: field, resource: @resource, index: index, form: form, compact: true)
             %>
           <% end %>

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -72,7 +72,7 @@ module Avo
 
     def get_attributes_for_action
       get_fields.map do |field|
-        [field.id, field.value]
+        [field.id, field.value || field.default]
       end.to_h
     end
 

--- a/spec/dummy/app/avo/actions/toggle_inactive.rb
+++ b/spec/dummy/app/avo/actions/toggle_inactive.rb
@@ -5,7 +5,7 @@ class ToggleInactive < Avo::BaseAction
   field :message, as: :text, default: "Your account has been marked as inactive."
 
   def handle(**args)
-    models, fields, current_user, resource = args.values_at(:models, :fields, :current_user, :resource)
+    models, fields, _ = args.values_at(:models, :fields, :current_user, :resource)
 
     models.each do |model|
       if model.active

--- a/spec/dummy/app/avo/actions/toggle_published.rb
+++ b/spec/dummy/app/avo/actions/toggle_published.rb
@@ -8,7 +8,7 @@ class TogglePublished < Avo::BaseAction
   field :message, as: :text, default: "Your account has been marked as inactive."
 
   def handle(**args)
-    models, fields, current_user, resource = args.values_at(:models, :fields, :current_user, :resource)
+    models, _ = args.values_at(:models, :fields, :current_user, :resource)
 
     models.each do |model|
       if model.published_at.present?

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe "Actions", type: :system do
         click_on "Actions"
 
         # Check to see if all the actions are present and which are disabled by default
-        expect(page.find('a', text: "Toggle inactive")['data-disabled']).to eq 'true'
-        expect(page.find('a', text: "Toggle admin")['data-disabled']).to eq 'true'
-        expect(page.find('a', text: "Dummy action")['data-disabled']).to eq 'false'
-        expect(page.find('a', text: "Download file")['data-disabled']).to eq 'false'
+        expect(page.find("a", text: "Toggle inactive")["data-disabled"]).to eq "true"
+        expect(page.find("a", text: "Toggle admin")["data-disabled"]).to eq "true"
+        expect(page.find("a", text: "Dummy action")["data-disabled"]).to eq "false"
+        expect(page.find("a", text: "Download file")["data-disabled"]).to eq "false"
       end
     end
 
@@ -122,55 +122,64 @@ RSpec.describe "Actions", type: :system do
     end
   end
 
+  describe "default values" do
+    it "displays the default value" do
+      visit "/admin/resources/users/#{user.slug}/actions/toggle_inactive"
+
+      expect(page).to have_field "fields[notify_user]", checked: true
+      expect(page).to have_field "fields[message]", text: "Your account has been marked as inactive."
+    end
+  end
+
   #   let!(:roles) { { admin: false, manager: false, writer: false } }
   #   let!(:user) { create :user, active: true, roles: roles }
 
-  #   context 'index' do
-  #     describe 'without actions attached' do
-  #       let(:url) { '/admin/resources/teams' }
+  #   context "index" do
+  #     describe "without actions attached" do
+  #       let(:url) { "/admin/resources/teams" }
 
-  #       it 'does not display the actions button' do
+  #       it "does not display the actions button" do
   #         visit url
 
-  #         expect(page).not_to have_text 'Actions'
+  #         expect(page).not_to have_text "Actions"
   #       end
   #     end
 
-  #     describe 'with actions attached' do
+  #     describe "with actions attached" do
   #       let!(:roles) { { admin: false, manager: false, writer: false } }
   #       let!(:second_user) { create :user, active: true, roles: roles }
-  #       let(:url) { '/admin/resources/users' }
+  #       let(:url) { "/admin/resources/users" }
 
-  #       it 'displays the actions button disabled' do
+  #       it "displays the actions button disabled" do
   #         visit url
 
-  #         expect(page).to have_button('Actions', disabled: true)
+  #         expect(page).to have_button("Actions", disabled: true)
   #       end
 
-  #       it 'enables the button when selecting a record' do
+  #       it "enables the button when selecting a record" do
   #         visit url
 
-  #         expect(page).to have_button('Actions', disabled: true)
+  #         expect(page).to have_button("Actions", disabled: true)
 
-  #         find("tr[resource-name=users][resource-id='#{user.id}'] input[type=checkbox]").click
+  #         find("tr[resource-name=users][resource-id="#{user.id}"] input[type=checkbox]").click
 
-  #         expect(page).to have_button('Actions', disabled: false)
+  #         expect(page).to have_button("Actions", disabled: false)
   #       end
 
-  #       it 'runs the action' do
+  #       it "runs the action" do
   #         visit url
 
   #         expect(user.active).to be true
   #         expect(second_user.active).to be true
 
-  #         find("tr[resource-name=users][resource-id='#{user.id}'] input[type=checkbox]").click
-  #         find("tr[resource-name=users][resource-id='#{second_user.id}'] input[type=checkbox]").click
+  #         find("tr[resource-name=users][resource-id="#{user.id}"] input[type=checkbox]").click
+  #         find("tr[resource-name=users][resource-id="#{second_user.id}"] input[type=checkbox]").click
 
-  #         expect(page).to have_button('Actions', disabled: false)
+  #         expect(page).to have_button("Actions", disabled: false)
 
-  #         click_on 'Actions'
-  #         click_on 'Mark inactive'
-  #         click_on 'Run'
+  #         click_on "Actions"
+  #         click_on "Mark inactive"
+  #         click_on "Run"
 
   #         wait_for_loaded
 
@@ -178,130 +187,130 @@ RSpec.describe "Actions", type: :system do
   #         expect(second_user.reload.active).to be false
   #       end
 
-  #       it 'runs the action without confirmation' do
+  #       it "runs the action without confirmation" do
   #         visit url
 
-  #         expect(user.roles['admin']).to be false
-  #         expect(second_user.roles['admin']).to be false
+  #         expect(user.roles["admin"]).to be false
+  #         expect(second_user.roles["admin"]).to be false
 
-  #         find("tr[resource-name=users][resource-id='#{user.id}'] input[type=checkbox]").click
-  #         find("tr[resource-name=users][resource-id='#{second_user.id}'] input[type=checkbox]").click
+  #         find("tr[resource-name=users][resource-id="#{user.id}"] input[type=checkbox]").click
+  #         find("tr[resource-name=users][resource-id="#{second_user.id}"] input[type=checkbox]").click
 
-  #         expect(page).to have_button('Actions', disabled: false)
+  #         expect(page).to have_button("Actions", disabled: false)
 
-  #         click_on 'Actions'
-  #         click_on 'Make admin'
+  #         click_on "Actions"
+  #         click_on "Make admin"
 
   #         wait_for_loaded
 
-  #         # expect(page).to have_text 'New admin(s) on the board!'
-  #         expect(user.reload.roles['admin']).to be true
-  #         expect(second_user.reload.roles['admin']).to be true
+  #         # expect(page).to have_text "New admin(s) on the board!"
+  #         expect(user.reload.roles["admin"]).to be true
+  #         expect(second_user.reload.roles["admin"]).to be true
   #       end
 
-  #       describe 'when resources still selected' do
-  #         it 'runs the action' do
+  #       describe "when resources still selected" do
+  #         it "runs the action" do
   #           visit url
 
-  #           expect(page).to have_button('Actions', disabled: true)
+  #           expect(page).to have_button("Actions", disabled: true)
 
-  #           find("tr[resource-name=users][resource-id='#{user.id}'] input[type=checkbox]").click
+  #           find("tr[resource-name=users][resource-id="#{user.id}"] input[type=checkbox]").click
 
-  #           expect(page).to have_button('Actions', disabled: false)
+  #           expect(page).to have_button("Actions", disabled: false)
 
-  #           click_on 'Posts'
+  #           click_on "Posts"
   #           wait_for_loaded
-  #           click_on 'Users'
+  #           click_on "Users"
   #           wait_for_loaded
 
-  #           expect(page).to have_button('Actions', disabled: true)
+  #           expect(page).to have_button("Actions", disabled: true)
   #         end
   #       end
   #     end
   #   end
 
-  #   context 'show' do
+  #   context "show" do
   #     let!(:roles) { { admin: false, manager: false, writer: false } }
   #     let!(:user) { create :user, active: true, roles: roles }
   #     let!(:post) { create :post, published_at: nil }
 
-  #     describe 'with fields' do
+  #     describe "with fields" do
   #       let(:url) { "/admin/resources/users/#{user.id}" }
 
-  #       it 'lists the action' do
+  #       it "lists the action" do
   #         visit url
 
-  #         click_on 'Actions'
+  #         click_on "Actions"
 
-  #         expect(find('.js-actions-panel')).to have_text 'Mark inactive'
+  #         expect(find(".js-actions-panel")).to have_text "Mark inactive"
   #       end
 
-  #       it 'opens the action modal and executes the action' do
+  #       it "opens the action modal and executes the action" do
   #         visit url
-  #         expect(find_field_value_element('active')).to have_css 'svg[data-checked="1"]'
+  #         expect(find_field_value_element("active")).to have_css "svg[data-checked="1"]"
 
-  #         click_on 'Actions'
-  #         click_on 'Mark inactive'
+  #         click_on "Actions"
+  #         click_on "Mark inactive"
 
-  #         expect(find('.vm--modal')).to have_text 'Mark inactive'
-  #         expect(find('.vm--modal')).to have_text 'Notify user'
-  #         expect(find('.vm--modal')).to have_text 'Message'
-  #         expect(find('.vm--modal #message').value).to eq 'Your account has been marked as inactive.'
+  #         expect(find(".vm--modal")).to have_text "Mark inactive"
+  #         expect(find(".vm--modal")).to have_text "Notify user"
+  #         expect(find(".vm--modal")).to have_text "Message"
+  #         expect(find(".vm--modal #message").value).to eq "Your account has been marked as inactive."
 
-  #         check 'notify_user'
-  #         fill_in 'message', with: 'Your account has been marked as very inactive.'
+  #         check "notify_user"
+  #         fill_in "message", with: "Your account has been marked as very inactive."
 
-  #         click_on 'Run'
+  #         click_on "Run"
   #         wait_for_loaded
 
-  #         expect(page).to have_text 'Perfect!'
+  #         expect(page).to have_text "Perfect!"
   #         expect(user.reload.active).to be false
-  #         expect(find_field_value_element('active')).to have_css 'svg[data-checked="0"]'
+  #         expect(find_field_value_element("active")).to have_css "svg[data-checked="0"]"
   #       end
 
-  #       it 'executes the action without confirmation' do
+  #       it "executes the action without confirmation" do
   #         visit url
 
-  #         expect(find_field_value_element('roles').find('svg', match: :first)['data-checked']).to eq '0'
+  #         expect(find_field_value_element("roles").find("svg", match: :first)["data-checked"]).to eq "0"
 
-  #         click_on 'Actions'
-  #         click_on 'Make admin'
+  #         click_on "Actions"
+  #         click_on "Make admin"
 
   #         sleep 0.2
   #         wait_for_loaded
 
-  #         expect(user.reload.roles['admin']).to be true
-  #         expect(find_field_value_element('roles').find('svg', match: :first)['data-checked']).to eq '1'
+  #         expect(user.reload.roles["admin"]).to be true
+  #         expect(find_field_value_element("roles").find("svg", match: :first)["data-checked"]).to eq "1"
   #       end
   #     end
 
-  #     describe 'without fields' do
+  #     describe "without fields" do
   #       let(:url) { "/admin/resources/posts/#{post.id}" }
 
-  #       it 'lists the action with a custom name' do
+  #       it "lists the action with a custom name" do
   #         visit url
 
-  #         click_on 'Actions'
+  #         click_on "Actions"
 
-  #         expect(find('.js-actions-panel')).to have_text 'Toggle post published'
+  #         expect(find(".js-actions-panel")).to have_text "Toggle post published"
   #       end
 
-  #       it 'opens the action modal and executes the action' do
+  #       it "opens the action modal and executes the action" do
   #         visit url
 
-  #         click_on 'Actions'
-  #         click_on 'Toggle post published'
+  #         click_on "Actions"
+  #         click_on "Toggle post published"
 
-  #         expect(find('.vm--modal')).to have_text 'Toggle post published'
-  #         expect(find('.vm--modal')).to have_text 'Are you sure, sure?'
-  #         expect(find('.vm--modal')).to have_text 'Toggle'
-  #         expect(find('.vm--modal')).to have_text "Don't toggle yet"
+  #         expect(find(".vm--modal")).to have_text "Toggle post published"
+  #         expect(find(".vm--modal")).to have_text "Are you sure, sure?"
+  #         expect(find(".vm--modal")).to have_text "Toggle"
+  #         expect(find(".vm--modal")).to have_text "Don"t toggle yet"
 
-  #         click_on 'Toggle'
+  #         click_on "Toggle"
 
-  #         expect(page).to have_text 'Perfect!'
+  #         expect(page).to have_text "Perfect!"
   #         expect(post.reload.published_at).not_to be nil
-  #         expect(current_path).to eq '/admin/resources/posts'
+  #         expect(current_path).to eq "/admin/resources/posts"
   #       end
   #     end
   #   end

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe "Actions", type: :system do
       visit "/admin/resources/users/#{user.slug}/actions/toggle_inactive"
 
       expect(page).to have_field "fields[notify_user]", checked: true
-      expect(page).to have_field "fields[message]", text: "Your account has been marked as inactive."
+      expect(page).to have_field "fields[message]", with: "Your account has been marked as inactive."
     end
   end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1343

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to a user
1. Open the "toggle inactive" action
2. Observe the default values applied

Manual reviewer: please leave a comment with output from the test if that's the case.
