### PR TITLE
fix: destroy the search modal when disconnected

### DIFF
--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -110,6 +110,8 @@ export default class extends Controller {
   }
 
   disconnect() {
+    // Don't leave open autocompletes around when disconnected. Otherwise it will still
+    // be visible when navigating back to this page.
     if (this.destroyMethod) {
       this.destroyMethod();
       this.destroyMethod = nil;

--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -113,8 +113,8 @@ export default class extends Controller {
     // Don't leave open autocompletes around when disconnected. Otherwise it will still
     // be visible when navigating back to this page.
     if (this.destroyMethod) {
-      this.destroyMethod();
-      this.destroyMethod = nil;
+      this.destroyMethod()
+      this.destroyMethod = nil
     }
   }
 

--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -76,7 +76,7 @@ export default class extends Controller {
     // This line fixes a bug where the search box would be duplicated on back navigation.
     this.autocompleteTarget.innerHTML = ''
 
-    autocomplete({
+    const { destroy } = autocomplete({
       container: this.autocompleteTarget,
       placeholder: this.translationKeys.placeholder,
       translations: {
@@ -101,11 +101,18 @@ export default class extends Controller {
     })
 
     // document.addEventListener('turbo:before-render', destroy)
-    // this.destroyMethod = destroy
+    this.destroyMethod = destroy
 
     // When using search for belongs-to
     if (this.buttonTarget.dataset.shouldBeDisabled !== 'true') {
       this.buttonTarget.removeAttribute('disabled')
+    }
+  }
+
+  disconnect() {
+    if (this.destroyMethod) {
+      this.destroyMethod();
+      this.destroyMethod = nil;
     }
   }
 


### PR DESCRIPTION
# Description
The Algolia `autocomplete()` method returns a `destroy` method. We hold a pointer to this and call it when the controller is disconnected. This addresses a problem where a zombie search would remain on screen when navigating back.

Fixes #1365

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
1. Perform a global or resource search
1. Select one of the search results
1. Click the browser back button

**What should happen:** The search modal should no longer be visible when you navigate back.