### PR TITLE
bug: enter should submit rather than cancelling action

### DIFF
--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -34,7 +34,8 @@
         </div>
       <% end %>
       <% c.controls do %>
-        <%= a_button data: { action: 'click->modal#close' },
+        <%= a_button type: :button,
+          data: { action: 'click->modal#close' },
           size: :sm,
           color: :gray do %>
           <%= @action.cancel_button_label %>


### PR DESCRIPTION
# Description

[Pressing enter in a form](https://www.w3.org/TR/2018/SPSD-html5-20180327/forms.html#implicit-submission) will trigger the first button of `type="submit"` in the form. "submit" is the [default type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type) for buttons inside a form. Explicitly set `type="button"` on the cancel button so that it won't be triggered by enter. This causes the true submit button to be triggered instead.

Fixes #1427

## Behavior before this change

https://user-images.githubusercontent.com/549149/201212767-6e9f907c-339a-4b3a-96c6-49cf1066adb4.mov

## Behavior after this change

https://user-images.githubusercontent.com/549149/201215161-9b78bacb-d0eb-4d08-ade6-4b841f31b0b5.mov

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps

1. Run the sample app
2. Go to http://localhost:3030/admin/resources/posts/35
3. Click on "Toggle post published"
4. Click into the text field and start typing
5. Hit enter.

I also tested that both buttons still work fine when clicking with the mouse.