### PR TITLE
fix: sidebars on community tier

### DIFF
--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -114,7 +114,7 @@ class Avo::ResourceComponent < Avo::BaseComponent
   end
 
   def sidebars
-    return if Avo.license.lacks_with_trial(:resource_sidebar)
+    return [] if Avo.license.lacks_with_trial(:resource_sidebar)
 
     @item.items.select do |item|
       item.is_sidebar?


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

On render when we check for `sidebars.any?` we should assure that `sidebars` returns an array even on community license.
 
Fixes #2047 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
