### PR TITLE
Fallback to resources class / link to child resource feature

### DIFF
--- a/app/components/avo/base_component.rb
+++ b/app/components/avo/base_component.rb
@@ -46,8 +46,9 @@ class Avo::BaseComponent < ViewComponent::Base
 
   def parent_or_child_resource
     return @resource unless link_to_child_resource_is_enabled?
+    return @resource if @resource.model.class.base_class == @resource.model.class
 
-    ::Avo::App.get_resource_by_model_name(@resource.model.class).dup
+    ::Avo::App.get_resource_by_model_name(@resource.model.class).dup || @resource
   end
 
   def link_to_child_resource_is_enabled?

--- a/db/factories.rb
+++ b/db/factories.rb
@@ -65,6 +65,11 @@ FactoryBot.define do
     type { "Sibling" }
   end
 
+  factory :brother do
+    name { "#{Faker::Name.first_name} #{Faker::Name.last_name}" }
+    type { "Brother" }
+  end
+
   factory :fish do
     name { %w[Tilapia Salmon Trout Catfish Pangasius Carp].sample }
   end

--- a/spec/dummy/app/models/brother.rb
+++ b/spec/dummy/app/models/brother.rb
@@ -1,0 +1,14 @@
+# == Schema Information
+#
+# Table name: people
+#
+#  id         :bigint           not null, primary key
+#  name       :string
+#  type       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint
+#  person_id  :bigint
+#
+class Brother < Person
+end

--- a/spec/features/avo/has_many_field_spec.rb
+++ b/spec/features/avo/has_many_field_spec.rb
@@ -144,4 +144,15 @@ RSpec.feature "HasManyField", type: :feature do
       expect(link.course.id).to eq course.id
     end
   end
+
+  describe "same model no resource" do
+    let!(:person) { create :person }
+    let!(:brother) { create :brother }
+
+    it "does not raise an error" do
+      expect {
+        visit "/admin/resources/people"
+      }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Link to child resources
 
A small bug. 
if the parent resource is the same as the base class or if the child class is missing we fallback to the parent class. 
We may as well raise an exception ? 


# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
