### PR TITLE
Refactor Resource loading to simplify and centralize behavior

### DIFF
--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -18,16 +18,6 @@ module Avo
   IN_DEVELOPMENT = ENV["AVO_IN_DEVELOPMENT"] == "1"
   PACKED = !IN_DEVELOPMENT
   COOKIES_KEY = "avo"
-  ENTITIES = {
-    cards: ["app", "avo", "cards"],
-    scopes: ["app", "avo", "scopes"],
-    fields: ["app", "avo", "fields"],
-    filters: ["app", "avo", "filters"],
-    actions: ["app", "avo", "actions"],
-    resources: ["app", "avo", "resources"],
-    dashboards: ["app", "avo", "dashboards"],
-    resource_tools: ["app", "avo", "resource_tools"]
-  }
 
   class LicenseVerificationTemperedError < StandardError; end
 

--- a/lib/avo/dynamic_router.rb
+++ b/lib/avo/dynamic_router.rb
@@ -1,39 +1,15 @@
 module Avo
   class DynamicRouter
-    def self.eager_load(entity)
-      paths = Avo::ENTITIES.fetch entity
-
-      return unless paths.present?
-
-      pathname = Rails.root.join(*paths)
-      if pathname.directory?
-        Rails.autoloaders.main.eager_load_dir(pathname.to_s)
-      end
-    end
-
     def self.routes
       Avo::Engine.routes.draw do
         scope "resources", as: "resources" do
-          # Check if the user chose to manually register the resource files.
-          # If so, eager_load the resources dir.
-          if Avo.configuration.resources.nil?
-            Avo::DynamicRouter.eager_load(:resources) unless Rails.application.config.eager_load
-          end
-
-          Avo::Resources::ResourceManager.fetch_resources
-            .select do |resource|
-              resource != :BaseResource
-            end
-            .select do |resource|
-              resource.is_a? Class
-            end
-            .map do |resource|
-              resources resource.route_key do
-                member do
-                  get :preview
-                end
+          Avo::Resources::ResourceManager.fetch_resources.map do |resource|
+            resources resource.route_key do
+              member do
+                get :preview
               end
             end
+          end
         end
       end
     end


### PR DESCRIPTION
# Description
I saw that v3 has switched to standard Zeitwerk-compatible namespacing and took a look at the implementation, saw some opportunity for tidying up.

# Checklist:
- [x] I have performed a self-review of my own code
~ I have commented my code, particularly in hard-to-understand areas
~ I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
~ I have added tests that prove my fix is effective or that my feature works

## Manual review steps
I would consider the existing test suite sufficient