### PR TITLE
fix: divider renders invisible by default

### DIFF
--- a/lib/avo/dashboards/base_divider.rb
+++ b/lib/avo/dashboards/base_divider.rb
@@ -11,7 +11,7 @@ module Avo
 
       class_attribute :id
 
-      def initialize(dashboard: nil, label: nil, invisible: false, index: nil, visible: nil)
+      def initialize(dashboard: nil, label: nil, invisible: false, index: nil, visible: true)
         @dashboard = dashboard
         @label = label
         @invisible = invisible


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where the dividers are rendered invisible by default.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works
