### PR TITLE
fix: extract fields from sidebar and add them to permitted params

### DIFF
--- a/lib/avo/concerns/has_items.rb
+++ b/lib/avo/concerns/has_items.rb
@@ -309,11 +309,20 @@ module Avo
         end
       end
 
+      # Extracts fields from a structure
+      # Structures can be panels, rows and sidebars
       def extract_fields(structure)
         structure.items.map do |item|
           next item if item.is_field?
-          next extract_fields(item) if item.is_panel? || item.is_row? || (item.is_sidebar? && !view.index?)
+
+          extract_fields(item) if extractable_structure?(item)
         end.compact
+      end
+
+      # Extractable structures are panels, rows and sidebars
+      # Sidebars are only extractable if they are not on the index view
+      def extractable_structure?(structure)
+        structure.is_panel? || structure.is_row? || (structure.is_sidebar? && !view.index?)
       end
 
       # Standalone items are fields that don't have their own panel

--- a/lib/avo/concerns/has_items.rb
+++ b/lib/avo/concerns/has_items.rb
@@ -315,7 +315,7 @@ module Avo
         thing.items.each do |item|
           if item.is_field?
             fields << item
-          elsif item.is_panel? || item.is_row? || item.is_sidebar?
+          elsif item.is_panel? || item.is_row? || (item.is_sidebar? && !view.index?)
             fields << extract_fields_from_items(item)
           end
         end

--- a/lib/avo/concerns/has_items.rb
+++ b/lib/avo/concerns/has_items.rb
@@ -87,19 +87,19 @@ module Avo
           unless only_root
             # Dive into panels to fetch their fields
             if item.is_panel?
-              fields << extract_fields_from_items(item)
+              fields << extract_fields(item)
             end
 
             # Dive into tabs to fetch their fields
             if item.is_tab_group?
               item.items.map do |tab|
-                fields << extract_fields_from_items(tab)
+                fields << extract_fields(tab)
               end
             end
 
             # Dive into sidebar to fetch their fields
             if item.is_sidebar?
-              fields << extract_fields_from_items(item)
+              fields << extract_fields(item)
             end
           end
 
@@ -108,11 +108,11 @@ module Avo
           end
 
           if item.is_row?
-            fields << extract_fields_from_items(tab)
+            fields << extract_fields(tab)
           end
 
           if item.is_main_panel?
-            fields << extract_fields_from_items(item)
+            fields << extract_fields(item)
           end
         end
 
@@ -309,18 +309,11 @@ module Avo
         end
       end
 
-      def extract_fields_from_items(thing)
-        fields = []
-
-        thing.items.each do |item|
-          if item.is_field?
-            fields << item
-          elsif item.is_panel? || item.is_row? || (item.is_sidebar? && !view.index?)
-            fields << extract_fields_from_items(item)
-          end
-        end
-
-        fields
+      def extract_fields(structure)
+        structure.items.map do |item|
+          next item if item.is_field?
+          next extract_fields(item) if item.is_panel? || item.is_row? || (item.is_sidebar? && !view.index?)
+        end.compact
       end
 
       # Standalone items are fields that don't have their own panel

--- a/lib/avo/concerns/has_items.rb
+++ b/lib/avo/concerns/has_items.rb
@@ -313,9 +313,13 @@ module Avo
       # Structures can be panels, rows and sidebars
       def extract_fields(structure)
         structure.items.map do |item|
-          next item if item.is_field?
-
-          extract_fields(item) if extractable_structure?(item)
+          if item.is_field?
+            item
+          elsif extractable_structure?(item)
+            extract_fields(item)
+          else
+            nil
+          end
         end.compact
       end
 

--- a/lib/avo/concerns/has_items.rb
+++ b/lib/avo/concerns/has_items.rb
@@ -315,7 +315,7 @@ module Avo
         thing.items.each do |item|
           if item.is_field?
             fields << item
-          elsif item.is_panel? || item.is_row?
+          elsif item.is_panel? || item.is_row? || item.is_sidebar?
             fields << extract_fields_from_items(item)
           end
         end

