### PR TITLE
[Fix] When initializing an Action any class variables should be set to nil if appropriate

### DIFF
--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -58,10 +58,10 @@ module Avo
     end
 
     def initialize(model: nil, resource: nil, user: nil, view: nil, arguments: {})
-      self.class.model = model if model.present?
-      self.class.resource = resource if resource.present?
-      self.class.user = user if user.present?
-      self.class.view = view if view.present?
+      self.class.model = model
+      self.class.resource = resource
+      self.class.user = user
+      self.class.view = view
       @arguments = arguments
 
       self.class.message ||= I18n.t("avo.are_you_sure_you_want_to_run_this_option")

--- a/spec/dummy/app/avo/actions/release_fish.rb
+++ b/spec/dummy/app/avo/actions/release_fish.rb
@@ -1,7 +1,7 @@
 class ReleaseFish < Avo::BaseAction
   self.name = "Release fish"
   self.message = -> {
-    "Are you sure you want to release the #{record.name}?"
+    "Are you sure you want to release the #{record&.name || :fish}?"
   }
 
   field :message, as: :trix, help: "Tell the fish something before releasing."


### PR DESCRIPTION
# Description

Hey all. I think I have spotted an issue here and this is my suggested fix, but Im not 100% sure why the original `present?` checks are there, so please let me know if Im missing something fundamental!

When initializing an Action any class variables should be set to nil if no value provided. For example when on an `Index` view, `model` == `nil` intentionally. 

The existing implementation behaves in such a way that breaks `.message` for example. 

Lets say you visit a show page, an Action is initialized with `model` set to the current record you are viewing. Thus `self.class.model` is set to it.

if you then navigate to the `index` page, the Action is initialized with `model == nil`, but the `present?` check means `self.class.model` still points to previous record instance. Therefore when `message` is called `record` references the last visited show page model and you will possibly generate a message for that record rather that the Index page.



<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->



# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works  (Im not sure where to add test for this ...)

