### PR TITLE
fix: `via_resource_class` on `belongs_to` fields

### DIFF
--- a/app/components/avo/fields/has_one_field/show_component.rb
+++ b/app/components/avo/fields/has_one_field/show_component.rb
@@ -41,6 +41,7 @@ class Avo::Fields::HasOneField::ShowComponent < Avo::Fields::ShowComponent
     args = {
       via_relation: association_id,
       via_relation_class: @resource.model_class.to_s,
+      via_resource_class: @resource.class,
       via_record_id: @resource.record.to_param,
       via_association_type: :has_one
     }

--- a/spec/features/avo/create_has_one_spec.rb
+++ b/spec/features/avo/create_has_one_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "CreateHasOne", type: :feature do
 
     click_on "Create new main post"
 
-    expect(page).to have_current_path("/admin/resources/posts/new?via_association_type=has_one&via_record_id=#{user.slug}&via_relation=user&via_relation_class=User")
+    expect(page).to have_current_path("/admin/resources/posts/new?via_association_type=has_one&via_record_id=#{user.slug}&via_relation=user&via_relation_class=User&via_resource_class=Avo%3A%3AResources%3A%3AUser")
     expect(page).to have_text user.name
 
     fill_in "post_name", with: "Main post name"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

`via_resource_class` on create path was missing from `belongs_to` fields. This PR adds `via_resource_class` like we use it on create path for `has_many` field.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
