### PR TITLE
feature: format_using and update_using field options

### DIFF
--- a/app/components/avo/fields/area_field/edit_component.html.erb
+++ b/app/components/avo/fields/area_field/edit_component.html.erb
@@ -1,5 +1,6 @@
 <%= field_wrapper **field_wrapper_args do %>
   <%= @form.text_field @field.id,
+    value: @field.value,
     class: classes("w-full"),
     value: field.value.to_s,
     placeholder: @field.placeholder,

--- a/app/components/avo/fields/boolean_field/edit_component.html.erb
+++ b/app/components/avo/fields/boolean_field/edit_component.html.erb
@@ -1,6 +1,7 @@
 <%= field_wrapper **field_wrapper_args, dash_if_blank: false do %>
   <div class="h-8 flex items-center">
     <%= @form.check_box @field.id,
+      value: @field.value,
       checked: @field.value,
       class: "text-lg h-4 w-4 checked:bg-primary-400 focus:checked:!bg-primary-400 #{@field.get_html(:classes, view: view, element: :input)}",
       data: @field.get_html(:data, view: view, element: :input),

--- a/app/components/avo/fields/code_field/edit_component.html.erb
+++ b/app/components/avo/fields/code_field/edit_component.html.erb
@@ -1,6 +1,7 @@
 <%= field_wrapper **field_wrapper_args, full_width: true do %>
   <div data-controller="code-field">
     <%= @form.text_area @field.id,
