### PR TITLE
Fix authenticate_with in avo config template

### DIFF
--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -17,7 +17,8 @@ Avo.configure do |config|
 
   ## == Authentication ==
   # config.current_user_method = {}
-  # config.authenticate_with = {}
+  # config.authenticate_with do
+  # end
 
   ## == Authorization ==
   # config.authorization_methods = {


### PR DESCRIPTION
# Description
`Avo::Configuration` has no `authenticate_with=` method. Instead use `authenticate_with` with a block.

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps

1. generate a new rails project
2. install avo
3. see generated config file in `config/initializers/avo.rb`

Manual reviewer: please leave a comment with output from the test if that's the case.
