### PR TITLE
fix: use resource find record on search instead model direct find

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -182,9 +182,8 @@ module Avo
     def fetch_parent
       return unless params[:via_reflection_id].present?
 
-      parent_class = BaseResource.valid_model_class params[:via_reflection_class]
-
-      parent_class.find params[:via_reflection_id]
+      parent_resource = ::Avo::App.get_resource_by_model_name params[:via_reflection_class]
+      parent_resource.find_record params[:via_reflection_id], params: params
     end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1809

When searching on a has many association table, the `fetch_parent` method was directly using `ParentModel.find id` strategy instead `ParentResource.find_record id`

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
