### PR TITLE
feature: timezone callable

### DIFF
--- a/lib/avo/fields/date_time_field.rb
+++ b/lib/avo/fields/date_time_field.rb
@@ -4,7 +4,6 @@ module Avo
       attr_reader :format
       attr_reader :picker_format
       attr_reader :time_24hr
-      attr_reader :timezone
       attr_reader :relative
 
       def initialize(id, **args, &block)
@@ -49,6 +48,14 @@ module Avo
         else
           value
         end
+      end
+
+      def timezone
+        if @timezone.respond_to?(:call)
+          return Avo::Hosts::ResourceViewRecordHost.new(block: @timezone, record: resource.model, resource: resource, view: view).handle
+        end
+
+        @timezone
       end
     end
   end

--- a/lib/avo/fields/time_field.rb
+++ b/lib/avo/fields/time_field.rb
@@ -36,14 +36,6 @@ module Avo
 
         model
       end
-
-      def utc_time(value)
-        if timezone.present?
-          ActiveSupport::TimeZone.new(timezone).local_to_utc(Time.parse(value))
-        else
-          value
-        end
-      end
     end
   end
 end

--- a/spec/dummy/app/avo/resources/course_resource.rb
+++ b/spec/dummy/app/avo/resources/course_resource.rb
@@ -48,9 +48,11 @@ class CourseResource < Avo::BaseResource
     end
   end
 
-  field :starting_at, as: :time,
+  field :starting_at,
+    as: :time,
     picker_format: "H:i",
     format: "HH:mm:ss z",
+    timezone: -> { "Europe/Berlin" },
     picker_options: {
       hourIncrement: 1,
       minuteIncrement: 1,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1506

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to a course
1. See that the timezone block gets evaluated to `Berlin`

Manual reviewer: please leave a comment with output from the test if that's the case.
