### PR TITLE
fix: display model errors on destroy

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -224,6 +224,9 @@ module Avo
         @errors = Array.wrap(exception.message)
       end
 
+      # Add the errors from the model
+      @errors = Array.wrap([@errors, @model.errors.full_messages]).compact
+
       succeeded
     end
 
@@ -483,7 +486,7 @@ module Avo
     end
 
     def destroy_fail_message
-      @errors.present? ? @errors.first : t("avo.failed")
+      @errors.present? ? @errors.join(". ") : t("avo.failed")
     end
 
     def after_destroy_path

--- a/spec/system/model_errors_spec.rb
+++ b/spec/system/model_errors_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.feature "ModelErrors", type: :system do
+  let(:comment) { create :comment }
+
+  around do |example|
+    Comment.before_destroy do
+      errors.add(:base, "Some Errors")
+
+      throw(:abort)
+    end
+
+    example.run
+
+    Comment.before_destroy do
+      false
+    end
+  end
+
+  it "does not swallow errors" do
+    visit "/admin/resources/comments/#{comment.id}"
+
+    accept_alert do
+      click_on "Delete"
+    end
+    wait_for_loaded
+
+    expect(page).to have_text "Some Errors"
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1414

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Add a `before_destroy` callback to a model similar like in the spec.
1. Try and destroy it
2. you should see that error pop up on the screen

Manual reviewer: please leave a comment with output from the test if that's the case.
