### PR TITLE
feature: allow suggestions_max_items option on tags field

### DIFF
--- a/app/components/avo/fields/tags_field/edit_component.html.erb
+++ b/app/components/avo/fields/tags_field/edit_component.html.erb
@@ -4,6 +4,7 @@
       tags_field_whitelist_items_value: @field.suggestions.to_json,
       tags_field_disallowed_items_value: @field.disallowed.to_json,
       tags_field_enforce_suggestions_value: @field.enforce_suggestions,
+      tags_field_suggestions_max_items_value: @field.suggestions_max_items,
       tags_field_close_on_select_value: @field.close_on_select,
       tags_field_delimiters_value: @field.delimiters,
       tags_field_fetch_values_from_value: @field.fetch_values_from,

--- a/app/javascript/js/controllers/fields/tags_field_controller.js
+++ b/app/javascript/js/controllers/fields/tags_field_controller.js
@@ -1,126 +1,130 @@
-import { first, isObject, merge } from 'lodash'
-import Tagify from '@yaireo/tagify'
-import URI from 'urijs'
+import { first, isObject, merge } from "lodash";
+import Tagify from "@yaireo/tagify";
+import URI from "urijs";
 
-import { suggestionItemTemplate, tagTemplate } from './tags_field_helpers'
-import BaseController from '../base_controller'
-import debouncePromise from '../../helpers/debounce_promise'
+import { suggestionItemTemplate, tagTemplate } from "./tags_field_helpers";
+import BaseController from "../base_controller";
+import debouncePromise from "../../helpers/debounce_promise";
 
 export default class extends BaseController {
-  static targets = ['input', 'fakeInput'];
+  static targets = ["input", "fakeInput"];
 
   static values = {
     whitelistItems: { type: Array, default: [] },
     disallowedItems: { type: Array, default: [] },
     enforceSuggestions: { type: Boolean, default: false },
+    suggestionsMaxItems: { type: Number, default: 20 },
     closeOnSelect: { type: Boolean, default: false },
     delimiters: { type: Array, default: [] },
     mode: String,
     fetchValuesFrom: String,
-  }
+  };
 
   tagify = null;
 
-  searchDebounce = 500
+  searchDebounce = 500;
 
   debouncedFetch = debouncePromise(fetch, this.searchDebounce);
 
   get suggestionsAreObjects() {
-    return isObject(first(this.whitelistItemsValue)) || this.fetchValuesFromValue
+    return (
+      isObject(first(this.whitelistItemsValue)) || this.fetchValuesFromValue
+    );
   }
 
   get tagifyOptions() {
     let options = {
       whitelist: this.whitelistItemsValue,
       blacklist: this.disallowedItemsValue,
-      enforceWhitelist: this.enforceSuggestionsValue || this.fetchValuesFromValue,
-      delimiters: this.delimitersValue.join('|'),
+      enforceWhitelist:
+        this.enforceSuggestionsValue || this.fetchValuesFromValue,
+      delimiters: this.delimitersValue.join("|"),
       dropdown: {
-        maxItems: 20,
+        maxItems: this.suggestionsMaxItemsValue,
         enabled: 0,
         searchKeys: [this.labelAttributeValue],
         closeOnSelect: this.closeOnSelectValue,
       },
-    }
+    };
 
     if (this.modeValue) {
-      options.mode = this.modeValue // null or "select"
+      options.mode = this.modeValue; // null or "select"
     }
 
     if (this.suggestionsAreObjects) {
       options = merge(options, {
-        tagTextProp: 'label',
+        tagTextProp: "label",
         dropdown: {
-          searchKeys: ['label'],
-          mapValueTo: 'value',
+          searchKeys: ["label"],
+          mapValueTo: "value",
         },
         templates: {
           tag: tagTemplate,
           dropdownItem: suggestionItemTemplate,
         },
-        originalInputValueFormat: (valuesArr) => valuesArr.map((item) => item.value),
-      })
+        originalInputValueFormat: (valuesArr) =>
+          valuesArr.map((item) => item.value),
+      });
     } else {
       options = merge(options, {
-        originalInputValueFormat: (valuesArr) => valuesArr.map((item) => item.value).join(','),
-      })
+        originalInputValueFormat: (valuesArr) =>
+          valuesArr.map((item) => item.value).join(","),
+      });
     }
 
-    return options
+    return options;
   }
 
   connect() {
     if (this.hasInputTarget) {
-      this.hideFakeInput()
-      this.showRealInput()
-      this.initTagify()
+      this.hideFakeInput();
+      this.showRealInput();
+      this.initTagify();
     }
   }
 
   initTagify() {
-    this.tagify = new Tagify(this.inputTarget, this.tagifyOptions)
-    const that = this
+    this.tagify = new Tagify(this.inputTarget, this.tagifyOptions);
+    const that = this;
 
     function onInput(e) {
       // Create the URL from which to fetch the values
-      const query = e.detail.value
-      const uri = new URI(that.fetchValuesFromValue)
+      const query = e.detail.value;
+      const uri = new URI(that.fetchValuesFromValue);
       uri.addSearch({
         q: query,
-      })
+      });
 
       // reset current whitelist
