### PR TITLE
Add base_field_translation_key to BaseResouce allowing fields to be nested localized

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -119,6 +119,7 @@ ignore_missing:
   - 'avo.resource_translations.user'
   - 'avo.resource_translations.team_members'
   - 'avo.x_items_more'
+  - 'avo.field_translations.project.status'
 
 # - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
 # - '{devise,simple_form}.*'

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -48,6 +48,7 @@ module Avo
     class_attribute :includes, default: []
     class_attribute :authorization_policy
     class_attribute :translation_key
+    class_attribute :base_field_translation_key
     class_attribute :default_view_type, default: :table
     class_attribute :devise_password_optional, default: false
     class_attribute :scopes_loader

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -95,7 +95,7 @@ module Avo
       def translation_key
         return @translation_key if @translation_key.present?
 
-        return "#{@resource.base_field_translation_key}.#{@id}" if @resource.base_field_translation_key.present?
+        return "#{@resource.base_field_translation_key}.#{@id}" if @resource.try(:base_field_translation_key)
 
         "avo.field_translations.#{@id}"
       end

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -93,7 +93,11 @@ module Avo
       end
 
       def translation_key
-        @translation_key || "avo.field_translations.#{@id}"
+        return @translation_key if @translation_key.present?
+
+        return "#{@resource.base_field_translation_key}.#{@id}" if @resource.base_field_translation_key.present?
+
+        "avo.field_translations.#{@id}"
       end
 
       def translated_name(default:)

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -47,6 +47,11 @@ en:
         one: person
         other: people
         zero: people
+      project:
+        status:
+          one: Status Nested
+          other: Status Nesteds
+          zero: Status Nesteds
     filter_by: Filter by
     filters: Filters
     go_back: Go back

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -47,11 +47,6 @@ en:
         one: person
         other: people
         zero: people
-      project:
-        status:
-          one: Status Nested
-          other: Status Nesteds
-          zero: Status Nesteds
     filter_by: Filter by
     filters: Filters
     go_back: Go back

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -47,6 +47,12 @@ en:
         one: person
         other: people
         zero: people
+      status: Status
+      project:
+        status:
+          zero: Status Nesteds
+          other: Status Nesteds
+          one: Status Nested
     filter_by: Filter by
     filters: Filters
     go_back: Go back

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -52,7 +52,6 @@ en:
           one: Status Nested
           other: Status Nesteds
           zero: Status Nesteds
-      status: Status
     filter_by: Filter by
     filters: Filters
     go_back: Go back

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -47,12 +47,12 @@ en:
         one: person
         other: people
         zero: people
-      status: Status
       project:
         status:
-          zero: Status Nesteds
-          other: Status Nesteds
           one: Status Nested
+          other: Status Nesteds
+          zero: Status Nesteds
+      status: Status
     filter_by: Filter by
     filters: Filters
     go_back: Go back

--- a/spec/dummy/app/avo/resources/project.rb
+++ b/spec/dummy/app/avo/resources/project.rb
@@ -1,6 +1,8 @@
 class Avo::Resources::Project < Avo::BaseResource
   self.title = :name
 
