### PR TITLE
refactor: enable action namespacing

### DIFF
--- a/app/components/avo/actions_component.rb
+++ b/app/components/avo/actions_component.rb
@@ -53,13 +53,15 @@ class Avo::ActionsComponent < ViewComponent::Base
 
   def single_record_path(id)
     Avo::Services::URIService.parse(@resource.record_path)
-      .append_paths("actions", id)
+      .append_paths("actions")
+      .append_query("action_id": id)
       .to_s
   end
 
   def many_records_path(id)
     Avo::Services::URIService.parse(@resource.records_path)
-      .append_paths("actions", id)
+      .append_paths("actions")
+      .append_query("action_id": id)
       .to_s
   end
 end

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -9,7 +9,7 @@
   >
     <%= form_with model: @model,
       scope: 'fields',
-      url: "#{@resource.records_path}/actions/#{@action.param_id}",
+      url: "#{@resource.records_path}/actions",
       local: true,
       data: @action.class.form_data_attributes do |form|
     %>
@@ -20,6 +20,7 @@
       <div class="flex-1 flex">
         <%= @action.get_message %>
       </div>
+      <%= hidden_field_tag :action_id, @action.param_id %>
       <%= form.hidden_field :avo_resource_ids, value: params[:resource_ids], 'data-action-target': 'resourceIds' %>
       <%= form.hidden_field :avo_selected_query, 'data-action-target': 'selectedAllQuery' %>
       <% if @action.get_fields.present? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,8 +28,8 @@ Avo::Engine.routes.draw do
     delete "/:resource_name/:id/active_storage_attachments/:attachment_name/:attachment_id", to: "attachments#destroy"
 
     # Actions
-    get "/:resource_name(/:id)/actions/:action_id", to: "actions#show"
-    post "/:resource_name(/:id)/actions/:action_id", to: "actions#handle"
+    get "/:resource_name(/:id)/actions/(:action_id)", to: "actions#show"
+    post "/:resource_name(/:id)/actions/(:action_id)", to: "actions#handle"
 
     # Generate resource routes as below:
     # resources :posts

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -145,7 +145,7 @@ module Avo
     end
 
     def param_id
-      self.class.to_s.demodulize.underscore.tr "/", "_"
+      self.class.to_s
     end
 
     def succeed(text)

--- a/lib/avo/resources/controls/action.rb
+++ b/lib/avo/resources/controls/action.rb
@@ -18,7 +18,10 @@ module Avo
         end
 
         def path
-          Avo::Services::URIService.parse(@resource.record_path).append_paths("actions", action.param_id).to_s
+          Avo::Services::URIService.parse(@resource.record_path)
+            .append_paths("actions")
+            .append_query(action_id: action.param_id)
+            .to_s
         end
 
         def label

--- a/spec/dummy/app/avo/actions/sub/dummy_action.rb
+++ b/spec/dummy/app/avo/actions/sub/dummy_action.rb
@@ -1,4 +1,4 @@
-class DummyAction < Avo::BaseAction
+class Sub::DummyAction < Avo::BaseAction
   self.name = "Dummy action"
   self.standalone = true
   self.visible = -> do

--- a/spec/dummy/app/avo/resources/fish_resource.rb
+++ b/spec/dummy/app/avo/resources/fish_resource.rb
@@ -32,7 +32,7 @@ class FishResource < Avo::BaseResource
     case_insensitive: true
   }
 
-  action DummyAction, arguments: {
+  action Sub::DummyAction, arguments: {
     special_message: true
   }
 

--- a/spec/dummy/app/avo/resources/team_resource.rb
+++ b/spec/dummy/app/avo/resources/team_resource.rb
@@ -74,5 +74,5 @@ class TeamResource < Avo::BaseResource
   filter MembersFilter
   filter NameFilter
 
-  action DummyAction
+  action Sub::DummyAction
 end

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -126,7 +126,7 @@ class UserResource < Avo::BaseResource
 
   action ToggleInactive
   action ToggleAdmin
-  action DummyAction
+  action Sub::DummyAction
   action DownloadFile
 
   filter UserNamesFilter

--- a/spec/features/avo/custom_resource_controls_spec.rb
+++ b/spec/features/avo/custom_resource_controls_spec.rb
@@ -19,10 +19,10 @@ RSpec.feature "CustomResourceControls", type: :feature do
 
         # actions_list
         expect(page).to have_button "Runnables"
-        expect(page).to have_link "Dummy action", href: /\/admin\/resources\/fish\/#{fish.id}\/actions\/dummy_action/, visible: false
+        expect(page).to have_link "Dummy action", href: /\/admin\/resources\/fish\/#{fish.id}\/actions\?action_id=Sub::DummyAction/, visible: false
 
         # action link
-        expect(page).to have_link "Release fish", href: /\/admin\/resources\/fish\/#{fish.id}\/actions\/release_fish/
+        expect(page).to have_link "Release fish", href: /\/admin\/resources\/fish\/#{fish.id}\/actions\?action_id=ReleaseFish/
         expect(page).to have_selector 'a[data-turbo-frame="actions_show"][data-action="click->actions-picker#visitAction"]', text: "Release fish"
 
         # edit button


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where you can't use namespace actions.

Now instead of just using `DummyAction`, you can nest them inside directories `Sub::DummyAction`.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works
