### PR TITLE
fix: prevent eager loading of computed file fields

### DIFF
--- a/app/components/avo/fields/file_field/index_component.rb
+++ b/app/components/avo/fields/file_field/index_component.rb
@@ -6,10 +6,10 @@ class Avo::Fields::FileField::IndexComponent < Avo::Fields::IndexComponent
   end
 
   def has_image_tag?
-    @field.value.attached? && @field.value.representable? && @field.is_image
+    field.value.present? && field.value.attached? && field.value.representable? && field.is_image
   end
 
   def has_audio_tag?
-    @field.value.attached? && @field.is_audio
+    field.value.present? && field.value.attached? && field.is_audio
   end
 end

--- a/app/components/avo/fields/index_component.rb
+++ b/app/components/avo/fields/index_component.rb
@@ -3,6 +3,7 @@
 class Avo::Fields::IndexComponent < Avo::BaseComponent
   include Avo::ResourcesHelper
 
+  attr_reader :field
   attr_reader :parent_resource
   attr_reader :view
 

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -235,8 +235,15 @@ module Avo
     end
 
     def eager_load_files(resource, query)
-      if resource.attached_file_fields.present?
-        resource.attached_file_fields.map do |field|
+      # Get the non-computed file fields and try to eager load them
+      attachment_fields = resource
+        .attachment_fields
+        .reject do |field|
+          field.computed
+        end
+
+      if attachment_fields.present?
+        attachment_fields.map do |field|
           attachment = case field.class.to_s
           when "Avo::Fields::FileField"
             "attachment"

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -301,7 +301,7 @@ module Avo
       view_types
     end
 
-    def attached_file_fields
+    def attachment_fields
       get_field_definitions.select do |field|
         [Avo::Fields::FileField, Avo::Fields::FilesField].include? field.class
       end

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -124,6 +124,11 @@ class UserResource < Avo::BaseResource
     body :url, as: :text
   end
 
+  # Uncomment this to test computed file fields
+  # field :first_post_image, as: :file, is_image: true do |model|
+  #   model&.posts&.first&.cover_photo
+  # end
+
   action ToggleInactive
   action ToggleAdmin
   action Sub::DummyAction


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where Avo tried to eager load computed file fields. That would crash the app because you can't really do that.

From [here](https://discord.com/channels/740892036978442260/740893011994738751/1118232114647810098)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to the user resource
1. uncomment the `first_post_image` field
2. ensure it's not crashing the app.

Manual reviewer: please leave a comment with output from the test if that's the case.