--- a/spec/dummy/app/avo/resources/user.rb
+++ b/spec/dummy/app/avo/resources/user.rb
@@ -121,7 +121,7 @@ class Avo::Resources::User < Avo::BaseResource
     field :password, as: :password, name: "User Password", required: false, only_on: :forms, help: 'You may verify the password strength <a href="http://www.passwordmeter.com/" target="_blank">here</a>.'
     field :password_confirmation, as: :password, name: "Password confirmation", required: false
 
-    with_options only_on: :display do
+    with_options only_on: :show do
       field :dev, as: :heading, label: '<div class="underline uppercase font-bold">DEV</div>', as_html: true
       field :custom_css, as: :code, theme: "dracula", language: "css", help: "This enables you to edit the user's custom styles.", height: "250px"
     end

--- a/spec/dummy/app/avo/resources/user.rb
+++ b/spec/dummy/app/avo/resources/user.rb
@@ -121,7 +121,7 @@ class Avo::Resources::User < Avo::BaseResource
     field :password, as: :password, name: "User Password", required: false, only_on: :forms, help: 'You may verify the password strength <a href="http://www.passwordmeter.com/" target="_blank">here</a>.'
     field :password_confirmation, as: :password, name: "Password confirmation", required: false
 
-    with_options only_on: :show do
+    with_options hide_on: :forms do
       field :dev, as: :heading, label: '<div class="underline uppercase font-bold">DEV</div>', as_html: true
       field :custom_css, as: :code, theme: "dracula", language: "css", help: "This enables you to edit the user's custom styles.", height: "250px"
     end

--- a/spec/dummy/app/avo/resources/user.rb
+++ b/spec/dummy/app/avo/resources/user.rb
@@ -121,8 +121,10 @@ class Avo::Resources::User < Avo::BaseResource
     field :password, as: :password, name: "User Password", required: false, only_on: :forms, help: 'You may verify the password strength <a href="http://www.passwordmeter.com/" target="_blank">here</a>.'
     field :password_confirmation, as: :password, name: "Password confirmation", required: false
 
-    field :dev, as: :heading, label: '<div class="underline uppercase font-bold">DEV</div>', as_html: true
-    field :custom_css, as: :code, theme: "dracula", language: "css", help: "This enables you to edit the user's custom styles.", height: "250px"
+    with_options only_on: :display do
+      field :dev, as: :heading, label: '<div class="underline uppercase font-bold">DEV</div>', as_html: true
+      field :custom_css, as: :code, theme: "dracula", language: "css", help: "This enables you to edit the user's custom styles.", height: "250px"
+    end
     field :team_id, as: :hidden, default: 0 # For testing purposes
 
     test_sidebar
@@ -165,6 +167,10 @@ class Avo::Resources::User < Avo::BaseResource
         end
       field :outside_link, as: :text, only_on: [:show], format_using: -> { link_to("hey", value, target: "_blank") } do
         main_app.hey_url
+      end
+      with_options only_on: :forms do
+        field :dev, as: :heading, label: '<div class="underline uppercase font-bold">DEV</div>', as_html: true
+        field :custom_css, as: :code, theme: "dracula", language: "css", help: "This enables you to edit the user's custom styles.", height: "250px"
       end
     end
   end

--- a/spec/system/avo/resource_sidebar_spec.rb
+++ b/spec/system/avo/resource_sidebar_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "ResourceSidebars", type: :feature do
+RSpec.feature "ResourceSidebars", type: :system do
   let(:fish) { create :fish }
   let(:team) { create :team }
 
@@ -20,5 +20,21 @@ RSpec.feature "ResourceSidebars", type: :feature do
     visit avo.resources_team_path(team)
 
     expect(page).to have_css ".resource-sidebar-component"
+  end
+
+  it "allow fields to be eddited on sidebar" do
+    admin.update!(custom_css: "")
+    visit avo.edit_resources_user_path(admin)
+
+    within ".CodeMirror" do
+      current_scope.click
+      field = current_scope.find("textarea", visible: false)
+      field.send_keys "Some custom css"
+    end
+
+    click_on "Save"
+    wait_for_loaded
+
+    expect(page).to have_css(".CodeMirror-code", text: "Some custom css")
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Extract fields from sidebars and add them to permitted params.

Fixes #2051 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

