### PR TITLE
Handle missing field_options more gracefully.

### DIFF
--- a/lib/generators/avo/resource_generator.rb
+++ b/lib/generators/avo/resource_generator.rb
@@ -135,7 +135,9 @@ module Generators
         fields_string = "\n  # Fields generated from the model"
 
         fields.each do |field_name, field_options|
+          # if field_options are not available (likely a missing resource for an association), skip the field
           fields_string += "\n  # Could not generate a field for #{field_name}" and next unless field_options
+          
           options = ""
           field_options[:options].each { |k, v| options += ", #{k}: #{v}" } if field_options[:options].present?
 

--- a/lib/generators/avo/resource_generator.rb
+++ b/lib/generators/avo/resource_generator.rb
@@ -135,6 +135,7 @@ module Generators
         fields_string = "\n  # Fields generated from the model"
 
         fields.each do |field_name, field_options|
+          fields_string += "\n  # Could not generate a field for #{field_name}" and next unless field_options
           options = ""
           field_options[:options].each { |k, v| options += ", #{k}: #{v}" } if field_options[:options].present?
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where if the generator can't parse a field, it would crash.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