-      that.tagify.whitelist = null
+      that.tagify.whitelist = null;
       // show the loader animation
-      that.tagify.loading(true)
+      that.tagify.loading(true);
 
       // get new whitelist from a request
-      that.fetchResults(uri.toString())
+      that
+        .fetchResults(uri.toString())
         .then((result) => {
-          that.tagify.settings.whitelist = result // add already-existing tags to the new whitelist array
+          that.tagify.settings.whitelist = result; // add already-existing tags to the new whitelist array
 
-          that.tagify
-            .loading(false)
-            .dropdown.show(e.detail.value) // render the suggestions dropdown.
+          that.tagify.loading(false).dropdown.show(e.detail.value); // render the suggestions dropdown.
         })
-        .catch(() => that.tagify.dropdown.hide())
+        .catch(() => that.tagify.dropdown.hide());
     }
 
     if (this.fetchValuesFromValue) {
-      this.tagify.on('input', onInput)
+      this.tagify.on("input", onInput);
     }
   }
 
   fetchResults(endpoint) {
-    return this.debouncedFetch(endpoint)
-      .then((response) => response.json())
+    return this.debouncedFetch(endpoint).then((response) => response.json());
   }
 
   hideFakeInput() {
-    this.fakeInputTarget.classList.add('hidden')
+    this.fakeInputTarget.classList.add("hidden");
   }
 
   showRealInput() {
-    this.inputTarget.classList.remove('hidden')
+    this.inputTarget.classList.remove("hidden");
   }
 }

--- a/app/javascript/js/controllers/fields/tags_field_controller.js
+++ b/app/javascript/js/controllers/fields/tags_field_controller.js
@@ -1,130 +1,127 @@
-import { first, isObject, merge } from "lodash";
-import Tagify from "@yaireo/tagify";
-import URI from "urijs";
+import { first, isObject, merge } from 'lodash'
+import Tagify from '@yaireo/tagify'
+import URI from 'urijs'
 
-import { suggestionItemTemplate, tagTemplate } from "./tags_field_helpers";
-import BaseController from "../base_controller";
-import debouncePromise from "../../helpers/debounce_promise";
+import { suggestionItemTemplate, tagTemplate } from './tags_field_helpers'
+import BaseController from '../base_controller'
+import debouncePromise from '../../helpers/debounce_promise'
 
 export default class extends BaseController {
-  static targets = ["input", "fakeInput"];
+  static targets = ['input', 'fakeInput'];
 
   static values = {
     whitelistItems: { type: Array, default: [] },
     disallowedItems: { type: Array, default: [] },
     enforceSuggestions: { type: Boolean, default: false },
-    suggestionsMaxItems: { type: Number, default: 20 },
     closeOnSelect: { type: Boolean, default: false },
     delimiters: { type: Array, default: [] },
+    suggestionsMaxItems: { type: Number, default: 20 },
     mode: String,
     fetchValuesFrom: String,
-  };
+  }
 
   tagify = null;
 
-  searchDebounce = 500;
+  searchDebounce = 500
 
   debouncedFetch = debouncePromise(fetch, this.searchDebounce);
 
   get suggestionsAreObjects() {
-    return (
-      isObject(first(this.whitelistItemsValue)) || this.fetchValuesFromValue
-    );
+    return isObject(first(this.whitelistItemsValue)) || this.fetchValuesFromValue
   }
 
   get tagifyOptions() {
     let options = {
       whitelist: this.whitelistItemsValue,
       blacklist: this.disallowedItemsValue,
-      enforceWhitelist:
-        this.enforceSuggestionsValue || this.fetchValuesFromValue,
-      delimiters: this.delimitersValue.join("|"),
+      enforceWhitelist: this.enforceSuggestionsValue || this.fetchValuesFromValue,
+      delimiters: this.delimitersValue.join('|'),
       dropdown: {
         maxItems: this.suggestionsMaxItemsValue,
         enabled: 0,
         searchKeys: [this.labelAttributeValue],
         closeOnSelect: this.closeOnSelectValue,
       },
-    };
+    }
 
     if (this.modeValue) {
-      options.mode = this.modeValue; // null or "select"
+      options.mode = this.modeValue // null or "select"
     }
 
     if (this.suggestionsAreObjects) {
       options = merge(options, {
-        tagTextProp: "label",
+        tagTextProp: 'label',
         dropdown: {
-          searchKeys: ["label"],
-          mapValueTo: "value",
+          searchKeys: ['label'],
+          mapValueTo: 'value',
         },
         templates: {
           tag: tagTemplate,
           dropdownItem: suggestionItemTemplate,
         },
-        originalInputValueFormat: (valuesArr) =>
-          valuesArr.map((item) => item.value),
-      });
+        originalInputValueFormat: (valuesArr) => valuesArr.map((item) => item.value),
+      })
     } else {
       options = merge(options, {
-        originalInputValueFormat: (valuesArr) =>
-          valuesArr.map((item) => item.value).join(","),
-      });
+        originalInputValueFormat: (valuesArr) => valuesArr.map((item) => item.value).join(','),
+      })
     }
 
