### PR TITLE
feature: Added new badge 'secondary' for option like drafting

### DIFF
--- a/app/components/avo/fields/common/badge_viewer_component.html.erb
+++ b/app/components/avo/fields/common/badge_viewer_component.html.erb
@@ -4,6 +4,7 @@
     success: 'bg-green-500',
     danger: 'bg-red-500',
     warning: 'bg-yellow-500',
+    secondary: 'bg-gray-500',
   }
 
   label = @value

--- a/db/factories.rb
+++ b/db/factories.rb
@@ -32,7 +32,7 @@ FactoryBot.define do
   factory :project do
     name { Faker::App.name }
     status { ['closed', :rejected, :failed, 'loading', :running, :waiting].sample }
-    stage { ["Discovery", "Idea", "Done", "On hold", "Cancelled"].sample }
+    stage { ["Discovery", "Idea", "Done", "On hold", "Cancelled", "Drafting"].sample }
     budget { Faker::Number.decimal(l_digits: 4) }
     country { Faker::Address.country_code }
     description { Faker::Markdown.sandwich(sentences: 5) }

--- a/lib/avo/fields/badge_field.rb
+++ b/lib/avo/fields/badge_field.rb
@@ -8,7 +8,7 @@ module Avo
 
         hide_on [:edit, :new]
 
-        default_options = {info: :info, success: :success, danger: :danger, warning: :warning}
+        default_options = {info: :info, success: :success, danger: :danger, warning: :warning, secondary: :secondary}
         @options = args[:options].present? ? default_options.merge(args[:options]) : default_options
       end
     end

--- a/spec/dummy/app/avo/resources/project_resource.rb
+++ b/spec/dummy/app/avo/resources/project_resource.rb
@@ -17,7 +17,7 @@ class ProjectResource < Avo::BaseResource
     placeholder: "Choose the stage",
     display_value: true,
     include_blank: false
-  field :stage, as: :badge, options: {info: ["Discovery", "Idea"], success: "Done", warning: "On hold", danger: "Cancelled"}
+  field :stage, as: :badge, options: {info: ["Discovery", "Idea"], success: "Done", warning: "On hold", danger: "Cancelled", secondary: "Drafting"}
   field :country,
     as: :country,
     index_text_align: :left,

--- a/spec/dummy/app/models/project.rb
+++ b/spec/dummy/app/models/project.rb
@@ -17,7 +17,7 @@
 #  progress       :integer
 #
 class Project < ApplicationRecord
-  enum stage: {Discovery: "discovery", Idea: "idea", Done: "done", "On hold": "on hold", Cancelled: "cancelled"}
+  enum stage: {Discovery: "discovery", Idea: "idea", Done: "done", "On hold": "on hold", Cancelled: "cancelled", Drafting: "drafting"}
 
   validates :name, presence: true
   validates :users_required, numericality: {greater_than: 9, less_than: 1000000}

--- a/spec/features/avo/badge_field_spec.rb
+++ b/spec/features/avo/badge_field_spec.rb
@@ -87,4 +87,31 @@ RSpec.describe "BadgeField", type: :feature do
       it { is_expected.not_to have_css ".bg-blue-500" }
     end
   end
+
+  describe "with a secondary status" do
+    let!(:project) { create :project, stage: "drafting" }
+
+    subject {
+      visit url
+      find_field_element(:stage)
+    }
+
+    context "index" do
+      let!(:url) { "/admin/resources/projects" }
+
+      it { is_expected.to have_text "Drafting" }
+      it { is_expected.to have_css ".rounded-md" }
+      it { is_expected.to have_css ".bg-gray-500" }
+      it { is_expected.not_to have_css ".bg-blue-500" }
+    end
+
+    context "show" do
+      let!(:url) { "/admin/resources/projects/#{project.id}" }
+
+      it { is_expected.to have_text "Drafting" }
+      it { is_expected.to have_css ".rounded-md" }
+      it { is_expected.to have_css ".bg-gray-500" }
+      it { is_expected.not_to have_css ".bg-blue-500" }
+    end
+  end
 end

