### PR TITLE
feature: field level file authorization

### DIFF
--- a/app/components/avo/fields/common/single_file_viewer_component.html.erb
+++ b/app/components/avo/fields/common/single_file_viewer_component.html.erb
@@ -20,7 +20,7 @@
     </div>
     <div class="flex space-x-2">
       <div class="flex">
-        <% if @resource.authorization.authorize_action(:download_attachments?, raise_exception: false) %>
+        <% if can_download_file? %>
           <%= a_link Rails.application.routes.url_helpers.rails_blob_path(file, only_path: true, disposition: :attachment),
             icon: 'heroicons/outline/download',
             color: :primary,
@@ -33,7 +33,7 @@
         <% end %>
       </div>
       <div>
-        <% if @resource.authorization.authorize_action(:delete_attachments?, raise_exception: false) %>
+        <% if can_delete_file? %>
           <%= a_link destroy_path,
             icon: 'heroicons/outline/trash',
             color: :red,

--- a/app/components/avo/fields/common/single_file_viewer_component.rb
+++ b/app/components/avo/fields/common/single_file_viewer_component.rb
@@ -2,8 +2,9 @@
 
 class Avo::Fields::Common::SingleFileViewerComponent < ViewComponent::Base
   include Avo::ApplicationHelper
+  include Avo::Fields::Concerns::FileAuthorization
 
-  def initialize(file: nil, field:, resource:)
+  def initialize(field:, resource:, file: nil)
     @file = file
     @field = field
     @resource = resource
@@ -45,7 +46,7 @@ class Avo::Fields::Common::SingleFileViewerComponent < ViewComponent::Base
     record_persisted?
   end
 
-   # If model is not persistent blob is automatically destroyed otherwise it can be "lost" on storage
+  # If model is not persistent blob is automatically destroyed otherwise it can be "lost" on storage
   def record_persisted?
     return true if @resource.model.persisted?
 

--- a/app/components/avo/fields/file_field/edit_component.html.erb
+++ b/app/components/avo/fields/file_field/edit_component.html.erb
@@ -5,7 +5,7 @@
     </div>
   <% end %>
 
-  <% if @resource.authorization.authorize_action(:upload_attachments?, raise_exception: false) %>
+  <% if can_upload_file? %>
     <%= @form.file_field @field.id,
       accept: @field.accept,
       data: @field.get_html(:data, view: view, element: :input),

--- a/app/components/avo/fields/file_field/edit_component.rb
+++ b/app/components/avo/fields/file_field/edit_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Avo::Fields::FileField::EditComponent < Avo::Fields::EditComponent
+  include Avo::Fields::Concerns::FileAuthorization
 end

--- a/app/components/avo/fields/files_field/edit_component.html.erb
+++ b/app/components/avo/fields/files_field/edit_component.html.erb
@@ -1,7 +1,7 @@
 <%= field_wrapper **field_wrapper_args, full_width: true do %>
   <%= render Avo::Fields::Common::FilesListViewerComponent.new(field: @field, resource: @resource) if @field.value.present? %>
 
-  <% if @resource.authorization.authorize_action(:upload_attachments?, raise_exception: false) %>
+  <% if can_upload_file? %>
     <div class="mt-2">
       <%= @form.file_field @field.id,
         accept: @field.accept,

--- a/app/components/avo/fields/files_field/edit_component.rb
+++ b/app/components/avo/fields/files_field/edit_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Avo::Fields::FilesField::EditComponent < Avo::Fields::EditComponent
+  include Avo::Fields::Concerns::FileAuthorization
 end

--- a/lib/avo/fields/concerns/file_authorization.rb
+++ b/lib/avo/fields/concerns/file_authorization.rb
@@ -8,15 +8,23 @@ module Avo
         delegate :authorize_action, to: :authorization
         delegate :id, :model, to: :@field
 
