### PR TITLE
fix: markdown field not appearing on edit in tab

### DIFF
--- a/app/javascript/js/controllers/fields/easy_mde_controller.js
+++ b/app/javascript/js/controllers/fields/easy_mde_controller.js
@@ -20,6 +20,7 @@ export default class extends Controller {
     const options = {
       element: this.elementTarget,
       spellChecker: this.componentOptions.spell_checker,
+      autoRefresh: { delay: 500},
     }
 
     if (this.view === 'show') {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1843 

This pull request addresses a bug that caused the markdown field value to be hidden until clicked. This issue occurred specifically when the field was displayed within a secondary tab in the edit view.

Inspired from this issue: https://github.com/Ionaru/easy-markdown-editor/issues/499

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
