### PR TITLE
Warn developers if they forget to set attachment_key on trix fields

### DIFF
--- a/app/controllers/avo/attachments_controller.rb
+++ b/app/controllers/avo/attachments_controller.rb
@@ -10,6 +10,10 @@ module Avo
       blob = ActiveStorage::Blob.create_and_upload! io: params[:file], filename: params[:filename]
       association_name = BaseResource.valid_attachment_name(@model, params[:attachment_key])
 
+      if association_name.blank?
+        raise ActionController::BadRequest.new("Could not find the attachment association for #{params[:attachment_key]} (check the `attachment_key` for this Trix field)")
+      end
+
       @model.send(association_name).attach blob
 
       render json: {

--- a/app/javascript/js/controllers/fields/trix_field_controller.js
+++ b/app/javascript/js/controllers/fields/trix_field_controller.js
@@ -55,7 +55,7 @@ export default class extends Controller {
         }
 
         // Prevent file uploads for resources that haven't been saved yet.
-        if (this.resourceId === '') {
+        if (!this.resourceId) {
           event.preventDefault()
           alert("You can't upload files into the Trix editor until you save the resource.")
 
@@ -63,7 +63,7 @@ export default class extends Controller {
         }
 
         // Prevent file uploads for fields without an attachment key.
-        if (this.attachmentKey === '') {
+        if (!this.attachmentKey) {
           event.preventDefault()
           alert("You haven't set an `attachment_key` to this Trix field.")
         }

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -117,9 +117,10 @@ module Avo
       end
 
       def valid_attachment_name(record, association_name)
-        get_record_associations(record).keys.each do |name|
-          return association_name if name == "#{association_name}_attachment" || name == "#{association_name}_attachments"
+        association_exists = get_record_associations(record).keys.any? do |name|
+          name == "#{association_name}_attachment" || name == "#{association_name}_attachments"
         end
+        return association_name if association_exists
       end
 
       def get_available_models


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

To use attachments on a trix field, you need to set an attachment_key in the field definition (which gives the name of the association which attachments can be stored in).

Although there is code in the trix stimuls controller to warn the user if they haven't set this, it doesn't work, because it expects the `data-attachment-key` attribute to be set but empty and does not work if the attribute isn't set at all (which is how the html actually works if attachment_key isn't set).

Also, although the server throws an error if you try to attach something without setting the attachment name (it throws an error because it cannot find the right association to use), the error is unhelpful:

    TypeError ([...] is not a symbol nor a string)

(Where the array contains the name of every association on the model.)

I've updated this so that:

1. The javascript error is shown if the HTML attribute is empty OR undefined
2. It raises a more descriptive error on the server if it cannot find the correct association

Fixes # (issue)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Add a trix field without setting `attachment_key:`, try to attach a file and confirm that an error is raised in the browser console
2. Add a trix field with an `attachment_key:` but make it for an association that does not exist, then when you try to attach a file it should show a helpful error in the rails logs
3. Add a trix field with a valid `attachment_key:` and it should work as expected.

Manual reviewer: please leave a comment with output from the test if that's the case.