-        # Dynamically generate can_upload_file?, can_delete_file?, and can_download_file? methods
-        [:upload, :delete, :download].each do |action|
-          define_method "can_#{action}_file?" do
-            # Check if the current user can perform the corresponding actions
-            # upload_attachments?, delete_attachments?, and download_attachments?
-            if authorize_action("#{action}_attachments?".to_sym, raise_exception: false)
-              # Check if the current user can perform the action on the current file
-              authorize_action("#{action}_#{id}?", record: model, raise_exception: false)
-            end
+        def can_upload_file?
+          authorize_file_action(:upload)
+        end
+
+        def can_delete_file?
+          authorize_file_action(:delete)
+        end
+
+        def can_download_file?
+          authorize_file_action(:download)
+        end
+
+        private
+
+        def authorize_file_action(action)
+          if authorize_action("#{action}_attachments?", raise_exception: false)
+            authorize_action("#{action}_#{id}?", record: model, raise_exception: false)
           end
         end
       end

--- a/lib/avo/fields/concerns/file_authorization.rb
+++ b/lib/avo/fields/concerns/file_authorization.rb
@@ -1,0 +1,25 @@
+module Avo
+  module Fields
+    module Concerns
+      module FileAuthorization
+        extend ActiveSupport::Concern
+
+        delegate :authorization, to: :@resource
+        delegate :authorize_action, to: :authorization
+        delegate :id, :model, to: :@field
+
+        # Dynamically generate can_upload_file?, can_delete_file?, and can_download_file? methods
+        [:upload, :delete, :download].each do |action|
+          define_method "can_#{action}_file?" do
+            # Check if the current user can perform the corresponding actions
+            # upload_attachments?, delete_attachments?, and download_attachments?
+            if authorize_action("#{action}_attachments?".to_sym, raise_exception: false)
+              # Check if the current user can perform the action on the current file
+              authorize_action("#{action}_#{id}?", record: model, raise_exception: false)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/app/policies/post_policy.rb
+++ b/spec/dummy/app/policies/post_policy.rb
@@ -43,6 +43,14 @@ class PostPolicy < ApplicationPolicy
     true
   end
 
+  [:cover_photo, :audio].each do |file|
+    [:upload, :download, :delete].each do |action|
+      define_method "#{action}_#{file}?" do
+        true
+      end
+    end
+  end
+
   def view_comments?
     true
   end

--- a/spec/dummy/app/policies/project_policy.rb
+++ b/spec/dummy/app/policies/project_policy.rb
@@ -39,6 +39,12 @@ class ProjectPolicy < ApplicationPolicy
     true
   end
 
+  [:upload, :download, :delete].each do |action|
+    define_method "#{action}_files?" do
+      true
+    end
+  end
+
   def attach_comments?
     true
   end

--- a/spec/dummy/app/policies/user_policy.rb
+++ b/spec/dummy/app/policies/user_policy.rb
@@ -83,6 +83,12 @@ class UserPolicy < ApplicationPolicy
     true
   end
 
+  [:upload, :download, :delete].each do |action|
+    define_method "#{action}_cv?" do
+      true
+    end
+  end
+
   class Scope < Scope
     def resolve
       scope.all

--- a/spec/system/avo/tags_spec.rb
+++ b/spec/system/avo/tags_spec.rb
@@ -138,7 +138,7 @@ end
 def wait_for_tags_to_load(element, time = Capybara.default_max_wait_time)
   klass = "tagify--loading"
   Timeout.timeout(time) do
-    sleep(0.05) until !element[:class].to_s.include?(klass)
+    sleep(0.05) while element[:class].to_s.include?(klass)
   end
 end
 

--- a/spec/system/avo/tags_spec.rb
+++ b/spec/system/avo/tags_spec.rb
@@ -132,7 +132,6 @@ RSpec.describe "Tags", type: :system do
 
       CourseResource.restore_items_from_backup
     end
-
   end
 end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Now we can police each file using field level authorization methods.

```ruby
# app/avo/resources/post_resource.rb
field :cover_photo, as: :file, is_image: true
```

```ruby
# app/policies/post_policy.rb
def upload_cover_photo?
  user.student?
end

def download_cover_photo?
  true
end

def delete_cover_photo?
  user.admin?
end
```

Fixes #1624

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

Docs PR https://github.com/avo-hq/avodocs/pull/25