### PR TITLE
Don't set the csrf token if it's not available

### DIFF
--- a/app/javascript/js/controllers/fields/trix_field_controller.js
+++ b/app/javascript/js/controllers/fields/trix_field_controller.js
@@ -93,7 +93,10 @@ export default class extends Controller {
 
     xhr.open('POST', this.uploadUrl, true)
 
-    xhr.setRequestHeader('X-CSRF-Token', document.querySelector('meta[name="csrf-token"]').content)
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
+    if (csrfToken) {
+      xhr.setRequestHeader('X-CSRF-Token', csrfToken)
+    }
 
     xhr.upload.addEventListener('progress', (event) => {
       // eslint-disable-next-line no-mixed-operators


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

It's possible to disable csrf tokens by setting
`config.action_controller.allow_forgery_protection = false` in your environment config file. This is the default in the test environment.

Unfortunately, the trix field controller assumes that the csrf token will always be available, which makes it crash if it's not. Because of that it's not possible to use avo trix fields in tests.

I've changed the code so that if the csrf token isn't set then we don't use it.

Fixes # (issue)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Disable csrf tokens in your development environment by setting `config.action_controller.allow_forgery_protection = false` in `config/environments/development.rb`
2. Try to edit and save a resource with a trix field (this should work on this branch but hit errors on main)

Manual reviewer: please leave a comment with output from the test if that's the case.
