### PR TITLE
Make search work when using strange selects in ransack

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -51,7 +51,7 @@ module Avo
       ).handle
 
       # Get the count
-      results_count = query.unscope(:select).count
+      results_count = query.reselect(:id).count
 
       # Get the results
       query = query.limit(8)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Another attempt at fixing fa513705f2b79ca8f498d05e755f55759f42c824. It turns out that simply unscoping select does not fix the issue as rails does something weird with the count query, as explained in #1494 

Fixes # (issue)

 #1494 

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Search for any resource and confirm that the count (the number of matching models) is correct
2. 
Manual reviewer: please leave a comment with output from the test if that's the case.
