### PR TITLE
feature: default executes in host

### DIFF
--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -114,7 +114,7 @@ export default class extends Controller {
     // be visible when navigating back to this page.
     if (this.destroyMethod) {
       this.destroyMethod()
-      this.destroyMethod = nil
+      this.destroyMethod = null
     }
   }
 

--- a/lib/avo/fields/concerns/has_default.rb
+++ b/lib/avo/fields/concerns/has_default.rb
@@ -1,0 +1,17 @@
+module Avo
+  module Fields
+    module Concerns
+      module HasDefault
+        extend ActiveSupport::Concern
+
+        def computed_default_value
+          if default.respond_to? :call
+            Avo::Hosts::ResourceViewRecordHost.new(block: default, record: model, view: view, resource: resource).handle
+          else
+            default
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/avo/fields/concerns/is_readonly.rb
+++ b/lib/avo/fields/concerns/is_readonly.rb
@@ -6,7 +6,7 @@ module Avo
 
         def is_readonly?
           if readonly.respond_to? :call
-            Avo::Hosts::ViewRecordHost.new(block: readonly, record: model, view: view).handle
+            Avo::Hosts::ResourceViewRecordHost.new(block: required, record: model, view: view, resource: resource).handle
           else
             readonly
           end

--- a/lib/avo/fields/concerns/is_readonly.rb
+++ b/lib/avo/fields/concerns/is_readonly.rb
@@ -6,7 +6,7 @@ module Avo
 
         def is_readonly?
           if readonly.respond_to? :call
-            Avo::Hosts::ResourceViewRecordHost.new(block: required, record: model, view: view, resource: resource).handle
+            Avo::Hosts::ResourceViewRecordHost.new(block: readonly, record: model, view: view, resource: resource).handle
           else
             readonly
           end

--- a/lib/avo/fields/concerns/is_required.rb
+++ b/lib/avo/fields/concerns/is_required.rb
@@ -6,7 +6,7 @@ module Avo
 
         def is_required?
           if required.respond_to? :call
-            Avo::Hosts::ViewRecordHost.new(block: required, record: model, view: view).handle
+            Avo::Hosts::ResourceViewRecordHost.new(block: required, record: model, view: view, resource: resource).handle
           else
             required.nil? ? required_from_validators : required
           end
@@ -18,7 +18,7 @@ module Avo
           return false if model.nil?
 
           validators.any? do |validator|
-            validator.kind_of? ActiveModel::Validations::PresenceValidator
+            validator.is_a? ActiveModel::Validations::PresenceValidator
           end
         end
 

--- a/lib/avo/hosts/resource_view_record_host.rb
+++ b/lib/avo/hosts/resource_view_record_host.rb
@@ -1,0 +1,7 @@
+module Avo
+  module Hosts
+    class ResourceViewRecordHost < ViewRecordHost
+      option :resource
+    end
+  end
+end

--- a/spec/features/avo/default_field_spec.rb
+++ b/spec/features/avo/default_field_spec.rb
@@ -68,4 +68,29 @@ RSpec.describe "DefaultField", type: :feature do
       end
     end
   end
+
+  describe "with a computed default value" do
+    before :all do
+      TeamResource.with_temporary_items do
+        field :name, as: :text, default: -> do
+          result = []
+          result << resource.class.to_s
+          result << view.to_s
+          result << record.class.to_s
+
+          result.join " - "
+        end
+      end
+    end
+
+    after :all do
+      TeamResource.restore_items_from_backup
+    end
+
+    it "fills the field with a computed default value" do
+      visit avo.new_resources_team_path
+
+      expect(page).to have_field id: "team_name", with: "TeamResource - new - Team"
+    end
+  end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds the ability to access the `resource`, `record`, `view` and more in the default block.

Alternative to https://github.com/avo-hq/avo/pull/1380

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

