### PR TITLE
Pass resource to default

### DIFF
--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -170,7 +170,7 @@ module Avo
         if @view.in?([:new, :create]) || @action.present?
           if default.present?
             final_value = if default.respond_to?(:call)
-              default.call
+              default.call resource: @resource
             else
               default
             end

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -170,7 +170,12 @@ module Avo
         if @view.in?([:new, :create]) || @action.present?
           if default.present?
             final_value = if default.respond_to?(:call)
-              default.call resource: @resource
+              # support parameters and no parameters to maintain original behavior
+              if default.call.arity.zero?
+                default.call
+              else
+                default.call resource: @resource
+              end
             else
               default
             end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
At the moment if a block is passed to default it is executed in isolation. It would be very useful to be able to access the model or the resource in default so that a default can be set that is based on parameters or other attributes (similar to how we can with visible).

Fixes # (issue)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Set a default value for an attribute that takes a parameter and uses the resource to calculate a default value
2. Make sure this works and doesn't crash avo

Manual reviewer: please leave a comment with output from the test if that's the case.
