### PR TITLE
Add Rails 7.0.x to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
         rails:
           - '6.0'
           - '6.1'
+          - '7.0'
         exclude:
           - ruby: '3.2.2'
             rails: '6.0'

--- a/lib/avo/concerns/fetches_things.rb
+++ b/lib/avo/concerns/fetches_things.rb
@@ -24,9 +24,7 @@ module Avo
 
         # Filters out the resources that are missing the model_class
         def valid_resources
-          resources.select do |resource|
-            resource.model_class.present?
-          end
+          resources.select { |resource| resource.model_class.present? }.sort_by(&:name)
         end
 
         # Returns the Avo resource by camelized name


### PR DESCRIPTION
# Description
In order to ensure compatibility with the latest rails release, add `7.0` to the test matrix in github CI.

Fixes # (issue)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
