### PR TITLE
fix: tabs persistence when tab name has spaces

### DIFF
--- a/app/components/avo/tab_group_component.rb
+++ b/app/components/avo/tab_group_component.rb
@@ -7,6 +7,8 @@ class Avo::TabGroupComponent < Avo::BaseComponent
   attr_reader :form
   attr_reader :resource
 
+  delegate :group_param, to: :@group
+
   def initialize(resource:, group:, index:, form:, params:, view:)
     @resource = resource
     @group = group
@@ -24,10 +26,6 @@ class Avo::TabGroupComponent < Avo::BaseComponent
 
   def tabs_have_content?
     visible_tabs.present?
-  end
-
-  def group_param
-    group.id
   end
 
   def active_tab_name

--- a/app/components/avo/tab_switcher_component.rb
+++ b/app/components/avo/tab_switcher_component.rb
@@ -12,6 +12,7 @@ class Avo::TabSwitcherComponent < Avo::BaseComponent
   attr_reader :resource
 
   delegate :white_panel_classes, to: :helpers
+  delegate :group_param, to: :@group
 
   def initialize(resource:, group:, current_tab:, active_tab_name:, view:)
     @active_tab_name = active_tab_name
@@ -47,10 +48,6 @@ class Avo::TabSwitcherComponent < Avo::BaseComponent
   end
 
   private
-
-  def group_param
-    "tab-group_#{group.id}"
-  end
 
   def tab_param_missing?
     params[group_param].blank?

--- a/lib/avo/resources/items/tab_group.rb
+++ b/lib/avo/resources/items/tab_group.rb
@@ -37,6 +37,10 @@ class Avo::Resources::Items::TabGroup
     "#{Avo::Resources::Items::TabGroup.to_s.parameterize} #{index}".parameterize
   end
 
+  def group_param
+    "tab-group_#{id}"
+  end
+
   class Builder
     include Avo::Concerns::BorrowItemsHolder
 

--- a/spec/system/avo/tabs_spec.rb
+++ b/spec/system/avo/tabs_spec.rb
@@ -140,4 +140,26 @@ RSpec.describe "Tabs", type: :system do
       find('a[data-selected="true"][data-tabs-tab-name-param="Posts"]')
     end
   end
+
+  describe "tabs with names that have spaces" do
+    it "keeps tab on reload" do
+      visit avo.resources_user_path user
+
+      find('a[data-selected="true"][data-tabs-tab-name-param="Fish"]')
+      find('a[data-selected="false"][data-tabs-tab-name-param="Projects"]').click
+      find('a[data-selected="false"][data-tabs-tab-name-param="Team memberships"]')
+
+      refresh
+
+      find('a[data-selected="false"][data-tabs-tab-name-param="Fish"]')
+      find('a[data-selected="true"][data-tabs-tab-name-param="Projects"]')
+      find('a[data-selected="false"][data-tabs-tab-name-param="Team memberships"]').click
+
+      refresh
+
+      find('a[data-selected="false"][data-tabs-tab-name-param="Fish"]')
+      find('a[data-selected="false"][data-tabs-tab-name-param="Projects"]')
+      find('a[data-selected="true"][data-tabs-tab-name-param="Team memberships"]')
+    end
+  end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR removes the double `group_param` definition moving it to `Avo::Resources::Items::TabGroup` and delegating to that class when usage is necessary.

Fixes #2265

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots
<!-- Does the PR introduce any visual changes? Can you show us before and after? -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
