### PR TITLE
fix: search count is incorrect when attach_scope

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -51,13 +51,13 @@ module Avo
         scope: resource.class.scope
       ).handle
 
+      query = apply_scope(query) if should_apply_any_scope?
+
       # Get the count
       results_count = query.reselect(resource.model_class.primary_key).count
 
       # Get the results
       query = query.limit(8)
-
-      query = apply_scope(query) if should_apply_any_scope?
 
       results = apply_search_metadata(query, resource)
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1930

This PR applies the scopes before making the count on search.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
