### PR TITLE
Fix/activestorage dependency details

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -27,6 +27,7 @@ app_root do
   header 'Installing Yarn packages'
   run! 'yarn'
   run! '(cd spec/dummy; yarn)'
+  run! '(cp spec/dummy/.env.test.sample spec/dummy/.env.test)'
 
   if use_docker == 'y'
     header 'Creating the Docker volume'

--- a/bin/init
+++ b/bin/init
@@ -26,6 +26,7 @@ app_root do
 
   header 'Installing Yarn packages'
   run! 'yarn'
+  run! '(cd spec/dummy; yarn)'
 
   if use_docker == 'y'
     header 'Creating the Docker volume'

--- a/lib/avo/app.rb
+++ b/lib/avo/app.rb
@@ -59,10 +59,12 @@ module Avo
 
         # Set the current host for ActiveStorage
         begin
-          if Rails::VERSION::MAJOR === 6
-            ActiveStorage::Current.host = request.base_url
-          elsif Rails::VERSION::MAJOR === 7
-            ActiveStorage::Current.url_options = request.base_url
+          if defined?(ActiveStorage::Current)
+            if Rails::VERSION::MAJOR === 6
+              ActiveStorage::Current.host = request.base_url
+            elsif Rails::VERSION::MAJOR === 7
+              ActiveStorage::Current.url_options = request.base_url
+            end
           end
         rescue => exception
           Rails.logger.debug "[Avo] Failed to set ActiveStorage::Current.url_options, #{exception.inspect}"

--- a/spec/components/avo/sidebar_profile_component_spec.rb
+++ b/spec/components/avo/sidebar_profile_component_spec.rb
@@ -63,6 +63,10 @@ RSpec.describe Avo::SidebarProfileComponent, type: :component do
         Avo.configuration.sign_out_path_name = :sign_out_path_name
       end
 
+      after do
+        Avo.configuration.sign_out_path_name = nil
+      end
+
       it "renders sign out link" do
         with_controller_class Avo::BaseController do
           render_inline(described_class.new(user: nil))


### PR DESCRIPTION
# Description

Minor fixups for noise when ActiveStorage isn't present, and for workstation setup for contributors.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps

Executed fragment of code in IRB.

Unfortunately, I'm encountering major problems getting the test suite running locally.

For starters, seemingly every test fails because of a license key check where the license_key value is nil.  If I change the stub, then I get other problems:

* Missing URL helpers in a bunch of tests (`undefined method `sign_out_path_name' for #<Module:0x000000010eff3598>`)
* Failures in the code that's meant to check the licensing functionality and is rendered incorrect by having changed the stub
* Capybara failures because the user wasn't logged in and so the login page was rendered (e.g. `Unable to find css "turbo-frame[id='dashy_users_metric'][data-card-index='3']"` -- screenshot shows a completely unstyled login page), etc.

Basically, just all kinds of weirdness.
