### PR TITLE
fix: get correct search results count

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -44,11 +44,17 @@ module Avo
     end
 
     def search_resource(resource)
-      query =  Avo::Hosts::SearchScopeHost.new(
+      query = Avo::Hosts::SearchScopeHost.new(
         block: resource.search_query,
         params: params,
-        scope: resource.class.scope.limit(8)
+        scope: resource.class.scope
       ).handle
+
+      # Get the count
+      results_count = query.count
+
+      # Get the results
+      query = query.limit(8)
 
       query = apply_scope(query) if should_apply_any_scope?
 
@@ -56,15 +62,15 @@ module Avo
 
       header = resource.plural_name
 
-      if results.length > 0
-        header += " (#{results.length})"
+      if results_count > 0
+        header = "#{header} (#{results_count})"
       end
 
       result_object = {
         header: header,
         help: resource.class.search_query_help,
         results: results,
-        count: results.length
+        count: results_count
       }
 
       [resource.name.pluralize.downcase, result_object]


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1448

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Search resources
1. Notice the right count number showing up

Manual reviewer: please leave a comment with output from the test if that's the case.
