### PR TITLE
feature: allow authorization features on ordering close #1562

### DIFF
--- a/app/components/avo/index/resource_controls_component.html.erb
+++ b/app/components/avo/index/resource_controls_component.html.erb
@@ -1,6 +1,9 @@
 <div class="space-x-2 flex flex-row justify-around w-full">
   <% button_classes = "text-gray-600 h-6 hover:text-gray-600" %>
-  <%= render Avo::Index::Ordering::ButtonsComponent.new resource: @resource, reflection: @reflection, view_type: @view_type %>
+
+  <% if can_reorder? %>
+    <%= render Avo::Index::Ordering::ButtonsComponent.new resource: @resource, reflection: @reflection, view_type: @view_type %>
+  <% end %>
 
   <% if can_view? %>
     <%= link_to helpers.svg('eye', class: button_classes),

--- a/app/components/avo/index/resource_controls_component.rb
+++ b/app/components/avo/index/resource_controls_component.rb
@@ -31,6 +31,12 @@ class Avo::Index::ResourceControlsComponent < Avo::ResourceComponent
     @resource.authorization.authorize_action(:show, raise_exception: false)
   end
 
+  def can_reorder?
+    return authorize_association_for(:reorder) if @reflection.present?
+
+    @resource.authorization.authorize_action(:reorder, raise_exception: false)
+  end
+
   def show_path
     args = {}
 

--- a/spec/dummy/app/avo/resources/course_link_resource.rb
+++ b/spec/dummy/app/avo/resources/course_link_resource.rb
@@ -2,13 +2,14 @@ class CourseLinkResource < Avo::BaseResource
   self.title = :link
   self.includes = [:course]
   self.model_class = Course::Link
+  self.authorization_policy = CourseLinkPolicy
   self.search_query = -> do
     scope.ransack(id_eq: params[:q], link_cont: params[:q], m: "or").result(distinct: false)
   end
 
   self.ordering = {
     display_inline: true,
-    visible_on: :index, # :index or :association
+    visible_on: %i[index association], # :index or :association or both
     actions: {
       higher: -> { record.move_higher }, # has access to record, resource, options, params
       lower: -> { record.move_lower },

--- a/spec/dummy/app/avo/resources/course_resource.rb
+++ b/spec/dummy/app/avo/resources/course_resource.rb
@@ -1,6 +1,7 @@
 class CourseResource < Avo::BaseResource
   self.title = :name
   self.includes = []
+  self.authorization_policy = CoursePolicy
   self.search_query = -> do
     scope.ransack(id_eq: params[:q], name_cont: params[:q], m: "or").result(distinct: false)
   end

--- a/spec/dummy/app/policies/course_link_policy.rb
+++ b/spec/dummy/app/policies/course_link_policy.rb
@@ -1,0 +1,63 @@
+class CourseLinkPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def edit?
+    update?
+  end
+
+  def update?
+    true
+  end
+
+  def reorder?
+    true
+  end
+
+  def create?
+    true
+  end
+
+  def new?
+    create?
+  end
+
+  def destroy?
+    true
+  end
+
+  def act_on?
+    true
+  end
+
+  def upload_attachments?
+    true
+  end
+
+  def download_attachments?
+    true
+  end
+
+  def delete_attachments?
+    true
+  end
+
+  def view_comments?
+    true
+  end
+
+  def edit_comments?
+    true
+  end
+
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/spec/dummy/app/policies/course_policy.rb
+++ b/spec/dummy/app/policies/course_policy.rb
@@ -1,0 +1,63 @@
+class CoursePolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def edit?
+    update?
+  end
+
+  def update?
+    true
+  end
+
+  def reorder_links?
+    false
+  end
+
+  def create?
+    true
+  end
+
+  def new?
+    create?
+  end
+
+  def destroy?
+    true
+  end
+
+  def act_on?
+    true
+  end
+
+  def upload_attachments?
+    true
+  end
+
+  def download_attachments?
+    true
+  end
+
+  def delete_attachments?
+    true
+  end
+
+  def view_comments?
+    true
+  end
+
+  def edit_comments?
+    true
+  end
+
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Adds `can_reorder?` as an option to choose when we want to show the ordering buttons from the policies. 
Fixes # (issue)
#1562 
# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 1. Check CourseLink index, you should see reordering buttons
 2. Click on any Course, will redirects you to the Course where you shouldn't be able to reorder the Links.
This test both possible uses of the policy and the new method.
<!--
  By submitting the Contribution, you acknowledge that you have read the [Contributor License Agreement](https://avohq.io/cla) and agree to be bound by its terms.
  https://avohq.io/cla
-->
