### PR TITLE
Make placeholder and help callable

### DIFF
--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -61,7 +61,13 @@ class Avo::FieldWrapperComponent < ViewComponent::Base
   end
 
   def help
-    @help || @field.help
+    help_obj = @help || @field.help
+
+    if help_obj.respond_to?(:call)
+      help_obj.call
+    else
+      help_obj
+    end
   end
 
   def record

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -145,9 +145,11 @@ module Avo
       end
 
       def placeholder
-        return @placeholder if @placeholder.present?
-
-        name
+        if @placeholder.present? && @placeholder.respond_to?(:call)
+          @placeholder.call resource: @resource
+        else
+          @placeholder || name
+        end
       end
 
       def visible?


### PR DESCRIPTION
# Description
This will make the `help` and `placeholder` fields callable.

Fixes # (issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


As a follow-up PR, I'd like to centralize the callable fields to a single pattern and do a full review of all fields to make sure it's consistent. In that PR I can also attempt to update the docs as well.