### PR TITLE
fix(searchControllerJs): encodes special chars in query

### DIFF
--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -211,7 +211,9 @@ export default class extends Controller {
   searchUrl(query) {
     const url = URI()
 
-    return url.segment([window.Avo.configuration.root_path, ...this.searchSegments()]).search(this.searchParams(query)).readable().toString()
+    return url.segment([window.Avo.configuration.root_path, ...this.searchSegments()])
+              .search(this.searchParams(encodeURIComponent(query)))
+              .readable().toString()
   }
 
   searchSegments() {

--- a/spec/features/avo/search_spec.rb
+++ b/spec/features/avo/search_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "Search", type: :system do
       let!(:post) { create :post, name: "New hehe post", body: "New hehe post description." }
       let!(:user) { create :user, first_name: "Hehe", last_name: "user", roles: {admin: true, manager: true, writer: true} }
       let!(:user2) { create :user, first_name: "Hehe ahi", last_name: "user", roles: {admin: true, manager: true, writer: true} }
-      let!(:user3) { create :user, first_name: "Hehe+a$i", last_name: "user", roles: {admin: true, manager: true, writer: true} }
+      let!(:user3) { create :user, first_name: "Haha+a$i", last_name: "user", roles: {admin: true, manager: true, writer: true} }
 
       it "goes to the search result" do
         visit url
@@ -61,7 +61,6 @@ RSpec.feature "Search", type: :system do
         expect(page).to have_content "New hehe post"
         expect(page).to have_content "New hehe post description."
         expect(page).to have_content "Hehe user"
-        expect(page).to have_content "Hehe+a$i user"
         expect(page).to have_content "This user has the following roles: admin, manager, writer"
 
         find(".aa-Input").send_keys :arrow_down
@@ -78,8 +77,8 @@ RSpec.feature "Search", type: :system do
         open_global_search_box
         expect_search_panel_open
 
-        write_in_search "hehe+a$"
-        expect(page).to have_content "Hehe+a$i user"
+        write_in_search "haha+a$"
+        expect(page).to have_content "Haha+a$i user"
       end
     end
   end

--- a/spec/features/avo/search_spec.rb
+++ b/spec/features/avo/search_spec.rb
@@ -47,6 +47,7 @@ RSpec.feature "Search", type: :system do
       let!(:post) { create :post, name: "New hehe post", body: "New hehe post description." }
       let!(:user) { create :user, first_name: "Hehe", last_name: "user", roles: {admin: true, manager: true, writer: true} }
       let!(:user2) { create :user, first_name: "Hehe ahi", last_name: "user", roles: {admin: true, manager: true, writer: true} }
+      let!(:user3) { create :user, first_name: "Hehe+a$i", last_name: "user", roles: {admin: true, manager: true, writer: true} }
 
       it "goes to the search result" do
         visit url
@@ -60,6 +61,7 @@ RSpec.feature "Search", type: :system do
         expect(page).to have_content "New hehe post"
         expect(page).to have_content "New hehe post description."
         expect(page).to have_content "Hehe user"
+        expect(page).to have_content "Hehe+a$i user"
         expect(page).to have_content "This user has the following roles: admin, manager, writer"
 
         find(".aa-Input").send_keys :arrow_down
@@ -69,6 +71,15 @@ RSpec.feature "Search", type: :system do
         wait_for_loaded
 
         expect(current_path).to eql "/admin/resources/users/#{user2.slug}"
+      end
+
+      it 'should display results with special characters' do
+        visit url
+        open_global_search_box
+        expect_search_panel_open
+
+        write_in_search "hehe+a$"
+        expect(page).to have_content "Hehe+a$i user"
       end
     end
   end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Adds encoding to the built search query to allow using special characters in searchable resources (`+$@/...`)
- Adds some test (run pending)

Fixes #1701
<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [X] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Rename any searchable field to include a non-standard character
2. Use any of the search options to find it

Manual reviewer: please leave a comment with output from the test if that's the case.

<img width="705" alt="Screenshot 2023-05-15 at 10 17 29" src="https://github.com/avo-hq/avo/assets/60799999/180945b4-fc4a-4d1c-b4e5-b97e6dbf62db">
