### PR TITLE
feature: add dashboard name to page title

### DIFF
--- a/app/controllers/avo/dashboards_controller.rb
+++ b/app/controllers/avo/dashboards_controller.rb
@@ -5,6 +5,7 @@ module Avo
     before_action :set_dashboard, only: :show
 
     def show
+      @page_title = @dashboard.name
     end
 
     private

--- a/spec/system/avo/dashboards_spec.rb
+++ b/spec/system/avo/dashboards_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe "Dashboards", type: :system do
       expect(content).to have_text "Tiny dashboard description"
       expect(content).to have_text "No cards present"
       expect(content).to have_css "[data-target='table-empty-state-svg']"
+
+      expect(page).to have_title "Sales — Avocadelicious"
     end
   end
 
@@ -36,6 +38,8 @@ RSpec.describe "Dashboards", type: :system do
       expect(content).to have_text "The first dashbaord"
       expect(content).not_to have_text "No cards present"
       expect(content).not_to have_css "[data-target='table-empty-state-svg']"
+
+      expect(page).to have_title "Dashy — Avocadelicious"
     end
 
     describe "metric card" do


### PR DESCRIPTION
# Description

Put the dashboard name in the page title to get more descriptive tab names.

<img width="475" alt="image" src="https://user-images.githubusercontent.com/549149/200961579-8b748b51-f2de-4626-b5f2-7672f0720961.png">


# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps

Check page titles on both named and unnamed dashboards. If the dashboard has a name, it will be prepended to the app name in the page title.
