### PR TITLE
feature: add use resource option to belongs to field

### DIFF
--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -57,6 +57,8 @@ module Avo
     # - is_disabled?
 
     class BelongsToField < BaseField
+      include Avo::Fields::Concerns::UseResource
+
       attr_accessor :target
 
       attr_reader :polymorphic_as
@@ -79,6 +81,7 @@ module Avo
         @attach_scope = args[:attach_scope]
         @polymorphic_help = args[:polymorphic_help]
         @target = args[:target]
+        @use_resource = args[:use_resource] || nil
       end
 
       def searchable
@@ -222,6 +225,8 @@ module Avo
       end
 
       def target_resource
+        return use_resource if use_resource.present?
+
         if is_polymorphic?
           if value.present?
             return App.get_resource_by_model_name(value.class)

--- a/lib/avo/fields/concerns/use_resource.rb
+++ b/lib/avo/fields/concerns/use_resource.rb
@@ -1,0 +1,13 @@
+module Avo
+  module Fields
+    module Concerns
+      module UseResource
+        extend ActiveSupport::Concern
+
+        def use_resource
+          App.get_resource @use_resource
+        end
+      end
+    end
+  end
+end

--- a/lib/avo/fields/has_base_field.rb
+++ b/lib/avo/fields/has_base_field.rb
@@ -1,6 +1,8 @@
 module Avo
   module Fields
     class HasBaseField < BaseField
+      include Avo::Fields::Concerns::UseResource
+
       attr_accessor :display
       attr_accessor :scope
       attr_accessor :attach_scope
@@ -25,10 +27,6 @@ module Avo
 
       def searchable
         @searchable && ::Avo::App.license.has_with_trial(:searchable_associations)
-      end
-
-      def use_resource
-        App.get_resource @use_resource
       end
 
       def resource

--- a/spec/dummy/app/avo/resources/comment_resource.rb
+++ b/spec/dummy/app/avo/resources/comment_resource.rb
@@ -23,7 +23,7 @@ class CommentResource < Avo::BaseResource
     picker_format: "Y-m-d H:i:S",
     format: "cccc, d LLLL yyyy, HH:mm ZZZZ" # Wednesday, 10 February 1988, 16:00 GMT
 
-  field :user, as: :belongs_to
+  field :user, as: :belongs_to, use_resource: CompactUserResource
   field :commentable, as: :belongs_to, polymorphic_as: :commentable, types: [::Post, ::Project]
 
   # tabs do

--- a/spec/dummy/app/avo/resources/compact_user_resource.rb
+++ b/spec/dummy/app/avo/resources/compact_user_resource.rb
@@ -1,0 +1,14 @@
+class CompactUserResource < Avo::BaseResource
+  self.title = :name
+  self.model_class = ::User
+  self.find_record_method = ->(model_class:, id:, params:) {
+    model_class.friendly.find id
+  }
+
+  heading "personal information"
+  field :first_name, as: :text
+  field :last_name, as: :text
+  field :birthday, as: :date
+  heading "contact"
+  field :email, as: :text
+end

--- a/spec/dummy/app/controllers/avo/compact_users_controller.rb
+++ b/spec/dummy/app/controllers/avo/compact_users_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::CompactUsersController < Avo::ResourcesController
+end

--- a/spec/features/avo/use_resource_spec.rb
+++ b/spec/features/avo/use_resource_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Post comments use_resource PhotoCommentResource", type: :feature do
   let!(:post) { create :post, user: admin }
   let!(:comments) { create_list :comment, 20, commentable: post }
-  let!(:comment) { create :comment }
+  let!(:comment) { create :comment, user: admin }
 
   describe "tests" do
     it "if have diferent fields from original comment resource" do
@@ -63,6 +63,19 @@ RSpec.describe "Post comments use_resource PhotoCommentResource", type: :feature
       click_on "Attach"
       expect(page).to have_text "Photo comment attached."
       expect(page).to have_text comment.tiny_name
+    end
+
+    it "applyes on belongs to" do
+      visit "admin/resources/comments/#{comment.id}"
+
+      expect(page).to have_link comment.user.name,
+        href: "/admin/resources/compact_users/#{comment.user.slug}?via_resource_class=CommentResource&via_resource_id=#{comment.id}"
+
+      click_on comment.user.name
+      expect(page).to have_current_path "/admin/resources/compact_users/#{comment.user.slug}?via_resource_class=CommentResource&via_resource_id=#{comment.id}"
+
+      expect(page).to have_text "Personal information"
+      expect(page).to have_text "Contact"
     end
   end
 end

--- a/spec/system/avo/belongs_to_polymorphic_spec.rb
+++ b/spec/system/avo/belongs_to_polymorphic_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "belongs_to", type: :system do
             return_to_comment_page
 
             expect(find_field_value_element("body")).to have_text "Sample comment"
-            expect(find_field_value_element("user")).to have_link user.name, href: "/admin/resources/users/#{user.slug}?via_resource_class=CommentResource&via_resource_id=#{Comment.last.id}"
+            expect(find_field_value_element("user")).to have_link user.name, href: "/admin/resources/compact_users/#{user.slug}?via_resource_class=CommentResource&via_resource_id=#{Comment.last.id}"
             expect(find_field_value_element("commentable")).to have_text empty_dash
           end
         end
@@ -216,7 +216,7 @@ RSpec.feature "belongs_to", type: :system do
           click_on comment.id.to_s
 
           expect(find_field_value_element("body")).to have_text "hey there"
-          expect(find_field_value_element("user")).to have_link user.name, href: "/admin/resources/users/#{user.slug}?via_resource_class=CommentResource&via_resource_id=#{comment.id}"
+          expect(find_field_value_element("user")).to have_link user.name, href: "/admin/resources/compact_users/#{user.slug}?via_resource_class=CommentResource&via_resource_id=#{comment.id}"
           expect(find_field_value_element("commentable")).to have_link project.name, href: "/admin/resources/projects/#{project.id}?via_resource_class=CommentResource&via_resource_id=#{comment.id}"
 
           click_on "Edit"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Add `use_resource` option to `belongs_to` field.

Fixes #1616

### Somewhere inside `CommentResource`

```ruby
  field :user, as: :belongs_to, use_resource: CompactUserResource
```

### `CompactUserResource`
```ruby
class CompactUserResource < Avo::BaseResource
  self.title = :name
  self.model_class = ::User
  self.find_record_method = ->(model_class:, id:, params:) {
    model_class.friendly.find id
  }

  heading "personal information"
  field :first_name, as: :text
  field :last_name, as: :text
  field :birthday, as: :date
  heading "contact"
  field :email, as: :text
end

```

### Behavior
[use_resource_belongs_to.webm](https://user-images.githubusercontent.com/69730720/224484103-072b256b-0dc3-4b8b-a6ad-cdae5cd6957f.webm)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works

Docs PR https://github.com/avo-hq/avodocs/pull/23