### PR TITLE
feature: disable belongs_to creation from association

### DIFF
--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -81,12 +81,14 @@
                 <%= @form.hidden_field @field.id_input_foreign_key %>
               <% end %>
             <% end %>
-            <% create_href = create_path(Avo.resource_manager.get_resource_by_model_class(type.to_s)) %>
-            <% if !disabled && create_href.present? %>
-              <%= link_to t("avo.create_new_item", item: type.to_s.downcase),
-                          create_href,
-                          class: "text-sm"
-              %>
+            <% if field.allow_creation? %>
+              <% create_href = create_path(Avo.resource_manager.get_resource_by_model_class(type.to_s)) %>
+              <% if !disabled && create_href.present? %>
+                <%= link_to t("avo.create_new_item", item: type.to_s.downcase),
+                            create_href,
+                            class: "text-sm"
+                %>
+              <% end %>
             <% end %>
           <% end %>
         </div>
@@ -125,8 +127,10 @@
           <%= @form.hidden_field @field.id_input_foreign_key %>
         <% end %>
       <% end %>
-      <% if !disabled && create_path.present? %>
-        <%= link_to t("avo.create_new_item", item: @field.name.downcase), create_path, class: "text-sm" %>
+      <% if field.allow_creation? %>
+        <% if !disabled && create_path.present? %>
+          <%= link_to t("avo.create_new_item", item: @field.name.downcase), create_path, class: "text-sm" %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -83,6 +83,7 @@ module Avo
         @polymorphic_help = args[:polymorphic_help]
         @target = args[:target]
         @use_resource = args[:use_resource] || nil
+        @allow_creation = args[:allow_creation].nil? ? true : args[:allow_creation]
       end
 
       def value
@@ -262,6 +263,10 @@ module Avo
         return polymorphic_as.to_s.humanize if polymorphic_as.present? && view.index?
 
         super
+      end
+
+      def allow_creation?
+        @allow_creation
       end
 
       private

--- a/spec/system/avo/create_via_belongs_to_spec.rb
+++ b/spec/system/avo/create_via_belongs_to_spec.rb
@@ -155,4 +155,20 @@ RSpec.describe 'Create Via Belongs to', type: :system do
       )
     end
   end
+
+  context 'disable' do
+    it 'dont show the link', :aggregate_failures do
+      Avo::Resources::CourseLink.with_temporary_items do
+        field :course, as: :belongs_to, searchable: true, allow_creation: false
+      end
+
+      visit '/admin/resources/course_links/new'
+
+      within field_wrapper(:course) do
+        expect(page).not_to have_text 'Create new course'
+      end
+
+      Avo::Resources::CourseLink.restore_items_from_backup
+    end
+  end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

`allow_creation: false` now disables the link to create from the `belongs_to` field
Fixes #2033 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots
<!-- Does the PR introduce any visual changes? Can you show us before and after? -->
![image](https://github.com/avo-hq/avo/assets/69730720/a8af7d23-c29a-497a-9a8e-f34fb5e86f9f)

![image](https://github.com/avo-hq/avo/assets/69730720/e67d1db2-3e6a-45ea-8753-71e70c4ac9ad)

