### PR TITLE
fix: may-download-file data attr missing on action form

### DIFF
--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -34,9 +34,9 @@ module Avo
       def form_data_attributes
         # We can't respond with a file download from Turbo se we disable it on the form
         if may_download_file
-          {turbo: false, remote: false}
+          {turbo: false, remote: false, action_target: :form}
         else
-          {"turbo-frame": "_top", "action-target": "form"}
+          {turbo_frame: :_top, action_target: :form}
         end
       end
 

--- a/spec/dummy/app/avo/actions/export_csv.rb
+++ b/spec/dummy/app/avo/actions/export_csv.rb
@@ -1,0 +1,31 @@
+class ExportCsv < Avo::BaseAction
+  self.name = "Export csv"
+  self.no_confirmation = false
+  self.may_download_file = true
+
+  def handle(**args)
+    models, resource = args.values_at(:models, :resource)
+
+    return fail "No record selected" if models.blank?
+
+    attributes = get_attributes models.first
+
+    file = CSV.generate(headers: true) do |csv|
+      csv << attributes
+
+      models.each do |record|
+        csv << attributes.map do |attr|
+          record.send(attr)
+        end
+      end
+    end
+
+    download file, "#{resource.plural_name}.csv"
+  end
+
+  def get_attributes(record)
+    # return ["id", "created_at"] # uncomment this and fill in for custom model properties
+
+    record.class.columns_hash.keys
+  end
+end

--- a/spec/dummy/app/avo/resources/project_resource.rb
+++ b/spec/dummy/app/avo/resources/project_resource.rb
@@ -35,6 +35,8 @@ class ProjectResource < Avo::BaseResource
   field :comments, as: :has_many, searchable: true
   field :reviews, as: :has_many
 
+  action ExportCsv
+
   # filter PeopleFilter
   # filter People2Filter
   # filter FeaturedFilter

--- a/spec/dummy/app/policies/project_policy.rb
+++ b/spec/dummy/app/policies/project_policy.rb
@@ -47,6 +47,10 @@ class ProjectPolicy < ApplicationPolicy
     true
   end
 
+  def act_on?
+    true
+  end
+
   class Scope < Scope
     def resolve
       scope.all

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
   # config.assets.debug = true
 
   # Suppress logger output for asset requests.
-  config.assets.quiet = true
+  # config.assets.quiet = true
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
@@ -69,7 +69,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = {host: "localhost", port: 3030}
 
   config.action_view.logger = nil
-  config.assets.logger = nil
+  # config.assets.logger = nil
 
   config.hotwire_livereload.listen_paths << Avo::Engine.root.join("app/assets/stylesheets")
   config.hotwire_livereload.listen_paths << Rails.root.join("app/avo")


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where a data attribute was missing.
Add an export to CSV action.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to projects
2. use the export to csv action

Manual reviewer: please leave a comment with output from the test if that's the case.
