### PR TITLE
Fix adding tags without acts as taggable on

### DIFF
--- a/app/javascript/js/controllers/fields/tags_field_controller.js
+++ b/app/javascript/js/controllers/fields/tags_field_controller.js
@@ -60,6 +60,10 @@ export default class extends BaseController {
         },
         originalInputValueFormat: (valuesArr) => valuesArr.map((item) => item.value),
       })
+    } else {
+      options = merge(options, {
+        originalInputValueFormat: (valuesArr) => valuesArr.map((item) => item.value).join(','),
+      })
     }
 
     return options

--- a/spec/system/avo/tags_spec.rb
+++ b/spec/system/avo/tags_spec.rb
@@ -89,6 +89,29 @@ RSpec.describe "Tags", type: :system do
     end
   end
 
+  describe 'without acts_as_taggable' do
+    let(:course) { create :course, skills: [] }
+    let(:path) { "/admin/resources/courses/#{course.id}/edit" }
+    let(:tag_input) { tags_element(find_field_value_element("skills")) }
+    let(:input_textbox) { 'span[contenteditable][data-placeholder="Skills"]' }
+
+    it "adds skills" do
+      course.skills = ["some", "skills"]
+      course.save
+
+      visit path
+
+      tag_input.find(input_textbox).click
+      tag_input.find(input_textbox).set("one, two, three,")
+      sleep 0.3
+
+      click_on "Save"
+      wait_for_loaded
+
+      expect(course.reload.skills.sort).to eq ["some", "skills", "one", "two", "three"].sort
+    end
+  end
+
   describe "ajax request" do
     let(:field_value_slot) { tags_element(find_field_value_element("user_id")) }
     let(:tags_input) { field_value_slot.find("span[contenteditable]") }


### PR DESCRIPTION
# Description
When we edit the tags for a model without `acts_as_taggable_on` or provide only values in suggestions as in #1643 , the application will save JSON string to database  `[{ "value": "game lovers", "{ "tapas fans", "{ "mini golf enthusiasts".]`. I added a logic to map values to an array in case they are not an object

Fixes #1643

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
1. Go to edit courses page 
2. Add new tags
3. Save the course 

