### PR TITLE
fix: always eager load all associations

### DIFF
--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -136,7 +136,7 @@ module Avo
     end
 
     def model_find_scope
-      eager_load_files(@resource, model_scope)
+      eager_load_associations(@resource, model_scope)
     end
 
     def model_scope
@@ -149,7 +149,7 @@ module Avo
       @related_model = if @field.is_a? Avo::Fields::HasOneField
         @model.send association_name
       else
-        eager_load_files(@related_resource, @model.send(association_name)).find params[:related_id]
+        eager_load_associations(@related_resource, @model.send(association_name)).find params[:related_id]
       end
     end
 
@@ -235,7 +235,7 @@ module Avo
       App.get_resource_by_model_name reflected_model
     end
 
-    def eager_load_files(resource, query)
+    def eager_load_associations(resource, query)
       if resource.attached_file_fields.present?
         resource.attached_file_fields.map do |field|
           attachment = case field.class.to_s
@@ -249,6 +249,10 @@ module Avo
 
           return query.includes "#{field.id}_#{attachment}": :blob
         end
+      end
+
+      if resource.includes.present?
+        query = query.includes(*resource.includes)
       end
 
       query

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -247,7 +247,7 @@ module Avo
             "attachment"
           end
 
-          return query.includes "#{field.id}_#{attachment}": :blob
+          query = query.includes "#{field.id}_#{attachment}": :blob
         end
       end
 

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -34,13 +34,8 @@ module Avo
         @query = @query.unscoped
       end
 
-      # Eager load the associations
-      if @resource.includes.present?
-        @query = @query.includes(*@resource.includes)
-      end
-
-      # Eager load the active storage attachments
-      @query = eager_load_files(@resource, @query)
+      # Eager load the active storage attachments and associations
+      @query = eager_load_associations(@resource, @query)
 
       # Sort the items
       if @index_params[:sort_by].present?

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -41,6 +41,8 @@ module AvoDummy
     # ---
 
     config.action_view.form_with_generates_remote_forms = false
-    config.active_record.strict_loading_by_default = true
+    if Rails::VERSION::MAJOR >= 6 && Rails::VERSION::MINOR >= 1
+      config.active_record.strict_loading_by_default = true
+    end
   end
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -41,5 +41,6 @@ module AvoDummy
     # ---
 
     config.action_view.form_with_generates_remote_forms = false
+    config.active_record.strict_loading_by_default = true
   end
 end


### PR DESCRIPTION
# Description
Since Rails 6.1 you can set `strict_loading` to raise errors when you access associations that are not explicitedly eager loaded.  [It's explained a bit further in this blog post](https://www.bigbinary.com/blog/rails-6-1-adds-strict_loading-to-warn-lazy-loading-associations).

For a new app I'm working on I want to set this globally via the Rails config. I'm running into issues with Avo though, where for the non-index actions the assocations are not eager loaded yet.

Since there is already a `self.includes` setting for resources, it was quite easy to also load them for the other actions.

Also found an earlier reported issue (but closed) for this: #816 

I wasn't sure how to test this, there are a few options:
1. Configure it on one model that sets `self.strict_loading_by_default = true` and have regular tests for all actions. 
2. Configure it on one model that sets `self.strict_loading_by_default = true` and have explicit tests for the eager loading part.
3. Configure it globally (this is what I did in this PR) and not change any tests.

I'm also not sure if there is a downside to always loading the assocations, I don't think so though. The only situation I can think of is having fields specified in `self.includes` that are then not used in the form (no fields that use it). Right now that would not load the resource, with this change it would. What are your thought on that?

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Manual review steps
1. Set `config.active_record.strict_loading_by_default = true` or `self.strict_loading_by_default = true` on a specific model.
5. Load a Avo resource in the Avo panel that includes a field for an association
6. See that is raises an error without these changes

