### PR TITLE
feature: inherit_association_from_policy

### DIFF
--- a/lib/avo/concerns/policy_helpers.rb
+++ b/lib/avo/concerns/policy_helpers.rb
@@ -1,0 +1,31 @@
+module Avo
+  module Concerns
+    module PolicyHelpers
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def inherit_association_from_policy(association_name, policy_class)
+          [:create, :edit, :update, :destroy, :show, :reorder, :act_on].each do |method_action|
+            define_policy_method(method_action, association_name, policy_class)
+          end
+
+          define_policy_method("view", association_name, policy_class, "index")
+        end
+
+        private
+
+        # Define a method for the given action and association name.
+        # Call the policy class with the given action passing the user and record.
+        # Example:
+        #  def create_team_members?
+        #   TeamMemberPolicy.new(user, record).create?
+        #  end
+        def define_policy_method(method_action, association_name, policy_class, policy_action = method_action)
+          define_method "#{method_action}_#{association_name}?" do
+            policy_class.new(user, record).send "#{policy_action}?"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/app/policies/course_policy.rb
+++ b/spec/dummy/app/policies/course_policy.rb
@@ -1,4 +1,7 @@
 class CoursePolicy < ApplicationPolicy
+  include Avo::Concerns::PolicyHelpers
+  inherit_association_from_policy :links, CourseLinkPolicy
+
   def index?
     true
   end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1663

We offer a new concern for, PolicyHelpers. This concern is supposed to DRY your policy classes.

Usage:

```ruby
include Avo::Concerns::PolicyHelpers
inherit_association_from_policy :links, CourseLinkPolicy
```

The line `inherit_association_from_policy :links, CourseLinkPolicy` means that all association methods for links will be policed by parent policy `CourseLinkPolicy`

For example, if we include `inherit_association_from_policy :links, CourseLinkPolicy` in our `CoursePolicy` this helper will define the following methods on our policy:

```ruby
def create_links?
  CourseLinkPolicy.new(user, record).create?
end

def edit_links?
  CourseLinkPolicy.new(user, record).edit?
end

def update_links?
  CourseLinkPolicy.new(user, record).update?
end

def destroy_links?
  CourseLinkPolicy.new(user, record).destroy?
end

def show_links?
  CourseLinkPolicy.new(user, record).show?
end

def reorder_links?
  CourseLinkPolicy.new(user, record).reorder?
end

def act_on_links?
  CourseLinkPolicy.new(user, record).act_on?
end

def view_links?
  CourseLinkPolicy.new(user, record).index?
end
```

These methods would not be visible on your policy code but you will be always able to override them by declaring them. For example if we write the following code on our `CoursePolicy` this code will be executed instead the defined one by the helper:

```ruby
def destroy_links?
  false
end
```

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. `include Avo::Concerns::PolicyHelpers` on some policy or on `ApplicationPolicy`
2. Write this line `inherit_association_from_policy :association, ParentPolicy` on some policy
3. Verify that policy from `ParentPolicy` is applied on the `:association`

