### PR TITLE
fix: expose the parent record from association policy methods

### DIFF
--- a/spec/dummy/app/policies/team_policy.rb
+++ b/spec/dummy/app/policies/team_policy.rb
@@ -43,34 +43,50 @@ class TeamPolicy < ApplicationPolicy
   # Team members association
   # index? method
   def view_team_members?
+    # This logger is here for testing purposes. Please do not remove.
+    Rails.logger.info "view_team_members?->#{record.class}"
     true
   end
 
   def show_team_members?
+    # This logger is here for testing purposes. Please do not remove.
+    Rails.logger.info "show_team_members?->#{record.class}"
     true
   end
 
   def create_team_members?
+    # This logger is here for testing purposes. Please do not remove.
+    Rails.logger.info "create_team_members?->#{record.class}"
     true
   end
 
   def destroy_team_members?
+    # This logger is here for testing purposes. Please do not remove.
+    Rails.logger.info "destroy_team_members?->#{record.class}"
     true
   end
 
   def edit_team_members?
+    # This logger is here for testing purposes. Please do not remove.
+    Rails.logger.info "edit_team_members?->#{record.class}"
     Pundit.policy!(user, record).edit?
   end
 
   def attach_team_members?
+    # This logger is here for testing purposes. Please do not remove.
+    Rails.logger.info "attach_team_members?->#{record.class}"
     true
   end
 
   def detach_team_members?
+    # This logger is here for testing purposes. Please do not remove.
+    Rails.logger.info "detach_team_members?->#{record.class}"
     true
   end
 
   def act_on_team_members?
+    # This logger is here for testing purposes. Please do not remove.
+    Rails.logger.info "act_on_team_members?->#{record.class}"
     true
   end
 

--- a/spec/features/avo/authorization_spec.rb
+++ b/spec/features/avo/authorization_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.feature "Authorizations", type: :feature do
+  let(:team) { create :team, team_members: [admin] }
+
+  it "checks for the field authorization with the Team instance" do
+    allow(Rails.logger).to receive(:info).and_call_original
+    expect(Rails.logger).to receive(:info).with("view_team_members?->Team").at_least :once
+
+    visit "/admin/resources/teams/#{team.id}"
+  end
+
+  it "checks authorization for each individually" do
+    allow(Rails.logger).to receive(:info).and_call_original
+
+    # Some checks run on the parent record
+    expect(Rails.logger).to receive(:info).with("create_team_members?->Team").at_least :once
+    expect(Rails.logger).to receive(:info).with("attach_team_members?->Team").at_least :once
+    expect(Rails.logger).to receive(:info).with("act_on_team_members?->Team").at_least :once
+
+    # Some checks run on the child record
+    expect(Rails.logger).to receive(:info).with("show_team_members?->User").at_least :once
+    expect(Rails.logger).to receive(:info).with("destroy_team_members?->User").at_least :once
+    expect(Rails.logger).to receive(:info).with("edit_team_members?->User").at_least :once
+    expect(Rails.logger).to receive(:info).with("detach_team_members?->User").at_least :once
+
+    visit "/admin/resources/teams/#{team.id}/team_members?turbo_frame=has_many_field_show_team_members"
+  end
+end

--- a/spec/support/wait_for_loaded.rb
+++ b/spec/support/wait_for_loaded.rb
@@ -37,14 +37,14 @@ def wait_for_turbo_frame_src(frame_src = "", time = Capybara.default_max_wait_ti
   wait_for_element_missing("turbo-frame[src='#{frame_src}'][busy]", time)
 end
 
-def wait_for_body_class_missing(klass = 'turbo-loading', time = Capybara.default_max_wait_time)
+def wait_for_body_class_missing(klass = "turbo-loading", time = Capybara.default_max_wait_time)
   Timeout.timeout(time) do
     if page.present? &&
         page.find("body").present? &&
         page.find("body")[:class].present? &&
         page.find("body")[:class].is_a?(String)
 
-        sleep(0.05) until page.present? && !page.find("body")[:class].to_s.include?(klass)
+      sleep(0.05) until page.present? && !page.find("body")[:class].to_s.include?(klass)
     else
       sleep 0.1
     end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

As described in `BaseComponent`, when authorizing the associations we don't always have access to the child association.

In the `Post` `has_many` `Comments` example, when you want to authorize `show_comments?` you will have a `Comment` instance as the `record` variable in `PostPolicy`, but when you try to authorize the `attach_comments?` policy method, you won't have a `Comment` instance, because you want to create one, but we expose the parent `Post` instance so you have more information about that authorization action that you're trying to make.

Docs clarification [here](https://docs.avohq.io/2.0/authorization.html#associations)

![CleanShot 2022-12-03 at 17 48 41@2x](https://user-images.githubusercontent.com/1334409/205449587-ce5b098e-f5fa-46cf-b6b5-7a610e5c0779.jpg)


Fixes https://github.com/avo-hq/avo/issues/1459

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to a Team
1. You'll see in the logs what kind of record you have access to.
2. Observe that ivor the view, create, attach and act methods you have a `Team` instance and for the rest you have a `Comment` instance.

Manual reviewer: please leave a comment with output from the test if that's the case.
