### PR TITLE
fix: create belongs_to from associations with buttons on form footers

### DIFF
--- a/app/components/avo/views/resource_edit_component.html.erb
+++ b/app/components/avo/views/resource_edit_component.html.erb
@@ -81,10 +81,12 @@
         <% if Avo.configuration.buttons_on_form_footers %>
           <% c.with_footer_tools do %>
             <div class="mt-4">
-              <%= a_link back_path,
-              style: :text,
-              icon: 'arrow-left' do %>
-                <%= t('avo.cancel').capitalize %>
+              <% if back_path.present? %>
+                <%= a_link back_path,
+                style: :text,
+                icon: 'arrow-left' do %>
+                  <%= t('avo.cancel').capitalize %>
+                <% end %>
               <% end %>
               <% if can_see_the_save_button? %>
                 <%= a_button color: :primary,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The form footer lacked a safeguard for rendering buttons, leading to an issue where the back button attempted to render without a valid path within the belongs_to modal creation.

Fixes #2008 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
