### PR TITLE
Fix: Only attempt to eager load directories that exist

### DIFF
--- a/lib/avo/app.rb
+++ b/lib/avo/app.rb
@@ -22,7 +22,10 @@ module Avo
 
         return unless paths.present?
 
-        Rails.autoloaders.main.eager_load_dir(Rails.root.join(*paths).to_s)
+        pathname = Rails.root.join(*paths)
+        if pathname.exist? && pathname.directory?
+          Rails.autoloaders.main.eager_load_dir(pathname.to_s)
+        end
       end
 
       def boot


### PR DESCRIPTION
# Description
Avo causes Zeitwerk to panic when `App.init_dashboards` attempts to eager load the "dashboards" director if it doesn't exist. Let's check that first.

Fixes #1425

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
1. Pre-fix repo, delete the dashboards directory and try to start the server, observe error.
2. Post-fix, do the same, no error.
