### PR TITLE
Stringify message before sanitization

### DIFF
--- a/app/components/avo/alert_component.html.erb
+++ b/app/components/avo/alert_component.html.erb
@@ -10,7 +10,7 @@
       </div>
       <div class="ml-3 w-0 flex-1 pt-0.5">
         <p class="text-sm leading-5 font-semibold">
-          <%= sanitize message %>
+          <%= sanitize message.to_s %>
         </p>
       </div>
       <div class="ml-4 flex-shrink-0 flex items-center">


### PR DESCRIPTION
In order to handle non-string `message` values, call `to_s` before the sanitization step. This is consistent with other templates where `sanitize` is used.

# Description
When `message` is a non-string value (i.e. `true`), passing it to `sanitize` results in an exception. Elsewhere in the code, we avoid this by first applying `to_s`.

Fixes # (issue)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