+  self.base_field_translation_key = "avo.field_translations.project"
+
   self.search = {
     query: -> {
       query.ransack(id_eq: params[:q], name_cont: params[:q], country_cont: params[:q], m: "or").result(distinct: false)

--- a/spec/dummy/app/avo/resources/project.rb
+++ b/spec/dummy/app/avo/resources/project.rb
@@ -1,8 +1,6 @@
 class Avo::Resources::Project < Avo::BaseResource
   self.title = :name
 
-  self.base_field_translation_key = "avo.field_translations.project"
-
   self.search = {
     query: -> {
       query.ransack(id_eq: params[:q], name_cont: params[:q], country_cont: params[:q], m: "or").result(distinct: false)

--- a/spec/system/avo/base_field_spec.rb
+++ b/spec/system/avo/base_field_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Base Fields", type: :system do
-  let(:project) { create :project, :with_files }
+  let!(:project) { create :project }
 
   after :each do
     Avo::Resources::Project.restore_items_from_backup
@@ -10,26 +10,26 @@ RSpec.feature "Base Fields", type: :system do
   describe "base_field_translation_key" do
     it "renders the the default status name" do
       Avo::Resources::Project.with_temporary_items do
-        self.base_field_translation_key = nil
-
         field :status, as: :text
       end
 
       visit "/admin/resources/projects"
 
-      status_wrapper = find('[data-table-header-field-type="status"]')
-      expect(status_wrapper).to have_text("Status")
+      status_text = find('th[data-control="resource-field-th"][data-table-header-field-id="status"]').text
+      expect(status_text).to eq("STATUS")
     end
 
     it "renders the nested translated key" do
       Avo::Resources::Project.with_temporary_items do
+        self.base_field_translation_key = "avo.field_translations.project"
         field :status, as: :text
       end
 
       visit "/admin/resources/projects"
 
-      status_wrapper = find('[data-table-header-field-type="status"]')
-      expect(status_wrapper).to have_text("Status Nested")
+
+      status_text = find('th[data-control="resource-field-th"][data-table-header-field-id="status"]').text
+      expect(status_text).to eq("STATUS NESTED")
     end
   end
 end

--- a/spec/system/avo/base_field_spec.rb
+++ b/spec/system/avo/base_field_spec.rb
@@ -21,6 +21,18 @@ RSpec.feature "Base Fields", type: :system do
 
     it "renders the nested translated key" do
       Avo::Resources::Project.with_temporary_items do
+        I18n.backend.store_translations :en, avo: {
+          field_translations: {
+            project: {
+              status: {
+                one: "Status Nested",
+                other: "Status Nesteds",
+                zero: "Status Nesteds",
+              }
+            }
+          }
+        }
+
         self.base_field_translation_key = "avo.field_translations.project"
         field :status, as: :text
       end

--- a/spec/system/avo/base_field_spec.rb
+++ b/spec/system/avo/base_field_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Base Fields", type: :system do
       visit "/admin/resources/projects"
 
       status_wrapper = find('[data-table-header-field-type="status"]')
-      expect(status_wrapper).to have_text("Status nested")
+      expect(status_wrapper).to have_text("Status Nested")
     end
   end
 end

--- a/spec/system/avo/base_field_spec.rb
+++ b/spec/system/avo/base_field_spec.rb
@@ -21,18 +21,6 @@ RSpec.feature "Base Fields", type: :system do
 
     it "renders the nested translated key" do
       Avo::Resources::Project.with_temporary_items do
-        I18n.backend.store_translations :en, avo: {
-          field_translations: {
-            project: {
-              status: {
-                one: "Status Nested",
-                other: "Status Nesteds",
-                zero: "Status Nesteds",
-              }
-            }
-          }
-        }
-
         self.base_field_translation_key = "avo.field_translations.project"
         field :status, as: :text
       end

--- a/spec/system/avo/base_field_spec.rb
+++ b/spec/system/avo/base_field_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.feature "Base Fields", type: :system do
+  let(:project) { create :project, :with_files }
+
+  after :each do
+    Avo::Resources::Project.restore_items_from_backup
+  end
+
+  describe "base_field_translation_key" do
+    it "renders the the default status name" do
+      Avo::Resources::Project.with_temporary_items do
+        self.base_field_translation_key = nil
+
+        field :status, as: :text
+      end
+
+      visit "/admin/resources/projects"
+
+      status_wrapper = find('[data-table-header-field-type="status"]')
+      expect(status_wrapper).to have_text("Status")
+    end
+
+    it "renders the nested translated key" do
+      Avo::Resources::Project.with_temporary_items do
+        field :status, as: :text
+      end
+
+      visit "/admin/resources/projects"
+
+      status_wrapper = find('[data-table-header-field-type="status"]')
+      expect(status_wrapper).to have_text("Status nested")
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently Avo supports users to Localize Resources or Fields as in a root-level perspective. You can define `translation_key` for resources or each field, but you cannot tell avo to translate fields from a specific nested base point.

The proposed change allow users to continue to use the regular approach, but also adds the support for specifying where the fields from a specific resource will be localized.

This is useful for migrating big applications with other Admin capabilities, but also it allows users to have the same field name in different locations. 

Fixes #1593


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots
<!-- Does the PR introduce any visual changes? Can you show us before and after? -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Pull the branch
2. Change your `avo.en.yml` locale file


```yml
# lib/generators/avo/templates/locales/avo.en.yml
field_translations:
      status: Status Root
      project:
        status:
          zero: Status Nesteds
          other: Status Nesteds
          one: Status Nested
```

3. Inside `class Avo::Resources::Project < Avo::BaseResource`, write:

```rb
self.base_field_translation_key = "avo.field_translations.project"
```

4. Go to the dummy project /projects path
5. You should expect to see Status Nested as the table column instead of just Status

Output:

<img width="565" alt="image" src="https://github.com/avo-hq/avo/assets/3402/57e6a621-db8f-4a44-875f-7dbd9e05b890">
