### PR TITLE
Fix: ActiveStorage current url_options should be set as a hash of url options

### DIFF
--- a/lib/avo/app.rb
+++ b/lib/avo/app.rb
@@ -63,7 +63,7 @@ module Avo
             if Rails::VERSION::MAJOR === 6
               ActiveStorage::Current.host = request.base_url
             elsif Rails::VERSION::MAJOR === 7
-              ActiveStorage::Current.url_options = request.base_url
+              ActiveStorage::Current.url_options = {protocol: request.protocol, host: request.host, port: request.port}
             end
           end
         rescue => exception


### PR DESCRIPTION
# Description

`ActiveStorage::Current.url_options` is set as a hash for Rails 7.

Fixes https://github.com/avo-hq/avo/issues/1706

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

