### PR TITLE
✨ Add icon to menu items

### DIFF
--- a/app/components/avo/sidebar/item_switcher_component.html.erb
+++ b/app/components/avo/sidebar/item_switcher_component.html.erb
@@ -1,11 +1,11 @@
 <% if item.is_a? Avo::Menu::Link %>
-  <%= render Avo::Sidebar::LinkComponent.new label: item.name, path: item.path, target: item.target, data: item.data %>
+  <%= render Avo::Sidebar::LinkComponent.new label: item.name, path: item.path, target: item.target, data: item.data, icon: item.icon %>
 <% end %>
 <% if item.is_a? Avo::Menu::Resource %>
-  <%= render Avo::Sidebar::LinkComponent.new label: item.navigation_label, path: helpers.resources_path(resource: resource), data: item.data %>
+  <%= render Avo::Sidebar::LinkComponent.new label: item.navigation_label, path: helpers.resources_path(resource: resource), data: item.data, icon: item.icon %>
 <% end %>
 <% if item.is_a? Avo::Menu::Dashboard %>
-  <%= render Avo::Sidebar::LinkComponent.new label: item.navigation_label, path: dashboard.navigation_path, data: item.data %>
+  <%= render Avo::Sidebar::LinkComponent.new label: item.navigation_label, path: dashboard.navigation_path, data: item.data, icon: item.icon %>
 <% end %>
 <% if item.is_a? Avo::Menu::Section %>
   <%= render Avo::Sidebar::SectionComponent.new item: item %>

--- a/app/components/avo/sidebar/link_component.html.erb
+++ b/app/components/avo/sidebar/link_component.html.erb
@@ -1,5 +1,11 @@
 <% if path.present? %>
   <%= send link_method, path, class: classes, active: active, target: target, data: data do %>
+    <% if icon.present? %>
+      <span class="min-w-[20px]">
+        <%= helpers.svg icon %>
+      </span>
+    <% end %>
+
     <%= label %>
     <% if target == :_blank %>
       <%= helpers.svg('heroicons/outline/external-link', class: 'self-center ml-auto h-3 mr-2') %>
@@ -7,6 +13,12 @@
   <% end %>
 <% else %>
   <%= content_tag :div, class: classes, active: active, target: target, data: data do %>
+    <% if icon.present? %>
+      <span class="min-w-[20px]">
+        <%= helpers.svg icon %>
+      </span>
+    <% end %>
+
     <%= label %>
   <% end %>
 <% end %>

--- a/app/components/avo/sidebar/link_component.html.erb
+++ b/app/components/avo/sidebar/link_component.html.erb
@@ -1,11 +1,6 @@
 <% if path.present? %>
   <%= send link_method, path, class: classes, active: active, target: target, data: data do %>
-    <% if icon.present? %>
-      <span class="min-w-[20px]">
-        <%= helpers.svg icon %>
-      </span>
-    <% end %>
-
+    <%= helpers.svg icon, class: "h-4" if icon.present? %>
     <%= label %>
     <% if target == :_blank %>
       <%= helpers.svg('heroicons/outline/external-link', class: 'self-center ml-auto h-3 mr-2') %>
@@ -13,12 +8,7 @@
   <% end %>
 <% else %>
   <%= content_tag :div, class: classes, active: active, target: target, data: data do %>
-    <% if icon.present? %>
-      <span class="min-w-[20px]">
-        <%= helpers.svg icon %>
-      </span>
-    <% end %>
-
+    <%= helpers.svg icon, class: "h-4" if icon.present? %>
     <%= label %>
   <% end %>
 <% end %>

--- a/app/components/avo/sidebar/link_component.rb
+++ b/app/components/avo/sidebar/link_component.rb
@@ -6,13 +6,15 @@ class Avo::Sidebar::LinkComponent < ViewComponent::Base
   attr_reader :label
   attr_reader :path
   attr_reader :data
+  attr_reader :icon
 
