### PR TITLE
fix: card missing current_user

### DIFF
--- a/app/controllers/avo/dashboards/cards_controller.rb
+++ b/app/controllers/avo/dashboards/cards_controller.rb
@@ -21,7 +21,7 @@ module Avo
 
       def set_card
         @card = @dashboard.item_at_index(params[:index].to_i).tap do |card|
-          card.hydrate(dashboard: @dashboard, params: params)
+          card.hydrate(dashboard: @dashboard)
         end
       end
 

--- a/lib/avo/base_card.rb
+++ b/lib/avo/base_card.rb
@@ -20,6 +20,10 @@ module Avo
     attr_accessor :params
 
     delegate :context, to: ::Avo::App
+    delegate :current_user, to: ::Avo::App
+    delegate :view_context, to: ::Avo::App
+    delegate :params, to: ::Avo::App
+    delegate :request, to: ::Avo::App
 
     class << self
       def query(&block)
@@ -106,9 +110,8 @@ module Avo
       self
     end
 
-    def hydrate(dashboard: nil, params: nil)
+    def hydrate(dashboard: nil)
       @dashboard = dashboard if dashboard.present?
-      @params = params if params.present?
 
       self
     end

--- a/spec/dummy/app/avo/cards/metric_from_param.rb
+++ b/spec/dummy/app/avo/cards/metric_from_param.rb
@@ -1,0 +1,8 @@
+class MetricFromParam < Avo::Dashboards::MetricCard
+  self.id = "metric_from_param"
+  self.label = "Metric from param"
+
+  def query
+    result params[:metric] || current_user&.id || 101
+  end
+end

--- a/spec/dummy/app/avo/dashboards/dashy.rb
+++ b/spec/dummy/app/avo/dashboards/dashy.rb
@@ -17,11 +17,12 @@ class Dashy < Avo::Dashboards::BaseDashboard
       active_users: true
     }
   card PercentDone
-  card ExampleLineChart, cols: 1
+  card ExampleLineChart, cols: 2
   card AmountRaised
   card ExampleColumnChart
   card ExamplePieChart
-  card ExampleBarChart
+  card ExampleBarChart, cols: 2
+  card MetricFromParam
 
   divider label: "Custom partials"
 

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -3,6 +3,6 @@ ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../../Gemfile", __dir__)
 
 ENV["AVO_IN_DEVELOPMENT"] = "1"
 
-require "bootsnap/setup" unless ENV["CI"] # Speed up boot time by caching expensive operations.
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+require "bootsnap/setup" unless ENV["CI"] # Speed up boot time by caching expensive operations.
 $LOAD_PATH.unshift File.expand_path("../../../lib", __dir__)

--- a/spec/features/avo/metric_receives_params_spec.rb
+++ b/spec/features/avo/metric_receives_params_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.feature "MetricReceivesParams", type: :feature do
+  it "returns the current_user id" do
+    visit "/admin/dashboards/dashy/cards/dashy.metric_from_param?index=10"
+
+    within find(".text-5xl") do
+      expect(page).to have_text admin.id
+    end
+  end
+
+  it "returns the param" do
+    visit "/admin/dashboards/dashy/cards/dashy.metric_from_param?index=10&metric=333"
+
+    within find(".text-5xl") do
+      expect(page).to have_text "333"
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1464

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to `Dashy` dashboard
2. observe the `Metric from param` card to have the current user id value
3. add `metric=111` param in the url
4. observe that same card have the `111` value

Manual reviewer: please leave a comment with output from the test if that's the case.
