### PR TITLE
fix: detach should not destroy attachment

### DIFF
--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -81,7 +81,7 @@ module Avo
       association_name = BaseResource.valid_association_name(@model, params[:related_name])
 
       if reflection_class == "HasManyReflection"
-        @model.send(association_name).destroy @attachment_model
+        @model.send(association_name).delete @attachment_model
       else
         @model.send("#{association_name}=", nil)
       end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

[This change](https://github.com/avo-hq/avo/pull/1856/files#diff-b1f64e5509fa895bb0217e2740a262487a1344069c30bef0391e92f05c760b91) intended to make sure that validations / callbacks are called when detaching a record from a `has_many` associations. Unfortunately it introduced a bug where the record getting detached is actually deleted from DB.

[`destroy(*records)`](https://edgeapi.rubyonrails.org/classes/ActiveRecord/Associations/CollectionProxy.html#method-i-destroy)

> ...
This method will always remove record from the database ignoring the :dependent option.
...

Delete is what we want here but [`delete(*records)`](https://edgeapi.rubyonrails.org/classes/ActiveRecord/Associations/CollectionProxy.html#method-i-delete) will not run associations callbacks...

Fixes https://discord.com/channels/740892036978442260/1157144752752427048

We should find a way to trigger associations callbacks using `delete` or another strategy.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

