### PR TITLE
feature: label and content available in the html option

### DIFF
--- a/app/components/avo/field_wrapper_component.html.erb
+++ b/app/components/avo/field_wrapper_component.html.erb
@@ -2,18 +2,16 @@
   class: classes,
   style: style,
   data: data do %>
-  <div class="h-full <% if stacked? %> md:pt-4 <% else %> md:pt-0 md:h-14 <% end %> pt-4 flex self-start items-center text-slate-800">
-    <div class="w-48 <% if compact? %> md:w-48 xl:w-64 <% else %> md:w-64 <% end %> px-6 flex uppercase font-semibold text-gray-500 text-sm" data-slot="label">
-      <% if form.present? %>
-        <%= form.label field.id, label %>
-      <% else %>
-        <%= field.name %>
-      <% end %>
-      <% if on_edit? && field.is_required? %> <span class="text-red-600 ml-1">*</span> <% end %>
-    </div>
+  <div class="h-full <% if stacked? %> md:pt-4 <% else %> md:pt-0 md:h-14 <% end %> pt-4 flex self-start items-center <%= @field.get_html(:classes, view: view, element: :label) %> w-48 <% if compact? %> md:w-48 xl:w-64 <% else %> md:w-64 <% end %> px-6 uppercase font-semibold text-gray-500 text-sm" data-slot="label">
+    <% if form.present? %>
+      <%= form.label field.id, label %>
+    <% else %>
+      <%= field.name %>
+    <% end %>
+    <% if on_edit? && field.is_required? %> <span class="text-red-600 ml-1">*</span> <% end %>
   </div>
-  <div class="flex-1 flex flex-row md:min-h-inherit py-2 <% if stacked? %> pb-4 <% else %><% end %> px-6">
-    <div class="self-center <% if full_width? || compact? || stacked? %> w-full <% else %> md:w-8/12 <% end %>" data-slot="value">
+  <div class="flex-1 flex flex-row md:min-h-inherit py-2 <% if stacked? %> pb-4 <% else %><% end %> px-6 <%= @field.get_html(:classes, view: view, element: :content) %>" data-slot="value">
+    <div class="self-center <% if full_width? || compact? || stacked? %> w-full <% else %> md:w-8/12 <% end %>">
       <% if on_show? %>
         <% if field.value.blank? and dash_if_blank %>
           —

--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -41,7 +41,7 @@ class Avo::FieldWrapperComponent < ViewComponent::Base
   end
 
   def classes(extra_classes = "")
-    "relative flex flex-col flex-grow pb-2 md:pb-0 leading-tight min-h-14 #{stacked? ? "field-wrapper-layout-stacked" : "field-wrapper-layout-inline md:flex-row md:items-center"} #{compact? ? "field-wrapper-size-compact" : "field-wrapper-size-regular"} #{full_width? ? "field-width-full" : "field-width-regular"} #{@classes || ""} #{extra_classes || ""} #{@field.get_html(:classes, view: view, element: :wrapper)}"
+    "field-wrapper relative flex flex-col flex-grow pb-2 md:pb-0 leading-tight min-h-14 #{stacked? ? "field-wrapper-layout-stacked" : "field-wrapper-layout-inline md:flex-row md:items-center"} #{compact? ? "field-wrapper-size-compact" : "field-wrapper-size-regular"} #{full_width? ? "field-width-full" : "field-width-regular"} #{@classes || ""} #{extra_classes || ""} #{@field.get_html(:classes, view: view, element: :wrapper)}"
   end
 
   def style

