### PR TITLE
feature: callable app_name

### DIFF
--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -2,8 +2,9 @@ module Avo
   class Configuration
     include ResourceConfiguration
 
+    attr_writer :app_name
+    attr_writer :branding
     attr_writer :root_path
-    attr_accessor :app_name
     attr_accessor :timezone
     attr_accessor :per_page
     attr_accessor :per_page_steps
@@ -43,7 +44,6 @@ module Avo
     attr_accessor :sign_out_path_name
     attr_accessor :resources
     attr_accessor :prefix_path
-    attr_writer :branding
 
     def initialize
       @root_path = "/avo"
@@ -138,6 +138,14 @@ module Avo
 
     def branding
       Avo::Configuration::Branding.new(**@branding || {})
+    end
+
+    def app_name
+      if @app_name.respond_to? :call
+        Avo::Hosts::BaseHost.new(block: @app_name).handle
+      else
+        @app_name
+      end
     end
   end
 

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -1,7 +1,7 @@
 Avo.configure do |config|
   ## == Base configs ==
   config.root_path = "/admin"
-  config.app_name = "Avocadelicious"
+  config.app_name = -> { "Avocadelicious #{params[:app_name_suffix]}" }
   config.home_path = -> { avo.dashboard_path(:dashy) }
   config.set_initial_breadcrumbs do
     add_breadcrumb "Dashboard", "/admin/dashboards/dashy"

--- a/spec/features/avo/app_spec.rb
+++ b/spec/features/avo/app_spec.rb
@@ -20,4 +20,13 @@ RSpec.describe "App", type: :feature do
       expect(page).to have_text "Current.user.id = #{admin.id}"
     end
   end
+
+  describe "callable app_name" do
+    it "displayes the app name with a param" do
+      visit "/admin/custom_tool?app_name_suffix=yup"
+
+      # Label on the menu builder
+      expect(page).to have_text "Avocadelicious yup"
+    end
+  end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds the ability to use a block in the `app_name` configuration.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works