--- a/spec/features/avo/badge_spec.rb
+++ b/spec/features/avo/badge_spec.rb
@@ -61,6 +61,17 @@ RSpec.describe "badge", type: :feature do
         is_expected.to have_css ".bg-red-500"
       }
     end
+
+    describe "with secondary value" do
+      let(:stage) { "Drafting" }
+      let!(:project) { create :project, users_required: 15, stage: stage }
+
+      it {
+        is_expected.to have_text stage
+        is_expected.to have_css ".rounded-md"
+        is_expected.to have_css ".bg-gray-500"
+      }
+    end
   end
 
   context "show" do
@@ -121,6 +132,17 @@ RSpec.describe "badge", type: :feature do
         is_expected.to have_text stage
         is_expected.to have_css ".rounded-md"
         is_expected.to have_css ".bg-red-500"
+      }
+    end
+
+    describe "with secondary value" do
+      let(:stage) { "Drafting" }
+      let!(:project) { create :project, users_required: 15, stage: stage }
+
+      it {
+        is_expected.to have_text stage
+        is_expected.to have_css ".rounded-md"
+        is_expected.to have_css ".bg-gray-500"
       }
     end
   end

--- a/spec/features/avo/select_field/enum_hash_display_value_true_spec.rb
+++ b/spec/features/avo/select_field/enum_hash_display_value_true_spec.rb
@@ -43,6 +43,13 @@ RSpec.describe "SelectField", type: :feature do
 
         it { is_expected.to have_text stage.humanize }
       end
+
+      describe "with secondary stage" do
+        let(:stage) { "secondary" }
+        let!(:project) { create :project, users_required: 15, stage: stage }
+
+        it { is_expected.to have_text stage.humanize }
+      end
     end
 
     subject do

--- a/spec/features/avo/select_field/enum_hash_display_value_true_spec.rb
+++ b/spec/features/avo/select_field/enum_hash_display_value_true_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "SelectField", type: :feature do
       end
     end
 
-    let(:stages_without_placeholder) { ["discovery", "idea", "done", "on hold", "cancelled"] }
+    let(:stages_without_placeholder) { ["discovery", "idea", "done", "on hold", "cancelled", "Drafting"] }
     let(:placeholder) { "Choose the stage" }
     let(:stages_with_placeholder) { stages_without_placeholder.prepend(placeholder) }
 

--- a/spec/features/avo/select_field/enum_hash_display_value_true_spec.rb
+++ b/spec/features/avo/select_field/enum_hash_display_value_true_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "SelectField", type: :feature do
       end
     end
 
-    let(:stages_without_placeholder) { ["discovery", "idea", "done", "on hold", "cancelled", "Drafting"] }
+    let(:stages_without_placeholder) { ["discovery", "idea", "done", "on hold", "cancelled", "drafting"] }
     let(:placeholder) { "Choose the stage" }
     let(:stages_with_placeholder) { stages_without_placeholder.prepend(placeholder) }
 

--- a/spec/features/avo/select_field/enum_hash_display_value_true_spec.rb
+++ b/spec/features/avo/select_field/enum_hash_display_value_true_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe "SelectField", type: :feature do
         it { is_expected.to have_text stage.humanize }
       end
 
-      describe "with secondary stage" do
-        let(:stage) { "secondary" }
+      describe "with drafting stage" do
+        let(:stage) { "drafting" }
         let!(:project) { create :project, users_required: 15, stage: stage }
 
         it { is_expected.to have_text stage.humanize }


### PR DESCRIPTION
# Description
This PR addresses the feature requirement for including new secondary badge to differentiate option like drafting in badges

Fixes #1909 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works


## Manual review steps

1. Created new project in test app using drafting option from stages

![drafting_badge](https://github.com/avo-hq/avo/assets/514363/eea2846c-dcda-4afe-a1ec-9e9bd0dcc395)
