### PR TITLE
refactor: default the cache store to filestore

### DIFF
--- a/lib/avo/app.rb
+++ b/lib/avo/app.rb
@@ -31,10 +31,23 @@ module Avo
       def boot
         init_fields
 
-        if Rails.cache.instance_of?(ActiveSupport::Cache::NullStore)
-          self.cache_store ||= ActiveSupport::Cache::MemoryStore.new
+        self.cache_store = get_cache_store
+      end
+
+      # When not in production we'll just use the MemoryStore which is good enough.
+      # Wehn running in production we'll try to use memcached or redis if available.
+      # If not, we'll use the FileStore.
+      # We decided against the MemoryStore in production because it will not be shared between multiple processes (when using Puma).
+      def get_cache_store
+        if Rails.env.production?
+          case Rails.cache.class
+          when ActiveSupport::Cache::MemCacheStore, ActiveSupport::Cache::RedisCacheStore
+            Rails.cache
+          else
+            ActiveSupport::Cache::FileStore.new
+          end
         else
-          self.cache_store = Rails.cache
+          ActiveSupport::Cache::MemoryStore.new
         end
       end
 

--- a/lib/avo/licensing/h_q.rb
+++ b/lib/avo/licensing/h_q.rb
@@ -106,6 +106,7 @@ module Avo
           **other_metadata(:filters),
           main_menu_present: Avo.configuration.main_menu.present?,
           profile_menu_present: Avo.configuration.profile_menu.present?,
+          cache_store: Avo::App.cache_store&.class&.to_s,
           **config_metadata
         }
       rescue


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where the HQ response was not properly cached in some scenarios.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