-  def initialize(label: nil, path: nil, active: :inclusive, target: nil, data: {})
+  def initialize(label: nil, path: nil, active: :inclusive, target: nil, data: {}, icon: nil)
     @label = label
     @path = path
     @active = active
     @target = target
     @data = data
+    @icon = icon
   end
 
   def is_external?
@@ -28,6 +30,6 @@ class Avo::Sidebar::LinkComponent < ViewComponent::Base
   end
 
   def classes
-    "px-4 pr-0 flex-1 flex mx-6 leading-none py-2 text-black rounded font-medium hover:bg-gray-100"
+    "px-4 pr-0 flex-1 flex mx-6 leading-none py-2 text-black rounded font-medium hover:bg-gray-100 gap-2 items-center"
   end
 end

--- a/app/components/avo/sidebar/link_component.rb
+++ b/app/components/avo/sidebar/link_component.rb
@@ -30,6 +30,6 @@ class Avo::Sidebar::LinkComponent < ViewComponent::Base
   end
 
   def classes
-    "px-4 pr-0 flex-1 flex mx-6 leading-none py-2 text-black rounded font-medium hover:bg-gray-100 gap-2 items-center"
+    "px-4 pr-0 flex-1 flex mx-6 leading-none py-2 text-black rounded font-medium hover:bg-gray-100 gap-1"
   end
 end

--- a/app/components/avo/sidebar_component.html.erb
+++ b/app/components/avo/sidebar_component.html.erb
@@ -25,7 +25,7 @@
 
               <div class="w-full space-y-1">
                 <% dashboards.sort_by { |r| r.navigation_label }.each do |dashboard| %>
-                  <%= render Avo::Sidebar::LinkComponent.new label: dashboard.navigation_label, path: dashboard.navigation_path %>
+                  <%= render Avo::Sidebar::LinkComponent.new label: dashboard.navigation_label, path: dashboard.navigation_path, icon: resource.icon %>
                 <% end %>
               </div>
             </div>
@@ -36,7 +36,7 @@
 
             <div class="w-full space-y-1">
               <% resources.sort_by { |r| r.navigation_label }.each do |resource| %>
-                <%= render Avo::Sidebar::LinkComponent.new label: resource.navigation_label, path: helpers.resources_path(resource: resource) %>
+                <%= render Avo::Sidebar::LinkComponent.new label: resource.navigation_label, path: helpers.resources_path(resource: resource), icon: resource.icon %>
               <% end %>
             </div>
           </div>

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -76,7 +76,7 @@ Avo.configure do |config|
   ## == Menus ==
   config.main_menu = -> do
     section I18n.t("avo.dashboards"), icon: "dummy-adjustments.svg" do
-      dashboard :dashy, visible: -> { true }
+      dashboard :dashy, visible: -> { true }, icon: "bolt"
       dashboard "Sales", visible: -> { true }
 
       group "All dashboards", visible: false, collapsable: true do
@@ -114,7 +114,7 @@ Avo.configure do |config|
       group "Blog", collapsable: true do
         # resource :z_posts
         resource :posts
-        resource :comments
+        resource :comments, icon: "chat-bubble-bottom-center-text"
         resource :photo_comments, visible: -> do
           authorize current_user, Comment, "index?", policy_class: PhotoCommentPolicy, raise_exception: false
         end


### PR DESCRIPTION
# Description
Add icons to the sub-menus. This will give more **life** to the sidebar.


```ruby
# in config/initializers/avo.rb
config.main_menu = -> do
  dashboard :dashy, icon: "bolt"
  resource :comments, icon: "chat-bubble-bottom-center-text"
end
```

<img width="577" alt="CleanShot 2023-06-22 at 13 55 40@2x" src="https://github.com/avo-hq/avo/assets/1334409/991eb20c-b5ea-44ba-9bf5-f596058b1553">


# Checklist:
- [ X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
1. Add `icon: 'user'` next to the resource
1. Watch it appear in the menu

Manual reviewer: please leave a comment with output from the test if that's the case.
