### PR TITLE
fix: message don't appear on fail destroy on associations

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -504,8 +504,10 @@ module Avo
     end
 
     def destroy_fail_action
+      flash[:error] = destroy_fail_message
+
       respond_to do |format|
-        format.html { redirect_back fallback_location: params[:referrer] || resources_path(resource: @resource, turbo_frame: params[:turbo_frame], view_type: params[:view_type]), error: destroy_fail_message }
+        format.turbo_stream { render partial: "avo/partials/flash_alerts" }
       end
     end
 

--- a/app/views/avo/partials/_flash_alerts.turbo_stream.erb
+++ b/app/views/avo/partials/_flash_alerts.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.append "alerts" do %>
-  <%= render Avo::FlashAlertsComponent.new flashes: flash %>
+  <%= render Avo::FlashAlertsComponent.new flashes: flash.discard %>
 <% end %>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1918

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
