### PR TITLE
Add missing pundit dependency

### DIFF
--- a/avo.gemspec
+++ b/avo.gemspec
@@ -46,4 +46,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-initializer"
   spec.add_dependency "docile"
   spec.add_dependency "inline_svg"
+  spec.add_dependency "pundit"
 end


### PR DESCRIPTION
# Description
I just did a fresh install and I got the following error `uninitialized constant Avo::Services::AuthorizationClients::PunditClient::Pundit`

<a href="https://ibb.co/GsjSZdb"><img src="https://i.ibb.co/M8L0zg3/avo-error.png" alt="avo-error" border="0"></a>


Fixes # (issue)
add the pundit dependency 


