### PR TITLE
fix: main_panel extraction

### DIFF
--- a/lib/avo/concerns/has_items.rb
+++ b/lib/avo/concerns/has_items.rb
@@ -101,6 +101,13 @@ module Avo
             if item.is_sidebar?
               fields << extract_fields(item)
             end
+          else
+            # When `item.is_main_panel? == true` then also `item.is_panel? == true`
+            # But when only_root == true we want to extract main_panel items
+            # In all other circumstances items will get extracted when checking for `item.is_panel?`
+            if item.is_main_panel?
+              fields << extract_fields(item)
+            end
           end
 
           if item.is_field?
@@ -109,10 +116,6 @@ module Avo
 
           if item.is_row?
             fields << extract_fields(tab)
-          end
-
-          if item.is_main_panel?
-            fields << extract_fields(item)
           end
         end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Main panel fields were fetched twice when `only_root == false`

Fixes #2077
Fixes  [discord thread](https://discord.com/channels/740892036978442260/1138182212655788054/1184003726730592316)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots
### Before
#### Filters
<img src="https://github.com/avo-hq/avo/assets/69730720/1eb2bcc8-6b15-4339-8015-b64c7d78dcd3" height="300">

#### Preview
<img src="https://github.com/avo-hq/avo/assets/69730720/c9239d98-420d-4985-a6f6-53ce3d213640" height="200">

### After
#### Filters
<img src="https://github.com/avo-hq/avo/assets/69730720/3860a610-6550-423a-9d1a-0dbda8d3a067" height="200">

#### Preview
<img src="https://github.com/avo-hq/avo/assets/69730720/228f33a8-de2d-4879-a902-a59410daa4a8" height="200">
