### PR TITLE
feature: stacked fields by default

### DIFF
--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -41,7 +41,7 @@ class Avo::FieldWrapperComponent < ViewComponent::Base
   end
 
   def classes(extra_classes = "")
-    "relative flex flex-col flex-grow pb-2 md:pb-0 leading-tight min-h-14 #{stacked? ? "" : "md:flex-row md:items-center"} #{@classes || ""} #{extra_classes || ""} #{@field.get_html(:classes, view: view, element: :wrapper)}"
+    "relative flex flex-col flex-grow pb-2 md:pb-0 leading-tight min-h-14 #{stacked? ? "field-wrapper-layout-stacked" : "field-wrapper-layout-inline md:flex-row md:items-center"} #{@classes || ""} #{extra_classes || ""} #{@field.get_html(:classes, view: view, element: :wrapper)}"
   end
 
   def style

--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -19,7 +19,7 @@ class Avo::FieldWrapperComponent < ViewComponent::Base
     full_width: false,
     label: nil, # do we really need it?
     resource: nil,
-    stacked: false,
+    stacked: nil,
     style: "",
     view: :show,
     **args
@@ -91,7 +91,14 @@ class Avo::FieldWrapperComponent < ViewComponent::Base
   end
 
   def stacked?
-    @stacked
+    # Override on the declaration level
+    return @stacked unless @stacked.nil?
+
+    # Fetch it from the field
+    return field.stacked unless field.stacked.nil?
+
+    # Fallback to defaults
+    Avo.configuration.field_wrapper_layout == :stacked
   end
 
   def compact?

--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -41,7 +41,7 @@ class Avo::FieldWrapperComponent < ViewComponent::Base
   end
 
   def classes(extra_classes = "")
-    "relative flex flex-col flex-grow pb-2 md:pb-0 leading-tight min-h-14 #{stacked? ? "field-wrapper-layout-stacked" : "field-wrapper-layout-inline md:flex-row md:items-center"} #{@classes || ""} #{extra_classes || ""} #{@field.get_html(:classes, view: view, element: :wrapper)}"
+    "relative flex flex-col flex-grow pb-2 md:pb-0 leading-tight min-h-14 #{stacked? ? "field-wrapper-layout-stacked" : "field-wrapper-layout-inline md:flex-row md:items-center"} #{compact? ? "field-wrapper-size-compact" : "field-wrapper-size-regular"} #{@classes || ""} #{extra_classes || ""} #{@field.get_html(:classes, view: view, element: :wrapper)}"
   end
 
   def style

--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -41,7 +41,7 @@ class Avo::FieldWrapperComponent < ViewComponent::Base
   end
 
   def classes(extra_classes = "")
-    "relative flex flex-col flex-grow pb-2 md:pb-0 leading-tight min-h-14 #{stacked? ? "field-wrapper-layout-stacked" : "field-wrapper-layout-inline md:flex-row md:items-center"} #{compact? ? "field-wrapper-size-compact" : "field-wrapper-size-regular"} #{@classes || ""} #{extra_classes || ""} #{@field.get_html(:classes, view: view, element: :wrapper)}"
+    "relative flex flex-col flex-grow pb-2 md:pb-0 leading-tight min-h-14 #{stacked? ? "field-wrapper-layout-stacked" : "field-wrapper-layout-inline md:flex-row md:items-center"} #{compact? ? "field-wrapper-size-compact" : "field-wrapper-size-regular"} #{full_width? ? "field-width-full" : "field-width-regular"} #{@classes || ""} #{extra_classes || ""} #{@field.get_html(:classes, view: view, element: :wrapper)}"
   end
 
   def style

--- a/app/components/avo/fields/edit_component.rb
+++ b/app/components/avo/fields/edit_component.rb
@@ -12,7 +12,7 @@ class Avo::Fields::EditComponent < ViewComponent::Base
   attr_reader :stacked
   attr_reader :view
 
-  def initialize(field: nil, resource: nil, index: 0, form: nil, compact: false, stacked: false, multiple: false, **kwargs)
+  def initialize(field: nil, resource: nil, index: 0, form: nil, compact: false, stacked: nil, multiple: false, **kwargs)
     @compact = compact
     @field = field
     @form = form

--- a/app/components/avo/fields/show_component.rb
+++ b/app/components/avo/fields/show_component.rb
@@ -10,7 +10,7 @@ class Avo::Fields::ShowComponent < ViewComponent::Base
   attr_reader :stacked
   attr_reader :view
 
-  def initialize(field: nil, resource: nil, index: 0, form: nil, compact: false, stacked: false)
+  def initialize(field: nil, resource: nil, index: 0, form: nil, compact: false, stacked: nil)
     @compact = compact
     @field = field
     @index = index

--- a/app/components/avo/item_switcher_component.html.erb
+++ b/app/components/avo/item_switcher_component.html.erb
@@ -7,7 +7,10 @@
     <% c.body do %>
       <div class="divide-y">
         <% item.items.each_with_index do |field, index| %>
-          <%= render field.hydrate(resource: @resource, model: @resource.model, user: resource.user, view: view).component_for_view(view).new(field: field, resource: @resource, index: index, form: form) %>
+          <%= render field
+            .hydrate(resource: @resource, model: @resource.model, user: resource.user, view: view)
+            .component_for_view(view)
+            .new(field: field, resource: @resource, index: index, form: form) %>
         <% end %>
       </div>
     <% end %>

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -38,6 +38,7 @@ module Avo
     attr_accessor :tabs_style
     attr_accessor :resource_default_view
     attr_accessor :authorization_client
