### PR TITLE
fix: correctly parse and build the trix attachment path

### DIFF
--- a/app/javascript/js/controllers/fields/trix_field_controller.js
+++ b/app/javascript/js/controllers/fields/trix_field_controller.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-alert */
 import 'trix'
+import URI from 'urijs'
+
 import { Controller } from '@hotwired/stimulus'
 import { castBoolean } from '../../helpers/cast_boolean'
 
@@ -35,7 +37,16 @@ export default class extends Controller {
   }
 
   get uploadUrl() {
-    return `${window.location.origin}${window.Avo.configuration.root_path}/avo_api/resources/${this.resourceName}/${this.resourceId}/attachments`
+    // Parse the current URL
+    const url = new URI(window.location.origin)
+    // Parse the root path
+    const rootPath = new URI(window.Avo.configuration.root_path)
+    // Build the trix field path
+    url.path(`${rootPath.path()}/avo_api/resources/${this.resourceName}/${this.resourceId}/attachments`)
+    // Add the params back
+    url.query(rootPath.query())
+
+    return url.toString()
   }
 
   connect() {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1386#issuecomment-1340692517
[Pre-release](https://rubygems.org/gems/avo/versions/2.21.1.pre.pr1484)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Got to a post
1. use the `force_locale=ro` param
2. upload a file in the trix field
3. observe that it is uploaded properly

Manual reviewer: please leave a comment with output from the test if that's the case.
