### PR TITLE
fix: association policy has the wrong record

### DIFF
--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -53,6 +53,7 @@ class Avo::ResourceComponent < Avo::BaseComponent
     end
   end
 
+  # Ex: A Post has many Comments
   def authorize_association_for(policy_method)
     policy_result = true
 
@@ -67,11 +68,12 @@ class Avo::ResourceComponent < Avo::BaseComponent
 
       if association_name.present?
         method_name = "#{policy_method}_#{association_name}?".to_sym
-        # Prepare the authorization service
+        # Use the policy methods from the parent (Post)
         service = reflection_resource.authorization
 
         if service.has_method?(method_name, raise_exception: false)
-          policy_result = service.authorize_action(method_name, raise_exception: false)
+          # Override the record with the child record (Comment not Post)
+          policy_result = service.authorize_action(method_name, record: resource.model, raise_exception: false)
         end
       end
     end

--- a/lib/avo/services/authorization_service.rb
+++ b/lib/avo/services/authorization_service.rb
@@ -119,7 +119,7 @@ module Avo
       end
 
       def authorize_action(action, **args)
-        self.class.authorize_action(user, record, action, policy_class: policy_class, **args)
+        self.class.authorize_action(user, args[:record] || record, action, policy_class: policy_class, **args)
       end
 
       def apply_policy(model)
@@ -131,7 +131,7 @@ module Avo
       end
 
       def has_method?(method, **args)
-        defined_methods(record, **args).include? method.to_sym
+        defined_methods(args[:record] || record, **args).include? method.to_sym
       end
     end
   end

--- a/spec/dummy/app/policies/team_policy.rb
+++ b/spec/dummy/app/policies/team_policy.rb
@@ -59,7 +59,7 @@ class TeamPolicy < ApplicationPolicy
   end
 
   def edit_team_members?
-    true
+    Pundit.policy!(user, record).edit?
   end
 
   def attach_team_members?


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1459

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Update the `UserPolicy.update?` method to return `record.id.odd?`. This ill remove the edit buttons for users that have an odd id.
1. Go to users. Observe that the even ones have the edit button visible and the odd ones does not
2. Go to a team. Observe the same thing for the team members.

Manual reviewer: please leave a comment with output from the test if that's the case.
