### PR TITLE
Resource generator incorrect date_time field fix

### DIFF
--- a/lib/generators/avo/resource_generator.rb
+++ b/lib/generators/avo/resource_generator.rb
@@ -289,13 +289,13 @@ module Generators
             field: "number"
           },
           datetime: {
-            field: "datetime"
+            field: "date_time"
           },
           timestamp: {
-            field: "datetime"
+            field: "date_time"
           },
           time: {
-            field: "datetime"
+            field: "date_time"
           },
           date: {
             field: "date"

--- a/lib/generators/avo/resource_generator.rb
+++ b/lib/generators/avo/resource_generator.rb
@@ -62,7 +62,7 @@ module Generators
       end
 
       def db_columns_to_ignore
-        %w[id encrypted_password reset_password_token reset_password_sent_at remember_created_at created_at updated_at]
+        %w[id encrypted_password reset_password_token reset_password_sent_at remember_created_at created_at updated_at password_digest]
       end
 
       def reflections

--- a/spec/dummy/app/models/event.rb
+++ b/spec/dummy/app/models/event.rb
@@ -1,0 +1,2 @@
+class Event < ApplicationRecord
+end

--- a/spec/dummy/db/migrate/20221224005546_create_events.rb
+++ b/spec/dummy/db/migrate/20221224005546_create_events.rb
@@ -1,0 +1,10 @@
+class CreateEvents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :events do |t|
+      t.string :name
+      t.datetime :event_time
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20221224005546_create_events.rb
+++ b/spec/dummy/db/migrate/20221224005546_create_events.rb
@@ -1,4 +1,4 @@
-class CreateEvents < ActiveRecord::Migration[6.1]
+class CreateEvents < ActiveRecord::Migration[6.0]
   def change
     create_table :events do |t|
       t.string :name

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_11_150126) do
+ActiveRecord::Schema.define(version: 2022_12_24_005546) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,13 @@ ActiveRecord::Schema.define(version: 2022_10_11_150126) do
     t.string "country"
     t.string "city"
     t.time "starting_at"
+  end
+
+  create_table "events", force: :cascade do |t|
+    t.string "name"
+    t.datetime "event_time"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "fish", force: :cascade do |t|

--- a/spec/features/avo/generators/resource_generator_spec.rb
+++ b/spec/features/avo/generators/resource_generator_spec.rb
@@ -12,4 +12,21 @@ RSpec.feature "resource generator", type: :feature do
 
     check_files_and_clean_up files
   end
+
+  context 'when generating resources from a DB model' do
+    it 'generates with the correct date_time field type' do
+      files = [
+        Rails.root.join("app", "avo", "resources", "event_resource.rb").to_s,
+        Rails.root.join("app", "controllers", "avo", "events_controller.rb").to_s
+      ]
+
+      Rails::Generators.invoke("avo:resource", ["event", "-q"], {destination_root: Rails.root})
+
+      expect(File.read(files[0])).to include('field :event_time, as: :date_time')
+
+      check_files_and_clean_up files
+    end
+  end
+
+
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This fixes a bug with the Resource generator where it uses the wrong field type for datetime database fields. It should map to the Avo date_time field, whereas it currently maps incorrectly to datetime.


Also added password_digest to the ignored db fields as this is another common password field people use in Rails apps.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs) (N/A)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Create a minimal rails app with a model that has a datetime field, I.E. a User model with a confirmed_at datetime field
1. Run the Avo resource generator for that model (I.E. ```bin/rails generator avo:resource user```) and observe the datetime field getting set to ``` as: :date_time ``` whereas running the same steps from the main branch will result in ```as: :datetime```

