### PR TITLE
fix: readonly as proc

### DIFF
--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -119,7 +119,7 @@ class Avo::ResourceComponent < Avo::BaseComponent
     end
 
     if filtered_fields.present?
-      filtered_fields.find { |f| f.id == @reflection.name }.readonly
+      filtered_fields.find { |f| f.id == @reflection.name }.is_readonly?
     else
       false
     end

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -85,7 +85,6 @@ module Avo
 
         @args = args
 
-        @updatable = !readonly
         @computable = true
         @computed = block.present?
         @computed_value = nil
@@ -257,7 +256,7 @@ module Avo
       end
 
       def updatable
-        @updatable && visible?
+        !is_readonly? && visible?
       end
 
       private


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1688

We were wrongly initializing `@updatable = !readonly`, this would not work when `readonly` is a proc.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

