### PR TITLE
refactor: trix id not unique when used as native

### DIFF
--- a/app/components/avo/fields/trix_field/edit_component.html.erb
+++ b/app/components/avo/fields/trix_field/edit_component.html.erb
@@ -1,5 +1,6 @@
 <%= field_wrapper **field_wrapper_args, full_width: true do %>
-  <%= content_tag :div, class: "relative block overflow-x-auto max-w-full",
+  <%= content_tag :div,
+    class: "relative block overflow-x-auto max-w-full",
     data: {
       controller: "trix-field",
       trix_field_target: "controller",

--- a/app/components/avo/fields/trix_field/edit_component.rb
+++ b/app/components/avo/fields/trix_field/edit_component.rb
@@ -20,6 +20,10 @@ class Avo::Fields::TrixField::EditComponent < Avo::Fields::EditComponent
   end
 
   def trix_id
-    "trix_#{resource_name}_#{@field.id}"
+    if resource_name.present?
+      "trix_#{resource_name}_#{@field.id}"
+    elsif form.present?
+      "trix_#{form.index}_#{@field.id}"
+    end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where trix field ids were not unique when used as native fields.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

