### PR TITLE
fix: Fix problem with HasHTMLAttributes memoization

### DIFF
--- a/spec/dummy/app/avo/resources/team_resource.rb
+++ b/spec/dummy/app/avo/resources/team_resource.rb
@@ -6,7 +6,18 @@ class TeamResource < Avo::BaseResource
   end
 
   field :id, as: :id
-  field :name, as: :text, sortable: true
+  field :name, as: :text, sortable: true, html: -> do
+    index do
+      wrapper do
+        style do
+          if record.color
+            "color: #{record.color}"
+          end
+        end
+      end
+    end
+  end
+
   field :logo, as: :external_image,hide_on: :show, as_avatar: :rounded do |model|
     if model.url
       "//logo.clearbit.com/#{URI.parse(model.url).host}?size=180"

--- a/spec/features/avo/html_attribute_spec.rb
+++ b/spec/features/avo/html_attribute_spec.rb
@@ -11,4 +11,24 @@ RSpec.feature "HtmlAttributes", type: :feature do
       expect(field_wrapper(:title).find('[data-slot="label"]')[:class]).to include "bg-gray-50 !text-pink-600"
     end
   end
+
+  context "on index" do
+    let(:red_team) { create :team, color: "#FF0000" }
+    let(:green_team) { create :team, color: "#00FF00" }
+    let(:user) { create :user }
+
+    before do
+      # Only teams with members show on index page
+      [red_team, green_team].each do |team|
+        team.team_members << user
+      end
+    end
+
+    it "evaluates the block syntax" do
+      visit avo.resources_teams_path
+
+      expect(field_element_by_resource_id("name", red_team.id)["style"]).to match(/color: #FF0000/)
+      expect(field_element_by_resource_id("name", green_team.id)["style"]).to match(/color: #00FF00/)
+    end
+  end
 end


### PR DESCRIPTION
# Description

`parsed_html` was being memoized at the field level, but it depends on the record. Since the field is only instantiated once, that resulted in cached results from the first record being applied to all records.

I have removed the memoization and refactored the code slightly so that the parsing will happen once per call to `get_html`. There might be a way to reintroduce memoization in a more robust way, but I'm not sure if the speed increase would be enough to justify the complexity. Let me know what you think.

I updated `TeamResource` to exercise this code and added a test.

Fixes #1430

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Notice that `TeamResource` has been modified to generate a style for each team name on the index page.
1. Go to /admin/resources/teams

Before this change all rows used the color of the first team. Now they all have the appropriate color.

<img width="559" alt="image" src="https://user-images.githubusercontent.com/549149/201451345-e5cb9419-6478-4389-845b-4a28cae37d03.png">
