### PR TITLE
improvement: another approach on attachments field level authorization

### DIFF
--- a/app/controllers/avo/attachments_controller.rb
+++ b/app/controllers/avo/attachments_controller.rb
@@ -40,9 +40,7 @@ module Avo
     private
 
     def authorized_to(action)
-      if @resource.authorization.authorize_action("#{action}_attachments?".to_sym, raise_exception: false)
-        @resource.authorization.authorize_action("#{action}_#{params[:attachment_name]}?", record: @model, raise_exception: false)
-      end
+      @resource.authorization.authorize_action("#{action}_#{params[:attachment_name]}?", record: @model, raise_exception: false)
     end
   end
 end

--- a/lib/avo/fields/concerns/file_authorization.rb
+++ b/lib/avo/fields/concerns/file_authorization.rb
@@ -22,32 +22,7 @@ module Avo
 
         private
 
-        # First we check if user have authorization to act on attachments
-        # If attachemnts level authorization is defined and user do NOT have authorization to act on attachments
-        # We return false
-
-        # If attachemnts level authorization is defined and user have authorization to act on attachments
-        # We check if field level authorization is defined
-
-        # If field level authorization is NOT defined we return true
-        # If field level authorization is defined we return field level authorization
         def authorize_file_action(action)
-          # If act on atachments (upload, download, delete) is defined
-          # Check if user have authorization to act on attachments
-          if authorization.has_method?("#{action}_attachments?", raise_exception: false)
-            return false unless authorize_action("#{action}_attachments?", raise_exception: false)
-
-            # If user have authorization to act on attachments
-            # And field level authorization is not defined
-            # We return true
-            if !authorization.has_method?("#{action}_#{id}?", raise_exception: false)
-              return true
-            end
-          end
-
-          # If field level authorization is defined
-          # And act on attachemnts is not defined or user have authorization to act on attachments
-          # Return field level authorization
           authorize_action("#{action}_#{id}?", record: model, raise_exception: false)
         end
       end

--- a/lib/avo/fields/concerns/file_authorization.rb
+++ b/lib/avo/fields/concerns/file_authorization.rb
@@ -23,19 +23,31 @@ module Avo
         private
 
         # First we check if user have authorization to act on attachments
-        # If attachemnts level authorization is defined and user have authorization to act on attachments
-        # We check field level authorization
-        # If field level authorization is not defined or user do NOT have authorization to act on attachments
+        # If attachemnts level authorization is defined and user do NOT have authorization to act on attachments
         # We return false
+
+        # If attachemnts level authorization is defined and user have authorization to act on attachments
+        # We check if field level authorization is defined
+
+        # If field level authorization is NOT defined we return true
+        # If field level authorization is defined we return field level authorization
         def authorize_file_action(action)
           # If act on atachments (upload, download, delete) is defined
           # Check if user have authorization to act on attachments
           if authorization.has_method?("#{action}_attachments?", raise_exception: false)
             return false unless authorize_action("#{action}_attachments?", raise_exception: false)
+
+            # If user have authorization to act on attachments
+            # And field level authorization is not defined
+            # We return true
+            if !authorization.has_method?("#{action}_#{id}?", raise_exception: false)
+              return true
+            end
           end
 
-          # If act on attachemnts is not defined or user have authorization to act on attachments
-          # Check  field level authorization
+          # If field level authorization is defined
+          # And act on attachemnts is not defined or user have authorization to act on attachments
+          # Return field level authorization
           authorize_action("#{action}_#{id}?", record: model, raise_exception: false)
         end
       end

--- a/lib/avo/fields/concerns/file_authorization.rb
+++ b/lib/avo/fields/concerns/file_authorization.rb
@@ -22,8 +22,21 @@ module Avo
 
         private
 
+        # First we check if user have authorization to act on attachments
+        # If attachemnts level authorization is defined and user have authorization to act on attachments
+        # We check field level authorization
+        # If field level authorization is not defined or user do NOT have authorization to act on attachments
+        # We return false
         def authorize_file_action(action)
-          authorize_action("#{action}_attachments?", raise_exception: false) || authorize_action("#{action}_#{id}?", record: model, raise_exception: false)
+          # If act on atachments (upload, download, delete) is defined
+          # Check if user have authorization to act on attachments
+          if authorization.has_method?("#{action}_attachments?", raise_exception: false)
+            return false unless authorize_action("#{action}_attachments?", raise_exception: false)
+          end
+
+          # If act on attachemnts is not defined or user have authorization to act on attachments
+          # Check  field level authorization
+          authorize_action("#{action}_#{id}?", record: model, raise_exception: false)
         end
       end
     end

--- a/spec/dummy/app/policies/course_link_policy.rb
+++ b/spec/dummy/app/policies/course_link_policy.rb
@@ -39,18 +39,6 @@ class CourseLinkPolicy < ApplicationPolicy
     true
   end
 
