### PR TITLE
Add autocomplete field option

### DIFF
--- a/app/components/avo/fields/country_field/edit_component.html.erb
+++ b/app/components/avo/fields/country_field/edit_component.html.erb
@@ -10,6 +10,7 @@
     data: @field.get_html(:data, view: view, element: :input),
     disabled: disabled?,
     style: @field.get_html(:style, view: view, element: :input),
-    placeholder: @field.include_blank.present? ? nil : @field.placeholder
+    placeholder: @field.include_blank.present? ? nil : @field.placeholder,
+    autocomplete: @field.autocomplete
   %>
 <% end %>

--- a/app/components/avo/fields/number_field/edit_component.html.erb
+++ b/app/components/avo/fields/number_field/edit_component.html.erb
@@ -7,6 +7,7 @@
     min: @field.min,
     placeholder: @field.placeholder,
     step: @field.step,
-    style: @field.get_html(:style, view: view, element: :input)
+    style: @field.get_html(:style, view: view, element: :input),
+    autocomplete: @field.autocomplete
   %>
 <% end %>

--- a/app/components/avo/fields/password_field/edit_component.html.erb
+++ b/app/components/avo/fields/password_field/edit_component.html.erb
@@ -4,6 +4,7 @@
     data: @field.get_html(:data, view: view, element: :input),
     disabled: disabled?,
     placeholder: @field.placeholder,
-    style: @field.get_html(:style, view: view, element: :input)
+    style: @field.get_html(:style, view: view, element: :input),
+    autocomplete: @field.autocomplete
     %>
 <% end %>

--- a/app/components/avo/fields/select_field/edit_component.html.erb
+++ b/app/components/avo/fields/select_field/edit_component.html.erb
@@ -10,6 +10,7 @@
     disabled: disabled?,
     style: @field.get_html(:style, view: view, element: :input),
     value: @field.model.present? ? @field.model[@field.id] : @field.value,
-    placeholder: @field.include_blank.present? ? nil : @field.placeholder
+    placeholder: @field.include_blank.present? ? nil : @field.placeholder,
+    autocomplete: @field.autocomplete
   %>
 <% end %>

--- a/app/components/avo/fields/text_field/edit_component.html.erb
+++ b/app/components/avo/fields/text_field/edit_component.html.erb
@@ -6,6 +6,7 @@
     placeholder: @field.placeholder,
     style: @field.get_html(:style, view: view, element: :input),
     # value: @field.value,
-    multiple: multiple
+    multiple: multiple,
+    autocomplete: @field.autocomplete
   %>
 <% end %>

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -30,6 +30,7 @@ module Avo
       attr_reader :nullable
       attr_reader :null_values
       attr_reader :format_using
+      attr_reader :autocomplete
       attr_reader :help
       attr_reader :default
       attr_reader :visible
@@ -70,6 +71,7 @@ module Avo
         @null_values = args[:null_values] || [nil, ""]
         @format_using = args[:format_using] || nil
         @placeholder = args[:placeholder]
+        @autocomplete = args[:autocomplete] || nil
         @help = args[:help] || nil
         @default = args[:default] || nil
         @visible = args[:visible]


### PR DESCRIPTION
# Description
In order to allow admins to add `autocomplete` attributes to form fields (e.g. to support address autofill from mapbox), create a new `autocomplete` field option. Default should be no `autocomplete` attribute at all on the form input element.

Fixes # (issue)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
