### PR TITLE
feature: allow params on resource menu item

### DIFF
--- a/app/components/avo/sidebar/item_switcher_component.html.erb
+++ b/app/components/avo/sidebar/item_switcher_component.html.erb
@@ -2,7 +2,7 @@
   <%= render Avo::Sidebar::LinkComponent.new label: item.name, path: item.path, target: item.target, data: item.data, icon: item.icon %>
 <% end %>
 <% if item.is_a? Avo::Menu::Resource %>
-  <%= render Avo::Sidebar::LinkComponent.new label: item.navigation_label, path: helpers.resources_path(resource: resource), data: item.data, icon: item.icon %>
+  <%= render Avo::Sidebar::LinkComponent.new label: item.navigation_label, path: helpers.resources_path(resource: resource, **item.fetch_params), data: item.data, icon: item.icon %>
 <% end %>
 <% if item.is_a? Avo::Menu::Dashboard %>
   <%= render Avo::Sidebar::LinkComponent.new label: item.navigation_label, path: dashboard.navigation_path, data: item.data, icon: item.icon %>

--- a/lib/avo/menu/resource.rb
+++ b/lib/avo/menu/resource.rb
@@ -3,6 +3,7 @@ class Avo::Menu::Resource < Avo::Menu::BaseItem
 
   option :resource
   option :label, optional: true
+  option :params, default: proc { {} }
 
   def parsed_resource
     Avo::App.guess_resource resource.to_s
@@ -10,5 +11,12 @@ class Avo::Menu::Resource < Avo::Menu::BaseItem
 
   def entity_label
     parsed_resource.navigation_label
+  end
+
+  def fetch_params
+    Avo::ExecutionContext.new(
+      target: params,
+      resource: resource
+    ).handle
   end
 end

--- a/lib/avo/menu/resource.rb
+++ b/lib/avo/menu/resource.rb
@@ -6,7 +6,7 @@ class Avo::Menu::Resource < Avo::Menu::BaseItem
   option :params, default: proc { {} }
 
   def parsed_resource
-    Avo::App.guess_resource resource.to_s
+    @parsed_resource ||= Avo::App.guess_resource resource.to_s
   end
 
   def entity_label
@@ -16,7 +16,7 @@ class Avo::Menu::Resource < Avo::Menu::BaseItem
   def fetch_params
     Avo::ExecutionContext.new(
       target: params,
-      resource: resource
+      resource: parsed_resource
     ).handle
   end
 end

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -99,7 +99,11 @@ Avo.configure do |config|
       end
 
       group "People", collapsable: true do
-        resource "UserResource", visible: -> do
+        resource "UserResource", params: -> do
+          decoded_filter = {"IsAdmin"=>["non_admins"]}
+
+          { filters: Avo::Filters::BaseFilter.encode_filters(decoded_filter)}
+        end, visible: -> do
           authorize current_user, User, "index?", raise_exception: false
         end
         resource :people

--- a/spec/features/avo/menu_builder_spec.rb
+++ b/spec/features/avo/menu_builder_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "MenuBuilders", type: :feature do
         end
 
         group "People" do
-          resource "UserResource"
+          resource "UserResource", params: { filters: "eyJJc0FkbWluIjpbIm5vbl9hZG1pbnMiXX0%3D%0A" }
           resource :people
           resource :spouses
         end
@@ -83,5 +83,10 @@ RSpec.feature "MenuBuilders", type: :feature do
     expect(subject.items.last.name).to eq "JSP"
     expect(subject.items.last.path).to eq "https://jumpstartrails.com/"
     expect(subject.items.last.target).to eq :_blank
+
+    # Checking path generated when :params used
+    users = subject.items.second.items[3].items.first
+    expect(users.resource).to eq "UserResource"
+    expect(users.params).to eq filters: "eyJJc0FkbWluIjpbIm5vbl9hZG1pbnMiXX0%3D%0A"
   end
 end

--- a/spec/features/avo/menu_item_spec.rb
+++ b/spec/features/avo/menu_item_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "menu item behaviour", type: :feature do
+  it "allows navigation via menu items" do
+    visit "/"
+
+    all("a", text: "Projects")[1].click
+
+    expect(page).to have_current_path("/admin/resources/projects")
+
+    all("a", text: "Users")[1].click
+
+    expect(page).to have_current_path("/admin/resources/users?filters=eyJJc0FkbWluIjpbIm5vbl9hZG1pbnMiXX0%3D%0A")
+  end
+end


### PR DESCRIPTION
# Description

Fixes https://github.com/avo-hq/avo/issues/1651

In this Pull Request I'm adding an option to pass `params` to the `resource` method on the `MenuBuilder`. It can be a Hash or a Proc that will return a Hash.

Whatever is passed as `params` will be added to the path of the menu item, when navigating to it.

Before this PR, there was a [POC](https://github.com/bryszard/avo/pull/1) on which @Paul-Bob helped me understand the scope of the changes to be done.

In the POC we've identified one caveat for future users of the feature - we don't support having multiple menu items for the same resource, but with different params. The reason is simple - if we have two menu items with the same path, they would be both highlighted as `active` when visited. The workarounds for that using current library `active_link_for` are imperfect and substituting it right now has no point.

As @Paul-Bob stated [here](https://github.com/bryszard/avo/pull/1#issuecomment-1728725362) - we already have a feature to achieve the goal of having different filters for the same resource applied and these are the scopes.

With this feature it will be possible to add some default params to the menu item, which don't necessarily need to be the filters.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Video QA

https://github.com/avo-hq/avo/assets/12682792/1f8720dd-24df-4042-908b-6647080cf046

## Manual review steps

1. Open the Avo app on local environment
1. Click on the `Users` resource and check the path

Manual reviewer: please leave a comment with output from the test if that's the case.
