### PR TITLE
fix: belongs_to row forms layout

### DIFF
--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -1,12 +1,10 @@
 <% if is_polymorphic? %>
-  <%= content_tag :div,
-    class: "divide-y",
-    data: {
-      controller: "belongs-to-field",
-      searchable: @field.is_searchable?,
-      association: @field.id,
-      association_class: @field&.target_resource&.model_class || nil
-    } do %>
+  <div class="divide-y"
+      data-controller="belongs-to-field"
+      data-searchable="<%= @field.is_searchable? %>"
+      data-association="<%= @field.id %>"
+      data-association-class="<%= @field&.target_resource&.model_class || nil %>"
+    >
     <%= field_wrapper **field_wrapper_args, help: @field.polymorphic_help || '' do %>
       <%= @form.select @field.type_input_foreign_key, @field.types.map { |type| [Avo.resource_manager.get_resource_by_model_class(type.to_s).name, type.to_s] },
       {
@@ -35,7 +33,7 @@
         data-belongs-to-field-target="type"
         data-type="<%= type %>"
       >
-        <%= field_wrapper **field_wrapper_args, label: Avo.resource_manager.get_resource_by_model_class(type.to_s).name do %>
+        <%= field_wrapper **field_wrapper_args.merge!(data: relaod_data), label: Avo.resource_manager.get_resource_by_model_class(type.to_s).name do %>
           <% if @field.is_searchable? %>
             <%= render Avo::Pro::SearchableAssociations::AutocompleteComponent.new form: @form,
               disabled: disabled,
@@ -81,9 +79,9 @@
         <% end %>
       </div>
     <% end %>
-  <% end %>
+  </div>
 <% else %>
-  <%= field_wrapper **field_wrapper_args do %>
+  <%= field_wrapper **field_wrapper_args.merge!(data: relaod_data) do %>
     <% if @field.is_searchable? %>
       <%= render Avo::Pro::SearchableAssociations::AutocompleteComponent.new form: @form,
         field: @field,

--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -1,5 +1,12 @@
 <% if is_polymorphic? %>
-  <div class="divide-y" <%= tag.attributes(data: data) %>>
+  <%= content_tag :div,
+    class: "divide-y",
+    data: {
+      controller: "belongs-to-field",
+      searchable: @field.is_searchable?,
+      association: @field.id,
+      association_class: @field&.target_resource&.model_class || nil
+    } do %>
     <%= field_wrapper **field_wrapper_args, help: @field.polymorphic_help || '' do %>
       <%= @form.select @field.type_input_foreign_key, @field.types.map { |type| [Avo.resource_manager.get_resource_by_model_class(type.to_s).name, type.to_s] },
       {
@@ -74,9 +81,9 @@
         <% end %>
       </div>
     <% end %>
-  </div>
+  <% end %>
 <% else %>
-  <%= field_wrapper **field_wrapper_args.merge!(data: data) do %>
+  <%= field_wrapper **field_wrapper_args do %>
     <% if @field.is_searchable? %>
       <%= render Avo::Pro::SearchableAssociations::AutocompleteComponent.new form: @form,
         field: @field,

--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -1,11 +1,4 @@
 <% if is_polymorphic? %>
-  <%
-    # Set the model keys so we can pass them over
-    model_keys = @field.types.map do |type|
-      resource = Avo.resource_manager.get_resource_by_model_class(type.to_s)
-      [type.to_s, resource.model_key]
-    end.to_h
-  %>
   <%= content_tag(
     :div, "",
     class: "divide-y",

--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -33,7 +33,7 @@
         data-belongs-to-field-target="type"
         data-type="<%= type %>"
       >
-        <%= field_wrapper **field_wrapper_args.merge!(data: relaod_data), label: Avo.resource_manager.get_resource_by_model_class(type.to_s).name do %>
+        <%= field_wrapper **field_wrapper_args.merge!(data: reload_data), label: Avo.resource_manager.get_resource_by_model_class(type.to_s).name do %>
           <% if @field.is_searchable? %>
             <%= render Avo::Pro::SearchableAssociations::AutocompleteComponent.new form: @form,
               disabled: disabled,
@@ -81,7 +81,7 @@
     <% end %>
   </div>
 <% else %>
-  <%= field_wrapper **field_wrapper_args.merge!(data: relaod_data) do %>
+  <%= field_wrapper **field_wrapper_args.merge!(data: reload_data) do %>
     <% if @field.is_searchable? %>
       <%= render Avo::Pro::SearchableAssociations::AutocompleteComponent.new form: @form,
         field: @field,

--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -1,4 +1,3 @@
-<%= reload_belongs_to_field_data %>
 <% if is_polymorphic? %>
   <%
     # Set the model keys so we can pass them over
@@ -7,12 +6,10 @@
       [type.to_s, resource.model_key]
     end.to_h
   %>
-  <div class="divide-y"
-    data-controller="belongs-to-field"
-    data-searchable="<%= @field.is_searchable? %>"
-    data-association="<%= @field.id %>"
-    data-association-class="<%= @field&.target_resource&.model_class || nil %>"
-  >
+  <%= content_tag(
+    :div, "",
+    class: "divide-y",
+    data: data) do %>
     <%= field_wrapper **field_wrapper_args, help: @field.polymorphic_help || '' do %>
       <%= @form.select @field.type_input_foreign_key, @field.types.map { |type| [Avo.resource_manager.get_resource_by_model_class(type.to_s).name, type.to_s] },
       {
@@ -87,9 +84,9 @@
         <% end %>
       </div>
     <% end %>
-  </div>
+  <% end %>
 <% else %>
-  <%= field_wrapper **field_wrapper_args do %>
+  <%= field_wrapper **field_wrapper_args.merge!(data: data) do %>
     <% if @field.is_searchable? %>
       <%= render Avo::Pro::SearchableAssociations::AutocompleteComponent.new form: @form,
         field: @field,

--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -1,8 +1,7 @@
 <% if is_polymorphic? %>
-  <%= content_tag(
-    :div,
+  <%= content_tag :div,
     class: "divide-y",
-    data: data) do %>
+    data: data do %>
     <%= field_wrapper **field_wrapper_args, help: @field.polymorphic_help || '' do %>
       <%= @form.select @field.type_input_foreign_key, @field.types.map { |type| [Avo.resource_manager.get_resource_by_model_class(type.to_s).name, type.to_s] },
       {

--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -1,7 +1,5 @@
 <% if is_polymorphic? %>
-  <%= content_tag :div,
-    class: "divide-y",
-    data: data do %>
+  <div class="divide-y" <%= tag.attributes(data: data) %>>
     <%= field_wrapper **field_wrapper_args, help: @field.polymorphic_help || '' do %>
       <%= @form.select @field.type_input_foreign_key, @field.types.map { |type| [Avo.resource_manager.get_resource_by_model_class(type.to_s).name, type.to_s] },
       {
@@ -76,7 +74,7 @@
         <% end %>
       </div>
     <% end %>
-  <% end %>
+  </div>
 <% else %>
   <%= field_wrapper **field_wrapper_args.merge!(data: data) do %>
     <% if @field.is_searchable? %>

--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -1,137 +1,130 @@
-<div data-controller="reload-belongs-to-field"
-     data-action="turbo:before-stream-render@document->reload-belongs-to-field#beforeStreamRender"
-     data-reload-belongs-to-field-polymorphic-value="<%= is_polymorphic? %>"
-     data-reload-belongs-to-field-searchable-value="<%= @field.is_searchable? %>"
-     data-reload-belongs-to-field-relation-name-value="<%= @field.id %>"
-     data-reload-belongs-to-field-target-name-value="<%= form.object_name %>[<%= @field.id_input_foreign_key %>]"
->
-  <% if is_polymorphic? %>
-    <%
-      # Set the model keys so we can pass them over
-      model_keys = @field.types.map do |type|
-        resource = Avo.resource_manager.get_resource_by_model_class(type.to_s)
-        [type.to_s, resource.model_key]
-      end.to_h
+<%= reload_belongs_to_field_data %>
+<% if is_polymorphic? %>
+  <%
+    # Set the model keys so we can pass them over
+    model_keys = @field.types.map do |type|
+      resource = Avo.resource_manager.get_resource_by_model_class(type.to_s)
+      [type.to_s, resource.model_key]
+    end.to_h
+  %>
+  <div class="divide-y"
+    data-controller="belongs-to-field"
+    data-searchable="<%= @field.is_searchable? %>"
+    data-association="<%= @field.id %>"
+    data-association-class="<%= @field&.target_resource&.model_class || nil %>"
+  >
+    <%= field_wrapper **field_wrapper_args, help: @field.polymorphic_help || '' do %>
+      <%= @form.select @field.type_input_foreign_key, @field.types.map { |type| [Avo.resource_manager.get_resource_by_model_class(type.to_s).name, type.to_s] },
+      {
+        value: @field.value,
+        include_blank: @field.placeholder,
+      },
+      {
+        class: classes("w-full"),
+        data: {
+          **@field.get_html(:data, view: view, element: :input),
+          action: "change->belongs-to-field#changeType #{field_html_action}",
+          'belongs-to-field-target': "select",
+        },
+        disabled: disabled
+      }
     %>
-    <div class="divide-y"
-      data-controller="belongs-to-field"
-      data-searchable="<%= @field.is_searchable? %>"
-      data-association="<%= @field.id %>"
-      data-association-class="<%= @field&.target_resource&.model_class || nil %>"
-    >
-      <%= field_wrapper **field_wrapper_args, help: @field.polymorphic_help || '' do %>
-        <%= @form.select @field.type_input_foreign_key, @field.types.map { |type| [Avo.resource_manager.get_resource_by_model_class(type.to_s).name, type.to_s] },
+      <%
+        # If the select field is disabled, no value will be sent. It's how HTML works.
+        # Thus the extra hidden field to actually send the related id to the server.
+        if disabled %>
+        <%= @form.hidden_field @field.type_input_foreign_key %>
+      <% end %>
+    <% end %>
+    <% @field.types.each do |type| %>
+      <div class="hidden"
+        data-belongs-to-field-target="type"
+        data-type="<%= type %>"
+      >
+        <%= field_wrapper **field_wrapper_args, label: Avo.resource_manager.get_resource_by_model_class(type.to_s).name do %>
+          <% if @field.is_searchable? %>
+            <%= render Avo::Pro::SearchableAssociations::AutocompleteComponent.new form: @form,
+              disabled: disabled,
+              field: @field,
+              foreign_key: @field.id_input_foreign_key,
+              model_key: model_keys[type.to_s],
+              polymorphic_record: polymorphic_record,
+              resource: @resource,
+              style: @field.get_html(:style, view: view, element: :input),
+              type: type,
+              classes: classes("w-full"),
+              view: view
+          %>
+          <% else %>
+            <%= @form.select @field.id_input_foreign_key,
+            options_for_select(@field.values_for_type(type), @resource.present? && @resource.record.present? ? @resource.record[@field.id_input_foreign_key] : nil),
+            {
+              value: @resource.record[@field.id_input_foreign_key].to_s,
+              include_blank: @field.placeholder,
+            },
+            {
+              class: classes("w-full"),
+              data: @field.get_html(:data, view: view, element: :input),
+              disabled: disabled
+            }
+          %>
+            <%
+            # If the select field is disabled, no value will be sent. It's how HTML works.
+            # Thus the extra hidden field to actually send the related id to the server.
+            if disabled %>
+              <%= @form.hidden_field @field.id_input_foreign_key %>
+            <% end %>
+          <% end %>
+          <% if field.can_create? %>
+            <% create_href = create_path(Avo.resource_manager.get_resource_by_model_class(type.to_s)) %>
+            <% if !disabled && create_href.present? %>
+              <%= link_to t("avo.create_new_item", item: type.to_s.downcase),
+                          create_href,
+                          class: "text-sm"
+              %>
+            <% end %>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <%= field_wrapper **field_wrapper_args do %>
+    <% if @field.is_searchable? %>
+      <%= render Avo::Pro::SearchableAssociations::AutocompleteComponent.new form: @form,
+        field: @field,
+        model_key: @field.target_resource&.model_key,
+        foreign_key: @field.id_input_foreign_key,
+        resource: @resource,
+        disabled: disabled,
+        classes: classes("w-full"),
+        view: view,
+        style: @field.get_html(:style, view: view, element: :input)
+      %>
+    <% else %>
+      <%= @form.select @field.id_input_foreign_key, @field.options,
         {
-          value: @field.value,
           include_blank: @field.placeholder,
+          value: @field.value
         },
         {
           class: classes("w-full"),
-          data: {
-            **@field.get_html(:data, view: view, element: :input),
-            action: "change->belongs-to-field#changeType #{field_html_action}",
-            'belongs-to-field-target': "select",
-          },
-          disabled: disabled
+          data: @field.get_html(:data, view: view, element: :input),
+          disabled: disabled,
+          style: @field.get_html(:style, view: view, element: :input)
         }
       %>
-        <%
-          # If the select field is disabled, no value will be sent. It's how HTML works.
-          # Thus the extra hidden field to actually send the related id to the server.
-          if disabled %>
-          <%= @form.hidden_field @field.type_input_foreign_key %>
-        <% end %>
+      <%
+        # If the select field is disabled, no value will be sent. It's how HTML works.
+        # Thus the extra hidden field to actually send the related id to the server.
+        if disabled %>
+        <%= @form.hidden_field @field.id_input_foreign_key %>
       <% end %>
-      <% @field.types.each do |type| %>
-        <div class="hidden"
-          data-belongs-to-field-target="type"
-          data-type="<%= type %>"
-        >
-          <%= field_wrapper **field_wrapper_args, label: Avo.resource_manager.get_resource_by_model_class(type.to_s).name do %>
-            <% if @field.is_searchable? %>
-              <%= render Avo::Pro::SearchableAssociations::AutocompleteComponent.new form: @form,
-                disabled: disabled,
-                field: @field,
-                foreign_key: @field.id_input_foreign_key,
-                model_key: model_keys[type.to_s],
-                polymorphic_record: polymorphic_record,
-                resource: @resource,
-                style: @field.get_html(:style, view: view, element: :input),
-                type: type,
-                classes: classes("w-full"),
-                view: view
-            %>
-            <% else %>
-              <%= @form.select @field.id_input_foreign_key,
-              options_for_select(@field.values_for_type(type), @resource.present? && @resource.record.present? ? @resource.record[@field.id_input_foreign_key] : nil),
-              {
-                value: @resource.record[@field.id_input_foreign_key].to_s,
-                include_blank: @field.placeholder,
-              },
-              {
-                class: classes("w-full"),
-                data: @field.get_html(:data, view: view, element: :input),
-                disabled: disabled
-              }
-            %>
-              <%
-              # If the select field is disabled, no value will be sent. It's how HTML works.
-              # Thus the extra hidden field to actually send the related id to the server.
-              if disabled %>
-                <%= @form.hidden_field @field.id_input_foreign_key %>
-              <% end %>
-            <% end %>
-            <% if field.can_create? %>
-              <% create_href = create_path(Avo.resource_manager.get_resource_by_model_class(type.to_s)) %>
-              <% if !disabled && create_href.present? %>
-                <%= link_to t("avo.create_new_item", item: type.to_s.downcase),
-                            create_href,
-                            class: "text-sm"
-                %>
-              <% end %>
-            <% end %>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
-  <% else %>
-    <%= field_wrapper **field_wrapper_args do %>
-      <% if @field.is_searchable? %>
-        <%= render Avo::Pro::SearchableAssociations::AutocompleteComponent.new form: @form,
-          field: @field,
-          model_key: @field.target_resource&.model_key,
-          foreign_key: @field.id_input_foreign_key,
-          resource: @resource,
-          disabled: disabled,
-          classes: classes("w-full"),
-          view: view,
-          style: @field.get_html(:style, view: view, element: :input)
-        %>
-      <% else %>
-        <%= @form.select @field.id_input_foreign_key, @field.options,
-          {
-            include_blank: @field.placeholder,
-            value: @field.value
-          },
-          {
-            class: classes("w-full"),
-            data: @field.get_html(:data, view: view, element: :input),
-            disabled: disabled,
-            style: @field.get_html(:style, view: view, element: :input)
-          }
-        %>
-        <%
-          # If the select field is disabled, no value will be sent. It's how HTML works.
-          # Thus the extra hidden field to actually send the related id to the server.
-          if disabled %>
-          <%= @form.hidden_field @field.id_input_foreign_key %>
-        <% end %>
-      <% end %>
-      <% if field.can_create? %>
-        <% if !disabled && create_path.present? %>
-          <%= link_to t("avo.create_new_item", item: @field.name.downcase), create_path, class: "text-sm" %>
-        <% end %>
+    <% end %>
+    <% if field.can_create? %>
+      <% if !disabled && create_path.present? %>
+        <%= link_to t("avo.create_new_item", item: @field.name.downcase), create_path, class: "text-sm" %>
       <% end %>
     <% end %>
   <% end %>
-</div>
+<% end %>

--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -1,6 +1,6 @@
 <% if is_polymorphic? %>
   <%= content_tag(
-    :div, "",
+    :div,
     class: "divide-y",
     data: data) do %>
     <%= field_wrapper **field_wrapper_args, help: @field.polymorphic_help || '' do %>

--- a/app/components/avo/fields/belongs_to_field/edit_component.rb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.rb
@@ -76,7 +76,7 @@ class Avo::Fields::BelongsToField::EditComponent < Avo::Fields::EditComponent
 
   def data
     attributes = {
-      controller: ["reload-belongs-to-field"],
+      controller: "reload-belongs-to-field",
       action: 'turbo:before-stream-render@document->reload-belongs-to-field#beforeStreamRender',
       reload_belongs_to_field_polymorphic_value: is_polymorphic?,
       reload_belongs_to_field_searchable_value: @field.is_searchable?,
@@ -85,7 +85,7 @@ class Avo::Fields::BelongsToField::EditComponent < Avo::Fields::EditComponent
     }
 
     if is_polymorphic?
-      attributes[:controller].push "belongs-to-field"
+      attributes[:controller] += " belongs-to-field"
 
       attributes.merge!({
         searchable: @field.is_searchable?,
@@ -95,5 +95,12 @@ class Avo::Fields::BelongsToField::EditComponent < Avo::Fields::EditComponent
     end
 
     attributes
+  end
+
+  def model_keys
+    @field.types.map do |type|
+      resource = Avo.resource_manager.get_resource_by_model_class(type.to_s)
+      [type.to_s, resource.model_key]
+    end.to_h
   end
 end

--- a/app/components/avo/fields/belongs_to_field/edit_component.rb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.rb
@@ -74,33 +74,21 @@ class Avo::Fields::BelongsToField::EditComponent < Avo::Fields::EditComponent
     @field.target_resource.to_s == params[:via_resource_class].to_s
   end
 
-  def data
-    attributes = {
+  def model_keys
+    @field.types.map do |type|
+      resource = Avo.resource_manager.get_resource_by_model_class(type.to_s)
+      [type.to_s, resource.model_key]
+    end.to_h
+  end
+
+  def field_wrapper_args
+    super.merge!(data: {
       controller: "reload-belongs-to-field",
       action: 'turbo:before-stream-render@document->reload-belongs-to-field#beforeStreamRender',
       reload_belongs_to_field_polymorphic_value: is_polymorphic?,
       reload_belongs_to_field_searchable_value: @field.is_searchable?,
       reload_belongs_to_field_relation_name_value: @field.id,
       reload_belongs_to_field_target_name_value: "#{form.object_name}[#{@field.id_input_foreign_key}]"
-    }
-
-    if is_polymorphic?
-      attributes[:controller] += " belongs-to-field"
-
-      attributes.merge!({
-        searchable: @field.is_searchable?,
-        association: @field.id,
-        association_class: @field&.target_resource&.model_class || nil
-      })
-    end
-
-    attributes
-  end
-
-  def model_keys
-    @field.types.map do |type|
-      resource = Avo.resource_manager.get_resource_by_model_class(type.to_s)
-      [type.to_s, resource.model_key]
-    end.to_h
+    })
   end
 end

--- a/app/components/avo/fields/belongs_to_field/edit_component.rb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.rb
@@ -73,4 +73,19 @@ class Avo::Fields::BelongsToField::EditComponent < Avo::Fields::EditComponent
   def visit_through_association?
     @field.target_resource.to_s == params[:via_resource_class].to_s
   end
+
+  def reload_belongs_to_field_data_attributes
+    {
+      controller: 'reload-belongs-to-field',
+      action: 'turbo:before-stream-render@document->reload-belongs-to-field#beforeStreamRender',
+      reload_belongs_to_field_polymorphic_value: is_polymorphic?,
+      reload_belongs_to_field_searchable_value: @field.is_searchable?,
+      reload_belongs_to_field_relation_name_value: @field.id,
+      reload_belongs_to_field_target_name_value: "#{form.object_name}[#{@field.id_input_foreign_key}]"
+    }
+  end
+
+  def reload_belongs_to_field_data
+    content_tag(:div, "", class: "hidden", data: reload_belongs_to_field_data_attributes)
+  end
 end

--- a/app/components/avo/fields/belongs_to_field/edit_component.rb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.rb
@@ -81,14 +81,14 @@ class Avo::Fields::BelongsToField::EditComponent < Avo::Fields::EditComponent
     end.to_h
   end
 
-  def field_wrapper_args
-    super.merge!(data: {
+  def reload_data
+    {
       controller: "reload-belongs-to-field",
       action: 'turbo:before-stream-render@document->reload-belongs-to-field#beforeStreamRender',
       reload_belongs_to_field_polymorphic_value: is_polymorphic?,
       reload_belongs_to_field_searchable_value: @field.is_searchable?,
       reload_belongs_to_field_relation_name_value: @field.id,
       reload_belongs_to_field_target_name_value: "#{form.object_name}[#{@field.id_input_foreign_key}]"
-    })
+    }
   end
 end

--- a/app/components/avo/fields/belongs_to_field/edit_component.rb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.rb
@@ -74,18 +74,26 @@ class Avo::Fields::BelongsToField::EditComponent < Avo::Fields::EditComponent
     @field.target_resource.to_s == params[:via_resource_class].to_s
   end
 
-  def reload_belongs_to_field_data_attributes
-    {
-      controller: 'reload-belongs-to-field',
+  def data
+    attributes = {
+      controller: ["reload-belongs-to-field"],
       action: 'turbo:before-stream-render@document->reload-belongs-to-field#beforeStreamRender',
       reload_belongs_to_field_polymorphic_value: is_polymorphic?,
       reload_belongs_to_field_searchable_value: @field.is_searchable?,
       reload_belongs_to_field_relation_name_value: @field.id,
       reload_belongs_to_field_target_name_value: "#{form.object_name}[#{@field.id_input_foreign_key}]"
     }
-  end
 
-  def reload_belongs_to_field_data
-    content_tag(:div, "", class: "hidden", data: reload_belongs_to_field_data_attributes)
+    if is_polymorphic?
+      attributes[:controller].push "belongs-to-field"
+
+      attributes.merge!({
+        searchable: @field.is_searchable?,
+        association: @field.id,
+        association_class: @field&.target_resource&.model_class || nil
+      })
+    end
+
+    attributes
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Removes the div wrap around `belongs_to` field edit component. It was causing a bad layout on froms

Fixes #2063

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots

```ruby
 def fields
    panel do
      row do
        field :link, as: :text, help: "Hehe. Something helpful."
        field :course, as: :belongs_to, stacked: true
      end
    end
  end
```

### Before
![before](https://github.com/avo-hq/avo/assets/69730720/ed79b0a1-d658-4a17-b881-1a267f6bc988)

### After
![image](https://github.com/avo-hq/avo/assets/69730720/27c7f4e2-70de-4cbb-ac10-a8f57f849e2f)
