### PR TITLE
fix: allow field visible false

### DIFF
--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -73,7 +73,7 @@ module Avo
         @placeholder = args[:placeholder]
         @help = args[:help] || nil
         @default = args[:default] || nil
-        @visible = args[:visible] || true
+        @visible = args[:visible]
         @as_label = args[:as_label] || false
         @as_avatar = args[:as_avatar] || false
         @as_description = args[:as_description] || false
@@ -156,7 +156,9 @@ module Avo
       end
 
       def visible?
-        if visible.present? && visible.respond_to?(:call)
+        return true if visible.nil?
+
+        if visible.respond_to?(:call)
           visible.call resource: @resource
         else
           visible


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where you can't set the `visible` field option to `false`.

```ruby
# example
field :user, as: belongs, visible: false # this does not hide the field
```

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


