### PR TITLE
feature: callable action message

### DIFF
--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -18,7 +18,7 @@
         <%= @action.action_name %>
       <% end %>
       <div class="flex-1 flex">
-        <%= @action.message %>
+        <%= @action.get_message %>
       </div>
       <%= form.hidden_field :avo_resource_ids, value: params[:resource_ids], 'data-action-target': 'resourceIds' %>
       <%= form.hidden_field :avo_selected_query, 'data-action-target': 'selectedAllQuery' %>

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -72,6 +72,14 @@ module Avo
       @response[:messages] = []
     end
 
+    def get_message
+      if self.class.message.respond_to? :call
+        Avo::Hosts::ResourceRecordHost.new(block: self.class.message, record: self.class.model, resource: self.class.resource).handle
+      else
+        self.class.message
+      end
+    end
+
     def get_attributes_for_action
       get_fields.map do |field|
         [field.id, field.value || field.default]

--- a/lib/avo/hosts/resource_record_host.rb
+++ b/lib/avo/hosts/resource_record_host.rb
@@ -1,0 +1,7 @@
+module Avo
+  module Hosts
+    class ResourceRecordHost < RecordHost
+      option :resource
+    end
+  end
+end

--- a/spec/dummy/app/avo/actions/release_fish.rb
+++ b/spec/dummy/app/avo/actions/release_fish.rb
@@ -1,6 +1,8 @@
 class ReleaseFish < Avo::BaseAction
   self.name = "Release fish"
-  self.message = "Are you sure you want to release this fish?"
+  self.message = -> {
+    "Are you sure you want to release the #{record.name}?"
+  }
 
   field :message, as: :trix, help: "Tell the fish something before releasing."
   field :user, as: :belongs_to, searchable: true, visible: ->(resource:) {

--- a/spec/system/avo/custom_resource_controls_spec.rb
+++ b/spec/system/avo/custom_resource_controls_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "CustomResourceControls", type: :system do
       click_on "Release fish"
       wait_for_loaded
 
-      expect(page).to have_text "Are you sure you want to release this fish?"
+      expect(page).to have_text "Are you sure you want to release the #{fish.name}?"
     end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1463

This can be used like this:

```ruby
class ReleaseFish < Avo::BaseAction
  self.message = -> {
	# you have access to params, current_user, context, view_context, request, resource, and record
    "Are you sure you want to release the #{record.name}?"
  }
end
```

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works

