### PR TITLE
fix: redirect on action when no_confirmation = true

### DIFF
--- a/app/javascript/js/controllers/action_controller.js
+++ b/app/javascript/js/controllers/action_controller.js
@@ -2,7 +2,7 @@ import { Controller } from '@hotwired/stimulus'
 import { castBoolean } from '../helpers/cast_boolean'
 
 export default class extends Controller {
-  static targets = ['controllerDiv', 'resourceIds', 'form', 'selectedAllQuery']
+  static targets = ['controllerDiv', 'resourceIds', 'submit', 'selectedAllQuery']
 
   connect() {
     this.resourceIdsTarget.value = this.resourceIds
@@ -13,7 +13,7 @@ export default class extends Controller {
     }
 
     if (this.noConfirmation) {
-      this.formTarget.submit()
+      this.submitTarget.click()
     } else {
       this.controllerDivTarget.classList.remove('hidden')
     }

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -32,19 +32,21 @@ module Avo
       def form_data_attributes
         # We can't respond with a file download from Turbo se we disable it on the form
         if may_download_file
-          {turbo: turbo || false, remote: false, action_target: :form}
+          {turbo: turbo || false, remote: false}
         else
-          {turbo: turbo, turbo_frame: :_top, action_target: :form}.compact
+          {turbo: turbo, turbo_frame: :_top}.compact
         end
       end
 
       # We can't respond with a file download from Turbo se we disable close the modal manually after a while (it's a hack, we know)
       def submit_button_data_attributes
+        attributes = { action_target: "submit" }
+
         if may_download_file
-          {action: "click->modal#delayedClose"}
-        else
-          {}
+          attributes[:action] = "click->modal#delayedClose"
         end
+
+        attributes
       end
     end
 

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -131,6 +131,35 @@ RSpec.describe "Actions", type: :system do
     end
   end
 
+  describe "redirects when no confirmation" do
+    it "redirects to hey page" do
+      no_confirmation = Sub::DummyAction.no_confirmation
+
+      Sub::DummyAction.class_eval do
+        self.no_confirmation = true
+
+        define_method(:redirect_handle) do |**args|
+          redirect_to main_app.hey_path
+        end
+
+        alias_method :handle, :redirect_handle
+      end
+
+      visit "/admin/resources/users"
+
+      click_on "Actions"
+      click_on "Dummy action"
+
+      expect(page).to have_text "hey en"
+
+
+      Sub::DummyAction.class_eval do
+        undef_method :redirect_handle
+      end
+
+      Sub::DummyAction.no_confirmation = no_confirmation
+    end
+  end
   #   let!(:roles) { { admin: false, manager: false, writer: false } }
   #   let!(:user) { create :user, active: true, roles: roles }
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When using `no_confirmation` on actions the form was getting submitted by JS resulting on `UnknownFormat`, changing the way that JS submit to actually click on the form button solved the issue.

Fixes https://discord.com/channels/740892036978442260/1174872788323020911

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
