### PR TITLE
fix: missing favicon config in avo config file

### DIFF
--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -77,8 +77,9 @@ Avo.configure do |config|
   #   },
   #   chart_colors: ["#0B8AE2", "#34C683", "#2AB1EE", "#34C6A8"],
   #   logo: "/avo-assets/logo.png",
-  #   logomark: "/avo-assets/logomark.png"
-  #   placeholder: "/avo-assets/placeholder.svg"
+  #   logomark: "/avo-assets/logomark.png",
+  #   placeholder: "/avo-assets/placeholder.svg",
+  #   favicon: "/avo-assets/favicon.ico"
   # }
 
   ## == Breadcrumbs ==


### PR DESCRIPTION
# Description
`Avo.configuration.favicon` is missing in the avo config file.
Also added some missing commas. 

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps

1. generate a new rails project
2. install avo
3. see generated config file in config/initializers/avo.rb

Manual reviewer: please leave a comment with output from the test if that's the case.