+      value: @field.value,
       class: classes("w-full"),
       data: {
         'code-field-target': 'element',

--- a/app/components/avo/fields/country_field/edit_component.html.erb
+++ b/app/components/avo/fields/country_field/edit_component.html.erb
@@ -1,5 +1,6 @@
 <%= field_wrapper **field_wrapper_args do %>
   <%= @form.select @field.id, @field.select_options, {
+      value: @field.value,
       selected: @field.value,
       include_blank: @field.include_blank
     },

--- a/app/components/avo/fields/markdown_field/edit_component.html.erb
+++ b/app/components/avo/fields/markdown_field/edit_component.html.erb
@@ -1,6 +1,7 @@
 <%= field_wrapper **field_wrapper_args, full_width: true do %>
   <div data-controller="easy-mde">
     <%= @form.text_area @field.id,
+      value: @field.value,
       class: classes("w-full js-has-easy-mde-editor"),
       data: {
         view: view,

--- a/app/components/avo/fields/number_field/edit_component.html.erb
+++ b/app/components/avo/fields/number_field/edit_component.html.erb
@@ -1,5 +1,6 @@
 <%= field_wrapper **field_wrapper_args do %>
   <%= @form.number_field @field.id,
+    value: @field.value,
     class: classes("w-full"),
     data: @field.get_html(:data, view: view, element: :input),
     disabled: disabled?,

--- a/app/components/avo/fields/password_field/edit_component.html.erb
+++ b/app/components/avo/fields/password_field/edit_component.html.erb
@@ -1,5 +1,6 @@
 <%= field_wrapper **field_wrapper_args do %>
   <%= @form.password_field @field.id,
+    value: @field.value,
     class: classes("w-full"),
     data: @field.get_html(:data, view: view, element: :input),
     disabled: disabled?,

--- a/app/components/avo/fields/progress_bar_field/edit_component.html.erb
+++ b/app/components/avo/fields/progress_bar_field/edit_component.html.erb
@@ -6,6 +6,7 @@
       </div>
     <% end %>
     <%= @form.range_field @field.id,
+      value: @field.value,
       class: "w-full #{@field.get_html(:classes, view: view, element: :input)}",
       data: {
         action: "input->progress-bar-field#update",

--- a/app/components/avo/fields/status_field/edit_component.html.erb
+++ b/app/components/avo/fields/status_field/edit_component.html.erb
@@ -5,6 +5,6 @@
     disabled: disabled?,
     placeholder: @field.placeholder,
     style: @field.get_html(:style, view: view, element: :input),
-    value: @resource.model.present? ? @resource.model[@field.id] : @field.value
+    value: @field.value
   %>
 <% end %>

--- a/app/components/avo/fields/text_field/edit_component.html.erb
+++ b/app/components/avo/fields/text_field/edit_component.html.erb
@@ -1,11 +1,11 @@
 <%= field_wrapper **field_wrapper_args do %>
   <%= form.text_field @field.id,
+    value: @field.value,
     class: classes("w-full"),
     data: @field.get_html(:data, view: view, element: :input),
     disabled: disabled?,
     placeholder: @field.placeholder,
     style: @field.get_html(:style, view: view, element: :input),
-    # value: @field.value,
     multiple: multiple,
     autocomplete: @field.autocomplete
   %>

--- a/app/components/avo/fields/textarea_field/edit_component.html.erb
+++ b/app/components/avo/fields/textarea_field/edit_component.html.erb
@@ -1,5 +1,6 @@
 <%= field_wrapper **field_wrapper_args do %>
   <%= @form.text_area @field.id,
+    value: @field.value,
     class: classes("w-full"),
     data: @field.get_html(:data, view: view, element: :input),
     disabled: disabled?,

--- a/app/components/avo/fields/trix_field/edit_component.html.erb
+++ b/app/components/avo/fields/trix_field/edit_component.html.erb
@@ -23,6 +23,7 @@
       <%= sanitize @field.value.to_s %>
     <% end %>
     <%= @form.text_area @field.id,
+      value: @field.value,
       class: classes("w-full hidden"),
       data: @field.get_html(:data, view: view, element: :input),
       disabled: disabled?,

--- a/app/components/avo/views/resource_edit_component.html.erb
+++ b/app/components/avo/views/resource_edit_component.html.erb
@@ -7,7 +7,7 @@
     selected_resources: [@resource.model.id],
     **@resource.stimulus_data_attributes
   } do %>
-  <%= form_with model: @resource.model,
+  <%= form_with model: @resource.record,
     scope: @resource.form_scope,
     url: form_url,
     method: form_method,

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -151,7 +151,8 @@ module Avo
     def record
       @model
     end
-    alias :model :record
+    alias_method :model, :record
+
 
     def hydrate(model: nil, view: nil, user: nil, params: nil)
       @view = view if view.present?
@@ -307,9 +308,9 @@ module Avo
       end
     end
 
-    def fill_model(model, params, extra_params: [])
-      # Map the received params to their actual fields
-      fields_by_database_id = get_field_definitions
+    # Map the received params to their actual fields.
+    def fields_by_database_id
+      get_field_definitions
         .reject do |field|
           field.computed
         end
@@ -317,7 +318,9 @@ module Avo
           [field.database_id.to_s, field]
         end
         .to_h
+    end
 
+    def fill_model(model, params, extra_params: [])
       # Write the field values
       params.each do |key, value|
         field = fields_by_database_id[key]
@@ -329,8 +332,11 @@ module Avo
 
       # Write the user configured extra params to the model
       if extra_params.present?
-        # Let Rails fill in the rest of the params
-        model.assign_attributes params.permit(extra_params)
+        # Get the extra missing params
+        # We do a diff here in order to omit overwriting the model with un-processed values from the resource tools.
+        params_diff = extra_params.map(&:to_s) - fields_by_database_id.keys
+
+        model.assign_attributes params.permit(params_diff)
       end
 
       model

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -332,11 +332,8 @@ module Avo
 
       # Write the user configured extra params to the model
       if extra_params.present?
-        # Get the extra missing params
-        # We do a diff here in order to omit overwriting the model with un-processed values from the resource tools.
-        params_diff = extra_params.map(&:to_s) - fields_by_database_id.keys
-
-        model.assign_attributes params.permit(params_diff)
+        # Let Rails fill in the rest of the params
+        model.assign_attributes params.permit(extra_params)
       end
 
       model

--- a/lib/avo/execution_context.rb
+++ b/lib/avo/execution_context.rb
@@ -10,6 +10,13 @@ module Avo
         end
       end
 
+      # If you want this block to behave like a view you can delegate the missing methods to the view_context
+      #
+      # Ex: Avo::ExecutionContext.new(target: ..., delegate_missing_to: :view_context).handle
+      if args[:delegate_missing_to].present?
+        self.class.send(:delegate_missing_to, args[:delegate_missing_to])
+      end
+
       # If target doesn't respond to call, we don't need to initialize the others attr_accessors.
       return unless (@target = args[:target]).respond_to? :call
 

--- a/lib/avo/execution_context.rb
+++ b/lib/avo/execution_context.rb
@@ -1,0 +1,36 @@
+module Avo
+  class ExecutionContext
+    attr_accessor :target, :context, :params, :view_context, :current_user, :request, :include, :main_app, :avo
+
+    def initialize(**args)
+      # Extend the class with custom modules if required.
+      if args[:include].present?
+        args[:include].each do |mod|
+          self.class.send(:include, mod)
+        end
+      end
+
+      # If target doesn't respond to call, we don't need to initialize the others attr_accessors.
+      return unless (@target = args[:target]).respond_to? :call
+
+      args.except(:target).each do |key, value|
+        singleton_class.class_eval { attr_accessor key }
+        instance_variable_set("@#{key}", value)
+      end
+
+      # Set defaults on not initialized accessors
+      @context ||= Avo::App.context
+      @params ||= Avo::App.params
+      @view_context ||= Avo::App.view_context
+      @current_user ||= Avo::App.current_user
+      @request ||= view_context.request
+      @main_app ||= view_context.main_app
+      @avo ||= view_context.avo
+    end
+
+    # Return target if target is not callable, otherwise, execute target on this instance context
+    def handle
+      target.respond_to?(:call) ? instance_exec(&target) : target
+    end
+  end
+end

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -70,6 +70,7 @@ module Avo
         @nullable = args[:nullable] || false
         @null_values = args[:null_values] || [nil, ""]
         @format_using = args[:format_using] || nil
+        @update_using = args[:update_using] || nil
         @placeholder = args[:placeholder]
         @autocomplete = args[:autocomplete] || nil
         @help = args[:help] || nil
@@ -83,8 +84,6 @@ module Avo
         @view = args[:view] || nil
         @value = args[:value] || nil
         @stacked = args[:stacked] || nil
-        @update_as = args[:update_as] || nil
-        @format_as = args[:format_as] || nil
         @resource = args[:resource]
 
         @args = args
@@ -206,8 +205,8 @@ module Avo
         model
       end
 
-      def update_as(model, key, value, params)
-        Avo::ExecutionContext.new(target: @update_as, model: model, key: key, value: value, resource: resource, field: self).handle
+      def update_using(model, key, value, params)
+        Avo::ExecutionContext.new(target: @update_using, model: model, key: key, value: value, resource: resource, field: self).handle
       end
 
       # Try to see if the field has a different database ID than it's name

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -187,7 +187,7 @@ module Avo
 
         if @format_using.present?
           # Apply the changes in the
-          Avo::ExecutionContext.new(target: @format_using, model: model, key: property, value: final_value, resource: resource, view: view, field: self).handle
+          Avo::ExecutionContext.new(target: @format_using, model: model, key: property, value: final_value, resource: resource, view: view, field: self, delegate_missing_to: :view_context).handle
         else
           final_value
         end

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -185,11 +185,9 @@ module Avo
           final_value = instance_exec(@model, @resource, @view, self, &block)
         end
 
-        if @format_as.present?
-          Avo::ExecutionContext.new(target: @format_as, model: model, key: property, value: final_value, resource: resource, view: view, field: self).handle
-        elsif @format_using.present?
-          # Run the value through resolver if present
-          instance_exec(final_value, &@format_using)
+        if @format_using.present?
+          # Apply the changes in the
+          Avo::ExecutionContext.new(target: @format_using, model: model, key: property, value: final_value, resource: resource, view: view, field: self).handle
         else
           final_value
         end
@@ -199,8 +197,8 @@ module Avo
       def fill_field(model, key, value, params)
         return model unless model.methods.include? key.to_sym
 
-        if @update_as.present?
-          value = update_as(model, key, value, params)
+        if @update_using.present?
+          value = update_using(model, key, value, params)
         end
 
         model.public_send("#{key}=", value)

--- a/spec/dummy/app/avo/resources/city_resource.rb
+++ b/spec/dummy/app/avo/resources/city_resource.rb
@@ -9,7 +9,7 @@ class CityResource < Avo::BaseResource
   self.search_result_path = -> {
     avo.resources_city_path record, custom: "yup"
   }
-  self.extra_params = [:name, :metadata, :coordinates, :city_center_area, :description, :population, :is_capital, :features, :image_url, :tiny_description, :status]
+  self.extra_params = [city: [:name, :metadata, :coordinates, :city_center_area, :description, :population, :is_capital, :image_url, :tiny_description, :status, :features, features: {}, metadata: {}]]
   self.default_view_type = :map
   self.map_view = {
     mapkick_options: {
@@ -43,7 +43,8 @@ class CityResource < Avo::BaseResource
       color: "#009099"
     }
   field :description, as: :trix, attachment_key: :description_file, visible: ->(resource:) { resource.params[:show_native_fields].blank? }
-  field :metadata, as: :code,
+  field :metadata,
+    as: :code,
     format_as: -> {
       if view == :edit
         JSON.generate(value)

--- a/spec/dummy/app/avo/resources/city_resource.rb
+++ b/spec/dummy/app/avo/resources/city_resource.rb
@@ -9,7 +9,7 @@ class CityResource < Avo::BaseResource
   self.search_result_path = -> {
     avo.resources_city_path record, custom: "yup"
   }
-  self.extra_params = [city: [:name, :metadata, :coordinates, :city_center_area, :description, :population, :is_capital, :image_url, :tiny_description, :status, :features, features: {}, metadata: {}]]
+  self.extra_params = [city: [:name, :metadata, :coordinates, :city_center_area, :description, :population, :is_capital, :image_url, :tiny_description, :status, features: {}, metadata: {}]]
   self.default_view_type = :map
   self.map_view = {
     mapkick_options: {
@@ -45,14 +45,14 @@ class CityResource < Avo::BaseResource
   field :description, as: :trix, attachment_key: :description_file, visible: ->(resource:) { resource.params[:show_native_fields].blank? }
   field :metadata,
     as: :code,
-    format_as: -> {
+    format_using: -> {
       if view == :edit
         JSON.generate(value)
       else
         value
       end
     },
-    update_as: -> do
+    update_using: -> do
       ActiveSupport::JSON.decode(value)
     end
   with_options hide_on: :forms do

--- a/spec/dummy/app/avo/resources/city_resource.rb
+++ b/spec/dummy/app/avo/resources/city_resource.rb
@@ -9,7 +9,7 @@ class CityResource < Avo::BaseResource
   self.search_result_path = -> {
     avo.resources_city_path record, custom: "yup"
   }
-  self.extra_params = [:fish_type, :something_else, properties: [], information: [:name, :history]]
+  self.extra_params = [:name, :metadata, :coordinates, :city_center_area, :description, :population, :is_capital, :features, :image_url, :tiny_description, :status]
   self.default_view_type = :map
   self.map_view = {
     mapkick_options: {
@@ -43,12 +43,22 @@ class CityResource < Avo::BaseResource
       color: "#009099"
     }
   field :description, as: :trix, attachment_key: :description_file, visible: ->(resource:) { resource.params[:show_native_fields].blank? }
+  field :metadata, as: :code,
+    format_as: -> {
+      if view == :edit
+        JSON.generate(value)
+      else
+        value
+      end
+    },
+    update_as: -> do
+      ActiveSupport::JSON.decode(value)
+    end
   with_options hide_on: :forms do
     field :name, as: :text, help: "The name of your city"
     field :population, as: :number
     field :is_capital, as: :boolean
     field :features, as: :key_value
-    field :metadata, as: :code
     field :image_url, as: :external_image
     field :tiny_description, as: :markdown
     field :status, as: :badge, enum: ::City.statuses

--- a/spec/dummy/app/avo/resources/comment_resource.rb
+++ b/spec/dummy/app/avo/resources/comment_resource.rb
@@ -10,7 +10,7 @@ class CommentResource < Avo::BaseResource
   self.after_update_path = :index
 
   field :id, as: :id
-  field :body, as: :textarea, format_using: ->(value) do
+  field :body, as: :textarea, format_using: -> do
     if view == :show
       content_tag(:div, style: "white-space: pre-line") { value }
     else

--- a/spec/dummy/app/avo/resources/photo_comment_resource.rb
+++ b/spec/dummy/app/avo/resources/photo_comment_resource.rb
@@ -14,7 +14,7 @@ class PhotoCommentResource < Avo::BaseResource
   end
 
   field :id, as: :id
-  field :body, as: :textarea, format_using: ->(value) do
+  field :body, as: :textarea, format_using: -> do
     if view == :show
       content_tag(:div, style: "white-space: pre-line") { value }
     else

--- a/spec/dummy/app/avo/resources/post_resource.rb
+++ b/spec/dummy/app/avo/resources/post_resource.rb
@@ -36,7 +36,7 @@ class PostResource < Avo::BaseResource
     enforce_suggestions: true,
     help: "The only allowed values here are `one`, `two`, and `three`"
   field :cover_photo, as: :file, is_image: true, as_avatar: :rounded, full_width: true, hide_on: [], accept: "image/*", display_filename: false
-  field :cover_photo, as: :external_image, name: "Cover photo", required: true, hide_on: :all, link_to_resource: true, as_avatar: :rounded, format_using: ->(value) { value.present? ? value&.url : nil }
+  field :cover_photo, as: :external_image, name: "Cover photo", required: true, hide_on: :all, link_to_resource: true, as_avatar: :rounded, format_using: -> { value.present? ? value&.url : nil }
   field :audio, as: :file, is_audio: true, accept: "audio/*"
   field :excerpt, as: :text, hide_on: :all, as_description: true do |model|
     extract_excerpt model.body

--- a/spec/dummy/app/avo/resources/product_resource.rb
+++ b/spec/dummy/app/avo/resources/product_resource.rb
@@ -31,7 +31,7 @@ class ProductResource < Avo::BaseResource
       }
     }
     title :title, as: :text
-    body :description, as: :textarea, format_using: ->(value) {
+    body :description, as: :textarea, format_using: -> {
       simple_format value
     }
   end

--- a/spec/dummy/app/avo/resources/team_resource.rb
+++ b/spec/dummy/app/avo/resources/team_resource.rb
@@ -31,7 +31,7 @@ class TeamResource < Avo::BaseResource
     rows: 5,
     readonly: false,
     hide_on: :index,
-    format_using: ->(value) { value.to_s.truncate 30 },
+    format_using: -> { value.to_s.truncate 30 },
     default: "This is a wonderful team!",
     nullable: true,
     null_values: ["0", "", "null", "nil"]

--- a/spec/dummy/app/avo/resources/user_resource.rb
+++ b/spec/dummy/app/avo/resources/user_resource.rb
@@ -85,7 +85,7 @@ class UserResource < Avo::BaseResource
       hide_on: :edit do |model, resource, view, field|
         model.posts.to_a.size > 0 ? "yes" : "no"
       end
-    field :outside_link, as: :text, only_on: [:show], format_using: ->(url) { link_to("hey", url, target: "_blank") } do |model, *args|
+    field :outside_link, as: :text, only_on: [:show], format_using: -> { link_to("hey", value, target: "_blank") } do |model, *args|
       main_app.hey_url
     end
   end

--- a/spec/dummy/app/avo/resources/z_post_resource.rb
+++ b/spec/dummy/app/avo/resources/z_post_resource.rb
@@ -34,7 +34,7 @@ class ZPostResource < Avo::BaseResource
     enforce_suggestions: true,
     help: "The only allowed values here are `one`, `two`, and `three`"
   field :cover_photo, as: :file, is_image: true, as_avatar: :rounded, full_width: true, hide_on: [], accept: "image/*"
-  field :cover_photo, as: :external_image, name: "Cover photo", required: true, hide_on: :all, link_to_resource: true, as_avatar: :rounded, format_using: ->(value) { value.present? ? value&.url : nil }
+  field :cover_photo, as: :external_image, name: "Cover photo", required: true, hide_on: :all, link_to_resource: true, as_avatar: :rounded, format_using: -> { value.present? ? value&.url : nil }
   field :audio, as: :file, is_audio: true, accept: "audio/*"
   field :excerpt, as: :text, hide_on: :all, as_description: true do |model|
     ActionView::Base.full_sanitizer.sanitize(model.body).truncate 130

--- a/spec/dummy/app/models/city.rb
+++ b/spec/dummy/app/models/city.rb
@@ -38,4 +38,13 @@ class City < ApplicationRecord
     self.latitude = value.first
     self.longitude = value.last
   end
+
+  # alternative to format_as and update_as
+  def json_metadata
+    ActiveSupport::JSON.encode(metadata)
+  end
+
+  def json_metadata=(value)
+    self.metadata = ActiveSupport::JSON.decode(value)
+  end
 end

--- a/spec/dummy/app/models/city.rb
+++ b/spec/dummy/app/models/city.rb
@@ -39,12 +39,12 @@ class City < ApplicationRecord
     self.longitude = value.last
   end
 
-  # alternative to format_as and update_as
-  def json_metadata
-    ActiveSupport::JSON.encode(metadata)
-  end
+  # alternative to format_using and update_using
+  # def json_metadata
+  #   ActiveSupport::JSON.encode(metadata)
+  # end
 
-  def json_metadata=(value)
-    self.metadata = ActiveSupport::JSON.decode(value)
-  end
+  # def json_metadata=(value)
+  #   self.metadata = ActiveSupport::JSON.decode(value)
+  # end
 end

--- a/spec/dummy/app/views/avo/resource_tools/_city_editor.html.erb
+++ b/spec/dummy/app/views/avo/resource_tools/_city_editor.html.erb
@@ -7,7 +7,6 @@
           <%= avo_edit_field(:number, :population, form: form, help: "The population of the city.") %>
           <%= avo_edit_field(:is_capital, as: :boolean, form: form) %>
           <%= avo_edit_field(:features, as: :key_value, form: form) %>
-          <%#= avo_edit_field(:metadata, as: :code, form: form) %>
           <%= avo_show_field(:image_url, as: :external_image, form: form) do |model|
             'https://images.unsplash.com/photo-1660061993776-098c0ee403ac?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8fHx8fHx8MTY2MDMxMzc4NA&ixlib=rb-1.2.1&q=80&w=1080'
           end %>

--- a/spec/dummy/app/views/avo/resource_tools/_city_editor.html.erb
+++ b/spec/dummy/app/views/avo/resource_tools/_city_editor.html.erb
@@ -7,7 +7,7 @@
           <%= avo_edit_field(:number, :population, form: form, help: "The population of the city.") %>
           <%= avo_edit_field(:is_capital, as: :boolean, form: form) %>
           <%= avo_edit_field(:features, as: :key_value, form: form) %>
-          <%= avo_show_field(:metadata, as: :code, form: form) %>
+          <%#= avo_edit_field(:metadata, as: :code, form: form) %>
           <%= avo_show_field(:image_url, as: :external_image, form: form) do |model|
             'https://images.unsplash.com/photo-1660061993776-098c0ee403ac?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8fHx8fHx8MTY2MDMxMzc4NA&ixlib=rb-1.2.1&q=80&w=1080'
           end %>

--- a/spec/features/avo/native_fields_spec.rb
+++ b/spec/features/avo/native_fields_spec.rb
@@ -10,7 +10,6 @@ RSpec.feature "NativeFields", type: :feature do
     expect(find_field('Population').value).to eq city.population.to_s
     expect(find_field('Is capital').value).to eq "1"
     expect(find_field('Features').value).to eq "\"#{city.features}\""
-    expect(find_field('metadata', visible: false, disabled: true).value).to eq city.metadata
 
     expect(page).to have_css 'img[src="https://images.unsplash.com/photo-1660061993776-098c0ee403ac?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8fHx8fHx8MTY2MDMxMzc4NA&ixlib=rb-1.2.1&q=80&w=1080"]'
     expect(find_field('Image url').value).to eq city.image_url
@@ -31,7 +30,6 @@ RSpec.feature "NativeFields", type: :feature do
     fill_in 'city[population]', with: 101
     find('[name="city[is_capital]"]').set(false)
     fill_in 'city[features]', with: "{\"hey\": \"features\"}"
-    find_field('metadata', visible: false, disabled: true).set("{\"hey\": \"metadata\"}")
 
     click_on "Save"
 

--- a/spec/system/avo/date_time_fields/date_time_eastern_spec.rb
+++ b/spec/system/avo/date_time_fields/date_time_eastern_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Date field on eastern zone", type: :system do
   subject(:text_input) { find '[data-field-id="posted_at"] [data-controller="date-field"] input[type="text"]' }
   before do
     CommentResource.with_temporary_items do
-      field :body, as: :textarea, format_using: ->(value) do
+      field :body, as: :textarea, format_using: -> do
         if view == :show
           content_tag(:div, style: "white-space: pre-line") { value }
         else

--- a/spec/system/avo/date_time_fields/date_time_utc_spec.rb
+++ b/spec/system/avo/date_time_fields/date_time_utc_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Date field", type: :system do
 
   before do
     CommentResource.with_temporary_items do
-      field :body, as: :textarea, format_using: ->(value) do
+      field :body, as: :textarea, format_using: -> do
         if view == :show
           content_tag(:div, style: "white-space: pre-line") { value }
         else

--- a/spec/system/avo/date_time_fields/date_time_western_spec.rb
+++ b/spec/system/avo/date_time_fields/date_time_western_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Date field on western zone", type: :system do
 
   before do
     CommentResource.with_temporary_items do
-      field :body, as: :textarea, format_using: ->(value) do
+      field :body, as: :textarea, format_using: -> do
         if view == :show
           content_tag(:div, style: "white-space: pre-line") { value }
         else


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Enables developers to add custom formatters before the data is displayed in the UI and before it gets saved to the database.

We retrofitted `format_using` to use the `ExecutionContext` and dropped the `value` argument.

The `update_using` block is run just before the value is saved on the model.

[Docs](https://docs.avohq.io/2.0/field-options.html#fields-formatter)


```ruby
field :metadata, as: :code,
  format_using: -> {
    if view == :edit
      JSON.generate(value)
    else
      value
    end
  },
  update_using: -> do
    ActiveSupport::JSON.decode(value)
  end
```

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works

