### PR TITLE
feature: make sign-out path name configurable

### DIFF
--- a/app/components/avo/sidebar_profile_component.rb
+++ b/app/components/avo/sidebar_profile_component.rb
@@ -33,8 +33,11 @@ class Avo::SidebarProfileComponent < ViewComponent::Base
     end
   end
 
+  # The name of the path for destroying the current user session (not the path itself).
   def destroy_user_session_path
-    "destroy_#{Avo.configuration.current_user_resource_name}_session_path".to_sym
+    # If `destroy_user_session_path` is configured, use it. Otherwise construct the
+    # path name based on `current_user_resource_name`.
+    (Avo.configuration.destroy_user_session_path || "destroy_#{Avo.configuration.current_user_resource_name}_session_path").to_sym
   end
 
   def can_destroy_user?

--- a/app/components/avo/sidebar_profile_component.rb
+++ b/app/components/avo/sidebar_profile_component.rb
@@ -33,11 +33,10 @@ class Avo::SidebarProfileComponent < ViewComponent::Base
     end
   end
 
-  # The name of the path for destroying the current user session (not the path itself).
   def destroy_user_session_path
-    # If `destroy_user_session_path` is configured, use it. Otherwise construct the
+    # If `sign_out_path_name` is configured, use it. Otherwise construct the
     # path name based on `current_user_resource_name`.
-    (Avo.configuration.destroy_user_session_path || "destroy_#{Avo.configuration.current_user_resource_name}_session_path").to_sym
+    (Avo.configuration.sign_out_path_name || "destroy_#{Avo.configuration.current_user_resource_name}_session_path").to_sym
   end
 
   def can_destroy_user?

--- a/bin/test
+++ b/bin/test
@@ -7,6 +7,7 @@ export NODE_ENV="test"
 if [[ -z "$1" ]] || [[ "$1" == "unit" ]]; then
   bundle exec rspec ./spec --tag type:feature
   bundle exec rspec ./spec --tag type:controller
+  bundle exec rspec ./spec --tag type:component
 fi;
 
 # Run system tests

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -40,6 +40,7 @@ module Avo
     attr_accessor :resource_default_view
     attr_accessor :authorization_client
     attr_accessor :field_wrapper_layout
+    attr_accessor :destroy_user_session_path
     attr_writer :branding
 
     def initialize

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -40,7 +40,7 @@ module Avo
     attr_accessor :resource_default_view
     attr_accessor :authorization_client
     attr_accessor :field_wrapper_layout
-    attr_accessor :destroy_user_session_path
+    attr_accessor :sign_out_path_name
     attr_writer :branding
 
     def initialize

--- a/spec/components/avo/sidebar_profile_component_spec.rb
+++ b/spec/components/avo/sidebar_profile_component_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe Avo::SidebarProfileComponent, type: :component do
+  before do
+    allow_message_expectations_on_nil
+    allow(Avo::App.license).to receive(:lacks_with_trial) { :menu_editor }.and_return(false)
+  end
+
+  describe 'destroy_user_session_path' do
+    context 'with default configuration' do
+      it "renders sign out link" do
+        with_controller_class Avo::BaseController do      
+          render_inline(described_class.new(user: nil))
+          expect(page).to have_css "form[action='/users/sign_out']", text: "Sign out"
+        end
+      end
+    end
+
+    context 'with missing route' do
+      before do
+        # Change the current_user_resource_name to generate a path
+        # that does not exist
+        Avo.configuration.current_user_resource_name = :missing
+      end
+
+      it "does not render sign out link" do
+        with_controller_class Avo::BaseController do      
+          render_inline(described_class.new(user: nil))
+          expect(page).to_not have_css "form", text: "Sign out"
+        end
+      end
+    end
+
+    context 'with current_user_resource_name' do
+      before do
+        without_partial_double_verification do
+          # Stub an additional route
+          allow(Rails.application.routes.url_helpers).to receive(:destroy_account_session_path).and_return("/accounts/sign_out")
+        end
+
+        Avo.configuration.current_user_resource_name = :account
+      end
+
+      it "renders sign out link" do
+        with_controller_class Avo::BaseController do      
+          render_inline(described_class.new(user: nil))
+          expect(page).to have_css "form[action='/accounts/sign_out']", text: "Sign out"
+        end
+      end
+    end
+
+    context 'with destroy_user_session_path' do
+      before do
+        without_partial_double_verification do
+          # Stub an additional route
+          allow(Rails.application.routes.url_helpers).to receive(:custom_signout_path).and_return("/custom/sign_out")
+        end
+
+        Avo.configuration.destroy_user_session_path = :custom_signout_path
+      end
+
+      it "renders sign out link" do
+        with_controller_class Avo::BaseController do      
+          render_inline(described_class.new(user: nil))
+          expect(page).to have_css "form[action='/custom/sign_out']", text: "Sign out"
+        end
+      end
+    end
+  end
+end

--- a/spec/components/avo/sidebar_profile_component_spec.rb
+++ b/spec/components/avo/sidebar_profile_component_spec.rb
@@ -49,14 +49,14 @@ RSpec.describe Avo::SidebarProfileComponent, type: :component do
       end
     end
 
-    context 'with destroy_user_session_path' do
+    context 'with sign_out_path_name' do
       before do
         without_partial_double_verification do
           # Stub an additional route
-          allow(Rails.application.routes.url_helpers).to receive(:custom_signout_path).and_return("/custom/sign_out")
+          allow(Rails.application.routes.url_helpers).to receive(:custom_sign_out_path).and_return("/custom/sign_out")
         end
 
-        Avo.configuration.destroy_user_session_path = :custom_signout_path
+        Avo.configuration.sign_out_path_name = :custom_sign_out_path
       end
 
       it "renders sign out link" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -100,6 +100,7 @@ RSpec.configure do |config|
   config.include TestHelpers::DisableHQRequest
   config.include Warden::Test::Helpers
   config.include DownloadHelpers
+  config.include ViewComponent::TestHelpers, type: :component
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
# Description
Added a new configuration option called `sign_out_path_name`. This allows callers to completely customize the name of the path that we use in our sign-out menu item.

Note that I have also turned on view component tests so that I could write some unit tests for this. If those were previously off for a reason, though, I can revert this part of the change.

Fixes #1407 

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
1. Verify that the sign-out menu item works if the sign-out path in your app uses the standard name of `destroy_user_session_path`
1. Verify that the sign-out menu item works if your app has a custom name for its sign-out path which you pass into `config.sign_out_path_name`