+    attr_accessor :field_wrapper_layout
     attr_writer :branding
 
     def initialize
@@ -87,6 +88,7 @@ module Avo
       @tabs_style = :tabs
       @resource_default_view = :show
       @authorization_client = :pundit
+      @field_wrapper_layout = :inline
     end
 
     def current_user_method(&block)

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -36,6 +36,7 @@ module Avo
       attr_reader :as_avatar
       attr_reader :as_description
       attr_reader :index_text_align
+      attr_reader :stacked
 
       # Private options
       attr_reader :updatable
@@ -78,6 +79,7 @@ module Avo
         @html = args[:html] || nil
         @view = args[:view] || nil
         @value = args[:value] || nil
+        @stacked = args[:stacked] || nil
 
         @args = args
 

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -59,6 +59,7 @@ Avo.configure do |config|
   # config.resource_controls = :right
   # config.tabs_style = :tabs # can be :tabs or :pills
   # config.buttons_on_form_footers = true
+  # config.field_wrapper_layout = true
 
   ## == Branding ==
   # config.branding = {

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -19,7 +19,7 @@ class UserResource < Avo::BaseResource
   field :id, as: :id, link_to_resource: true
   field :email, as: :gravatar, link_to_resource: true, as_avatar: :circle, only_on: :index
   heading "User Information"
-  field :first_name, as: :text, placeholder: "John"
+  field :first_name, as: :text, placeholder: "John", stacked: true
   field :last_name, as: :text, placeholder: "Doe"
   field :email, as: :text, name: "User Email", required: true, protocol: :mailto
   field :active, as: :boolean, name: "Is active", only_on: :index

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -33,6 +33,7 @@ Avo.configure do |config|
   # config.resource_controls_placement = ENV["AVO_RESOURCE_CONTROLS_PLACEMENT"]&.to_sym || :right
   config.resource_default_view = :show
   config.search_debounce = 300
+  # config.field_wrapper_layout = :stacked
 
   ## == Branding ==
   config.branding = {

--- a/spec/features/avo/stacked_wrapper_layout_spec.rb
+++ b/spec/features/avo/stacked_wrapper_layout_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.feature "StackedWrapperLayouts", type: :feature do
+  context "show" do
+    subject { visit avo.resources_user_path admin }
+
+    describe "with default settings" do
+      context "with field default" do
+        it "displays the inline layout" do
+          subject
+
+          expect(field_wrapper(:last_name)[:class]).to include "field-wrapper-layout-inline"
+        end
+      end
+
+      context "with field override to stacked" do
+        it "displays the stacked layout" do
+          subject
+
+          expect(field_wrapper(:first_name)[:class]).to include "field-wrapper-layout-stacked"
+        end
+      end
+    end
+
+    describe "with stacked settings" do
+      around do |example|
+        Avo.configuration.field_wrapper_layout = :stacked
+        example.run
+        Avo.configuration.field_wrapper_layout = :inline
+      end
+
+      context "with field default" do
+        it "displays the stacked layout" do
+          subject
+
+          expect(field_wrapper(:last_name)[:class]).to include "field-wrapper-layout-stacked"
+        end
+      end
+
+      context "with field override to stacked" do
+        it "displays the stacked layout" do
+          subject
+
+          expect(field_wrapper(:first_name)[:class]).to include "field-wrapper-layout-stacked"
+        end
+      end
+    end
+  end
+
+  context "edit" do
+    subject { visit avo.edit_resources_user_path admin }
+
+    describe "with default settings" do
+      context "with field default" do
+        it "displays the inline layout" do
+          subject
+
+          expect(field_wrapper(:last_name)[:class]).to include "field-wrapper-layout-inline"
+        end
+      end
+
+      context "with field override to stacked" do
+        it "displays the stacked layout" do
+          subject
+
+          expect(field_wrapper(:first_name)[:class]).to include "field-wrapper-layout-stacked"
+        end
+      end
+    end
+
+    describe "with stacked settings" do
+      before do
+        Avo.configure do |config|
+          config.field_wrapper_layout = :stacked
+        end
+      end
+
+      context "with field default" do
+        it "displays the stacked layout" do
+          subject
+
+          expect(field_wrapper(:last_name)[:class]).to include "field-wrapper-layout-stacked"
+        end
+      end
+
+      context "with field override to stacked" do
+        it "displays the stacked layout" do
+          subject
+
+          expect(field_wrapper(:first_name)[:class]).to include "field-wrapper-layout-stacked"
+        end
+      end
+    end
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -6,6 +6,10 @@ def find_field_element(field_id)
   find("[data-field-id='#{field_id}']")
 end
 
+def field_wrapper(field_id)
+  find("[data-field-id='#{field_id}']")
+end
+
 def find_field_value_element(field_id)
   find("[data-field-id='#{field_id}'] [data-slot='value']")
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

It allows a developer to set some fields or all of them in a stacked layout instead of inline.

![CleanShot 2022-10-24 at 12 49 13](https://user-images.githubusercontent.com/1334409/197499169-b4e9deea-a66f-4fc1-beba-10065e9fe1c2.jpg)


# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to the initializer and edit the `field_wrapper_layout` option to `:stacked`
2. See the show and edit views for a resource
3. observe that all the fields are stacked

---

1. Reset the initializer to how it was (`:inline`)
1. Go to the user and observe that only the `first_name` field is stacked. The rest are inline.

Manual reviewer: please leave a comment with output from the test if that's the case.
