### PR TITLE
add with_bare_sidebar to PanelComponent

### DIFF
--- a/app/components/avo/panel_component.html.erb
+++ b/app/components/avo/panel_component.html.erb
@@ -36,6 +36,11 @@
           <%= sidebar %>
         </div>
       <% end %>
+      <% if bare_sidebar? %>
+        <div class="w-full sm:w-1/3 flex-shrink-0 h-full">
+          <%= bare_sidebar %>
+        </div>
+      <% end %>
     </div>
   <% end %>
   <% if bare_content? %>

--- a/app/components/avo/panel_component.rb
+++ b/app/components/avo/panel_component.rb
@@ -10,7 +10,7 @@ class Avo::PanelComponent < ViewComponent::Base
   renders_one :tools
   renders_one :body
   renders_one :sidebar
-  renders_one :with_bare_sidebar
+  renders_one :bare_sidebar
   renders_one :bare_content
   renders_one :footer_tools
   renders_one :footer

--- a/app/components/avo/panel_component.rb
+++ b/app/components/avo/panel_component.rb
@@ -10,6 +10,7 @@ class Avo::PanelComponent < ViewComponent::Base
   renders_one :tools
   renders_one :body
   renders_one :sidebar
+  renders_one :with_bare_sidebar
   renders_one :bare_content
   renders_one :footer_tools
   renders_one :footer


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds a new rendering option for PanelComponent sidebars to skip the white background and provide a transparent container instead.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [X] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. In a Panel Component use `with_bare_sidebar` in place of `with_sidebar` and verify that the white background is gone.

Manual reviewer: please leave a comment with output from the test if that's the case.
