### PR TITLE
Refer to cache class without calling them

### DIFF
--- a/lib/avo/app.rb
+++ b/lib/avo/app.rb
@@ -40,8 +40,8 @@ module Avo
       # We decided against the MemoryStore in production because it will not be shared between multiple processes (when using Puma).
       def get_cache_store
         if Rails.env.production?
-          case Rails.cache.class
-          when ActiveSupport::Cache::MemCacheStore, ActiveSupport::Cache::RedisCacheStore
+          case Rails.cache.class.to_s
+          when 'ActiveSupport::Cache::MemCacheStore', 'ActiveSupport::Cache::RedisCacheStore'
             Rails.cache
           else
             ActiveSupport::Cache::FileStore.new


### PR DESCRIPTION
# Description
When checking for the use of specific cache types (redis, memcached) avoid calling those classes and triggering their onload code.

Fixes #1731 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
