### PR TITLE
fix: secret key base warning

### DIFF
--- a/lib/avo/services/encryption_service.rb
+++ b/lib/avo/services/encryption_service.rb
@@ -29,14 +29,27 @@ module Avo
 
       def encryption_key
         secret_key_base[0..31]
-      rescue
-        # This will fail the decryption process.
-        # It's here only to keep Avo from crashing
-        SecureRandom.random_bytes(32)
       end
 
       def secret_key_base
-        ENV["SECRET_KEY_BASE"] || Rails.application.credentials.secret_key_base || Rails.application.secrets.secret_key_base
+        # Try to fetch the secret key base from ENV or the credentials file
+        key = ENV["SECRET_KEY_BASE"] || Rails.application.credentials.secret_key_base
+
+        # If key is blank and Rails version is less than 7.2.0
+        # Try to fetch the secret key base from the secrets file
+        # Rails 7.2.0 made secret_key_base from secrets obsolete
+        if key.blank? && (Rails.gem_version < Gem::Version.new('7.2.0'))
+          key = Rails.application.secrets.secret_key_base
+        end
+
+        return key if key.present?
+
+        # Avoid breaking in production
+        # All features relying on encryption will not work properly without a configured secret key base
+        return SecureRandom.random_bytes(32) if Rails.env.production?
+
+        raise "Unable to fetch secret key base. Please set it in your credentials or environment variables\n" \
+          "For more information check https://docs.avohq.io/3.0/encryption-service.html#secret-key-base"
       end
     end
   end

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -3,6 +3,8 @@ ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../../Gemfile", __dir__)
 
 ENV["AVO_IN_DEVELOPMENT"] = "1"
 
+ENV["SECRET_KEY_BASE"] = "130b8d0a74b5b73bfb2d0505c3de8250"
+
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 require "bootsnap/setup" unless ENV["CI"] # Speed up boot time by caching expensive operations.
 $LOAD_PATH.unshift File.expand_path("../../../lib", __dir__)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,6 @@ require "spec_helper"
 require "fileutils"
 
 ENV["RAILS_ENV"] = "test"
-ENV["SECRET_KEY_BASE"] = "secret_key_base_to_avoid DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2."
 
 require_relative "dummy/config/environment"
 # Prevent database truncation if the environment is production


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2090

- Only fetch secret key from `Rails.application.secrets.secret_key_base` if rails version is less than `7.2.0`
- Raise custom error when not on production
- Keep same behavior on production

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
