### PR TITLE
fix: stimulus attributes crashing on grid view

### DIFF
--- a/lib/avo/fields/concerns/has_html_attributes.rb
+++ b/lib/avo/fields/concerns/has_html_attributes.rb
@@ -54,12 +54,16 @@ module Avo
         end
 
         def add_action_data_attributes(attributes, name, element)
+          return unless respond_to? :action
+
           if can_add_stimulus_attributes_for?(action, attributes, name, element)
             attributes.merge!(stimulus_attributes_for(action))
           end
         end
 
         def add_resource_data_attributes(attributes, name, element, view)
+          return unless respond_to? :resource
+
           if can_add_stimulus_attributes_for?(resource, attributes, name, element) && view.in?([:edit, :new])
             resource_stimulus_attributes = stimulus_attributes_for(resource)
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When on grid item `action` and `resource` are not accessible so adding stimulus attributes would raise an error `undefined local variable or method 'action' for #<Avo::Index::GridItemComponent...`

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots
<!-- Does the PR introduce any visual changes? Can you show us before and after? -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
