### PR TITLE
Made it possible to show a text field as a link

### DIFF
--- a/app/components/avo/fields/text_field/index_component.html.erb
+++ b/app/components/avo/fields/text_field/index_component.html.erb
@@ -1,6 +1,8 @@
 <%= index_field_wrapper **field_wrapper_args do %>
   <% if @field.as_html %>
     <%== @field.value %>
+  <% elsif @field.url.present? %>
+    <%= link_to @field.value, @field.value, target: "_blank" %>
   <% elsif @field.protocol.present? %>
     <%= link_to @field.value, "#{@field.protocol}:#{@field.value}" %>
   <% else %>

--- a/app/components/avo/fields/text_field/show_component.html.erb
+++ b/app/components/avo/fields/text_field/show_component.html.erb
@@ -1,6 +1,8 @@
 <%= field_wrapper **field_wrapper_args do %>
   <% if @field.as_html %>
     <%== @field.value %>
+  <% elsif @field.url.present? %>
+    <%= link_to @field.value, @field.value, target: "_blank" %>
   <% elsif @field.protocol.present? %>
     <%= link_to @field.value, "#{@field.protocol}:#{@field.value}" %>
   <% else %>

--- a/lib/avo/fields/text_field.rb
+++ b/lib/avo/fields/text_field.rb
@@ -3,6 +3,7 @@ module Avo
     class TextField < BaseField
       attr_reader :link_to_resource
       attr_reader :as_html
+      attr_reader :url
       attr_reader :protocol
 
       def initialize(id, **args, &block)
@@ -10,6 +11,7 @@ module Avo
 
         add_boolean_prop args, :link_to_resource
         add_boolean_prop args, :as_html
+        add_boolean_prop args, :url
         add_string_prop args, :protocol
       end
     end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Since the protocol option was added to text fields it's been possible to make text fields appear as a link on show and index pages, but there's no equivalent for http or https links. You can't use the protocol option for these because when rendering text with a protocol avo prepends the protocol to the link, but this doesn't make sense for urls, because they already include the protocol.

I've added a `url` option to text fields which displays them as a link without needing a protocol.


Fixes # (issue)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Add a text field without the `url` option set
2. Enter a link (eg. https://github.com) into the field
3. Save
4. View the resource
5. The text field should not be clickable
6. Update the resource definition to include `url: true` as an option
7. View the same resource again
8. The text field should now be a clickable link

Manual reviewer: please leave a comment with output from the test if that's the case.
