### PR TITLE
fix: status-field dynamic filter missing some options

### DIFF
--- a/lib/avo/fields/status_field.rb
+++ b/lib/avo/fields/status_field.rb
@@ -7,10 +7,12 @@ module Avo
         @loading_when = args[:loading_when].present? ? [args[:loading_when]].flatten.map(&:to_sym) : [:waiting, :running]
         @failed_when = args[:failed_when].present? ? [args[:failed_when]].flatten.map(&:to_sym) : [:failed]
         @success_when = args[:success_when].present? ? [args[:success_when]].flatten.map(&:to_sym) : []
+        @neutral_when = args[:neutral_when].present? ? [args[:neutral_when]].flatten.map(&:to_sym) : nil
       end
 
       def status
         status = "neutral"
+
         if value.present?
           status = "failed" if @failed_when.include? value.to_sym
           status = "loading" if @loading_when.include? value.to_sym
@@ -21,7 +23,7 @@ module Avo
       end
 
       def options_for_filter
-        [@failed_when, @loading_when].flatten
+        [@failed_when, @loading_when, @success_when, @neutral_when].flatten.uniq
       end
     end
   end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where dynamic filters would not have options because they are not declared anywhere for the neutral state.
Now, that we declare them in the `neutral_when` option, the dynamic filters will know about them and display them.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots
<!-- Does the PR introduce any visual changes? Can you show us before and after? -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Using `avo-advanced`
2. Change one project status field to something different `xoxo`
1. Go to the projects Index page and try to set a dynamic filter on `status`
2. Observe that the `xoxo` value is missing
3. now set the `neutral_when` value to `field :status, as: :status, neutral_when: [:xoxo]`
4. se the dynamic filter again and observe that the `xoxo` value is present.

Manual reviewer: please leave a comment with output from the test if that's the case.
