### PR TITLE
Don't swallow errors with labels and descriptions

### DIFF
--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -421,9 +421,7 @@ module Avo
     end
 
     def label
-      label_field.value || model_title
-    rescue
-      model_title
+      label_field&.value || model_title
     end
 
     def avatar_field
@@ -459,9 +457,7 @@ module Avo
     end
 
     def description
-      description_field.value
-    rescue
-      nil
+      description_field&.value
     end
 
     def form_scope


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Previously if there was an error thrown from the block for label or description fields, it would be silently swallowed and not show in the logs that there was an error.

Fixes # (issue)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

To reproduce, set `as_label: true` on a field, give the field a block and then throw an error inside the block. On main the error never appears, on this branch it is raised in the logs.

Manual reviewer: please leave a comment with output from the test if that's the case.
