### PR TITLE
Enable nonce for inline styles.

### DIFF
--- a/app/views/avo/partials/_branding.html.erb
+++ b/app/views/avo/partials/_branding.html.erb
@@ -1,6 +1,6 @@
-<style>
+<%= content_tag(:style, nonce: content_security_policy_nonce) do %>
   :root {
     <%= Avo.configuration.branding.css_colors %>
   }
-</style>
+<% end %>
 <%= favicon_link_tag Avo.configuration.branding.favicon %>


### PR DESCRIPTION
- similar to https://github.com/avo-hq/avo/pull/201 but for inline style
- there is no helper support in Rails directly, following https://dev.to/mdoyle13/rails-7-csp-how-to-add-a-nonce-to-an-inline-tag-if-you-must-59fm