### PR TITLE
Fix/generate has rich text

### DIFF
--- a/lib/avo/engine.rb
+++ b/lib/avo/engine.rb
@@ -7,6 +7,8 @@ Gem.loaded_specs["avo"].dependencies.each do |d|
     require "action_view/railtie"
   when "activestorage"
     require "active_storage/engine"
+  when "actiontext"
+    require "action_text/engine"
   else
     require d.name
   end

--- a/lib/generators/avo/resource_generator.rb
+++ b/lib/generators/avo/resource_generator.rb
@@ -87,12 +87,20 @@ module Generators
         end
       end
 
+      def rich_texts
+        @rich_texts ||= reflections.select do |_, reflection|
+          reflection.options[:class_name] == "ActionText::RichText"
+        end
+      end
+
       def tags
         @tags ||= reflections.select { |_, reflection| reflection.options[:as] == :taggable }
       end
 
       def associations
-        @associations ||= reflections.reject { |key| attachments.key?(key) || tags.key?(key) }
+        @associations ||= reflections.reject do |key|
+          attachments.key?(key) || tags.key?(key) || rich_texts.key?(key)
+        end
       end
 
       def fields
@@ -115,6 +123,7 @@ module Generators
         fields_from_model_enums
         fields_from_model_attachements
         fields_from_model_associations
+        fields_from_model_rich_texts
         fields_from_model_tags
 
         generated_fields_template
@@ -147,6 +156,12 @@ module Generators
         end
 
         generated_fields_template
+      end
+
+      def fields_from_model_rich_texts
+        rich_texts.each do |name, _|
+          fields[(name.delete_prefix("rich_text_"))] = {field: "trix"}
+        end
       end
 
       def fields_from_model_tags

--- a/spec/dummy/app/models/event.rb
+++ b/spec/dummy/app/models/event.rb
@@ -1,2 +1,3 @@
 class Event < ApplicationRecord
+  has_rich_text :body
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -7,10 +7,10 @@ require "active_storage/engine"
 require "action_controller/railtie"
 require "action_view/railtie"
 require "action_mailer/railtie"
+require "action_text/engine"
 # require "active_job/railtie"
 # require "action_cable/engine"
 # require "action_mailbox/engine"
-# require "action_text/engine"
 # require "rails/test_unit/railtie"
 
 Bundler.require(*Rails.groups)

--- a/spec/dummy/db/migrate/20230321130610_add_body_to_events.rb
+++ b/spec/dummy/db/migrate/20230321130610_add_body_to_events.rb
@@ -1,0 +1,5 @@
+class AddBodyToEvents < ActiveRecord::Migration[6.0]
+  def change
+    add_column :events, :body, :text
+  end
+end

--- a/spec/dummy/db/migrate/20230321133502_create_action_text_tables.action_text.rb
+++ b/spec/dummy/db/migrate/20230321133502_create_action_text_tables.action_text.rb
@@ -1,0 +1,14 @@
+# This migration comes from action_text (originally 20180528164100)
+class CreateActionTextTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :action_text_rich_texts do |t|
+      t.string     :name, null: false
+      t.text       :body, size: :long
+      t.references :record, null: false, polymorphic: true, index: false
+
+      t.timestamps
+
+      t.index [ :record_type, :record_id, :name ], name: "index_action_text_rich_texts_uniqueness", unique: true
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_21_130610) do
+ActiveRecord::Schema.define(version: 2023_03_21_133502) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "action_text_rich_texts", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "body"
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_15_105546) do
+ActiveRecord::Schema.define(version: 2023_03_21_130610) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 2023_02_15_105546) do
     t.datetime "event_time"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "body"
   end
 
   create_table "fish", force: :cascade do |t|

--- a/spec/features/avo/generators/resource_generator_spec.rb
+++ b/spec/features/avo/generators/resource_generator_spec.rb
@@ -28,5 +28,19 @@ RSpec.feature "resource generator", type: :feature do
     end
   end
 
+  context 'when generating resources from a rich texts' do
+    it 'generates with the correct trix field type' do
+      files = [
+        Rails.root.join("app", "avo", "resources", "event_resource.rb").to_s,
+        Rails.root.join("app", "controllers", "avo", "events_controller.rb").to_s
+      ]
+
+      Rails::Generators.invoke("avo:resource", ["event", "-q"], {destination_root: Rails.root})
+
+      expect(File.read(files[0])).to include('field :body, as: :trix')
+
+      check_files_and_clean_up files
+    end
+  end
 
 end


### PR DESCRIPTION
# Description
Fixes the problem with `has_rich_text` in the model during the resource generation #1635

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Manual review steps
1. Add the rich text to your model `has_rich_text :content `
2. Genereta avo resouce `rails generate avo:resource event `
3. It should add `field :content, as: :trix`