### PR TITLE
fix: create new record from belongs_to associations

### DIFF
--- a/app/components/avo/fields/belongs_to_field/edit_component.rb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.rb
@@ -63,7 +63,7 @@ class Avo::Fields::BelongsToField::EditComponent < Avo::Fields::EditComponent
     helpers.new_resource_path(**{
       via_relation: @field.id.to_s,
       resource: target_resource || @field.target_resource,
-      via_record_id: resource.record.to_param,
+      via_record_id: resource.record.persisted? ? resource.record.to_param : nil,
       via_belongs_to_resource_class: resource.class.name
     }.compact)
   end

--- a/spec/dummy/app/models/course/link.rb
+++ b/spec/dummy/app/models/course/link.rb
@@ -10,6 +10,8 @@
 #  position   :integer
 #
 class Course::Link < ApplicationRecord
+  has_prefix_id :course_link
+
   belongs_to :course, optional: true
   acts_as_list
   default_scope -> { order(position: :asc) }

--- a/spec/dummy/config/locales/avo.es.yml
+++ b/spec/dummy/config/locales/avo.es.yml
@@ -1,12 +1,12 @@
 ---
 es:
   avo:
-    action_ran_successfully: ¡Acción ejecutada con éxito!
+    action_ran_successfully: "¡Acción ejecutada con éxito!"
     actions: Acciones
     and_x_other_resources: y %{count} otros recursos
-    are_you_sure: ¿Estás seguro?
-    are_you_sure_detach_item: ¿Estás seguro de que quieres separar este/a %{item}?
-    are_you_sure_you_want_to_run_this_option: ¿Estás seguro de que quieres ejectuar esta acción?
+    are_you_sure: "¿Estás seguro?"
+    are_you_sure_detach_item: "¿Estás seguro de que quieres separar este/a %{item}?"
+    are_you_sure_you_want_to_run_this_option: "¿Estás seguro de que quieres ejectuar esta acción?"
     attach: Adjuntar
     attach_and_attach_another: Adjuntar y adjuntar otro
     attach_item: Adjuntar %{item}
@@ -23,6 +23,7 @@ es:
     create_new_item: Crear nuevo/a %{item}
     dashboard: Panel
     dashboards: Paneles
+    default_scope: Todos
     delete: eliminar
     delete_file: Eliminar fichero
     delete_item: Eliminar %{item}
@@ -80,6 +81,7 @@ es:
       to_top: Mover arriba del todo
     per_page: Por página
     prev_page: Página anterior
+    records_selected_from_all_pages_html: Todos los registros seleccionados de todas las páginas.
     remove_selection: Quitar la selección
     reset_filters: Reiniciar filtros
     resource_created: Recurso creado
@@ -121,4 +123,5 @@ es:
       zero: ningún elemento más
     x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> registros seleccionados en esta página de un total de <span class="font-bold text-gray-700">%{count}</span>
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> registros seleccionados en todas las páginas
+    x_records_selected_from_page_html: <span class="font-bold text-gray-700">%{selected}</span> registros seleccionados en esta página
     you_missed_something_check_form: Es posible que hayas pasado algo por alto. Comprueba el formulario.

--- a/spec/system/avo/create_via_belongs_to_spec.rb
+++ b/spec/system/avo/create_via_belongs_to_spec.rb
@@ -125,4 +125,34 @@ RSpec.describe 'Create Via Belongs to', type: :system do
       )
     end
   end
+
+  context 'with models that uses prefix_id' do
+    it 'successfully creates a new course and assigns it to the course link', :aggregate_failures do
+      visit '/admin/resources/course_links/new'
+
+      fill_in 'course_link_link', with: 'Test link'
+
+      click_on 'Create new course'
+
+      expect do
+        within('.modal-container') do
+          fill_in 'course_name', with: 'Test course'
+          click_on 'Save'
+          sleep 0.2
+        end
+      end.to change(Course, :count).by(1)
+
+      expect(page).to have_select('course_link_course_id', selected: Course.last.name)
+
+      expect do
+        click_on 'Save'
+        sleep 0.2
+      end.to change(Course::Link, :count).by(1)
+
+      expect(Course::Link.last).to have_attributes(
+        link: 'Test link',
+        course: Course.last
+      )
+    end
+  end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

` via_resource_id: resource.record.to_param` when `resource.record` is not a persistent yet `to_param` will return `nil` and that's fine. But in case you use `prefix_id` or some other ID manipulation it will break if the attributes used on the manipulation are blank.

Fixes #2045 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots
<!-- Does the PR introduce any visual changes? Can you show us before and after? -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
