### PR TITLE
fix: applied filters when filters are dynamic

### DIFF
--- a/lib/avo/filters/base_filter.rb
+++ b/lib/avo/filters/base_filter.rb
@@ -65,7 +65,11 @@ module Avo
 
       # Fetch the applied filters from the params
       def applied_filters
+        # Return empty hash if no filters are present
         return {} if (filters_from_params = params[PARAM_KEY]).blank?
+
+        # Return empty hash if the filters are not a string, decode_filters method expects a Base64 encoded string
+        # Dynamic filters also use the "filters" param key, but they are not Base64 encoded, they are a hash
         return {} if !filters_from_params.is_a?(String)
 
         self.class.decode_filters filters_from_params

--- a/lib/avo/filters/base_filter.rb
+++ b/lib/avo/filters/base_filter.rb
@@ -66,6 +66,7 @@ module Avo
       # Fetch the applied filters from the params
       def applied_filters
         return {} if (filters_from_params = params[PARAM_KEY]).blank?
+        return {} if !filters_from_params.is_a?(String)
 
         self.class.decode_filters filters_from_params
       end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Since we removed the rescue on record to catch relevant errors we should ensure that `params[:filters]` is a string before trying to decode it. When using dynamic filters `params[:filters]` is a Hash

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots
<!-- Does the PR introduce any visual changes? Can you show us before and after? -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
