### PR TITLE
bug: Update fetches_things.rb to use custom policy if available

### DIFF
--- a/lib/avo/concerns/fetches_things.rb
+++ b/lib/avo/concerns/fetches_things.rb
@@ -89,7 +89,7 @@ module Avo
         def get_available_resources(user = nil)
           valid_resources
             .select do |resource|
-              Services::AuthorizationService.authorize user, resource.model_class, Avo.configuration.authorization_methods.stringify_keys["index"], raise_exception: false
+              Services::AuthorizationService.authorize user, resource.model_class, Avo.configuration.authorization_methods.stringify_keys["index"], policy_class: resource.authorization_policy ,raise_exception: false
             end
             .sort_by { |r| r.name }
         end

--- a/lib/avo/concerns/fetches_things.rb
+++ b/lib/avo/concerns/fetches_things.rb
@@ -89,7 +89,12 @@ module Avo
         def get_available_resources(user = nil)
           valid_resources
             .select do |resource|
-              Services::AuthorizationService.authorize user, resource.model_class, Avo.configuration.authorization_methods.stringify_keys["index"], policy_class: resource.authorization_policy ,raise_exception: false
+            resource.authorization.class.authorize(
+              user,
+              resource.model_class,
+              Avo.configuration.authorization_methods.stringify_keys["index"],
+              raise_exception: false
+            )
             end
             .sort_by { |r| r.name }
         end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1955

If self.authorization_policy is set on a resource and the current user would pass the check for index? the resource does not show up in the navigation menu. 

Updating the `Services::AuthorizationService.authorize` call in `Avo::Concerns::FetchesThings#get_available_resources` appears to resolve this. 

No tests are failing locally, but I still need to figure out the test suite so that I can test this functionality 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
