### PR TITLE
feature: action redirect allow_other_host and status arguments & actions turbo attribute

### DIFF
--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -90,7 +90,7 @@ module Avo
               path = instance_eval(&path)
             end
 
-            redirect_to path
+            redirect_to path, **{allow_other_host: response[:allow_other_host], status: response[:status]}.compact
           elsif response[:type] == :reload
             redirect_back fallback_location: resources_path(resource: @resource)
           end

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -36,7 +36,7 @@ module Avo
       def form_data_attributes
         # We can't respond with a file download from Turbo se we disable it on the form
         if may_download_file
-          {turbo: false, remote: false, action_target: :form}
+          {turbo: turbo || false, remote: false, action_target: :form}
         else
           {turbo: turbo, turbo_frame: :_top, action_target: :form}.compact
         end

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -14,6 +14,7 @@ module Avo
     class_attribute :standalone, default: false
     class_attribute :visible
     class_attribute :may_download_file, default: false
+    class_attribute :turbo
 
     attr_accessor :response
     attr_accessor :model
@@ -37,7 +38,7 @@ module Avo
         if may_download_file
           {turbo: false, remote: false, action_target: :form}
         else
-          {turbo_frame: :_top, action_target: :form}
+          {turbo: turbo, turbo_frame: :_top, action_target: :form}.compact
         end
       end
 
@@ -196,8 +197,10 @@ module Avo
       self
     end
 
-    def redirect_to(path = nil, &block)
+    def redirect_to(path = nil, allow_other_host: nil, status: nil, &block)
       response[:type] = :redirect
+      response[:allow_other_host] = allow_other_host
+      response[:status] = status
       response[:path] = if block.present?
         block
       else

--- a/spec/dummy/app/avo/actions/sub/dummy_action.rb
+++ b/spec/dummy/app/avo/actions/sub/dummy_action.rb
@@ -1,6 +1,7 @@
 class Sub::DummyAction < Avo::BaseAction
   self.name = "Dummy action"
   self.standalone = true
+  # self.turbo = false
   self.visible = -> do
     if resource.is_a? UserResource
       view == :index
@@ -42,5 +43,7 @@ class Sub::DummyAction < Avo::BaseAction
     warn "Warning response ✌️"
     inform "Info response ✌️"
     error "Error response ✌️"
+
+    # redirect_to "https://www.google.com/"
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1761 , #1877 

Action's `redirect_to` method now accepts `allow_other_host` and `status` arguments.
It's also possible to turn turbo to false using the `self.turbo = false` action configuration, this is useful for external redirects for example.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

