### PR TITLE
Remove orphan closing tags from SVGs

### DIFF
--- a/app/assets/svgs/failed_to_load.svg
+++ b/app/assets/svgs/failed_to_load.svg
@@ -9,6 +9,5 @@
 <defs>
 <stop stop-color="#E3ECFA"/>
 <stop offset="1" stop-color="#DAE7FF"/>
-</linearGradient>
 </defs>
 </svg>

--- a/app/assets/svgs/grid-empty-state.svg
+++ b/app/assets/svgs/grid-empty-state.svg
@@ -22,7 +22,6 @@
 <feColorMatrix type="matrix" values="0 0 0 0 0.788235 0 0 0 0 0.803922 0 0 0 0 0.85098 0 0 0 0.349 0"/>
 <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_577_1090"/>
 <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_577_1090" result="shape"/>
-</filter>
 <filter id="filter1_d_577_1090" x="38.6401" y="0" width="170.72" height="78.1333" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>

--- a/app/assets/svgs/table-empty-state.svg
+++ b/app/assets/svgs/table-empty-state.svg
@@ -51,6 +51,5 @@
 </filter>
 <stop stop-color="#E3ECFA"/>
 <stop offset="1" stop-color="#DAE7FF"/>
-</linearGradient>
 </defs>
 </svg>


### PR DESCRIPTION
# Description
In order to display valid SVGs to browser clients, remove extra closing tags from several SVGs. These appear to have been paired to opening tags at some time, but the opening tags are no longer present.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. View a resource index page where there are no resource records. The `table_empty_state.svg` file should render in the main content area.
2. View a resource index page in grid mode. The `grid_empty_state.svg` file should render in the main content area.

I'm not sure how to test the `failed_to_load.svg` but I saw that it was invalid like the others so I corrected it.
Manual reviewer: please leave a comment with output from the test if that's the case.
