### PR TITLE
fix: warning instead raising error when can't find the inverse_of

### DIFF
--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -151,9 +151,11 @@ class Avo::ResourceComponent < Avo::BaseComponent
 
     inverse_of = current_reflection.inverse_of
 
-    if inverse_of.blank?
-      # Please configure the 'inverse_of' option for the ':users' association on the 'Project' model.
-      raise "Please configure the 'inverse_of' option for the '#{current_reflection.macro} :#{current_reflection.name}' association on the '#{current_reflection.active_record.name}' model."
+    if inverse_of.blank? && Rails.env.development?
+      puts "WARNING! Avo uses the 'inverse_of' option to determine the inverse association and figure out if the association permit or not detaching."
+      # Ex: Please configure the 'inverse_of' option for the ':users' association on the 'Project' model.
+      puts "Please configure the 'inverse_of' option for the '#{current_reflection.macro} :#{current_reflection.name}' association on the '#{current_reflection.active_record.name}' model."
+      puts "Otherwise the detach button will be visible by default.\n\n"
     end
 
     inverse_of

--- a/spec/dummy/app/models/project.rb
+++ b/spec/dummy/app/models/project.rb
@@ -26,7 +26,7 @@ class Project < ApplicationRecord
 
   has_many :comments, as: :commentable
   has_many :reviews, as: :reviewable
-  has_and_belongs_to_many :users, inverse_of: :projects
+  has_and_belongs_to_many :users
 
   default_scope { order(name: :asc) }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -195,3 +195,6 @@ require "support/js_error_detector"
 require "support/devise"
 require "support/shared_contexts"
 require "support/timezone"
+
+# https://github.com/titusfortner/webdrivers/issues/247
+Webdrivers::Chromedriver.required_version = "114.0.5735.90"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1873

In order to render the detach button we check for the inverse association using the `inverse_of` method. 

Occasionally, Rails may not identify the inverse association and we were raising an error to instruct where the `inverse_of` configuration is needed. We noticed that many apps was breaking due this error. 

To improve user experience and avoid breaking apps, we have made a modification. Instead of raising an error, we now display a warning during development, providing guidance on the necessity of configuring `inverse_of`.

![image](https://github.com/avo-hq/avo/assets/69730720/e26e291e-5c1b-4d5f-b32a-e4c9ef35be1a)


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

