### PR TITLE
fix: `belongs_to` index field name

### DIFF
--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -259,8 +259,8 @@ module Avo
         nil
       end
 
-      def name
-        return polymorphic_as.to_s.humanize if polymorphic_as.present? && view.index?
+      def default_name
+        return polymorphic_as.to_s.humanize if polymorphic_as.present?
 
         super
       end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

`belongs_to` name on index was hard-coded.

Fixes #2099 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
