### PR TITLE
refactor: equal width columns in rows

### DIFF
--- a/app/components/avo/field_wrapper_component.html.erb
+++ b/app/components/avo/field_wrapper_component.html.erb
@@ -2,15 +2,24 @@
   class: classes,
   style: style,
   data: data do %>
-  <div class="<% if stacked? %> md:pt-4 md:w-full <% else %> h-full md:pt-0 <% if short? %> md:h-10 <% else %> md:h-14 <% end %> <% end %> pt-4 flex self-start items-center flex-shrink-0 <%= @field.get_html(:classes, view: view, element: :label) %> w-48 <% if compact? %> md:w-48 xl:w-64 <% else %> md:w-64 <% end %> px-6 uppercase font-semibold text-gray-500 text-sm" data-slot="label">
+  <%= content_tag :div, class: class_names("pt-4 flex self-start items-center flex-shrink-0 w-48 px-6 uppercase font-semibold text-gray-500 text-sm", @field.get_html(:classes, view: view, element: :label), {
+    "md:pt-4 md:w-full": stacked?,
+    "h-full md:pt-0": !stacked?,
+    "md:h-10 ": !stacked? && short?,
+    "md:h-14 ": !stacked? && !short?,
+    "md:w-48 xl:w-64": compact?,
+    "md:w-64": !compact?,
+  }), data: {slot: "label"} do %>
     <% if form.present? %>
       <%= form.label field.id, label %>
     <% else %>
       <%= field.name %>
     <% end %>
     <% if on_edit? && field.is_required? %> <span class="text-red-600 ml-1">*</span> <% end %>
-  </div>
-  <div class="flex-1 flex flex-row md:min-h-inherit py-2 <% if stacked? %> pb-4 <% else %><% end %> px-6 <%= @field.get_html(:classes, view: view, element: :content) %>" data-slot="value">
+  <% end %>
+  <%= content_tag :div, class: class_names("flex-1 flex flex-row md:min-h-inherit py-2 px-6", @field.get_html(:classes, view: view, element: :content), {
+    "pb-4": stacked?,
+  }), data: {slot: "label"} do %>
     <div class="self-center w-full <% unless full_width? || compact? || stacked? %> md:w-8/12 <% end %>">
       <% if on_show? %>
         <% if field.value.blank? and dash_if_blank %>
@@ -28,7 +37,7 @@
         <% end %>
       <% end %>
     </div>
-  </div>
+  <% end %>
   <% if params[:avo_debug].present? %>
     <!-- Raw value: -->
     <!-- <%= sanitize field.value.inspect %> -->

--- a/app/components/avo/field_wrapper_component.html.erb
+++ b/app/components/avo/field_wrapper_component.html.erb
@@ -19,7 +19,7 @@
   <% end %>
   <%= content_tag :div, class: class_names("flex-1 flex flex-row md:min-h-inherit py-2 px-6", @field.get_html(:classes, view: view, element: :content), {
     "pb-4": stacked?,
-  }), data: {slot: "label"} do %>
+  }), data: {slot: "value"} do %>
     <div class="self-center w-full <% unless full_width? || compact? || stacked? %> md:w-8/12 <% end %>">
       <% if on_show? %>
         <% if field.value.blank? and dash_if_blank %>

--- a/app/components/avo/field_wrapper_component.html.erb
+++ b/app/components/avo/field_wrapper_component.html.erb
@@ -2,7 +2,7 @@
   class: classes,
   style: style,
   data: data do %>
-  <div class="h-full <% if stacked? %> md:pt-4 md:w-full <% else %> md:pt-0 <% if short? %> md:h-10 <% else %> md:h-14 <% end %> <% end %> pt-4 flex self-start items-center flex-shrink-0 <%= @field.get_html(:classes, view: view, element: :label) %> w-48 <% if compact? %> md:w-48 xl:w-64 <% else %> md:w-64 <% end %> px-6 uppercase font-semibold text-gray-500 text-sm" data-slot="label">
+  <div class="<% if stacked? %> md:pt-4 md:w-full <% else %> h-full md:pt-0 <% if short? %> md:h-10 <% else %> md:h-14 <% end %> <% end %> pt-4 flex self-start items-center flex-shrink-0 <%= @field.get_html(:classes, view: view, element: :label) %> w-48 <% if compact? %> md:w-48 xl:w-64 <% else %> md:w-64 <% end %> px-6 uppercase font-semibold text-gray-500 text-sm" data-slot="label">
     <% if form.present? %>
       <%= form.label field.id, label %>
     <% else %>

--- a/app/components/avo/row_component.html.erb
+++ b/app/components/avo/row_component.html.erb
@@ -1,3 +1,3 @@
-<div class="flex flex-col sm:flex-row min-h-14 grow shrink-0" data-component="<%= self.class %>">
+<%= content_tag :div, class: "relative grid auto-cols-fr grid-flow-col min-h-14", data: {component: self.class.to_s} do %>
   <%= body %>
-</div>
+<% end %>

--- a/spec/system/avo/app_spec.rb
+++ b/spec/system/avo/app_spec.rb
@@ -24,15 +24,15 @@ RSpec.describe "App", type: :system do
 
       expect(find_field("comment_body").value).to eql "hey there"
 
-      fill_in 'comment_body', with: 'yes'
-      click_on 'Save'
+      fill_in "comment_body", with: "yes"
+      click_on "Save"
       wait_for_loaded
-
-      comment.reload
-      expect(comment.body).to eq 'yes'
 
       expect(current_path).to eq "/admin/resources/projects/#{project.id}"
       expect(page).to have_text("Comment was successfully updated.").once
+
+      comment.reload
+      expect(comment.body).to eq "yes"
     end
 
     it "only displays one alert on record destroy from has_many" do


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where `row` columns are not equal.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots
<!-- Does the PR introduce any visual changes? Can you show us before and after? -->

#### Before
![CleanShot 2023-12-19 at 23 27 06@2x](https://github.com/avo-hq/avo/assets/1334409/70dd943c-d47f-496d-90dc-bf9a24cc9539)

#### After

![CleanShot 2023-12-19 at 23 27 31@2x](https://github.com/avo-hq/avo/assets/1334409/1a0e47d4-26d3-4491-91b1-67dd8a588022)
