### PR TITLE
fix: searchable belongs_to uses valid view

### DIFF
--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -52,7 +52,7 @@
               style: @field.get_html(:style, view: view, element: :input),
               type: type,
               classes: classes("w-full"),
-              view: @resource.view
+              view: view
           %>
           <% else %>
             <%= @form.select @field.id_input_foreign_key,
@@ -88,7 +88,7 @@
         resource: @resource,
         disabled: disabled,
         classes: classes("w-full"),
-        view: @resource.view,
+        view: view,
         style: @field.get_html(:style, view: view, element: :input)
       %>
     <% else %>

--- a/app/components/avo/fields/belongs_to_field/edit_component.rb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.rb
@@ -50,7 +50,7 @@ class Avo::Fields::BelongsToField::EditComponent < Avo::Fields::EditComponent
   end
 
   def field_html_action
-    @field.get_html(:data, view: @resource.view, element: :input).fetch(:action, nil)
+    @field.get_html(:data, view: view, element: :input).fetch(:action, nil)
   end
 
   private

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -167,6 +167,7 @@ end
 
 def set_picker_day(date)
   find(".flatpickr-day[aria-label=\"#{date}\"]").click
+  sleep 0.2
 end
 
 def set_picker_hour(value)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where a searchable `belongs_to` field used a different view than a non-searchable field.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Got to a resource with a belongs to
1. add a data attribute for the `edit` view
2. check that the attribute is added on `new` and `edit`

Manual reviewer: please leave a comment with output from the test if that's the case.
