### PR TITLE
fix: don't raise errors on community when pundit is missing

### DIFF
--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -48,6 +48,8 @@ module Avo
   class NotAuthorizedError < StandardError; end
 
   class NoPolicyError < StandardError; end
+
+  class MissingGemError < StandardError; end
 end
 
 loader.eager_load

--- a/lib/avo/services/authorization_clients/nil_client.rb
+++ b/lib/avo/services/authorization_clients/nil_client.rb
@@ -1,0 +1,37 @@
+module Avo
+  module Services
+    module AuthorizationClients
+      class NilClient
+        def authorize(user, record, action, policy_class: nil)
+          true
+        end
+
+        def policy(user, record)
+          NilPolicy.new
+        end
+
+        def policy!(user, record)
+          NilPolicy.new
+        end
+
+        def apply_policy(user, model, policy_class: nil)
+          model
+        end
+
+        class NilPolicy
+          def initialize(user = nil, record = nil)
+          end
+          # rubocop:enable Style/RedundantInitialize
+
+          def method_missing(method, *args, &block)
+            self
+          end
+
+          def respond_to_missing?
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/avo/services/authorization_service.rb
+++ b/lib/avo/services/authorization_service.rb
@@ -9,8 +9,12 @@ module Avo
         def client
           client = Avo.configuration.authorization_client
 
+          client = nil if Avo::App.license.lacks(:authorization)
+
           klass = case client
-          when :pundit, nil
+          when nil
+            nil_client
+          when :pundit
             pundit_client
           else
             if client.is_a?(String)
@@ -92,7 +96,13 @@ module Avo
         end
 
         def pundit_client
+          raise Avo::MissingGemError.new("Please add `gem 'pundit'` to your Gemfile.") unless defined?(Pundit)
+
           Avo::Services::AuthorizationClients::PunditClient
+        end
+
+        def nil_client
+          Avo::Services::AuthorizationClients::NilClient
         end
       end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where community version requires `pundit` even if it doesn't use it.

From https://github.com/avo-hq/avo/pull/1384

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Use Avo on Community license
2. Don't require `pundit` in the `Gemfile`
1. Observe that everything is running

Manual reviewer: please leave a comment with output from the test if that's the case.
