### PR TITLE
refactor: tailwind.css file clashes with other files

### DIFF
--- a/lib/generators/avo/tailwindcss/install_generator.rb
+++ b/lib/generators/avo/tailwindcss/install_generator.rb
@@ -27,12 +27,12 @@ module Generators
           end
 
 
-          unless (path = Rails.root.join("app", "assets", "stylesheets", "avo" ,"tailwind.css")).exist?
+          unless (path = Rails.root.join("app", "assets", "stylesheets", "avo" ,"avo.tailwind.css")).exist?
             say "Add default tailwind.css"
             copy_file template_path("avo.tailwind.css"), path
           end
 
-          script_name = "avo:tailwind:css"
+          script_name = "avo:tailwindcss"
           if Rails.root.join("Procfile.dev").exist?
             say "Add #{cmd = "avo_css: yarn #{script_name} --watch"} to Procfile.dev"
             append_to_file "Procfile.dev", "#{cmd}\n"
@@ -44,7 +44,7 @@ module Generators
             run "gem install foreman"
           end
 
-          script_command = "tailwindcss -i ./app/assets/stylesheets/avo/tailwind.css -o ./app/assets/builds/avo.tailwind.css -c ./config/avo/tailwind.config.js --minify"
+          script_command = "tailwindcss -i ./app/assets/stylesheets/avo/avo.tailwind.css -o ./app/assets/builds/avo.tailwind.css -c ./config/avo/tailwind.config.js --minify"
           pretty_script_command = "\"#{script_name}\": \"#{script_command}\""
 
           if (path = Rails.root.join("package.json")).exist?
@@ -69,12 +69,12 @@ module Generators
             # When running `rake assets:precompile` this is the order of events:
             # 1 - Task `avo:yarn_install`
             # 2 - Task `avo:sym_link`
-            # 3 - Cmd  `yarn avo:tailwind:css`
+            # 3 - Cmd  `yarn avo:tailwindcss`
             # 4 - Task `assets:precompile`
             Rake::Task["assets:precompile"].enhance(["avo:sym_link"])
             Rake::Task["avo:sym_link"].enhance(["avo:yarn_install"])
             Rake::Task["avo:sym_link"].enhance do
-              `yarn avo:tailwind:css`
+              `yarn avo:tailwindcss`
             end
 
           RUBY

--- a/lib/generators/avo/templates/tailwindcss/Procfile.dev
+++ b/lib/generators/avo/templates/tailwindcss/Procfile.dev
@@ -1,2 +1,2 @@
 web: bin/rails server -p 3000
-avo_css: yarn avo:tailwind:css --watch
+avo_css: yarn avo:tailwindcss --watch

--- a/lib/generators/avo/templates/tailwindcss/tailwind.config.js
+++ b/lib/generators/avo/templates/tailwindcss/tailwind.config.js
@@ -7,5 +7,5 @@ module.exports = {
     './app/views/**/*.html.erb',
     './app/helpers/**/*.rb',
     './app/javascript/**/*.js',
-  ]
+  ],
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where we generate a `tailwind.css` file and it clashes with the parent app's own file with the same name.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots
<!-- Does the PR introduce any visual changes? Can you show us before and after? -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
