### PR TITLE
fix: visible items

### DIFF
--- a/lib/avo/concerns/visible_items.rb
+++ b/lib/avo/concerns/visible_items.rb
@@ -28,6 +28,8 @@ module Avo
 
       def visible(item)
         if item.is_field?
+          return false if item.respond_to?(:authorized?) && item.resource.present? && !item.authorized?
+
           item.visible? && item.visible_on?(view)
         else
           item.visible?


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1812

When a tab is a `has_many_field` for example and is **not** visible by policy now is **not** rendered.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