-  def upload_attachments?
-    true
-  end
-
-  def download_attachments?
-    true
-  end
-
-  def delete_attachments?
-    true
-  end
-
   def view_comments?
     true
   end

--- a/spec/dummy/app/policies/course_policy.rb
+++ b/spec/dummy/app/policies/course_policy.rb
@@ -35,18 +35,6 @@ class CoursePolicy < ApplicationPolicy
     true
   end
 
-  def upload_attachments?
-    true
-  end
-
-  def download_attachments?
-    true
-  end
-
-  def delete_attachments?
-    true
-  end
-
   def view_comments?
     true
   end

--- a/spec/dummy/app/policies/photo_comment_policy.rb
+++ b/spec/dummy/app/policies/photo_comment_policy.rb
@@ -27,16 +27,10 @@ class PhotoCommentPolicy < ApplicationPolicy
     true
   end
 
-  def upload_attachments?
-    true
-  end
-
-  def download_attachments?
-    true
-  end
-
-  def delete_attachments?
-    true
+  [:upload, :download, :delete].each do |action|
+    define_method "#{action}_photo?" do
+      true
+    end
   end
 
   class Scope < Scope

--- a/spec/dummy/app/policies/post_policy.rb
+++ b/spec/dummy/app/policies/post_policy.rb
@@ -35,18 +35,6 @@ class PostPolicy < ApplicationPolicy
     true
   end
 
-  def upload_attachments?
-    true
-  end
-
-  def download_attachments?
-    true
-  end
-
-  def delete_attachments?
-    true
-  end
-
   [:cover_photo, :audio].each do |file|
     [:upload, :download, :delete].each do |action|
       define_method "#{action}_#{file}?" do

--- a/spec/dummy/app/policies/project_policy.rb
+++ b/spec/dummy/app/policies/project_policy.rb
@@ -27,18 +27,6 @@ class ProjectPolicy < ApplicationPolicy
     true
   end
 
-  def upload_attachments?
-    true
-  end
-
-  def download_attachments?
-    true
-  end
-
-  def delete_attachments?
-    true
-  end
-
   [:upload, :download, :delete].each do |action|
     define_method "#{action}_files?" do
       true

--- a/spec/dummy/app/policies/team_policy.rb
+++ b/spec/dummy/app/policies/team_policy.rb
@@ -31,19 +31,6 @@ class TeamPolicy < ApplicationPolicy
     true
   end
 
-  # Attachments
-  def upload_attachments?
-    true
-  end
-
-  def download_attachments?
-    true
-  end
-
-  def delete_attachments?
-    true
-  end
-
   # Team members association
   # index? method
   def view_team_members?

--- a/spec/dummy/app/policies/user_policy.rb
+++ b/spec/dummy/app/policies/user_policy.rb
@@ -75,18 +75,6 @@ class UserPolicy < ApplicationPolicy
     false
   end
 
-  def upload_attachments?
-    true
-  end
-
-  def download_attachments?
-    true
-  end
-
-  def delete_attachments?
-    true
-  end
-
   [:upload, :download, :delete].each do |action|
     define_method "#{action}_cv?" do
       true


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1662

# UPDATE

We have discovered that assigning different weights to two methods that police the same thing can be a complex and challenging task. As a result, we have decided to make `upload_attachments?`, `download_attachments?`, and `delete_attachments?` obsolete.

From now on, only field level authorization will be considered. If it is defined and returns true, the action will be granted; otherwise, it will not.

## Previous approach

~~How it works:~~

~~`upload_attachments?`, `download_attachments?` and `delete_attachments?` are first level authorization for attachments. 
`upload_file_name?`, `download_file_name?` and `delete_file_name?`  are second level authorization for each field.~~

~~Lets pick uploads example:~~

~~If `upload_attachments?` is NOT defined only `upload_file_name?` will count for authorize an action on a field...
If `upload_attachments?` is defined,  `upload_file_name?` will count  only if `upload_attachments?` return true.~~

~~Why? This way you can do something like:~~

~~All admins and managers can upload attachments but only admins can upload that important document...~~

```ruby
def upload_attachments?
  user.admin? || user.manager?
end

def upload_important_document?
   user.admin?
end
```

~~OR~~

~~Nobody can upload any attachments but admins can upload that important document...~~

```ruby
def upload_important_document?
   user.admin?
end
```

~~OR~~

~~Anyone can upload attachments but nobody can upload that important document.~~

```ruby
def upload_attachments?
  true
end

def upload_important_document?
   false
end
```


~~NOTICE:~~

~~The follow example don't make much sense to use it...
If upload_attachments are false, field level authorization will not be checked for uploads.
If you want to turn all uploads off and allow only specific uploads do NOT  define `uploads_attachments?`~~
```ruby
def upload_attachments?
  false
end

def upload_important_document?
   true
end
```
~~
<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

