### PR TITLE
Fix target_resource for direct polymorphic relationships

### DIFF
--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -245,8 +245,9 @@ module Avo
 
         reflection_key = polymorphic_as || id
 
-        if @model._reflections[reflection_key.to_s].klass.present?
-          App.get_resource_by_model_name @model._reflections[reflection_key.to_s].klass.to_s
+        klass = @model._reflections[reflection_key.to_s].klass
+        if klass.present?
+          App.get_resource_by_model_name(klass.to_s) || App.get_resource_by_name(klass.name)
         elsif @model._reflections[reflection_key.to_s].options[:class_name].present?
           App.get_resource_by_model_name @model._reflections[reflection_key.to_s].options[:class_name]
         else


### PR DESCRIPTION
# Description
If a `MyModel` references eg. `ModelWithInheritance` directly (eg. `myModel.my_model_with_inheritance_id`) instead of classic polymorphic relation (`…_id & …_type` fields) the code breaks with an exception.

The root cause seems to be the the provided change.

Example:

- `class Agency < Organization`
- `class MyModel < ApplicationRecord; belongs_to :agency`
- If MyModel has a `agency_id` the code returns nil

---

<img width="864" alt="Screenshot 2023-07-29 at 15 42 34" src="https://github.com/avo-hq/avo/assets/504684/f8eb8482-db0c-4164-8ba7-cd3e31890d73">
<img width="745" alt="Screenshot 2023-07-29 at 15 42 47" src="https://github.com/avo-hq/avo/assets/504684/562a4e88-58ef-4179-aecb-1cf2a0afd03f">
<img width="121" alt="Screenshot 2023-07-29 at 15 43 40" src="https://github.com/avo-hq/avo/assets/504684/8dfcb7ae-bfd0-40aa-a761-2a93ff256af9">

