### PR TITLE
Update select_field.rb

### DIFF
--- a/lib/avo/fields/select_field.rb
+++ b/lib/avo/fields/select_field.rb
@@ -46,7 +46,7 @@ module Avo
 
           return value if display_value
 
-          computed_options.invert.stringify_keys[value]
+          computed_options.invert.stringify_keys[value.to_s]
         elsif enum.present?
           if display_value
             options[value]
@@ -56,7 +56,7 @@ module Avo
         elsif display_value
           value
         else
-          options.invert.stringify_keys[value]
+          options.invert.stringify_keys[value.to_s]
         end
       end
     end


### PR DESCRIPTION
fixed select field's label method get nil  in show and index action

# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (select field's label method get nil  in show and index action)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 
```
  field :booked_for, as: :select, options: {
      '2 hours': 2,
      '5 hours': 4,
      '6 hours': 6,
      '8 hours': 8
    }
```
1. Step 2
   in show and index method, this field didn't show
Manual reviewer: please leave a comment with output from the test if that's the case.
