### PR TITLE
fix: respect inflection rules, humanize instead capitalize

### DIFF
--- a/app/components/avo/index/resource_controls_component.html.erb
+++ b/app/components/avo/index/resource_controls_component.html.erb
@@ -9,7 +9,7 @@
     <%= link_to helpers.svg('eye', class: button_classes),
       show_path,
       class: 'flex items-center',
-      title: t('avo.view_item', item: singular_resource_name).capitalize,
+      title: t('avo.view_item', item: singular_resource_name).humanize,
       data: {
         target: 'control:view',
         control: :show,
@@ -22,7 +22,7 @@
     <%= link_to helpers.svg('edit', class: button_classes),
       edit_path,
       class: 'flex items-center',
-      title: t('avo.edit_item', item: singular_resource_name).capitalize,
+      title: t('avo.edit_item', item: singular_resource_name).humanize,
       data: {
         target: 'control:edit',
         control: :edit,
@@ -41,7 +41,7 @@
         'data-turbo-frame': params[:turbo_frame]
       } do |form| %>
       <%= form.button helpers.svg('detach', class: button_classes),
-        title: t('avo.detach_item', item: singular_resource_name).capitalize,
+        title: t('avo.detach_item', item: singular_resource_name).humanize,
         type: :submit,
         data: {
           target: 'control:detach',
@@ -65,7 +65,7 @@
         'data-turbo-frame': params[:turbo_frame]
       } do |form| %>
       <%= form.button helpers.svg('trash', class: button_classes),
-        title: t('avo.delete_item',  item: singular_resource_name).capitalize,
+        title: t('avo.delete_item',  item: singular_resource_name).humanize,
         type: :submit,
         data: {
           target: 'control:destroy',

--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -13,7 +13,7 @@
           style: :text,
           'data-turbo-frame': 'attach_modal',
           'data-target': 'attach' do %>
-          <%= t('avo.attach_item', item: singular_resource_name).capitalize %>
+          <%= t('avo.attach_item', item: singular_resource_name).humanize %>
         <% end %>
       <% end %>
       <% if can_act_on? %>
@@ -25,7 +25,7 @@
           'data-target': 'create',
           style: :primary,
           color: :primary do %>
-          <%= t('avo.create_new_item', item: singular_resource_name.downcase ) %>
+          <%= t('avo.create_new_item', item: singular_resource_name.humanize(capitalize: false) ) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/avo/views/resource_show_component.html.erb
+++ b/app/components/avo/views/resource_show_component.html.erb
@@ -109,7 +109,7 @@
                 data: {
                   confirm: "Are you sure you want to detach this #{title}."
                 } do %>
-              <%= t('avo.detach_item', item: title).capitalize %>
+              <%= t('avo.detach_item', item: title).humanize %>
             <% end %>
           <% end %>
           <%= render Avo::ActionsComponent.new actions: @actions, resource: @resource, view: @view %>

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -263,7 +263,7 @@ module Avo
       return @name if @name.present?
 
       if translation_key && ::Avo::App.translation_enabled
-        t(translation_key, count: 1, default: default).capitalize
+        t(translation_key, count: 1, default: default).humanize
       else
         default
       end
@@ -277,7 +277,7 @@ module Avo
       default = name.pluralize
 
       if translation_key && ::Avo::App.translation_enabled
-        t(translation_key, count: 2, default: default).capitalize
+        t(translation_key, count: 2, default: default).humanize
       else
         default
       end

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -124,7 +124,7 @@ module Avo
         return @name if custom_name?
 
         if translation_key && ::Avo::App.translation_enabled
-          t(translation_key, count: 1, default: default_name).capitalize
+          t(translation_key, count: 1, default: default_name).humanize
         else
           default_name
         end
@@ -134,7 +134,7 @@ module Avo
         default = name.pluralize
 
         if translation_key && ::Avo::App.translation_enabled
-          t(translation_key, count: 2, default: default).capitalize
+          t(translation_key, count: 2, default: default).humanize
         else
           default
         end

--- a/lib/avo/resources/controls/detach_button.rb
+++ b/lib/avo/resources/controls/detach_button.rb
@@ -5,7 +5,7 @@ module Avo
         def initialize(**args)
           super(**args)
 
-          @label = I18n.t("avo.detach_item", item: title).capitalize
+          @label = I18n.t("avo.detach_item", item: title).humanize
         end
       end
     end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Avo was wrongly capitalizing resource names ignoring the acronyms configured on the `inflections.rb`

We start using `humanize` instead `capitalize` in many places in order to fix this issue.

Fixes #1858
<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
