### PR TITLE
fix: rename clashing controller

### DIFF
--- a/spec/dummy/app/avo/resources/active_record_attachment_resource.rb
+++ b/spec/dummy/app/avo/resources/active_record_attachment_resource.rb
@@ -1,4 +1,4 @@
-class AttachmentResource < Avo::BaseResource
+class ActiveRecordAttachmentResource < Avo::BaseResource
   self.title = :filename
   self.model_class = "ActiveStorage::Attachment"
 

--- a/spec/dummy/app/controllers/avo/active_record_attachments_controller.rb
+++ b/spec/dummy/app/controllers/avo/active_record_attachments_controller.rb
@@ -1,4 +1,4 @@
 # This controller has been generated to enable Rails' resource routes.
 # More information on https://docs.avohq.io/2.0/controllers.html
-class Avo::AttachmentsController < Avo::ResourcesController
+class Avo::ActiveRecordAttachmentsController < Avo::ResourcesController
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where the `AttachmentsController` would clash with the private one.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works