### PR TITLE
init script may be run repeatedly without error

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -13,10 +13,10 @@ app_root do
   current_upstream = `git config --get remote.upstream.url`.chomp
   if current_upstream.nil? || current_upstream.empty?
     puts "Adding new remote 'upstream' to #{target_upstream}"
-    `git remote add upstream #{target_upstream}`
+    run! "git remote add upstream #{target_upstream}"
   elsif current_upstream != target_upstream
     puts "Updating existing remote 'upstream' to #{target_upstream}"
-    `git remote set-url upstream #{target_upstream}`
+    run! "git remote set-url upstream #{target_upstream}"
   else
     puts "Remote 'upstream' already points to #{target_upstream}, no change"
   end

--- a/bin/init
+++ b/bin/init
@@ -9,7 +9,17 @@ app_root do
   )
 
   header 'Configuring git'
-  run! 'git remote add upstream https://github.com/avo-hq/avo.git'
+  target_upstream = "https://github.com/avo-hq/avo.git"
+  current_upstream = `git config --get remote.upstream.url`.chomp
+  if current_upstream.nil? || current_upstream.empty?
+    puts "Adding new remote 'upstream' to #{target_upstream}"
+    `git remote add upstream #{target_upstream}`
+  elsif current_upstream != target_upstream
+    puts "Updating existing remote 'upstream' to #{target_upstream}"
+    `git remote set-url upstream #{target_upstream}`
+  else
+    puts "Remote 'upstream' already points to #{target_upstream}, no change"
+  end
 
   header 'Installing gems'
   run! 'bundle install'


### PR DESCRIPTION
# Description
Init script checks to see if git upstream requires update, does if required, doesn't if doesn't.

~Fixes # (issue)~

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
- Run `bin/init`
- Run `bin/init`
- Great!

Compare to current state:
- Run `bin/init`
- Run `bin/init`
- Error!
