### PR TITLE
fix: valid file cache store path

### DIFF
--- a/lib/avo/app.rb
+++ b/lib/avo/app.rb
@@ -44,7 +44,7 @@ module Avo
           when "ActiveSupport::Cache::MemCacheStore", "ActiveSupport::Cache::RedisCacheStore"
             Rails.cache
           else
-            ActiveSupport::Cache.lookup_store(:file_store, "/tmp/cache")
+            ActiveSupport::Cache.lookup_store(:file_store, Rails.root.join("tmp", "cache"))
           end
         elsif Rails.env.test?
           Rails.cache


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where apps deployed in environments where they don't have access to `/tmp/cache` would fail to use the cache store.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

