### PR TITLE
fix: authorize show controls actions

### DIFF
--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -37,9 +37,7 @@ class Avo::ResourceComponent < Avo::BaseComponent
     @resource.authorization.authorize_action(:destroy, raise_exception: false)
   end
 
-  def can_see_the_actions_button?(check_for_controls: false)
-    return false if @actions.blank? && !check_for_controls
-
+  def can_act_on?
     return authorize_association_for(:act_on) if @reflection.present?
 
     @resource.authorization.authorize_action(:act_on, raise_exception: false) && !has_reflection_and_is_read_only

--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -37,8 +37,8 @@ class Avo::ResourceComponent < Avo::BaseComponent
     @resource.authorization.authorize_action(:destroy, raise_exception: false)
   end
 
-  def can_see_the_actions_button?
-    return false if @actions.blank?
+  def can_see_the_actions_button?(check_for_controls: false)
+    return false if @actions.blank? && !check_for_controls
 
     return authorize_association_for(:act_on) if @reflection.present?
 

--- a/app/components/avo/views/resource_edit_component.html.erb
+++ b/app/components/avo/views/resource_edit_component.html.erb
@@ -40,7 +40,7 @@
               <%= t('avo.delete').capitalize %>
             <% end %>
           <% end %>
-          <% if can_see_the_actions_button? %>
+          <% if can_act_on? %>
             <%= render Avo::ActionsComponent.new actions: @actions, resource: @resource, view: @view %>
           <% end %>
           <% if can_see_the_save_button? %>

--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -16,7 +16,7 @@
           <%= t('avo.attach_item', item: singular_resource_name).capitalize %>
         <% end %>
       <% end %>
-      <% if can_see_the_actions_button? %>
+      <% if can_act_on? %>
         <%= render Avo::ActionsComponent.new actions: @actions, resource: @resource, view: @view %>
       <% end %>
       <% if can_see_the_create_button? %>

--- a/app/components/avo/views/resource_show_component.html.erb
+++ b/app/components/avo/views/resource_show_component.html.erb
@@ -55,7 +55,7 @@
               <% end %>
             <% end %>
           <% elsif control.action? %>
-            <% if control.action.visible_in_view(parent_resource: @parent_resource) %>
+            <% if render_action_control?(control.action) %>
               <%= a_link control.path,
                   color: control.color,
                   style: control.style,

--- a/app/components/avo/views/resource_show_component.html.erb
+++ b/app/components/avo/views/resource_show_component.html.erb
@@ -39,7 +39,7 @@
                 <%= control.label %>
               <% end %>
             <% end %>
-          <% elsif can_see_the_actions_button? && control.actions_list? %>
+          <% elsif can_act_on? && control.actions_list? %>
             <%= render Avo::ActionsComponent.new actions: @actions, resource: @resource, view: @view, exclude: control.exclude, include: control.include, style: control.style, color: control.color, label: control.label %>
           <% elsif control.edit_button? %>
             <% if @resource.authorization.authorize_action(:edit, raise_exception: false) %>
@@ -142,7 +142,7 @@
               <%= t('avo.delete').capitalize %>
             <% end %>
           <% end %>
-          <% if can_see_the_actions_button? %>
+          <% if can_act_on? %>
             <%= render Avo::ActionsComponent.new actions: @actions, resource: @resource, view: @view %>
           <% end %>
           <% if @resource.authorization.authorize_action(:edit, raise_exception: false) %>

--- a/app/components/avo/views/resource_show_component.rb
+++ b/app/components/avo/views/resource_show_component.rb
@@ -46,7 +46,7 @@ class Avo::Views::ResourceShowComponent < Avo::ResourceComponent
   end
 
   def render_action_control?(action)
-    can_see_the_actions_button?(check_for_controls: true) && action.visible_in_view(parent_resource: @parent_resource)
+    can_act_on? && action.visible_in_view(parent_resource: @parent_resource)
   end
 
   private

--- a/app/components/avo/views/resource_show_component.rb
+++ b/app/components/avo/views/resource_show_component.rb
@@ -45,6 +45,10 @@ class Avo::Views::ResourceShowComponent < Avo::ResourceComponent
     helpers.edit_resource_path(model: @resource.model, resource: @resource, **args)
   end
 
+  def render_action_control?(action)
+    can_see_the_actions_button?(check_for_controls: true) && action.visible_in_view(parent_resource: @parent_resource)
+  end
+
   private
 
   # In development and test environments we shoudl show the invalid field errors


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1768

Show controls actions now respect the `act_on?` methods declared on the policies.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
