### PR TITLE
fix: dynamic filters

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -357,7 +357,8 @@ module Avo
     def set_applied_filters
       reset_filters if params[:reset_filter]
 
-      return @applied_filters = {} if (fetched_filters = fetch_filters).blank?
+      # Return if there are no filters or if the filters are actualy ActionController::Parameters (used by dynamic filters)
+      return @applied_filters = {} if (fetched_filters = fetch_filters).blank? || fetched_filters.is_a?(ActionController::Parameters)
 
       @applied_filters = Avo::Filters::BaseFilter.decode_filters(fetched_filters)
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

`set_applied_filters` method should ignore dynamic filter params

Fix:

![image](https://github.com/avo-hq/avo/assets/69730720/20a04729-d17c-4dca-a436-20c0fb2a3441)


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
