### PR TITLE
chore(deps): bump ransack from 3.0.1 to 4.0.0

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -2,7 +2,6 @@
   ["6.0", "6.1", "7.0"].each do |rails_version|
     appraise "rails-#{rails_version}-ruby-#{ruby_version}" do
       gem "rails", "~> #{rails_version}.0"
-      gem "ransack", "~> 3.1.0"
     end
   end
 end

--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,15 @@
 ["3.0.3", "3.2.2"].each do |ruby_version|
-  ["6.0", "6.1", "7.0"].each do |rails_version|
+  appraise "rails-6.0-ruby-#{ruby_version}" do
+    gem "rails", "~> 6.0.0"
+    gem "ransack", "~> 3.1.0"
+  end
+end
+
+["3.0.3", "3.2.2"].each do |ruby_version|
+  ["6.1", "7.0"].each do |rails_version|
     appraise "rails-#{rails_version}-ruby-#{ruby_version}" do
       gem "rails", "~> #{rails_version}.0"
+      gem "ransack", "~> 4.0.0"
     end
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,7 +256,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
-    minitest (5.18.1)
+    minitest (5.19.0)
     msgpack (1.5.6)
     multi_xml (0.6.0)
     net-imap (0.3.6)
@@ -328,9 +328,9 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    ransack (3.0.1)
-      activerecord (>= 6.0.4)
-      activesupport (>= 6.0.4)
+    ransack (4.0.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
       i18n
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -446,7 +446,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.8)
+    zeitwerk (2.6.11)
 
 PLATFORMS
   ruby
@@ -524,4 +524,4 @@ DEPENDENCIES
   zeitwerk
 
 BUNDLED WITH
-   2.3.24
+   2.4.14

--- a/gemfiles/rails_6.0_ruby_3.0.3.gemfile
+++ b/gemfiles/rails_6.0_ruby_3.0.3.gemfile
@@ -30,7 +30,7 @@ gem "addressable"
 gem "appraisal"
 gem "meta-tags"
 gem "manifester"
-gem "ransack"
+gem "ransack", "~> 3.1.0"
 gem "friendly_id", "~> 5.4.0"
 gem "aws-sdk-s3", require: false
 gem "net-smtp", require: false

--- a/gemfiles/rails_6.0_ruby_3.0.3.gemfile
+++ b/gemfiles/rails_6.0_ruby_3.0.3.gemfile
@@ -30,7 +30,7 @@ gem "addressable"
 gem "appraisal"
 gem "meta-tags"
 gem "manifester"
-gem "ransack", "~> 3.1.0"
+gem "ransack"
 gem "friendly_id", "~> 5.4.0"
 gem "aws-sdk-s3", require: false
 gem "net-smtp", require: false

--- a/gemfiles/rails_6.0_ruby_3.0.3.gemfile.lock
+++ b/gemfiles/rails_6.0_ruby_3.0.3.gemfile.lock
@@ -498,7 +498,7 @@ DEPENDENCIES
   pundit
   rails (~> 6.0.0)
   rails-controller-testing
-  ransack
+  ransack (~> 3.1.0)
   redis (~> 4.0)
   rspec-rails (~> 4.0.0)
   rubocop

--- a/gemfiles/rails_6.0_ruby_3.0.3.gemfile.lock
+++ b/gemfiles/rails_6.0_ruby_3.0.3.gemfile.lock
@@ -443,6 +443,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-linux
 
@@ -497,7 +498,7 @@ DEPENDENCIES
   pundit
   rails (~> 6.0.0)
   rails-controller-testing
-  ransack (~> 3.1.0)
+  ransack
   redis (~> 4.0)
   rspec-rails (~> 4.0.0)
   rubocop
@@ -518,4 +519,4 @@ DEPENDENCIES
   zeitwerk
 
 BUNDLED WITH
-   2.3.24
+   2.4.14

--- a/gemfiles/rails_6.0_ruby_3.2.2.gemfile
+++ b/gemfiles/rails_6.0_ruby_3.2.2.gemfile
@@ -30,7 +30,7 @@ gem "addressable"
 gem "appraisal"
 gem "meta-tags"
 gem "manifester"
-gem "ransack"
+gem "ransack", "~> 3.1.0"
 gem "friendly_id", "~> 5.4.0"
 gem "aws-sdk-s3", require: false
 gem "net-smtp", require: false

--- a/gemfiles/rails_6.0_ruby_3.2.2.gemfile
+++ b/gemfiles/rails_6.0_ruby_3.2.2.gemfile
@@ -30,7 +30,7 @@ gem "addressable"
 gem "appraisal"
 gem "meta-tags"
 gem "manifester"
