### PR TITLE
fix: action authorize variables, direct access to `view` and `resource` instead `action.resource.view` 

### DIFF
--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -234,7 +234,10 @@ module Avo
     def authorized?
       Avo::ExecutionContext.new(
         target: authorize,
-        action: self
+        action: self,
+        resource: @resource,
+        view: @view,
+        arguments: arguments
       ).handle
     end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes [#150](https://github.com/avo-hq/avodocs/issues/150)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
  - https://github.com/avo-hq/avodocs/pull/151
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots
<!-- Does the PR introduce any visual changes? Can you show us before and after? -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
