### PR TITLE
fix: time fields without relative don't cast the time

### DIFF
--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -114,7 +114,7 @@ export default class extends Controller {
     let value = this.parsedValue
 
     // Set the zone only if the type of field is date time or relative time.
-    if (this.fieldHasTime || this.relativeValue) {
+    if (this.fieldHasTime && this.relativeValue) {
       value = value.setZone(this.displayTimezone)
     }
 

--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -114,7 +114,7 @@ export default class extends Controller {
     let value = this.parsedValue
 
     // Set the zone only if the type of field is date time or relative time.
-    if (this.fieldHasTime && this.relativeValue) {
+    if (this.fieldHasTime || this.relativeValue) {
       value = value.setZone(this.displayTimezone)
     }
 

--- a/lib/avo/concerns/handles_field_args.rb
+++ b/lib/avo/concerns/handles_field_args.rb
@@ -12,10 +12,7 @@ module Avo
         value = default
 
         if type == :boolean
-          # If there's a property thats defined in the BaseField, check against that, if not, use the default.
-          if args[name.to_sym].present?
-            value = args[name.to_sym] == true
-          end
+          value = args[name.to_sym] == true
         else
           value = args[name.to_sym] unless args.dig(name.to_sym).nil?
         end

--- a/lib/avo/concerns/handles_field_args.rb
+++ b/lib/avo/concerns/handles_field_args.rb
@@ -9,10 +9,15 @@ module Avo
       # That may be a string, boolean, or array
       # Each args should also have a default value
       def add_prop_from_args(args = {}, name: nil, type: :string, default: nil)
-        value = default
-
         if type == :boolean
-          value = args[name.to_sym] == true
+          case args[name.to_sym]
+          when nil
+            value = default
+          when false
+            value = false
+          when true
+            value = true
+          end
         else
           value = args[name.to_sym] unless args.dig(name.to_sym).nil?
         end

--- a/lib/avo/concerns/handles_field_args.rb
+++ b/lib/avo/concerns/handles_field_args.rb
@@ -12,7 +12,10 @@ module Avo
         value = default
 
         if type == :boolean
-          value = args[name.to_sym] == true
+          # If there's a property thats defined in the BaseField, check against that, if not, use the default.
+          if args[name.to_sym].present?
+            value = args[name.to_sym] == true
+          end
         else
           value = args[name.to_sym] unless args.dig(name.to_sym).nil?
         end

--- a/lib/avo/concerns/handles_field_args.rb
+++ b/lib/avo/concerns/handles_field_args.rb
@@ -9,6 +9,8 @@ module Avo
       # That may be a string, boolean, or array
       # Each args should also have a default value
       def add_prop_from_args(args = {}, name: nil, type: :string, default: nil)
+        value = default
+
         if type == :boolean
           case args[name.to_sym]
           when nil

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -10,7 +10,6 @@ module Avo
       include ActionView::Helpers::UrlHelper
       include Avo::Fields::FieldExtensions::VisibleInDifferentViews
 
-      include Avo::Concerns::HandlesFieldArgs
       include Avo::Concerns::HasHTMLAttributes
       include Avo::Fields::Concerns::IsRequired
       include Avo::Fields::Concerns::IsReadonly

--- a/spec/components/avo/sidebar_profile_component_spec.rb
+++ b/spec/components/avo/sidebar_profile_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Avo::SidebarProfileComponent, type: :component do
   describe 'destroy_user_session_path' do
     context 'with default configuration' do
       it "renders sign out link" do
-        with_controller_class Avo::BaseController do      
+        with_controller_class Avo::BaseController do
           render_inline(described_class.new(user: nil))
           expect(page).to have_css "form[action='/users/sign_out']", text: "Sign out"
         end
@@ -24,7 +24,7 @@ RSpec.describe Avo::SidebarProfileComponent, type: :component do
       end
 
       it "does not render sign out link" do
-        with_controller_class Avo::BaseController do      
+        with_controller_class Avo::BaseController do
           render_inline(described_class.new(user: nil))
           expect(page).to_not have_css "form", text: "Sign out"
         end
@@ -41,8 +41,12 @@ RSpec.describe Avo::SidebarProfileComponent, type: :component do
         Avo.configuration.current_user_resource_name = :account
       end
 
+      after do
+        Avo.configuration.current_user_resource_name = nil
+      end
+
       it "renders sign out link" do
-        with_controller_class Avo::BaseController do      
+        with_controller_class Avo::BaseController do
           render_inline(described_class.new(user: nil))
           expect(page).to have_css "form[action='/accounts/sign_out']", text: "Sign out"
         end
@@ -53,14 +57,14 @@ RSpec.describe Avo::SidebarProfileComponent, type: :component do
       before do
         without_partial_double_verification do
           # Stub an additional route
-          allow(Rails.application.routes.url_helpers).to receive(:custom_sign_out_path).and_return("/custom/sign_out")
+          allow(Rails.application.routes.url_helpers).to receive(:sign_out_path_name).and_return("/custom/sign_out")
         end
 
-        Avo.configuration.sign_out_path_name = :custom_sign_out_path
+        Avo.configuration.sign_out_path_name = :sign_out_path_name
       end
 
       it "renders sign out link" do
-        with_controller_class Avo::BaseController do      
+        with_controller_class Avo::BaseController do
           render_inline(described_class.new(user: nil))
           expect(page).to have_css "form[action='/custom/sign_out']", text: "Sign out"
         end

--- a/spec/dummy/app/avo/resources/comment_resource.rb
+++ b/spec/dummy/app/avo/resources/comment_resource.rb
@@ -18,7 +18,8 @@ class CommentResource < Avo::BaseResource
     end
   end
   field :tiny_name, as: :text, only_on: :index, as_description: true
-  field :posted_at, as: :date_time,
+  field :posted_at,
+    as: :date_time,
     picker_format: "Y-m-d H:i:S",
     format: "cccc, d LLLL yyyy, HH:mm ZZZZ" # Wednesday, 10 February 1988, 16:00 GMT
 

--- a/spec/dummy/app/avo/resources/team_resource.rb
+++ b/spec/dummy/app/avo/resources/team_resource.rb
@@ -18,7 +18,7 @@ class TeamResource < Avo::BaseResource
     end
   end
 
-  field :logo, as: :external_image,hide_on: :show, as_avatar: :rounded do |model|
+  field :logo, as: :external_image, hide_on: :show, as_avatar: :rounded do |model|
     if model.url
       "//logo.clearbit.com/#{URI.parse(model.url).host}?size=180"
     end

--- a/spec/system/avo/date_time_fields/date_time_eastern_spec.rb
+++ b/spec/system/avo/date_time_fields/date_time_eastern_spec.rb
@@ -5,6 +5,26 @@ RSpec.describe "Date field on eastern zone", type: :system do
   let!(:comment) { create :comment, posted_at: Time.new(1988, 2, 10, 16, 22, 0, "UTC") }
 
   subject(:text_input) { find '[data-field-id="posted_at"] [data-controller="date-field"] input[type="text"]' }
+  before do
+    CommentResource.with_temporary_items do
+      field :body, as: :textarea, format_using: ->(value) do
+        if view == :show
+          content_tag(:div, style: "white-space: pre-line") { value }
+        else
+          value
+        end
+      end
+      field :posted_at,
+        as: :date_time,
+        relative: false,
+        picker_format: "Y-m-d H:i:S",
+        format: "cccc, d LLLL yyyy, HH:mm ZZZZ" # Wednesday, 10 February 1988, 16:00 GMT
+    end
+  end
+
+  after do
+    CommentResource.restore_items_from_backup
+  end
 
   describe "in an eastern (positive) Timezone", tz: "Europe/Bucharest" do
     it { reset_browser }

--- a/spec/system/avo/date_time_fields/date_time_utc_spec.rb
+++ b/spec/system/avo/date_time_fields/date_time_utc_spec.rb
@@ -6,6 +6,27 @@ RSpec.describe "Date field", type: :system do
   subject(:text_input) { find '[data-field-id="posted_at"] [data-controller="date-field"] input[type="text"]' }
   subject(:hidden_input) { find '[data-field-id="posted_at"] [data-controller="date-field"] input[type="hidden"]', visible: false }
 
+  before do
+    CommentResource.with_temporary_items do
+      field :body, as: :textarea, format_using: ->(value) do
+        if view == :show
+          content_tag(:div, style: "white-space: pre-line") { value }
+        else
+          value
+        end
+      end
+      field :posted_at,
+        as: :date_time,
+        relative: false,
+        picker_format: "Y-m-d H:i:S",
+        format: "cccc, d LLLL yyyy, HH:mm ZZZZ" # Wednesday, 10 February 1988, 16:00 GMT
+    end
+  end
+
+  after do
+    CommentResource.restore_items_from_backup
+  end
+
   describe "on UTC" do
     context "index" do
       it "displays the time" do

--- a/spec/system/avo/date_time_fields/date_time_western_spec.rb
+++ b/spec/system/avo/date_time_fields/date_time_western_spec.rb
@@ -6,6 +6,27 @@ RSpec.describe "Date field on western zone", type: :system do
 
   subject(:text_input) { find '[data-field-id="posted_at"] [data-controller="date-field"] input[type="text"]' }
 
+  before do
+    CommentResource.with_temporary_items do
+      field :body, as: :textarea, format_using: ->(value) do
+        if view == :show
+          content_tag(:div, style: "white-space: pre-line") { value }
+        else
+          value
+        end
+      end
+      field :posted_at,
+        as: :date_time,
+        relative: false,
+        picker_format: "Y-m-d H:i:S",
+        format: "cccc, d LLLL yyyy, HH:mm ZZZZ" # Wednesday, 10 February 1988, 16:00 GMT
+    end
+  end
+
+  after do
+    CommentResource.restore_items_from_backup
+  end
+
   describe "in a western (negative) Timezone", tz: "America/Chicago" do
     it { reset_browser }
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1441

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to team resource
1. observe the time to the browser timezone
2. add the `timezone` option to the `created_at` field
3. observe the time being casted to that timezone

Manual reviewer: please leave a comment with output from the test if that's the case.
