### PR TITLE
fix: search current_user

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -162,7 +162,7 @@ module Avo
         view: Avo::ViewInquirer.new(params[:via_reflection_view]),
         record: parent,
         params: params,
-        user: current_user
+        user: _current_user
       )
 
       reflection_resource.detect_fields.get_field_definitions.find do |field|


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes [discord thread](https://discord.com/channels/740892036978442260/1184299599830188092).

`current_user` was called instead `_current_user` helper on the `app/controllers/avo/search_controller.rb` 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
