### PR TITLE
feature: manually load resources

### DIFF
--- a/lib/avo/app.rb
+++ b/lib/avo/app.rb
@@ -115,8 +115,43 @@ module Avo
         end
       end
 
+      # Fetches the resources available to the application.
+      # We have two ways of doing that.
+      #
+      # 1. Through eager loading.
+      # We automatically eager load the resources directory and fetch the descendants from the scanned files.
+      # This is the simple way to get started.
+      #
+      # 2. Manually, declared by the user.
+      # We have this option to load the resources because when they are loaded automatically through eager loading,
+      # those Resource classes and their methods may trigger loading other classes. And that may disrupt Rails booting process.
+      # Ex: AdminResource may use self.model_class = User. That will trigger Ruby to load the User class and itself load
+      # other classes in a chain reaction.
+      # The scenario that comes up most often is when Rails boots, the routes are being computed which eager loads the resource files.
+      # At that boot time some migration might have not been run yet, but Rails tries to access them through model associations,
+      # and they are not available.
+      #
+      # To enable this feature add a `resources` array config in your Avo initializer.
+      # config.resources = [
+      #   "UserResource",
+      #   "FishResource",
+      # ]
+      def fetch_resources
+        resources = if Avo.configuration.resources.nil?
+          BaseResource.descendants
+        else
+          Avo.configuration.resources
+        end
+
+        resources.map do |resource|
+          return resource if resource.is_a?(Class)
+
+          resource.to_s.safe_constantize
+        end
+      end
+
       def init_resources
-        self.resources = BaseResource.descendants
+        self.resources = fetch_resources
           .select do |resource|
             # Remove the BaseResource. We only need the descendants
             resource != BaseResource

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -41,6 +41,7 @@ module Avo
     attr_accessor :authorization_client
     attr_accessor :field_wrapper_layout
     attr_accessor :sign_out_path_name
+    attr_accessor :resources
     attr_writer :branding
 
     def initialize
@@ -92,6 +93,7 @@ module Avo
       @resource_default_view = :show
       @authorization_client = :pundit
       @field_wrapper_layout = :inline
+      @resources = nil
     end
 
     def current_user_method(&block)

--- a/lib/avo/dynamic_router.rb
+++ b/lib/avo/dynamic_router.rb
@@ -3,9 +3,13 @@ module Avo
     def self.routes
       Avo::Engine.routes.draw do
         scope "resources", as: "resources" do
-          Avo::App.eager_load(:resources) unless Rails.application.config.eager_load
+          # Check if the user chose to manually register the resource files.
+          # If so, eager_load the resources dir.
+          if Avo.configuration.resources.nil?
+            Avo::App.eager_load(:resources) unless Rails.application.config.eager_load
+          end
 
-          BaseResource.descendants
+          Avo::App.fetch_resources
             .select do |resource|
               resource != :BaseResource
             end

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -59,6 +59,12 @@ Avo.configure do |config|
     # placeholder: "/avo-assets/placeholder.svg",
   }
 
+  # Uncomment to test out manual resource loading.
+  # config.resources = [
+  #   "UserResource",
+  #   "FishResource",
+  # ]
+
   ## == Menus ==
   config.main_menu = -> do
     section I18n.t("avo.dashboards"), icon: "dummy-adjustments.svg" do


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where eager loading the resource files breaks the initialization process.
This change enables the user to register the resources in the initializer manually. If they don't do that, then Avo will eager load the resources directory as usual.

```ruby
# config/initializers.rb
  config.resources = [
    "UserResource",
    "FishResource",
  ]
```

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Add a `resources` in the Avo initializer.
1. Observe that only the registered resources will be available.

Manual reviewer: please leave a comment with output from the test if that's the case.
