### PR TITLE
refactor: loose file authorization

### DIFF
--- a/app/components/avo/fields/file_field/edit_component.html.erb
+++ b/app/components/avo/fields/file_field/edit_component.html.erb
@@ -14,5 +14,7 @@
       style: @field.get_html(:style, view: view, element: :input),
       class: "w-full"
     %>
+  <% else %>
+    —
   <% end %>
 <% end %>

--- a/app/components/avo/fields/files_field/edit_component.html.erb
+++ b/app/components/avo/fields/files_field/edit_component.html.erb
@@ -13,5 +13,7 @@
         class: "w-full"
       %>
     </div>
+  <% else %>
+    —
   <% end %>
 <% end %>

--- a/lib/avo/fields/concerns/file_authorization.rb
+++ b/lib/avo/fields/concerns/file_authorization.rb
@@ -23,9 +23,7 @@ module Avo
         private
 
         def authorize_file_action(action)
-          if authorize_action("#{action}_attachments?", raise_exception: false)
-            authorize_action("#{action}_#{id}?", record: model, raise_exception: false)
-          end
+          authorize_action("#{action}_attachments?", raise_exception: false) || authorize_action("#{action}_#{id}?", record: model, raise_exception: false)
         end
       end
     end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Refactors the file authorization to allow control to either all attachments or granular per field.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works