--- a/app/components/avo/views/resource_edit_component.html.erb
+++ b/app/components/avo/views/resource_edit_component.html.erb
@@ -1,6 +1,8 @@
 <%= content_tag :div,
   data: {
-    'model-id': @resource.model.id,
+    model_name: @resource.model_name.to_s,
+    resource_name: @resource.class.to_s,
+    model_id: @resource.model.id,
     selected_resources_name: @resource.model_key,
     selected_resources: [@resource.model.id],
     **@resource.stimulus_data_attributes

--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -1,5 +1,7 @@
 <%= content_tag :div,
   data: {
+    model_name: @resource.model_name.to_s,
+    resource_name: @resource.class.to_s,
     **@resource.stimulus_data_attributes
   } do %>
   <%= render Avo::PanelComponent.new(name: title, description: description, data: { component: 'resources-index' }, display_breadcrumbs: @reflection.blank?) do |c| %>

--- a/app/components/avo/views/resource_show_component.html.erb
+++ b/app/components/avo/views/resource_show_component.html.erb
@@ -1,6 +1,8 @@
 <%= content_tag :div,
   data: {
-    'model-id': @resource.model.id,
+    model_name: @resource.model_name.to_s,
+    resource_name: @resource.class.to_s,
+    model_id: @resource.model.id,
     selected_resources_name: @resource.model_key,
     selected_resources: [@resource.model.id],
     **@resource.stimulus_data_attributes

--- a/db/factories.rb
+++ b/db/factories.rb
@@ -90,10 +90,10 @@ FactoryBot.define do
   end
 
   factory :product do
-    title { "MyString" }
-    description { "MyText" }
-    price { 1 }
-    status { "MyString" }
-    category { "MyString" }
+    title { Faker::App.name }
+    description { Faker::Lorem.paragraphs(number: rand(1...3)).join("\n") }
+    price { rand(10000..999000) }
+    status { "status" }
+    category { ::Product.categories.values.sample }
   end
 end

--- a/lib/avo/html/builder.rb
+++ b/lib/avo/html/builder.rb
@@ -13,6 +13,8 @@ class Avo::HTML::Builder
   attr_accessor :edit_stack
   attr_accessor :index_stack
   attr_accessor :input_stack
+  attr_accessor :label_stack
+  attr_accessor :content_stack
 
   attr_accessor :record
   attr_accessor :resource
@@ -30,6 +32,8 @@ class Avo::HTML::Builder
     @edit_stack = {}
     @index_stack = {}
     @input_stack = {}
+    @label_stack = {}
+    @content_stack = {}
 
     @record = record
     @resource = resource
@@ -75,6 +79,16 @@ class Avo::HTML::Builder
   # Takes a block
   def input(&block)
     capture_block :input, &block
+  end
+
+  # Takes a block
+  def label(&block)
+    capture_block :label, &block
+  end
+
+  # Takes a block
+  def content(&block)
+    capture_block :content, &block
   end
 
   # Takes a block

--- a/spec/dummy/app/avo/resources/product_resource.rb
+++ b/spec/dummy/app/avo/resources/product_resource.rb
@@ -4,7 +4,16 @@ class ProductResource < Avo::BaseResource
   self.default_view_type = :grid
 
   field :id, as: :id
-  field :title, as: :text
+  field :title, as: :text, html: {
+    show: {
+      label: {
+        classes: "bg-gray-50 !text-pink-600"
+      },
+      content: {
+        classes: "bg-gray-50 !text-pink-600"
+      }
+    }
+  }
   field :description, as: :trix
   field :image, as: :file, is_image: true
   field :price, as: :number
@@ -14,7 +23,7 @@ class ProductResource < Avo::BaseResource
     cover :image, as: :file, is_image: true, link_to_resource: true, html: {
       index: {
         wrapper: {
-          style: 'background: pink;'
+          style: "background: pink;"
         }
       }
     }

--- a/spec/features/avo/html_attribute_spec.rb
+++ b/spec/features/avo/html_attribute_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.feature "HtmlAttributes", type: :feature do
+  let(:product) { create :product }
+
+  context "on show" do
+    it "renders the html attributes" do
+      visit avo.resources_product_path product
+
+      expect(field_wrapper(:title).find('[data-slot="value"]')[:class]).to include "bg-gray-50 !text-pink-600"
+      expect(field_wrapper(:title).find('[data-slot="label"]')[:class]).to include "bg-gray-50 !text-pink-600"
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds the `label` and `content` helpers to the [`html` option](https://docs.avohq.io/2.0/stimulus-integration.html#attach-html-attributes).

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