-gem "ransack", "~> 3.1.0"
+gem "ransack"
 gem "friendly_id", "~> 5.4.0"
 gem "aws-sdk-s3", require: false
 gem "net-smtp", require: false

--- a/gemfiles/rails_6.0_ruby_3.2.2.gemfile.lock
+++ b/gemfiles/rails_6.0_ruby_3.2.2.gemfile.lock
@@ -498,7 +498,7 @@ DEPENDENCIES
   pundit
   rails (~> 6.0.0)
   rails-controller-testing
-  ransack
+  ransack (~> 3.1.0)
   redis (~> 4.0)
   rspec-rails (~> 4.0.0)
   rubocop

--- a/gemfiles/rails_6.0_ruby_3.2.2.gemfile.lock
+++ b/gemfiles/rails_6.0_ruby_3.2.2.gemfile.lock
@@ -443,6 +443,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-linux
 
@@ -497,7 +498,7 @@ DEPENDENCIES
   pundit
   rails (~> 6.0.0)
   rails-controller-testing
-  ransack (~> 3.1.0)
+  ransack
   redis (~> 4.0)
   rspec-rails (~> 4.0.0)
   rubocop
@@ -518,4 +519,4 @@ DEPENDENCIES
   zeitwerk
 
 BUNDLED WITH
-   2.3.24
+   2.4.14

--- a/gemfiles/rails_6.1_ruby_3.0.3.gemfile
+++ b/gemfiles/rails_6.1_ruby_3.0.3.gemfile
@@ -30,7 +30,7 @@ gem "addressable"
 gem "appraisal"
 gem "meta-tags"
 gem "manifester"
-gem "ransack"
+gem "ransack", "~> 4.0.0"
 gem "friendly_id", "~> 5.4.0"
 gem "aws-sdk-s3", require: false
 gem "net-smtp", require: false

--- a/gemfiles/rails_6.1_ruby_3.0.3.gemfile
+++ b/gemfiles/rails_6.1_ruby_3.0.3.gemfile
@@ -30,7 +30,7 @@ gem "addressable"
 gem "appraisal"
 gem "meta-tags"
 gem "manifester"
-gem "ransack", "~> 3.1.0"
+gem "ransack"
 gem "friendly_id", "~> 5.4.0"
 gem "aws-sdk-s3", require: false
 gem "net-smtp", require: false

--- a/gemfiles/rails_6.1_ruby_3.0.3.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_3.0.3.gemfile.lock
@@ -446,6 +446,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-linux
 
@@ -500,7 +501,7 @@ DEPENDENCIES
   pundit
   rails (~> 6.1.0)
   rails-controller-testing
-  ransack (~> 3.1.0)
+  ransack
   redis (~> 4.0)
   rspec-rails (~> 4.0.0)
   rubocop
@@ -521,4 +522,4 @@ DEPENDENCIES
   zeitwerk
 
 BUNDLED WITH
-   2.3.24
+   2.4.14

