### PR TITLE
refactor: remove default i18n load dir

### DIFF
--- a/lib/avo/engine.rb
+++ b/lib/avo/engine.rb
@@ -74,7 +74,6 @@ module Avo
 
     initializer "avo.locales" do |app|
       I18n.load_path += Dir[Avo::Engine.root.join("lib", "generators", "avo", "templates", "locales", "*.{rb,yml}")]
-      I18n.load_path += Dir[Rails.root.join("config", "locales", "*.{rb,yml}")]
     end
 
     # After deploy we want to make sure the license response is being cleared.


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1786
Fixes https://github.com/avo-hq/avo/pull/1765#discussion_r1224736534

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

