### PR TITLE
Feature Request | Allow panels or fields to be inserted to main panel or sidebar in edit/new pages

### DIFF
--- a/lib/avo/concerns/has_fields.rb
+++ b/lib/avo/concerns/has_fields.rb
@@ -311,6 +311,14 @@ module Avo
         [main_panel, *panelfull_items]
       end
 
+      def sidebar_items
+
+      end
+
+      def main_panel_items
+
+      end
+
       private
 
       def check_license

--- a/lib/avo/menu/base_item.rb
+++ b/lib/avo/menu/base_item.rb
@@ -10,6 +10,8 @@ class Avo::Menu::BaseItem
   option :name, default: proc { "" }
   option :visible, default: proc { true }
   option :data, default: proc { {} }
+  option :sidebar_item, optional: false
+  option :main_panel_item, optional: false
 
   def visible?
     return visible if visible.in? [true, false]


### PR DESCRIPTION
# Description
Draft PR for a new feature that will enable the items such as field or panel to be inserted to main panel or sidebar in new/edit pages with new options in the base_item 

```
option :sidebar_item, optional: false
option :main_panel_item, optional: false
```

Fixes # (issue)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


