### PR TITLE
By default have text fields convert ASCII-8BIT to UTF-8

### DIFF
--- a/app/views/layouts/avo/application.html.erb
+++ b/app/views/layouts/avo/application.html.erb
@@ -35,7 +35,7 @@
             <div class="content p-4 lg:p-6 flex-1 flex flex-col justify-between items-stretch <%= @container_classes %>">
               <%= render partial: "avo/partials/custom_tools_alert" %>
               <div class="flex flex-1 flex-col justify-between items-stretch space-y-8">
-                <%= yield %>
+                <%= yield.force_encoding('UTF-8') %>
                 <%= render partial: "avo/partials/footer" %>
               </div>
             </div>

--- a/lib/generators/avo/resource_generator.rb
+++ b/lib/generators/avo/resource_generator.rb
@@ -214,7 +214,7 @@ module Generators
       end
 
       def field(name, type)
-        names_mapping[name.to_sym] || fields_mapping[type.to_sym] || {field: "text"}
+        names_mapping[name.to_sym] || fields_mapping[type&.to_sym] || {field: "text"}
       end
 
       def associations_mapping

--- a/spec/dummy/db/seeds.rb
+++ b/spec/dummy/db/seeds.rb
@@ -15,7 +15,6 @@ Review.delete_all
 Fish.delete_all
 Course.delete_all
 Course::Link.delete_all
-Fish.delete_all
 TeamMembership.delete_all
 Team.delete_all
 Comment.delete_all


### PR DESCRIPTION
# Description
When columns with binary data come in as a text field (such as Geospatial data in MySQL) then it is an ASCII string that does not render properly in Avo.  By using a `format_using` on the field the encoding can be safely changed to UTF-8, and out of convenience this can be established as a default behaviour for rendering text fields.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code


## Manual review steps
1. Obtain (or create) a database in MySQL that has text fields encoded as ASCII-8BIT.  The original **[sakila](https://downloads.mysql.com/docs/sakila-db.zip)** test database from MySQL AB does use this kind of data type in the **Address** table for geospatial data.
2. Create a Resource file for the affected model, can use this for **sakila**:
```
bin/rails g avo:resource address
```
3. When rendering the page, note that this error appears:
```
incompatible character encodings: UTF-8 and ASCII-8BIT
```
4. Implement this `format_using` on the `location` field:
```
->(value) { value.encode!("UTF-8", invalid: :replace, undef: :replace, replace: "?") }
```
5. Note that the page now renders, and invalid characters in the `location` column have been replaced with **?**:
<img width="997" alt="Screenshot 2023-02-19 at 11 46 54" src="https://user-images.githubusercontent.com/5301131/219945979-46bfb00a-a58b-41fb-8f23-25e9f38c6010.png">
