### PR TITLE
fix: disable sorting on id field

### DIFF
--- a/lib/avo/fields/id_field.rb
+++ b/lib/avo/fields/id_field.rb
@@ -5,11 +5,12 @@ module Avo
 
       def initialize(id, **args, &block)
         args[:readonly] = true
-        args[:sortable] = true
 
         hide_on [:edit, :new]
 
         super(id, **args, &block)
+
+        add_boolean_prop args, :sortable, true
 
         @link_to_resource = args[:link_to_resource].present? ? args[:link_to_resource] : false
       end

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -19,7 +19,7 @@ class UserResource < Avo::BaseResource
   self.includes = [:posts, :post]
   self.devise_password_optional = true
 
-  field :id, as: :id, link_to_resource: true
+  field :id, as: :id, link_to_resource: true, sortable: false
   field :email, as: :gravatar, link_to_resource: true, as_avatar: :circle, only_on: :index
   heading "User Information"
   field :first_name, as: :text, placeholder: "John", stacked: true

--- a/spec/features/avo/field_sorting_spec.rb
+++ b/spec/features/avo/field_sorting_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.feature "Field Sorting", type: :feature do
+  let!(:user) { create :user }
+  let!(:project) { create :project }
+
+  describe "sortable field option" do
+    it "provides the ability to sort by the ID field by default" do
+      visit avo.resources_projects_path
+
+      expect(page).not_to have_css 'th[data-control="resource-field-th"][data-table-header-field-id="id"][data-table-header-field-type="id"] div'
+      expect(page).to have_css 'th[data-control="resource-field-th"][data-table-header-field-id="id"][data-table-header-field-type="id"] a svg'
+    end
+
+    it "hides the ability to sort by the id field" do
+      visit avo.resources_users_path
+
+      expect(page).to have_css 'th[data-control="resource-field-th"][data-table-header-field-id="id"][data-table-header-field-type="id"] div'
+      expect(page).not_to have_css 'th[data-control="resource-field-th"][data-table-header-field-id="id"][data-table-header-field-type="id"] a svg'
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1676

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Visit the users page. Observe that the ID field is not sortable
1. Visit the projects page. Observe that the ID field is sortable

Manual reviewer: please leave a comment with output from the test if that's the case.
