### PR TITLE
fix: sidebar group and heading are clickable to collapse/expand

### DIFF
--- a/app/components/avo/sidebar/group_component.html.erb
+++ b/app/components/avo/sidebar/group_component.html.erb
@@ -7,22 +7,28 @@
   <% end %>
 >
   <% if item.name.present? %>
-    <div
-      class="flex justify-between px-10 pr-2 pt-2 pb-0 text-gray-400"
-    >
-      <div class="flex items-center text-xs uppercase font-semibold leading-none">
-        <%= item.name %>
-      </div>
-      <% if collapsable %>
-        <div class="cursor-pointer <%= 'rotate-90' if collapsed %>"
-          data-action="click->menu#triggerCollapse"
+    <% if collapsable %>
+      <div
+        class="flex justify-between cursor-pointer px-10 pr-2 pt-2 pb-0 text-gray-400"
+        data-action="click->menu#triggerCollapse"
+        data-menu-key-param="<%= key %>"
+      >
+        <div class="flex items-center text-xs uppercase font-semibold leading-none">
+          <%= item.name %>
+        </div>
+        <div class="<%= 'rotate-90' if collapsed %>"
           data-menu-target="svg"
-          data-menu-key-param="<%= key %>"
           >
           <%= helpers.svg 'heroicons/outline/chevron-down', class: "h-4 mr-0.5"%>
         </div>
-      <% end %>
-    </div>
+      </div>
+    <% else %>
+      <div class="flex justify-between px-10 pr-2 pt-2 pb-0 text-gray-400">
+        <div class="flex items-center text-xs uppercase font-semibold leading-none">
+          <%= item.name %>
+        </div>
+      </div>
+    <% end %>
   <% end %>
   <div class="w-full space-y-1 <%= 'hidden' if collapsed %>" data-menu-target="items">
     <% items.each do |item| %>

--- a/app/components/avo/sidebar/heading_component.html.erb
+++ b/app/components/avo/sidebar/heading_component.html.erb
@@ -1,14 +1,21 @@
-<div class="flex justify-between px-4 pr-2 py-1 text-gray-500">
-  <div class="flex items-center text-sm uppercase font-semibold leading-none space-x-1">
-    <span class="min-w-[20px]"><%= icon %></span> <span><%= label %></span>
-  </div>
-  <% if collapsable %>
-    <div class="cursor-pointer <%= 'rotate-90' if collapsed %>"
-      data-action="click->menu#triggerCollapse"
-      data-menu-key-param="<%= key %>"
+<% if collapsable %>
+  <div class="flex justify-between cursor-pointer px-4 pr-2 py-1 text-gray-500"
+    data-action="click->menu#triggerCollapse"
+    data-menu-key-param="<%= key %>"
+  >
+    <div class="flex items-center text-sm uppercase font-semibold leading-none space-x-1">
+      <span class="min-w-[20px]"><%= icon %></span> <span><%= label %></span>
+    </div>
+    <div class="<%= 'rotate-90' if collapsed %>"
       data-menu-target="svg"
     >
       <%= helpers.svg 'heroicons/outline/chevron-down', class: 'h-5'%>
     </div>
-  <% end %>
-</div>
+  </div>
+<% else %>
+  <div class="flex justify-between px-4 pr-2 py-1 text-gray-500">
+    <div class="flex items-center text-sm uppercase font-semibold leading-none space-x-1">
+      <span class="min-w-[20px]"><%= icon %></span> <span><%= label %></span>
+    </div>
+  </div>
+<% end %>

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -213,6 +213,13 @@ ActiveRecord::Schema.define(version: 2022_10_11_150126) do
     t.string "color"
   end
 
+  create_table "types", force: :cascade do |t|
+    t.string "title"
+    t.bigint "fish_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "first_name"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -213,13 +213,6 @@ ActiveRecord::Schema.define(version: 2022_10_11_150126) do
     t.string "color"
   end
 
-  create_table "types", force: :cascade do |t|
-    t.string "title"
-    t.bigint "fish_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "first_name"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
  - Editor menu expandable only expand click on `icon`, so I resolved this issue now a user can expand the link by clicking on whole menu link.
  - This same issue with sub menus too, so I have also resolved into it.

Fixes # (issue)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.

## Video Demo

https://user-images.githubusercontent.com/105207904/201431065-66cb2b0c-ed19-4d01-b3b3-084199dfd48b.mp4



