### PR TITLE
Add space after `overflow-auto` class

### DIFF
--- a/app/components/avo/index/resource_map_component.html.erb
+++ b/app/components/avo/index/resource_map_component.html.erb
@@ -4,7 +4,7 @@
       <%= js_map(resource_location_markers, **resource_mapkick_options) %>
     </div>
     <% if render_table? %>
-      <div class="overflow-auto<%= table_component_order_class %>">
+      <div class="overflow-auto <%= table_component_order_class %>">
         <%= render(Avo::Index::ResourceTableComponent.new(resources: @resources, resource: @resource, reflection: @reflection, parent_model: @parent_model, parent_resource: @parent_resource, pagy: @pagy, query: @query)) %>
       </div>
     <% end %>


### PR DESCRIPTION
# Description
Add a space between the static `overflow-auto` class and the interpolated layout class.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
