### PR TITLE
fix: allow strings array on status loading running

### DIFF
--- a/db/factories.rb
+++ b/db/factories.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
 
   factory :project do
     name { Faker::App.name }
-    status { [:closed, :rejected, :failed, :loading, :running, :waiting].sample }
+    status { ['closed', :rejected, :failed, 'loading', :running, :waiting].sample }
     stage { ["Discovery", "Idea", "Done", "On hold", "Cancelled"].sample }
     budget { Faker::Number.decimal(l_digits: 4) }
     country { Faker::Address.country_code }

--- a/lib/avo/fields/status_field.rb
+++ b/lib/avo/fields/status_field.rb
@@ -4,8 +4,8 @@ module Avo
       def initialize(id, **args, &block)
         super(id, **args, &block)
 
-        @loading_when = args[:loading_when].present? ? [args[:loading_when]].flatten : [:waiting, :running]
-        @failed_when = args[:failed_when].present? ? [args[:failed_when]].flatten : [:failed]
+        @loading_when = args[:loading_when].present? ? [args[:loading_when]].flatten.map(&:to_sym) : [:waiting, :running]
+        @failed_when = args[:failed_when].present? ? [args[:failed_when]].flatten.map(&:to_sym) : [:failed]
       end
 
       def status

--- a/spec/dummy/app/avo/resources/project_resource.rb
+++ b/spec/dummy/app/avo/resources/project_resource.rb
@@ -9,7 +9,7 @@ class ProjectResource < Avo::BaseResource
   field :id, as: :id, link_to_resource: true
   field :name, as: :text, required: true, as_label: true, sortable: true
   field :progress, as: :progress_bar, value_suffix: "%", display_value: true
-  field :status, as: :status, failed_when: [:closed, :rejected, :failed, 'user_reject'], loading_when: [:loading, :running, :waiting, 'Hold On'], nullable: true
+  field :status, as: :status, failed_when: ['closed', :rejected, :failed, 'user_reject'], loading_when: ['loading', :running, :waiting, 'Hold On'], nullable: true
   field :stage,
     as: :select,
     hide_on: [:show, :index],

--- a/spec/dummy/app/avo/resources/project_resource.rb
+++ b/spec/dummy/app/avo/resources/project_resource.rb
@@ -9,7 +9,7 @@ class ProjectResource < Avo::BaseResource
   field :id, as: :id, link_to_resource: true
   field :name, as: :text, required: true, as_label: true, sortable: true
   field :progress, as: :progress_bar, value_suffix: "%", display_value: true
-  field :status, as: :status, failed_when: [:closed, :rejected, :failed], loading_when: [:loading, :running, :waiting], nullable: true
+  field :status, as: :status, failed_when: [:closed, :rejected, :failed, 'user_reject'], loading_when: [:loading, :running, :waiting, 'Hold On'], nullable: true
   field :stage,
     as: :select,
     hide_on: [:show, :index],

--- a/spec/features/avo/status_field_spec.rb
+++ b/spec/features/avo/status_field_spec.rb
@@ -263,4 +263,30 @@ RSpec.describe "StatusField", type: :feature do
       end
     end
   end
+
+  describe "with 'Hold On' loading_when value" do
+    let!(:project) { create :project, status: "Hold On" }
+
+    context "index" do
+      it "displays the projects status" do
+        visit "/admin/resources/projects"
+
+        expect(find_field_element("status")).to have_text "Hold On"
+        expect(find_field_element("status")).to have_css ".spinner"
+      end
+    end
+  end
+
+  describe "with 'user_reject' failed_when value" do
+    let!(:project) { create :project, status: "user_reject" }
+
+    context "index" do
+      it "displays the projects status" do
+        visit "/admin/resources/projects"
+
+        expect(find_field_element("status")).to have_text "user_reject"
+        expect(find_field_element("status")).to have_css ".text-red-600"
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Solves issue when we use strings on `loading_when` and `failed_when` conditions on the `status` field.
This kind of args: 
```
 failed_when: [:closed, :rejected, :failed, 'user_reject'], loading_when: [:loading, :running, :waiting, 'Hold On']
 ```
Did not work until now, even [when the docs](https://docs.avohq.io/2.0/fields/status.html) state they should.
# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Use any string for the `failed_when` or `loading_when` fields, you will notice these fallbacks to default behavior.

Before:
<img width="728" alt="Screen Shot 2023-01-27 at 09 47 04" src="https://user-images.githubusercontent.com/60799999/215090726-184c5428-4702-431a-8b1b-096715f232f8.png">
Now:
<img width="728" alt="Screen Shot 2023-01-27 at 09 47 45" src="https://user-images.githubusercontent.com/60799999/215090734-5b4dd301-a62e-45cb-b25b-288cc20616d2.png">
