### PR TITLE
feature: display_filename option for file and files field

### DIFF
--- a/app/components/avo/fields/common/single_file_viewer_component.html.erb
+++ b/app/components/avo/fields/common/single_file_viewer_component.html.erb
@@ -16,7 +16,9 @@
           </div>
         </div>
       <% end %>
-      <span class="text-gray-500 mt-2 text-sm truncate" title="<%= file.filename %>"><%= file.filename %></span>
+      <% if field.display_filename %>
+        <span class="text-gray-500 mt-2 text-sm truncate" title="<%= file.filename %>"><%= file.filename %></span>
+      <% end %>
     </div>
     <div class="flex space-x-2">
       <div class="flex">

--- a/app/components/avo/fields/common/single_file_viewer_component.rb
+++ b/app/components/avo/fields/common/single_file_viewer_component.rb
@@ -4,6 +4,8 @@ class Avo::Fields::Common::SingleFileViewerComponent < ViewComponent::Base
   include Avo::ApplicationHelper
   include Avo::Fields::Concerns::FileAuthorization
 
+  attr_reader :field
+
   def initialize(field:, resource:, file: nil)
     @file = file
     @field = field
@@ -15,29 +17,29 @@ class Avo::Fields::Common::SingleFileViewerComponent < ViewComponent::Base
   end
 
   def id
-    @field.id
+    field.id
   end
 
   def file
-    @file || @field.value.attachment
+    @file || field.value.attachment
   rescue
     nil
   end
 
   def is_image?
-    file.image? || @field.is_image
+    file.image? || field.is_image
   rescue
     false
   end
 
   def is_audio?
-    file.audio? || @field.is_audio
+    file.audio? || field.is_audio
   rescue
     false
   end
 
   def is_video?
-    file.video? || @field.is_video
+    file.video? || field.is_video
   rescue
     false
   end

--- a/lib/avo/fields/file_field.rb
+++ b/lib/avo/fields/file_field.rb
@@ -7,6 +7,7 @@ module Avo
       attr_accessor :is_audio
       attr_accessor :direct_upload
       attr_accessor :accept
+      attr_reader :display_filename
 
       def initialize(id, **args, &block)
         super(id, **args, &block)
@@ -17,6 +18,7 @@ module Avo
         @is_audio = args[:is_audio].present? ? args[:is_audio] : false
         @direct_upload = args[:direct_upload].present? ? args[:direct_upload] : false
         @accept = args[:accept].present? ? args[:accept] : nil
+        @display_filename = args[:display_filename].nil? ? true : args[:display_filename]
       end
 
       def path

--- a/lib/avo/fields/files_field.rb
+++ b/lib/avo/fields/files_field.rb
@@ -14,7 +14,7 @@ module Avo
         @is_image = args[:is_image].present? ? args[:is_image] : @is_avatar
         @direct_upload = args[:direct_upload].present? ? args[:direct_upload] : false
         @accept = args[:accept].present? ? args[:accept] : nil
-        @display_filename = args[:display_filename].present? ? args[:display_filename] : true
+        @display_filename = args[:display_filename].nil? ? true : args[:display_filename]
       end
 
       def view_component_name

--- a/lib/avo/fields/files_field.rb
+++ b/lib/avo/fields/files_field.rb
@@ -5,6 +5,7 @@ module Avo
       attr_accessor :is_image
       attr_accessor :direct_upload
       attr_accessor :accept
+      attr_reader :display_filename
 
       def initialize(id, **args, &block)
         super(id, **args, &block)
@@ -13,6 +14,7 @@ module Avo
         @is_image = args[:is_image].present? ? args[:is_image] : @is_avatar
         @direct_upload = args[:direct_upload].present? ? args[:direct_upload] : false
         @accept = args[:accept].present? ? args[:accept] : nil
+        @display_filename = args[:display_filename].present? ? args[:display_filename] : true
       end
 
       def view_component_name

--- a/spec/dummy/app/avo/resources/post_resource.rb
+++ b/spec/dummy/app/avo/resources/post_resource.rb
@@ -35,7 +35,7 @@ class PostResource < Avo::BaseResource
     suggestions: -> { Post.tags_suggestions },
     enforce_suggestions: true,
     help: "The only allowed values here are `one`, `two`, and `three`"
-  field :cover_photo, as: :file, is_image: true, as_avatar: :rounded, full_width: true, hide_on: [], accept: "image/*"
+  field :cover_photo, as: :file, is_image: true, as_avatar: :rounded, full_width: true, hide_on: [], accept: "image/*", display_filename: false
   field :cover_photo, as: :external_image, name: "Cover photo", required: true, hide_on: :all, link_to_resource: true, as_avatar: :rounded, format_using: ->(value) { value.present? ? value&.url : nil }
   field :audio, as: :file, is_audio: true, accept: "audio/*"
   field :excerpt, as: :text, hide_on: :all, as_description: true do |model|


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1664

Now it's possible to hide the caption of an image with the option `display_filename: false` on a `file`/`files` field


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
