### PR TITLE
feature: Allow custom destroy methods.

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -215,21 +215,21 @@ module Avo
 
     def save_model
       perform_action_and_record_errors do
-        save_record_action
+        save_model_action
       end
     end
 
-    def save_record_action
+    def save_model_action
       @model.save!
     end
 
     def destroy_model
       perform_action_and_record_errors do
-        destroy_record_action
+        destroy_model_action
       end
     end
 
-    def destroy_record_action
+    def destroy_model_action
       @model.destroy!
     end
 

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -215,8 +215,12 @@ module Avo
 
     def save_model
       perform_action_and_record_errors do
-        @model.save!
+        save_record_action
       end
+    end
+
+    def save_record_action
+      @model.save!
     end
 
     def destroy_model

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -221,13 +221,12 @@ module Avo
 
     def destroy_model
       perform_action_and_record_errors do
-        # If the resource has a custom destroy method, use that instead of the default destroy!
-        destroy_method = @resource.destroy_record_method
-        # If a custom destroy method is not a valid lambda, raise an error. Don't fall back to the default destroy!
-        # If a custom faulty destroy method is defined, the user likely does not want to lose data.
-        raise ArgumentError unless destroy_method.lambda?
-        destroy_method.call(record: @model)
+        destroy_record_action
       end
+    end
+
+    def destroy_record_action
+      @model.destroy!
     end
 
     def perform_action_and_record_errors(&block)

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -221,7 +221,12 @@ module Avo
 
     def destroy_model
       perform_action_and_record_errors do
-        @model.destroy!
+        # If the resource has a custom destroy method, use that instead of the default destroy!
+        destroy_method = @resource.destroy_record_method
+        # If a custom destroy method is not a valid lambda, raise an error. Don't fall back to the default destroy!
+        # If a custom faulty destroy method is defined, the user likely does not want to lose data.
+        raise ArgumentError unless destroy_method.lambda?
+        destroy_method.call(record: @model)
       end
     end
 

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -47,9 +47,6 @@ module Avo
     class_attribute :find_record_method, default: ->(model_class:, id:, params:) {
       model_class.find id
     }
-    class_attribute :destroy_record_method, default: -> (record:) {
-      record.destroy!
-    }
     class_attribute :ordering
     class_attribute :hide_from_global_search, default: false
     class_attribute :after_create_path, default: :show

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -47,6 +47,9 @@ module Avo
     class_attribute :find_record_method, default: ->(model_class:, id:, params:) {
       model_class.find id
     }
+    class_attribute :destroy_record_method, default: -> (record:) {
+      record.destroy!
+    }
     class_attribute :ordering
     class_attribute :hide_from_global_search, default: false
     class_attribute :after_create_path, default: :show


### PR DESCRIPTION
# Description
This is a proposed feature to add custom destroy methods to resources. This makes Avo compatible with soft delete gems like discard. Please reject if not appropriate. 

```
# widget_resource.rb
...
  self.destroy_record_method = -> (record:) {
    record.discard
  }
...
```

If not defined, the default destroy! is used. 

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


Manual reviewer: please leave a comment with output from the test if that's the case.
