### PR TITLE
refactor: base field initializes with a resource

### DIFF
--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -82,6 +82,7 @@ module Avo
         @view = args[:view] || nil
         @value = args[:value] || nil
         @stacked = args[:stacked] || nil
+        @resource = args[:resource]
 
         @args = args
 

--- a/spec/dummy/app/avo/resource_tools/team_membership_tool_playground.rb
+++ b/spec/dummy/app/avo/resource_tools/team_membership_tool_playground.rb
@@ -1,0 +1,4 @@
+class TeamMembershipToolPlayground < Avo::BaseResourceTool
+  self.name = "Team membership tool playground"
+  # self.partial = "avo/resource_tools/team_membership_tool_playground"
+end

--- a/spec/dummy/app/avo/resources/membership_resource.rb
+++ b/spec/dummy/app/avo/resources/membership_resource.rb
@@ -7,6 +7,7 @@ class MembershipResource < Avo::BaseResource
   end
   self.hide_from_global_search = true
   self.model_class = "TeamMembership"
+  self.stimulus_controllers = "test-controller"
 
   field :id, as: :id
   field :id, as: :number, only_on: :edit
@@ -33,4 +34,6 @@ class MembershipResource < Avo::BaseResource
     query
   }
   field :team, as: :belongs_to
+
+  tool TeamMembershipToolPlayground, show_on: :all
 end

--- a/spec/dummy/app/avo/resources/membership_resource.rb
+++ b/spec/dummy/app/avo/resources/membership_resource.rb
@@ -35,5 +35,5 @@ class MembershipResource < Avo::BaseResource
   }
   field :team, as: :belongs_to
 
-  tool TeamMembershipToolPlayground, show_on: :all
+  # tool TeamMembershipToolPlayground, show_on: :all
 end

--- a/spec/dummy/app/avo/resources/membership_resource.rb
+++ b/spec/dummy/app/avo/resources/membership_resource.rb
@@ -7,7 +7,7 @@ class MembershipResource < Avo::BaseResource
   end
   self.hide_from_global_search = true
   self.model_class = "TeamMembership"
-  self.stimulus_controllers = "test-controller"
+  self.stimulus_controllers = "test"
 
   field :id, as: :id
   field :id, as: :number, only_on: :edit

--- a/spec/dummy/app/views/avo/resource_tools/_team_membership_tool_playground.html.erb
+++ b/spec/dummy/app/views/avo/resource_tools/_team_membership_tool_playground.html.erb
@@ -1,0 +1,20 @@
+<div class="flex flex-col">
+  <%= render Avo::PanelComponent.new do |c| %>
+    <% c.body do %>
+      <% if form.present? %>
+        <%= field_container do %>
+        <%= @resource.get_stimulus_controllers %>
+          <%= avo_edit_field :team, form: form, as: :belongs_to, resource: @resource.hydrate(model: @model), html: {
+            edit: {
+              input: {
+                data: {
+                  foo: :barr
+                }
+              }
+            }
+          } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes and issue where one would try to use `avo_edit_field` and had to use the `stimulus_controllers` on a resource.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Add a `hey` stimulus controller to a `membership_resource`
1. add this field to a resource tool 
2. observe that the field has the `hey-target=teamBelongsTo` attribute added to the field

```ruby
class MembershipResource < Avo::BaseResource
  self.stimulus_controllers = "hey"
end
```

```erb
 <%= avo_edit_field :team, form: form, as: :belongs_to, resource: @resource.hydrate(model: @model), html: {
    edit: {
      input: {
        data: {
          foo: :barr
        }
      }
    }
  } %>
```

Manual reviewer: please leave a comment with output from the test if that's the case.
