### PR TITLE
feature: custom parent controller

### DIFF
--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -44,6 +44,7 @@ module Avo
     attr_accessor :sign_out_path_name
     attr_accessor :resources
     attr_accessor :prefix_path
+    attr_accessor :parent_controller
 
     def initialize
       @root_path = "/avo"
@@ -96,6 +97,7 @@ module Avo
       @field_wrapper_layout = :inline
       @resources = nil
       @prefix_path = nil
+      @parent_controller = "Avo::ResourcesController"
     end
 
     def current_user_method(&block)

--- a/lib/generators/avo/concerns/parent_controller.rb
+++ b/lib/generators/avo/concerns/parent_controller.rb
@@ -1,0 +1,20 @@
+module Generators
+  module Avo
+    module Concerns
+      module ParentController
+        extend ActiveSupport::Concern
+
+        included do
+          class_option "parent-controller",
+            desc: "The name of the parent controller.",
+            type: :string,
+            required: false
+        end
+
+        def parent_controller
+          options["parent-controller"] || ::Avo.configuration.parent_controller
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/avo/controller_generator.rb
+++ b/lib/generators/avo/controller_generator.rb
@@ -1,8 +1,11 @@
 require_relative "named_base_generator"
+require_relative "concerns/parent_controller"
 
 module Generators
   module Avo
     class ControllerGenerator < NamedBaseGenerator
+      include Generators::Avo::Concerns::ParentController
+
       source_root File.expand_path("templates", __dir__)
 
       namespace "avo:controller"

--- a/lib/generators/avo/resource_generator.rb
+++ b/lib/generators/avo/resource_generator.rb
@@ -1,8 +1,11 @@
 require_relative "named_base_generator"
+require_relative "concerns/parent_controller"
 
 module Generators
   module Avo
     class ResourceGenerator < NamedBaseGenerator
+      include Generators::Avo::Concerns::ParentController
+
       source_root File.expand_path("templates", __dir__)
 
       namespace "avo:resource"
@@ -12,18 +15,9 @@ module Generators
         type: :string,
         required: false
 
-      class_option "parent-controller",
-        desc: "The name of the parent controller.",
-        type: :string,
-        required: false
-
       def create
         template "resource/resource.tt", "app/avo/resources/#{resource_name}.rb"
         template "resource/controller.tt", "app/controllers/avo/#{controller_name}.rb"
-      end
-
-      def parent_controller
-        options["parent-controller"] || ::Avo.configuration.parent_controller
       end
 
       def resource_class

--- a/lib/generators/avo/resource_generator.rb
+++ b/lib/generators/avo/resource_generator.rb
@@ -1,5 +1,4 @@
 require_relative "named_base_generator"
-require "avo"
 
 module Generators
   module Avo

--- a/lib/generators/avo/resource_generator.rb
+++ b/lib/generators/avo/resource_generator.rb
@@ -1,4 +1,5 @@
 require_relative "named_base_generator"
+require "avo"
 
 module Generators
   module Avo
@@ -8,13 +9,22 @@ module Generators
       namespace "avo:resource"
 
       class_option "model-class",
+        desc: "The name of the model.",
         type: :string,
-        required: false,
-        desc: "The name of the model."
+        required: false
+
+      class_option "parent-controller",
+        desc: "The name of the parent controller.",
+        type: :string,
+        required: false
 
       def create
         template "resource/resource.tt", "app/avo/resources/#{resource_name}.rb"
         template "resource/controller.tt", "app/controllers/avo/#{controller_name}.rb"
+      end
+
+      def parent_controller
+        options["parent-controller"] || ::Avo.configuration.parent_controller
       end
 
       def resource_class
@@ -137,7 +147,7 @@ module Generators
         fields.each do |field_name, field_options|
           # if field_options are not available (likely a missing resource for an association), skip the field
           fields_string += "\n  # Could not generate a field for #{field_name}" and next unless field_options
-          
+
           options = ""
           field_options[:options].each { |k, v| options += ", #{k}: #{v}" } if field_options[:options].present?
 

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -67,6 +67,7 @@ Avo.configure do |config|
   # config.tabs_style = :tabs # can be :tabs or :pills
   # config.buttons_on_form_footers = true
   # config.field_wrapper_layout = true
+  # config.parent_controller = "Avo::ResourcesController"
 
   ## == Branding ==
   # config.branding = {

--- a/lib/generators/avo/templates/resource/controller.tt
+++ b/lib/generators/avo/templates/resource/controller.tt
@@ -1,4 +1,4 @@
 # This controller has been generated to enable Rails' resource routes.
 # More information on https://docs.avohq.io/2.0/controllers.html
-class <%= controller_class %> < Avo::ResourcesController
+class <%= controller_class %> < <%= parent_controller %>
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1822 

We have implemented the option to customize the parent controller from which newly generated controllers will inherit. This customization can be achieved through two different approaches.

## Initializer setting
Configure the `parent_controller` option on the `avo.rb` initializer

```ruby
Avo.configure do |config|
  # ...
  config.parent_controller = "Avo::MyCustomController" # "Avo::ResourcesController" is default value
  # ...
end
```

## `--parent-controller` option
When generating a resource pass the `--parent-controller` option:
`rails g avo:resource city --parent-controller Avo::MyCustomController`

**The `--parent-controller` option takes precedence when fetched. If left blank, the configuration `parent_controller` will be accessed as a fallback.**
<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
  - https://github.com/avo-hq/avodocs/pull/73
- [ ] I have added tests that prove my fix is effective or that my feature works

