### PR TITLE
fix: belongs to field target inside tab -> panel -> row

### DIFF
--- a/lib/avo/concerns/has_fields.rb
+++ b/lib/avo/concerns/has_fields.rb
@@ -294,8 +294,10 @@ module Avo
         panelfull_items.grep(Avo::TabGroup).each do |tab_group|
           tab_group.items.grep(Avo::Tab).each do |tab|
             tab.items.grep(Avo::Panel).each do |panel|
-              panel.items.grep(Avo::Fields::BelongsToField).each do |field|
-                field.target = :_top
+              set_target_to_top panel.items.grep(Avo::Fields::BelongsToField)
+
+              panel.items.grep(Avo::Row).each do |row|
+                set_target_to_top row.items.grep(Avo::Fields::BelongsToField)
               end
             end
           end
@@ -314,6 +316,12 @@ module Avo
       end
 
       private
+
+      def set_target_to_top(fields)
+        fields.each do |field|
+          field.target = :_top
+        end
+      end
 
       def check_license
         if !Rails.env.production? && App.license.present? && App.license.lacks(:resource_tools)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1842

This pull request resolves an issue where the target of links rendered on the `belongs_to` field was not being properly set when it is placed within a tab row. Since we are utilizing turbo-frames on tabs, all such links should aim the target to `_top` when they are inside tabs.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
