### PR TITLE
Added zoom to location fields

### DIFF
--- a/app/components/avo/fields/location_field/show_component.html.erb
+++ b/app/components/avo/fields/location_field/show_component.html.erb
@@ -1,6 +1,6 @@
 <%= field_wrapper **field_wrapper_args do %>
   <% if field.value_present? %>
-    <%= js_map [{latitude: field.value[0], longitude: field.value[1]}], id: "location-map" %>
+    <%= js_map [{latitude: field.value[0], longitude: field.value[1]}], id: "location-map", zoom: field.zoom, controls: true %>
   <% else %>
     —
   <% end %>

--- a/lib/avo/fields/location_field.rb
+++ b/lib/avo/fields/location_field.rb
@@ -3,13 +3,14 @@
 module Avo
   module Fields
     class LocationField < BaseField
-      attr_reader :stored_as
+      attr_reader :stored_as, :zoom
 
       def initialize(id, **args, &block)
         hide_on :index
         super(id, **args, &block)
 
         @stored_as = args[:stored_as].present? ? args[:stored_as] : nil # You can pass it an array of db columns [:latitude, :longitude]
+        @zoom = args[:zoom].present? ? args[:zoom].to_i : 15
       end
 
       def value_as_array?


### PR DESCRIPTION
# Description

I've added an extra attribute to the location field so you can override the zoom level in the resource. I've also made mapkick show the map controls so users can zoom in and out if they want to.

Fixes # (issue)

Right now location fields always load at the default zoom level of 15 and there's no way to customize it.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Find a resource with a location field in the code
2. View a model that uses that resource and see the zoom level of the location (should be very zoomed-in)
1. Edit the code so that the field has `zoom: 1`  on the location field
3. Reload the page
4. Check that the location field is now zoomed out really far

Manual reviewer: please leave a comment with output from the test if that's the case.
