### PR TITLE
fix: added note about the seeding step to Readme

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -54,6 +54,8 @@ You can run `bin/dev` from the root directory, which will start an overmind (sim
 
 ## Seeding the database for local development
 
+NOTE: If you used the `bin/init` script, this step has already been done for you.
+
 Run `AVO_ADMIN_PASSWORD=secret bin/rails db:seed` to seed the database with dummy data and create a user for yourself with the email `avo@avohq.io` and password `secret`.
 
 ## Using your fork from another project


### PR DESCRIPTION
# Description

While setting up the project for local development, I've noticed one unclear instruction in the Readme. It instructs to run the `db:seed` command, although seeding is part of the `bin/init` script.

I've decided to add a note to prevent confusion for future contributors.

Fixes # (issue)

N/A

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps

1. Setup fresh `avo` repository locally by running `bin/init`
1. Log in to the dashboard with `avo@avohq.io` / `secret` credentials
