### PR TITLE
improvement: apply policy scope on has many search query

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -112,12 +112,12 @@ module Avo
     # This scope is applied if the search is being performed on a has_many association
     def apply_has_many_scope
       association_name = BaseResource.valid_association_name(parent, params[:via_association_id])
+
+      # Get association records
       scope = parent.send(association_name)
 
-      begin
-        scope = policy_scope scope
-      rescue Pundit::NotDefinedError
-      end
+      # Apply policy scope if authorization is present
+      scope = resource.authorization&.apply_policy scope
 
       Avo::Hosts::SearchScopeHost.new(block: @resource.search_query, params: params, scope: scope).handle
     end

--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -112,7 +112,7 @@ module Avo
     # This scope is applied if the search is being performed on a has_many association
     def apply_has_many_scope
       association_name = BaseResource.valid_association_name(parent, params[:via_association_id])
-      scope = parent.send(association_name)
+      scope = policy_scope parent.send(association_name)
 
       Avo::Hosts::SearchScopeHost.new(block: @resource.search_query, params: params, scope: scope).handle
     end

--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -112,7 +112,12 @@ module Avo
     # This scope is applied if the search is being performed on a has_many association
     def apply_has_many_scope
       association_name = BaseResource.valid_association_name(parent, params[:via_association_id])
-      scope = policy_scope parent.send(association_name)
+      scope = parent.send(association_name)
+
+      begin
+        scope = policy_scope scope
+      rescue Pundit::NotDefinedError
+      end
 
       Avo::Hosts::SearchScopeHost.new(block: @resource.search_query, params: params, scope: scope).handle
     end

--- a/spec/features/avo/search_has_many_scope_spec.rb
+++ b/spec/features/avo/search_has_many_scope_spec.rb
@@ -77,5 +77,10 @@ RSpec.feature Avo::SearchController, type: :controller do
     3.times do |index|
       expect(json["course links"]["results"][index]["_id"]).to eq course_with_five_links.links[index].id
     end
+
+    # Undo the policy scope resolve method for future tests
+    CourseLinkPolicy::Scope.define_method(:resolve) do
+      scope.all
+    end
   end
 end

--- a/spec/features/avo/search_has_many_scope_spec.rb
+++ b/spec/features/avo/search_has_many_scope_spec.rb
@@ -54,4 +54,28 @@ RSpec.feature Avo::SearchController, type: :controller do
       expect(json["course links"]["results"][index]["_id"]).to eq course_with_five_links.links[index].id
     end
   end
+
+  it "applys the policy scope" do
+    CourseLinkPolicy::Scope.define_method(:resolve) do
+      scope.where("link like ?", "%test_link_%")
+    end
+
+    course_with_five_links.links.first(3).each_with_index do |link, index|
+      link.update!(link: "test_link_#{index}")
+    end
+
+    get :show, params: {
+      resource_name: "course_links",
+      via_association: "has_many",
+      via_association_id: "links",
+      via_reflection_class: "Course",
+      via_reflection_id: course_with_five_links.id
+    }
+
+    expect(json["course links"]["results"].count).to eq 3
+
+    3.times do |index|
+      expect(json["course links"]["results"][index]["_id"]).to eq course_with_five_links.links[index].id
+    end
+  end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1808

### Scope example
```ruby
class UserPolicy < ApplicationPolicy

  # . . .

  # . . .

  class Scope < Scope
    def resolve
      scope.where("first_name like ?", "%a%")
    end
  end
end
```

### Before
When searching on a has many field, the policy scope was not being applied, returning all association records.

[before.webm](https://github.com/avo-hq/avo/assets/69730720/f6b6045c-793e-4804-912b-76f13c9257b1)

### After
Now the policy scope is being applied on the search result.

[after.webm](https://github.com/avo-hq/avo/assets/69730720/709c916b-b066-42fd-afb7-b18f8c687c84)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [x] I have added tests that prove my fix is effective or that my feature works
