### PR TITLE
feature: add search_result_url and search_policy_class

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -68,6 +68,17 @@ gem 'avo', path: '../avo'
 
 Avo's assets will not show up by default, resulting in 404 errors on `/avo-assets/avo.base.js` and `/avo-assets/avo.base.css`. To avoid this, you need to compile the asset bundles, and symlink them into `public/avo-assets`.
 
+First, make sure you have `yarn` installed and then install Avo's dependencies:
+```bash
+yarn install
+```
+
+Run the first build to generate the files `app/assets/builds/avo.base.js` and `app/assets/builds/avo.base.css`:
+
+```bash
+yarn build
+```
+
 Create symlinks for compiled assets into the `public` directory. You'll only need to do this once.
 
 ```bash

--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -31,7 +31,7 @@
     <% end %>
     <% c.body do %>
       <div class="flex flex-col xs:flex-row xs:justify-between space-y-2 xs:space-y-0 py-4 <%= 'hidden' if @resource.search_query.nil? && @filters.empty? && available_view_types.count <= 1 %>">
-        <% unless hide_search_input %>
+        <% if show_search_input %>
           <div class="flex items-center px-4 w-64">
             <%= render partial: 'avo/partials/resource_search', locals: {resource: @resource.route_key, via_reflection: via_reflection} %>
           </div>

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -125,6 +125,9 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
   end
 
   def hide_search_input
+    if @resource.authorization.has_action_method?("search")
+      return true unless @resource.authorization.authorize_action("search", raise_exception: false)
+    end
     return true unless @resource.search_query.present?
 
     field&.hide_search_input || false

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -125,6 +125,7 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
   end
 
   def hide_search_input
+    # Hide the search if the authorization prevents it
     if @resource.authorization.has_action_method?("search")
       return true unless @resource.authorization.authorize_action("search", raise_exception: false)
     end

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -124,14 +124,19 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
     @resource.resource_description
   end
 
-  def hide_search_input
-    # Hide the search if the authorization prevents it
-    if @resource.authorization.has_action_method?("search")
-      return true unless @resource.authorization.authorize_action("search", raise_exception: false)
-    end
-    return true unless @resource.search_query.present?
+  def show_search_input
+    return false unless authorized_to_search?
+    return false unless @resource.search_query.present?
+    return false if field&.hide_search_input
 
-    field&.hide_search_input || false
+    true
+  end
+
+  def authorized_to_search?
+    # Hide the search if the authorization prevents it
+    return true unless @resource.authorization.has_action_method?("search")
+
+    @resource.authorization.authorize_action("search", raise_exception: false)
   end
 
   private

--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -27,8 +27,7 @@ module Avo
       resources
         .map do |resource|
           # Apply authorization
-          action = Avo.configuration.authorization_methods.stringify_keys['search'] || :search
-          next unless @authorization.set_record(resource.model_class).authorize_action(action, raise_exception: false)
+          next unless @authorization.set_record(resource.model_class).authorize_action(:search, raise_exception: false)
 
           # Filter out the models without a search_query
           next if resource.search_query.nil?

--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -27,7 +27,9 @@ module Avo
       resources
         .map do |resource|
           # Apply authorization
-          next unless @authorization.set_record(resource.model_class).authorize_action(:index, raise_exception: false)
+          action = Avo.configuration.authorization_methods.stringify_keys['search'] || :search
+          next unless @authorization.set_record(resource.model_class).authorize_action(action, raise_exception: false)
+
           # Filter out the models without a search_query
           next if resource.search_query.nil?
 
@@ -120,10 +122,16 @@ module Avo
       models.map do |model|
         resource = avo_resource.dup.hydrate(model: model).hydrate_fields(model: model)
 
+        record_path = if resource.search_result_path.present?
+          Avo::Hosts::ResourceRecordHost.new(block: resource.search_result_path, resource: resource, record: model).handle
+        else
+          resource.record_path
+        end
+
         result = {
           _id: model.id,
           _label: resource.label,
-          _url: resource.record_path,
+          _url: record_path
         }
 
         if App.license.has_with_trial(:enhanced_search_results)

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -30,6 +30,7 @@ module Avo
     class_attribute :description, default: :id
     class_attribute :search_query, default: nil
     class_attribute :search_query_help, default: ""
+    class_attribute :search_result_path
     class_attribute :includes, default: []
     class_attribute :authorization_policy
     class_attribute :translation_key

--- a/lib/avo/hosts/base_host.rb
+++ b/lib/avo/hosts/base_host.rb
@@ -10,6 +10,8 @@ module Avo
       option :params, default: proc { Avo::App.params }
       option :view_context, default: proc { Avo::App.view_context }
       option :current_user, default: proc { Avo::App.current_user }
+      option :main_app, default: proc { view_context.main_app }
+      option :avo, default: proc { view_context.avo }
       # This is optional because we might instantiate the `Host` first and later hydrate it with a block.
       option :block, optional: true
 

--- a/lib/avo/services/authorization_service.rb
+++ b/lib/avo/services/authorization_service.rb
@@ -132,6 +132,14 @@ module Avo
       def has_method?(method, **args)
         defined_methods(args[:record] || record, **args).include? method.to_sym
       end
+
+      # Check the received method to see if the user overrode it in their config and then checks if it's present on the policy.
+      def has_action_method?(method, **args)
+        method = Avo.configuration.authorization_methods.stringify_keys[method.to_s] || method
+        method = "#{method}?" unless method.to_s.end_with? "?"
+
+        has_method? method, **args
+      end
     end
   end
 end

--- a/lib/avo/services/authorization_service.rb
+++ b/lib/avo/services/authorization_service.rb
@@ -130,13 +130,13 @@ module Avo
       end
 
       def has_method?(method, **args)
+        method = "#{method}?" unless method.to_s.end_with? "?"
         defined_methods(args[:record] || record, **args).include? method.to_sym
       end
 
       # Check the received method to see if the user overrode it in their config and then checks if it's present on the policy.
       def has_action_method?(method, **args)
         method = Avo.configuration.authorization_methods.stringify_keys[method.to_s] || method
-        method = "#{method}?" unless method.to_s.end_with? "?"
 
         has_method? method, **args
       end

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -29,6 +29,7 @@ Avo.configure do |config|
   #   update: 'update?',
   #   create: 'create?',
   #   destroy: 'destroy?',
+  #   search: 'search?',
   # }
   # config.raise_error_on_missing_policy = false
   # config.authorization_client = :pundit

--- a/spec/dummy/app/avo/resources/city_resource.rb
+++ b/spec/dummy/app/avo/resources/city_resource.rb
@@ -1,9 +1,12 @@
 class CityResource < Avo::BaseResource
   self.title = :name
   self.includes = []
-  # self.search_query = ->(params:) do
-  #   scope.ransack(id_eq: params[:q], m: "or").result(distinct: false)
-  # end
+  self.search_query = -> do
+    scope.ransack(name_eq: params[:q]).result(distinct: false)
+  end
+  self.search_result_path = -> do
+    avo.resources_city_path record, custom: "yup"
+  end
   self.extra_params = [:fish_type, :something_else, properties: [], information: [:name, :history]]
 
   field :id, as: :id

--- a/spec/dummy/app/policies/application_policy.rb
+++ b/spec/dummy/app/policies/application_policy.rb
@@ -26,7 +26,7 @@ class ApplicationPolicy
     false
   end
 
-  def search?
+  def avo_search?
     false
   end
 

--- a/spec/dummy/app/policies/application_policy.rb
+++ b/spec/dummy/app/policies/application_policy.rb
@@ -26,6 +26,10 @@ class ApplicationPolicy
     false
   end
 
+  def search?
+    false
+  end
+
   def edit?
     update?
   end

--- a/spec/dummy/app/policies/course_link_policy.rb
+++ b/spec/dummy/app/policies/course_link_policy.rb
@@ -35,6 +35,10 @@ class CourseLinkPolicy < ApplicationPolicy
     true
   end
 
+  def search?
+    true
+  end
+
   def upload_attachments?
     true
   end

--- a/spec/dummy/app/policies/course_link_policy.rb
+++ b/spec/dummy/app/policies/course_link_policy.rb
@@ -35,7 +35,7 @@ class CourseLinkPolicy < ApplicationPolicy
     true
   end
 
-  def search?
+  def avo_search?
     true
   end
 

--- a/spec/dummy/app/policies/course_policy.rb
+++ b/spec/dummy/app/policies/course_policy.rb
@@ -59,6 +59,10 @@ class CoursePolicy < ApplicationPolicy
     false
   end
 
+  def avo_search?
+    true
+  end
+
   class Scope < Scope
     def resolve
       scope.all

--- a/spec/dummy/app/policies/post_policy.rb
+++ b/spec/dummy/app/policies/post_policy.rb
@@ -31,7 +31,7 @@ class PostPolicy < ApplicationPolicy
     true
   end
 
-  def search?
+  def avo_search?
     true
   end
 

--- a/spec/dummy/app/policies/post_policy.rb
+++ b/spec/dummy/app/policies/post_policy.rb
@@ -31,6 +31,10 @@ class PostPolicy < ApplicationPolicy
     true
   end
 
+  def search?
+    true
+  end
+
   def upload_attachments?
     true
   end

--- a/spec/dummy/app/policies/team_policy.rb
+++ b/spec/dummy/app/policies/team_policy.rb
@@ -27,7 +27,7 @@ class TeamPolicy < ApplicationPolicy
     true
   end
 
-  def search?
+  def avo_search?
     true
   end
 

--- a/spec/dummy/app/policies/team_policy.rb
+++ b/spec/dummy/app/policies/team_policy.rb
@@ -27,6 +27,10 @@ class TeamPolicy < ApplicationPolicy
     true
   end
 
+  def search?
+    true
+  end
+
   # Attachments
   def upload_attachments?
     true

--- a/spec/dummy/app/policies/user_policy.rb
+++ b/spec/dummy/app/policies/user_policy.rb
@@ -35,6 +35,10 @@ class UserPolicy < ApplicationPolicy
     true
   end
 
+  def search?
+    true
+  end
+
   def attach_post?
     true
   end

--- a/spec/dummy/app/policies/user_policy.rb
+++ b/spec/dummy/app/policies/user_policy.rb
@@ -35,7 +35,7 @@ class UserPolicy < ApplicationPolicy
     true
   end
 
-  def search?
+  def avo_search?
     true
   end
 

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -23,6 +23,9 @@ Avo.configure do |config|
       params: request.params
     }
   end
+  config.authorization_methods = {
+    search: "avo_search?" # override this method
+  }
   # config.raise_error_on_missing_policy = true
   # config.authorization_client = "Avo::Services::AuthorizationClients::ExtraPunditClient"
 

--- a/spec/features/avo/hidden_from_global_search_spec.rb
+++ b/spec/features/avo/hidden_from_global_search_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature Avo::SearchController, type: :controller do
   let!(:team_membership) { team.team_members << user }
 
   describe "global search" do
-    it "does not return the ream membership" do
+    it "does not return the team membership" do
       get :index
 
       expect(json['users']['count']).to eq 1
@@ -17,7 +17,7 @@ RSpec.feature Avo::SearchController, type: :controller do
   end
 
   describe "resource search" do
-    it "does not return the ream membership" do
+    it "does not return the team membership" do
       get :show, params: {
         resource_name: 'memberships'
       }

--- a/spec/features/avo/search_with_custom_path.rb
+++ b/spec/features/avo/search_with_custom_path.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.feature "Search with custom path", type: :system do
+  let(:url) { "/admin/resources/cities" }
+
+  subject do
+    visit url
+    page
+  end
+
+  describe "global search" do
+    let!(:city) { create :city, name: "São Paulo" }
+
+    context "when search result path has been changed" do
+      it "can find the city" do
+        visit url
+        open_global_search_box
+        expect_search_panel_open
+
+        write_in_search "São Paulo"
+        expect(page).to have_content "São Paulo"
+        find(".aa-Panel").find('.aa-Item div', text: 'São Paulo', match: :first).click
+        sleep 0.8
+        # wait_for_loaded # -> didn't work, had to use sleep above
+
+        expect(page.current_url).to include('custom=yup')
+      end
+    end
+  end
+end
+
+def open_global_search_box
+  find(".global-search").click
+end
+
+def expect_search_panel_open
+  expect(page).to have_css ".aa-InputWrapper .aa-Input"
+  expect(page).to have_selector(".aa-Input:focus")
+end

--- a/spec/features/avo/search_with_custom_path.rb
+++ b/spec/features/avo/search_with_custom_path.rb
@@ -19,11 +19,10 @@ RSpec.feature "Search with custom path", type: :system do
 
         write_in_search "São Paulo"
         expect(page).to have_content "São Paulo"
-        find(".aa-Panel").find('.aa-Item div', text: 'São Paulo', match: :first).click
+        find(".aa-Panel").find(".aa-Item div", text: "São Paulo", match: :first).click
         sleep 0.8
-        # wait_for_loaded # -> didn't work, had to use sleep above
 
-        expect(page.current_url).to include('custom=yup')
+        expect(page.current_url).to include("custom=yup")
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -129,6 +129,7 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
+  config.filter_run_when_matching :focus
 
   config.before(:each, type: :system) { driven_by test_driver }
 


### PR DESCRIPTION
Add two new class attributes to `Avo::BaseResource` to further customize the search behaviour:

- search_policy_class: responsible for setting the policy used to authorize the search on the applied resource
- search_result_url: responsible for setting the url to be used in the search results

## Context
An Avo app contains the following classes: 

- ReportResource (used only by admin users to manage reports)
- Avo::Customers::ReportsController (used by customer users to view reports)
- ReportPolicy (allowing only admin users to manage ReportResource)
- Customers::ReportPolicy (allowing customer users to view reports from the controller aforementioned)

When a customer searches for a report on the global search, Avo 2.28 will use `ReportPolicy` to authorize the search and it will deny since a customer can't manage ReportResource.

In order to fix that, I am introducing `search_policy_class`. This class attribute will allow people to set which policy class must be used to authorize seaches:

```ruby
class ReportResource < Avo::BaseResource
  self.title = :title
  self.includes = []
  self.search_policy_class = Customers::ReportPolicy
end
```

Once the authorization is fixed with the `search_policy_class` above, another problem is found: Avo 2.28 will point to `/avo/resources/reports/:report_id` as url in the search results. Remember: customers can't manage reports, so, search results should point to `/avo/customers/reports/:report_id` instead, that's why `search_result_url` has been introduced:

```ruby
class ReportResource < Avo::BaseResource
  self.title = :title
  self.includes = []
  self.search_policy_class = Customers::ReportPolicy
  self.search_result_url = ->(report, main_app, params) do
    if params[:global] == "true"
      main_app.customer_report_path(report)
    end
  end
end
```

In the example above, if the search is global (performed possibly by a customer), search results will point to `customer_report_path`, otherwise, if it's performed on the ReportResource index page (only by an admin) it will point to  `/avo/resources/reports/:report_id` (sames as in Avo 2.28).

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs) -> will open a PR for that
- [X] I have added tests that prove my fix is effective or that my feature works


## Manual review steps

1. Create a resource class, eg: ReportResource
2. Create a "tool" controller to read these resources
3. Create two policy classes: ReportPolicy to authorize ReportResource and Customers::ReportPolicy to authorize the tool controller
4. Perform a global search with an user that can only read the tool controller (not the ReportResource)