-    return options;
+    return options
   }
 
   connect() {
     if (this.hasInputTarget) {
-      this.hideFakeInput();
-      this.showRealInput();
-      this.initTagify();
+      this.hideFakeInput()
+      this.showRealInput()
+      this.initTagify()
     }
   }
 
   initTagify() {
-    this.tagify = new Tagify(this.inputTarget, this.tagifyOptions);
-    const that = this;
+    this.tagify = new Tagify(this.inputTarget, this.tagifyOptions)
+    const that = this
 
     function onInput(e) {
       // Create the URL from which to fetch the values
-      const query = e.detail.value;
-      const uri = new URI(that.fetchValuesFromValue);
+      const query = e.detail.value
+      const uri = new URI(that.fetchValuesFromValue)
       uri.addSearch({
         q: query,
-      });
+      })
 
       // reset current whitelist
-      that.tagify.whitelist = null;
+      that.tagify.whitelist = null
       // show the loader animation
-      that.tagify.loading(true);
+      that.tagify.loading(true)
 
       // get new whitelist from a request
-      that
-        .fetchResults(uri.toString())
+      that.fetchResults(uri.toString())
         .then((result) => {
-          that.tagify.settings.whitelist = result; // add already-existing tags to the new whitelist array
+          that.tagify.settings.whitelist = result // add already-existing tags to the new whitelist array
 
-          that.tagify.loading(false).dropdown.show(e.detail.value); // render the suggestions dropdown.
+          that.tagify
+            .loading(false)
+            .dropdown.show(e.detail.value) // render the suggestions dropdown.
         })
-        .catch(() => that.tagify.dropdown.hide());
+        .catch(() => that.tagify.dropdown.hide())
     }
 
     if (this.fetchValuesFromValue) {
-      this.tagify.on("input", onInput);
+      this.tagify.on('input', onInput)
     }
   }
 
   fetchResults(endpoint) {
-    return this.debouncedFetch(endpoint).then((response) => response.json());
+    return this.debouncedFetch(endpoint)
+      .then((response) => response.json())
   }
 
   hideFakeInput() {
-    this.fakeInputTarget.classList.add("hidden");
+    this.fakeInputTarget.classList.add('hidden')
   }
 
   showRealInput() {
-    this.inputTarget.classList.remove("hidden");
+    this.inputTarget.classList.remove('hidden')
   }
 }

--- a/lib/avo/fields/tags_field.rb
+++ b/lib/avo/fields/tags_field.rb
@@ -5,6 +5,7 @@ module Avo
       attr_reader :close_on_select
       attr_reader :delimiters
       attr_reader :enforce_suggestions
+      attr_reader :suggestions_max_items
       attr_reader :mode
 
       def initialize(id, **args, &block)
@@ -16,6 +17,7 @@ module Avo
         add_array_prop args, :disallowed
         add_array_prop args, :delimiters, [","]
         add_array_prop args, :suggestions
+        add_string_prop args, :suggestions_max_items
         add_string_prop args, :mode, nil
         add_string_prop args, :fetch_values_from
         add_string_prop args, :fetch_labels

--- a/spec/dummy/app/avo/resources/post_resource.rb
+++ b/spec/dummy/app/avo/resources/post_resource.rb
@@ -34,6 +34,7 @@ class PostResource < Avo::BaseResource
     placeholder: "add some tags",
     suggestions: -> { Post.tags_suggestions },
     enforce_suggestions: true,
+    suggestions_max_items: 2,
     help: "The only allowed values here are `one`, `two`, and `three`"
   field :cover_photo, as: :file, is_image: true, as_avatar: :rounded, full_width: true, hide_on: [], accept: "image/*", display_filename: false#, format_using: -> { value.variant(resize_to_limit: [100, 100]).processed.image }
   field :cover_photo, as: :external_image, name: "Cover photo", required: true, hide_on: :all, link_to_resource: true, as_avatar: :rounded, format_using: -> { value.present? ? value&.url : nil }


### PR DESCRIPTION
Fixes https://github.com/avo-hq/avo/issues/1926

# Description

We're using a JS library to handle tags `@yaireo/tagify`. 
There is a feature there that allows to show to the users tag suggestions - we provide a list of potential suggestions and we have some options around it. 
One of those options is `dropdown.max_items` which we have hard-coded currently to 20.

We want to allow users of Avo to set their own `max_items` limit, keeping the 20 as default.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Visual QA


https://github.com/avo-hq/avo/assets/12682792/f2890331-a9e9-4a11-8b2a-8f6713e98b36



## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Check the `Posts` resource in the dummy app
1. Remove the tags and show how many tags show up (limit is set to 2, there are 3 options, so you should see 2 and info that more tags are there but hidden)

Manual reviewer: please leave a comment with output from the test if that's the case.
