### PR TITLE
feature: add data attributes to table headers

### DIFF
--- a/app/views/avo/partials/_table_header.html.erb
+++ b/app/views/avo/partials/_table_header.html.erb
@@ -48,8 +48,8 @@
       class: "text-left uppercase px-3 py-3 whitespace-nowrap rounded-l",
       data: {
         control: "resource-field-th",
-        field_id: field.id,
-        field_type: field.type,
+        table_header_field_id: field.id,
+        table_header_field_type: field.type,
       } do %>
       <% if field.sortable %>
         <%= link_to params.permit!.merge(sort_by: sort_by, sort_direction: sort_direction), class: "flex items-center #{classes} #{'cursor-pointer' if field.sortable}", 'data-turbo-frame': params[:turbo_frame] do %>

--- a/app/views/avo/partials/_table_header.html.erb
+++ b/app/views/avo/partials/_table_header.html.erb
@@ -44,7 +44,13 @@
           ""
         end
     %>
-    <th class="text-left uppercase px-3 py-3 whitespace-nowrap rounded-l" data-control="resource-field-th">
+    <%= content_tag :th,
+      class: "text-left uppercase px-3 py-3 whitespace-nowrap rounded-l",
+      data: {
+        control: "resource-field-th",
+        field_id: field.id,
+        field_type: field.type,
+      } do %>
       <% if field.sortable %>
         <%= link_to params.permit!.merge(sort_by: sort_by, sort_direction: sort_direction), class: "flex items-center #{classes} #{'cursor-pointer' if field.sortable}", 'data-turbo-frame': params[:turbo_frame] do %>
           <%= field.name %>
@@ -55,7 +61,7 @@
           <%= field.name %>
         </div>
       <% end %>
-    </th>
+    <% end %>
   <% end %>
   <% if Avo.configuration.resource_controls_on_the_right? %>
     <th class="w-24" data-control="resource-controls-th">

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -3,7 +3,7 @@ def parsed_response
 end
 
 def find_field_element(field_id)
-  find("[data-field-id='#{field_id}']")
+  find("[data-field-id='#{field_id}']:not([data-control='resource-field-th'])")
 end
 
 def field_wrapper(field_id)

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -3,7 +3,7 @@ def parsed_response
 end
 
 def find_field_element(field_id)
-  find("[data-field-id='#{field_id}']:not([data-control='resource-field-th'])")
+  find("[data-field-id='#{field_id}']")
 end
 
 def field_wrapper(field_id)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds `data-field-id` and `data-field-type` to the table headers so one can target them using CSS and conditionally apply styles or through JS.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works
