### PR TITLE
Support virtual_attributes in key_value field

### DIFF
--- a/lib/avo/fields/key_value_field.rb
+++ b/lib/avo/fields/key_value_field.rb
@@ -81,7 +81,7 @@ module Avo
           new_value = {}
         end
 
-        model[key] = new_value
+        model.send("#{key}=", new_value)
 
         model
       end


### PR DESCRIPTION
# Description
Key value fields only appear to work with ActiveRecord attributes. In order to support virtual attributes (and real attributes) a subtle code change is needed.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
