### PR TITLE
Fix: Added check for tailwind.config.js based on its path #1764

### DIFF
--- a/lib/generators/avo/tailwindcss/install_generator.rb
+++ b/lib/generators/avo/tailwindcss/install_generator.rb
@@ -39,15 +39,19 @@ module Generators
           say "Adding the CSS asset to the partial"
           prepend_to_file Rails.root.join("app", "views", "avo", "partials", "_pre_head.html.erb"), "<%= stylesheet_link_tag \"avo.tailwind.css\", media: \"all\" %>"
 
-          tailwind_config_path = tailwindcss_config_path()
-          tailwind_script = "tailwindcss -i ./app/assets/stylesheets/avo.tailwind.css -o ./app/assets/builds/avo.tailwind.css"
-          tailwind_script += " -c #{tailwind_config_path}" if tailwind_config_path
-
+          tailwind_script = setup_tailwind_script
           say "Ensure you have the following script in your package.json file.", :yellow
           say %("scripts": { "avo:tailwindcss": "#{tailwind_script}" --minify }), :green
         end
 
         no_tasks do
+          def setup_tailwind_script
+            tailwind_config_path = tailwindcss_config_path()
+            tailwind_script = "tailwindcss -i ./app/assets/stylesheets/avo.tailwind.css -o ./app/assets/builds/avo.tailwind.css"
+            tailwind_script += " -c #{tailwind_config_path}" if tailwind_config_path
+            tailwind_script
+          end  
+
           def template_path(filename)
             Pathname.new(__dir__).join("..", "templates", "tailwindcss", filename).to_s
           end

--- a/lib/generators/avo/tailwindcss/install_generator.rb
+++ b/lib/generators/avo/tailwindcss/install_generator.rb
@@ -39,8 +39,12 @@ module Generators
           say "Adding the CSS asset to the partial"
           prepend_to_file Rails.root.join("app", "views", "avo", "partials", "_pre_head.html.erb"), "<%= stylesheet_link_tag \"avo.tailwind.css\", media: \"all\" %>"
 
+          tailwind_config_path = tailwindcss_config_path()
+          tailwind_script = "tailwindcss -i ./app/assets/stylesheets/avo.tailwind.css -o ./app/assets/builds/avo.tailwind.css"
+          tailwind_script += " -c #{tailwind_config_path}" if tailwind_config_path
+
           say "Ensure you have the following script in your package.json file.", :yellow
-          say %("scripts": { "avo:tailwindcss": "tailwindcss -i ./app/assets/stylesheets/avo.tailwind.css -o ./app/assets/builds/avo.tailwind.css --minify" }), :green
+          say %("scripts": { "avo:tailwindcss": "#{tailwind_script}" --minify }), :green
         end
 
         no_tasks do
@@ -50,6 +54,12 @@ module Generators
 
           def tailwindcss_installed?
             Rails.root.join("config", "tailwind.config.js").exist? || Rails.root.join("tailwind.config.js").exist?
+          end
+
+          def tailwindcss_config_path
+            if Rails.root.join("config", "tailwind.config.js").exist?
+              "./config/tailwind.config.js"
+            end
           end
         end
       end


### PR DESCRIPTION
# Description
Added check to fix issue of showing instruction based on the path of tailwind.config.js file and append the -c ./config/tailwind.config.js to the instructions.

Fixes #1764 

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps

1. Tested code by running `bin/rails generate avo:tailwindcss:install` command for dummy project
2. If we have tailwind.config.js in spec/dummy/config/tailwind.config.js path we get instruction as
`"scripts": { "avo:tailwindcss": "tailwindcss -i ./app/assets/stylesheets/avo.tailwind.css -o ./app/assets/builds/avo.tailwind.css -c ./config/tailwind.config.js" --minify }`
3. If we don't have file in config directory we get instruction as
`"scripts": { "avo:tailwindcss": "tailwindcss -i ./app/assets/stylesheets/avo.tailwind.css -o ./app/assets/builds/avo.tailwind.css" --minify }`


