### PR TITLE
fix: include field included_modules on format_using and update_using execution context

### DIFF
--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -186,7 +186,17 @@ module Avo
 
         if @format_using.present?
           # Apply the changes in the
-          Avo::ExecutionContext.new(target: @format_using, model: model, key: property, value: final_value, resource: resource, view: view, field: self, delegate_missing_to: :view_context).handle
+          Avo::ExecutionContext.new(
+            target: @format_using,
+            model: model,
+            key: property,
+            value: final_value,
+            resource: resource,
+            view: view,
+            field: self,
+            delegate_missing_to: :view_context,
+            include: self.class.included_modules
+          ).handle
         else
           final_value
         end
@@ -206,7 +216,15 @@ module Avo
       end
 
       def update_using(model, key, value, params)
-        Avo::ExecutionContext.new(target: @update_using, model: model, key: key, value: value, resource: resource, field: self).handle
+        Avo::ExecutionContext.new(
+          target: @update_using,
+          model: model,
+          key: key,
+          value: value,
+          resource: resource,
+          field: self,
+          include: self.class.included_modules
+        ).handle
       end
 
       # Try to see if the field has a different database ID than it's name

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -264,9 +264,7 @@ module Avo
       end
 
       def model_errors
-        return {} if model.nil?
-
-        model.errors
+        model.nil? ? {} : model.errors
       end
 
       def type
@@ -303,11 +301,7 @@ module Avo
       private
 
       def model_or_class(model)
-        if model.instance_of?(String)
-          "class"
-        else
-          "model"
-        end
+        model.instance_of?(String) ? "class" : "model"
       end
 
       def is_model?(model)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Helpers and other included modules were not accessible on the `format_using` and `update_using` execution context.

Fixes https://discord.com/channels/740892036978442260/1137012402899136582

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