--- a/gemfiles/rails_6.1_ruby_3.0.3.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_3.0.3.gemfile.lock
@@ -322,9 +322,9 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    ransack (3.1.0)
-      activerecord (>= 6.0.4)
-      activesupport (>= 6.0.4)
+    ransack (4.0.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
       i18n
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -501,7 +501,7 @@ DEPENDENCIES
   pundit
   rails (~> 6.1.0)
   rails-controller-testing
-  ransack
+  ransack (~> 4.0.0)
   redis (~> 4.0)
   rspec-rails (~> 4.0.0)
   rubocop

--- a/gemfiles/rails_6.1_ruby_3.2.2.gemfile
+++ b/gemfiles/rails_6.1_ruby_3.2.2.gemfile
@@ -30,7 +30,7 @@ gem "addressable"
 gem "appraisal"
 gem "meta-tags"
 gem "manifester"
-gem "ransack"
+gem "ransack", "~> 4.0.0"
 gem "friendly_id", "~> 5.4.0"
 gem "aws-sdk-s3", require: false
 gem "net-smtp", require: false

--- a/gemfiles/rails_6.1_ruby_3.2.2.gemfile
+++ b/gemfiles/rails_6.1_ruby_3.2.2.gemfile
@@ -30,7 +30,7 @@ gem "addressable"
 gem "appraisal"
 gem "meta-tags"
 gem "manifester"
-gem "ransack", "~> 3.1.0"
+gem "ransack"
 gem "friendly_id", "~> 5.4.0"
 gem "aws-sdk-s3", require: false
 gem "net-smtp", require: false

--- a/gemfiles/rails_6.1_ruby_3.2.2.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_3.2.2.gemfile.lock
@@ -446,6 +446,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-linux
 
@@ -500,7 +501,7 @@ DEPENDENCIES
   pundit
   rails (~> 6.1.0)
   rails-controller-testing
-  ransack (~> 3.1.0)
+  ransack
   redis (~> 4.0)
   rspec-rails (~> 4.0.0)
   rubocop
@@ -521,4 +522,4 @@ DEPENDENCIES
   zeitwerk
 
 BUNDLED WITH
-   2.3.24
+   2.4.14

--- a/gemfiles/rails_6.1_ruby_3.2.2.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_3.2.2.gemfile.lock
@@ -322,9 +322,9 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    ransack (3.1.0)
-      activerecord (>= 6.0.4)
-      activesupport (>= 6.0.4)
+    ransack (4.0.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
       i18n
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -501,7 +501,7 @@ DEPENDENCIES
   pundit
   rails (~> 6.1.0)
   rails-controller-testing
-  ransack
+  ransack (~> 4.0.0)
   redis (~> 4.0)
   rspec-rails (~> 4.0.0)
   rubocop

--- a/gemfiles/rails_7.0_ruby_3.0.3.gemfile
+++ b/gemfiles/rails_7.0_ruby_3.0.3.gemfile
@@ -30,7 +30,7 @@ gem "addressable"
 gem "appraisal"
 gem "meta-tags"
 gem "manifester"
-gem "ransack"
+gem "ransack", "~> 4.0.0"
 gem "friendly_id", "~> 5.4.0"
 gem "aws-sdk-s3", require: false
 gem "net-smtp", require: false

--- a/gemfiles/rails_7.0_ruby_3.0.3.gemfile
+++ b/gemfiles/rails_7.0_ruby_3.0.3.gemfile
@@ -30,7 +30,7 @@ gem "addressable"
 gem "appraisal"
 gem "meta-tags"
 gem "manifester"
-gem "ransack", "~> 3.1.0"
+gem "ransack"
 gem "friendly_id", "~> 5.4.0"
 gem "aws-sdk-s3", require: false
 gem "net-smtp", require: false

--- a/gemfiles/rails_7.0_ruby_3.0.3.gemfile.lock
+++ b/gemfiles/rails_7.0_ruby_3.0.3.gemfile.lock
@@ -452,6 +452,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-linux
 
@@ -506,7 +507,7 @@ DEPENDENCIES
   pundit
   rails (~> 7.0.0)
   rails-controller-testing
-  ransack (~> 3.1.0)
+  ransack
   redis (~> 4.0)
   rspec-rails (~> 4.0.0)
   rubocop
@@ -527,4 +528,4 @@ DEPENDENCIES
   zeitwerk
 
 BUNDLED WITH
-   2.3.24
+   2.4.14

--- a/gemfiles/rails_7.0_ruby_3.0.3.gemfile.lock
+++ b/gemfiles/rails_7.0_ruby_3.0.3.gemfile.lock
@@ -328,9 +328,9 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    ransack (3.1.0)
-      activerecord (>= 6.0.4)
-      activesupport (>= 6.0.4)
+    ransack (4.0.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
       i18n
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -507,7 +507,7 @@ DEPENDENCIES
   pundit
   rails (~> 7.0.0)
   rails-controller-testing
-  ransack
+  ransack (~> 4.0.0)
   redis (~> 4.0)
   rspec-rails (~> 4.0.0)
   rubocop

--- a/gemfiles/rails_7.0_ruby_3.2.2.gemfile
+++ b/gemfiles/rails_7.0_ruby_3.2.2.gemfile
@@ -30,7 +30,7 @@ gem "addressable"
 gem "appraisal"
 gem "meta-tags"
 gem "manifester"
-gem "ransack"
+gem "ransack", "~> 4.0.0"
 gem "friendly_id", "~> 5.4.0"
 gem "aws-sdk-s3", require: false
 gem "net-smtp", require: false

--- a/gemfiles/rails_7.0_ruby_3.2.2.gemfile
+++ b/gemfiles/rails_7.0_ruby_3.2.2.gemfile
@@ -30,7 +30,7 @@ gem "addressable"
 gem "appraisal"
 gem "meta-tags"
 gem "manifester"
-gem "ransack", "~> 3.1.0"
+gem "ransack"
 gem "friendly_id", "~> 5.4.0"
 gem "aws-sdk-s3", require: false
 gem "net-smtp", require: false

--- a/gemfiles/rails_7.0_ruby_3.2.2.gemfile.lock
+++ b/gemfiles/rails_7.0_ruby_3.2.2.gemfile.lock
@@ -452,6 +452,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-linux
 
@@ -506,7 +507,7 @@ DEPENDENCIES
   pundit
   rails (~> 7.0.0)
   rails-controller-testing
-  ransack (~> 3.1.0)
+  ransack
   redis (~> 4.0)
   rspec-rails (~> 4.0.0)
   rubocop
@@ -527,4 +528,4 @@ DEPENDENCIES
   zeitwerk
 
 BUNDLED WITH
-   2.3.24
+   2.4.14

--- a/gemfiles/rails_7.0_ruby_3.2.2.gemfile.lock
+++ b/gemfiles/rails_7.0_ruby_3.2.2.gemfile.lock
@@ -328,9 +328,9 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    ransack (3.1.0)
-      activerecord (>= 6.0.4)
-      activesupport (>= 6.0.4)
+    ransack (4.0.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
       i18n
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -507,7 +507,7 @@ DEPENDENCIES
   pundit
   rails (~> 7.0.0)
   rails-controller-testing
-  ransack
+  ransack (~> 4.0.0)
   redis (~> 4.0)
   rspec-rails (~> 4.0.0)
   rubocop

--- a/spec/dummy/app/models/city.rb
+++ b/spec/dummy/app/models/city.rb
@@ -30,6 +30,10 @@ class City < ApplicationRecord
     "https://source.unsplash.com/random"
   end
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w(name)
+  end
+
   # Alternative to stored_as location field
   # def coordinates
   #   [latitude, longitude]

--- a/spec/dummy/app/models/comment.rb
+++ b/spec/dummy/app/models/comment.rb
@@ -22,6 +22,10 @@ class Comment < ApplicationRecord
 
   scope :starts_with, ->(prefix) { where("LOWER(body) LIKE ?", "#{prefix}%") }
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id body)
+  end
+
   def tiny_name
     ActionView::Base.full_sanitizer.sanitize(body.to_s).truncate 60
   end

--- a/spec/dummy/app/models/course.rb
+++ b/spec/dummy/app/models/course.rb
@@ -46,4 +46,8 @@ class Course < ApplicationRecord
       Thailand: ["Chiang Mai", "Bangkok", "Phuket"]
     }
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id name)
+  end
 end

--- a/spec/dummy/app/models/course/link.rb
+++ b/spec/dummy/app/models/course/link.rb
@@ -14,6 +14,10 @@ class Course::Link < ApplicationRecord
   acts_as_list
   default_scope -> { order(position: :asc) }
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id link)
+  end
+
   def self.table_name_prefix
     "course_"
   end

