### PR TITLE
Add helpers for encoding/decoding filter params

### DIFF
--- a/app/helpers/avo/application_helper.rb
+++ b/app/helpers/avo/application_helper.rb
@@ -111,6 +111,14 @@ module Avo
       Avo::Engine.routes.find_script_name(params.permit!.to_h.symbolize_keys)
     end
 
+    def decode_filter_params(encoded_params)
+      Avo::Filters::BaseFilter.decode_filters(encoded_params)
+    end
+
+    def encode_filter_params(filter_params)
+      Avo::Filters::BaseFilter.encode_filters(filter_params)
+    end
+
     private
 
     # Taken from the original library

--- a/lib/avo/filters/base_filter.rb
+++ b/lib/avo/filters/base_filter.rb
@@ -21,6 +21,10 @@ module Avo
           {}
         end
 
+        def encode_filters(filter_params)
+          Base64.encode64(filter_params.to_json)
+        end
+
         def get_empty_message
           empty_message || I18n.t("avo.no_options_available")
         end

--- a/spec/helpers/avo/application_helper_spec.rb
+++ b/spec/helpers/avo/application_helper_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Avo::ApplicationHelper do
+  context "handling filter params" do
+    let(:params) {
+      {
+        "q" => {
+          "name" => "test"
+        }
+      }
+    }
+    let(:encoded_params) { Base64.encode64(params.to_json) }
+
+    describe "#decode_filter_params" do
+      it "decodes encoded params" do
+        expect(helper.decode_filter_params(encoded_params)).to eq(params)
+      end
+    end
+
+    describe "#encode_filter_params" do
+      it "encodes params" do
+        expect(helper.encode_filter_params(params)).to eq(encoded_params)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description
In order to allow page authors to create links that go to a resource page with a filter already enabled, expose encode and decode methods for filter params.

This was inspired by a conversation we had on the Avo discord.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
This PR does not include any user-visible changes. I'll add a comment with the test output.