### PR TITLE
feature: fetch_labels option for tags field

### DIFF
--- a/lib/avo/fields/tags_field.rb
+++ b/lib/avo/fields/tags_field.rb
@@ -18,9 +18,12 @@ module Avo
         add_array_prop args, :suggestions
         add_string_prop args, :mode, nil
         add_string_prop args, :fetch_values_from
+        add_string_prop args, :fetch_labels
       end
 
       def field_value
+        return fetched_labels if @fetch_labels.present?
+
         return json_value if acts_as_taggable_on.present?
 
         value || []
@@ -80,6 +83,14 @@ module Avo
       end
 
       private
+
+      def fetched_labels
+        if @fetch_labels.respond_to?(:call)
+          Avo::Hosts::ResourceRecordHost.new(block: @fetch_labels, resource: resource, record: model).handle
+        else
+          @fetch_labels
+        end
+      end
 
       def act_as_taggable_attribute(key)
         "#{key.singularize}_list="

--- a/spec/dummy/app/avo/actions/toggle_inactive.rb
+++ b/spec/dummy/app/avo/actions/toggle_inactive.rb
@@ -7,7 +7,8 @@ class ToggleInactive < Avo::BaseAction
     as: :tags,
     mode: :select,
     close_on_select: true,
-    fetch_values_from: -> { "/admin/resources/users/get_users?hey=you&record_id=#{resource.model.id}" },
+    visible: -> (resource:) { model.present? },
+    fetch_values_from: -> { "/admin/resources/users/get_users?hey=you&record_id=#{resource.model&.id}" },
     suggestions: -> do
       User.take(5).map do |user|
         {

--- a/spec/system/avo/tags_spec.rb
+++ b/spec/system/avo/tags_spec.rb
@@ -120,8 +120,8 @@ RSpec.describe "Tags", type: :system do
         field :skills, as: :tags,
           fetch_labels: -> {
             User.where(id: resource.model.skills)
-              .pluck(:id, :first_name, :last_name)
-              .map { |id, first_name, last_name| "FL #{first_name} #{last_name}" }.presence || resource.model.skills
+              .pluck(:first_name, :last_name)
+              .map { |first_name, last_name| "FL #{first_name} #{last_name}" }.presence || resource.model.skills
           }
       end
 

--- a/spec/system/avo/tags_spec.rb
+++ b/spec/system/avo/tags_spec.rb
@@ -119,9 +119,9 @@ RSpec.describe "Tags", type: :system do
       CourseResource.with_temporary_items do
         field :skills, as: :tags,
           fetch_labels: -> {
-            User.where(id: resource.model.skills)
+            User.where(id: record.skills)
               .pluck(:first_name, :last_name)
-              .map { |first_name, last_name| "FL #{first_name} #{last_name}" }.presence || resource.model.skills
+              .map { |first_name, last_name| "FL #{first_name} #{last_name}" }
           }
       end
 

--- a/spec/system/avo/tags_spec.rb
+++ b/spec/system/avo/tags_spec.rb
@@ -110,6 +110,30 @@ RSpec.describe "Tags", type: :system do
       click_on "Run"
     end
   end
+
+  describe "fetch labels" do
+    let!(:users) { create_list :user, 2 }
+    let!(:courses) { create_list :course, 2, skills: users.pluck(:id) }
+
+    it "fetches the labels" do
+      CourseResource.with_temporary_items do
+        field :skills, as: :tags,
+          fetch_labels: -> {
+            User.where(id: resource.model.skills)
+              .pluck(:id, :first_name, :last_name)
+              .map { |id, first_name, last_name| "FL #{first_name} #{last_name}" }.presence || resource.model.skills
+          }
+      end
+
+      visit "/admin/resources/courses"
+
+      expect(page).to have_text "FL #{users[0].first_name} #{users[0].last_name}"
+      expect(page).to have_text "FL #{users[1].first_name} #{users[1].last_name}"
+
+      CourseResource.restore_items_from_backup
+    end
+
+  end
 end
 
 def wait_for_tags_to_load(element, time = Capybara.default_max_wait_time)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Tags field option `fetch_labels` can now be used to dynamically fetch the labels for each record.

For example  

```ruby
field :skills, as: :tags,
    fetch_labels: -> { ["tag", "custom_label"] }
```
![image](https://user-images.githubusercontent.com/69730720/224538580-deeba9b8-fe72-4e90-b51b-b4e954711f09.png)

Of course this is supposed to be used dynamically, something like this:
```ruby
field :users, as: :tags,
    fetch_labels: -> {
      User.where(id: record.array_with_user_ids).pluck(:first_name)
    }
``` 
or
```ruby
field :users, as: :tags,
    fetch_labels: -> {
      User.where(id: record.array_with_user_ids).pluck(:first_name, :last_name)
        .map { |first_name, last_name| "#{first_name} #{last_name}" }.presence || resource.model.array_with_user_ids
    }
``` 

Fixes #1619
<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works

Docs PR https://github.com/avo-hq/avodocs/pull/24