--- a/spec/dummy/app/models/fish.rb
+++ b/spec/dummy/app/models/fish.rb
@@ -40,4 +40,9 @@ class Fish < ApplicationRecord
     # properties should be a hash
     puts ["information in the Fish model->", value].inspect unless Rails.env.test?
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id name)
+  end
+
 end

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -61,4 +61,8 @@ class Post < ApplicationRecord
   def update_slug
     self.slug = name.parameterize
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id name body)
+  end
 end

--- a/spec/dummy/app/models/project.rb
+++ b/spec/dummy/app/models/project.rb
@@ -29,4 +29,8 @@ class Project < ApplicationRecord
   has_and_belongs_to_many :users
 
   default_scope { order(name: :asc) }
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id name country)
+  end
 end

--- a/spec/dummy/app/models/sibling.rb
+++ b/spec/dummy/app/models/sibling.rb
@@ -12,4 +12,8 @@
 #
 class Sibling < Person
   has_many :spouses, foreign_key: :person_id
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id name)
+  end
 end

--- a/spec/dummy/app/models/spouse.rb
+++ b/spec/dummy/app/models/spouse.rb
@@ -11,4 +11,7 @@
 #  person_id  :bigint
 #
 class Spouse < Person
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id name)
+  end
 end

--- a/spec/dummy/app/models/team.rb
+++ b/spec/dummy/app/models/team.rb
@@ -20,4 +20,8 @@ class Team < ApplicationRecord
   has_one :admin, through: :admin_membership, source: :user, inverse_of: :teams
 
   has_many :reviews, as: :reviewable
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id name)
+  end
 end

--- a/spec/dummy/app/models/team_membership.rb
+++ b/spec/dummy/app/models/team_membership.rb
@@ -13,6 +13,11 @@ class TeamMembership < ApplicationRecord
   belongs_to :team
   belongs_to :user
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id)
+  end
+
+
   def name
     "#{team&.name} - #{user&.name}"
   end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -74,4 +74,8 @@ class User < ApplicationRecord
   def avo_title
     is_admin? ? "Admin" : "Member"
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id first_name last_name created_at)
+  end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Vulnerability report: [SNYK-RUBY-RANSACK-5776488](https://security.snyk.io/vuln/SNYK-RUBY-RANSACK-5776488)
Ransack changelog: https://github.com/activerecord-hackery/ransack/blob/main/CHANGELOG.md

We use ransack 4 in production for a while, however since ransack 3.1.0 is a transitive dependency in Avo, the vulnerability scanner continuously reports the problem with the dependency. 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
