### PR TITLE
fix: authentication before authorization

### DIFF
--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -18,8 +18,8 @@ module Avo
     before_action :init_app
     before_action :check_avo_license
     before_action :set_resource_name
-    before_action :set_authorization
     before_action :_authenticate!
+    before_action :set_authorization
     before_action :set_container_classes
     before_action :add_initial_breadcrumbs
     before_action :set_view


### PR DESCRIPTION
Fixes https://github.com/avo-hq/avo/issues/1608

# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
I switched the order of the authenticate and authorization before actions.

Fixes https://github.com/avo-hq/avo/issues/1608
<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
Set `authenticate_with` in `avo.rb`
1. Step 2
Without this patch the authorization happened first leading to unexpected results.

Manual reviewer: please leave a comment with output from the test if that's the case.
