### PR TITLE
fix: allow all chars on text filters

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -51,7 +51,6 @@ module Avo
       end
 
       # Apply filters to the current query
-
       filters_to_be_applied.each do |filter_class, filter_value|
         @query = filter_class.safe_constantize.new(
           arguments: @resource.get_filter_arguments(filter_class)

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -51,6 +51,7 @@ module Avo
       end
 
       # Apply filters to the current query
+
       filters_to_be_applied.each do |filter_class, filter_value|
         @query = filter_class.safe_constantize.new(
           arguments: @resource.get_filter_arguments(filter_class)
@@ -357,12 +358,12 @@ module Avo
     def set_applied_filters
       reset_filters if params[:reset_filter]
 
-      @applied_filters = Avo::Filters::BaseFilter.decode_filters(fetch_filters)
+      return @applied_filters = {} if (fetched_filters = fetch_filters).blank?
+
+      @applied_filters = Avo::Filters::BaseFilter.decode_filters(fetched_filters)
 
       # Some filters react to others and will have to be merged into this
       @applied_filters = @applied_filters.merge reactive_filters
-    rescue
-      @applied_filters = {}
     end
 
     def reactive_filters

--- a/app/javascript/js/controllers/filter_controller.js
+++ b/app/javascript/js/controllers/filter_controller.js
@@ -29,13 +29,13 @@ export default class extends Controller {
     // first we use encodeURIComponent to get percent-encoded UTF-8,
     // then we convert the percent encodings into raw bytes which
     // can be fed into btoa.
-    return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g,
-      (match, p1) => String.fromCharCode(`0x${p1}`)))
+    return encodeURIComponent(btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g,
+      (match, p1) => String.fromCharCode(`0x${p1}`))))
   }
 
   b64DecodeUnicode(str) {
     // Going backwards: from bytestream, to percent-encoding, to original string.
-    return decodeURIComponent(atob(str).split('').map((c) => `%${(`00${c.charCodeAt(0).toString(16)}`).slice(-2)}`).join(''))
+    return decodeURIComponent(atob(decodeURIComponent(str)).split('').map((c) => `%${(`00${c.charCodeAt(0). toString(16)}`).slice(-2)}`).join(''))
   }
 
   changeFilter() {

--- a/lib/avo/filters/base_filter.rb
+++ b/lib/avo/filters/base_filter.rb
@@ -23,8 +23,6 @@ module Avo
       class << self
         def decode_filters(filter_params)
           JSON.parse(Base64.decode64(filter_params))
-        rescue
-          {}
         end
 
         def encode_filters(filter_params)

--- a/lib/avo/filters/base_filter.rb
+++ b/lib/avo/filters/base_filter.rb
@@ -65,7 +65,9 @@ module Avo
 
       # Fetch the applied filters from the params
       def applied_filters
-        self.class.decode_filters params[PARAM_KEY]
+        return {} if (filters_from_params = params[PARAM_KEY]).blank?
+
+        self.class.decode_filters filters_from_params
       end
 
       def visible_in_view(resource: nil, parent_resource: nil)

--- a/spec/system/avo/filters/filters_spec.rb
+++ b/spec/system/avo/filters/filters_spec.rb
@@ -270,10 +270,12 @@ RSpec.describe "Filters", type: :system do
 
     let!(:team_without_members) { create :team, name: "Without Members" }
     let!(:team_with_members) { create :team, name: "With Members" }
+    let!(:team_音楽) { create :team, name: "音楽 ✓" }
 
     before do
       team_with_members.team_members << user
       team_without_members.team_members << user
+      team_音楽.team_members << user
     end
 
     let(:url) { "/admin/resources/teams?view_type=table" }
@@ -288,7 +290,7 @@ RSpec.describe "Filters", type: :system do
 
       it "filters by name" do
         visit url
-        expect(page).to have_text("Displaying 2 item")
+        expect(page).to have_text("Displaying 3 item")
 
         open_filters_menu
         fill_in "avo_filters_name_filter", with: "With Members"
@@ -302,7 +304,26 @@ RSpec.describe "Filters", type: :system do
 
         click_on "Reset filters"
         wait_for_loaded
-        expect(page).to have_text("Displaying 2 item")
+        expect(page).to have_text("Displaying 3 item")
+      end
+
+      it "filters by 音楽 ✓" do
+        visit url
+        expect(page).to have_text("Displaying 3 item")
+
+        open_filters_menu
+        fill_in "avo_filters_name_filter", with: "音楽 ✓"
+        click_on "Filter by name"
+        wait_for_loaded
+        expect(page).to have_text("Displaying 1 item")
+
+        open_filters_menu
+        expect(page).to have_text "音楽 ✓"
+        expect(page).to have_link("Reset filters")
+
+        click_on "Reset filters"
+        wait_for_loaded
+        expect(page).to have_text("Displaying 3 item")
       end
     end
   end

--- a/spec/system/avo/filters/filters_spec.rb
+++ b/spec/system/avo/filters/filters_spec.rb
@@ -270,12 +270,12 @@ RSpec.describe "Filters", type: :system do
 
     let!(:team_without_members) { create :team, name: "Without Members" }
     let!(:team_with_members) { create :team, name: "With Members" }
-    let!(:team_音楽) { create :team, name: "音楽 ✓" }
+    let!(:team) { create :team, name: "音楽 ✓" }
 
     before do
       team_with_members.team_members << user
       team_without_members.team_members << user
-      team_音楽.team_members << user
+      team.team_members << user
     end
 
     let(:url) { "/admin/resources/teams?view_type=table" }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2061 

1. Encode and decode filters on JS controller following [mdn official documentation about "the unicode problem"](https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem)
2. Un-silence decoding errors, we had some suppressed errors, that makes some bugs hard to debug and understand. 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works
