### PR TITLE
feature: delegate missing to view_context

### DIFF
--- a/lib/avo/execution_context.rb
+++ b/lib/avo/execution_context.rb
@@ -4,6 +4,8 @@ module Avo
 
     attr_accessor :target, :context, :params, :view_context, :current_user, :request, :include, :main_app, :avo, :locale
 
+    delegate_missing_to :@view_context
+
     def initialize(**args)
       # Extend the class with custom modules if required.
       if args[:include].present?

--- a/spec/dummy/app/avo/resources/product.rb
+++ b/spec/dummy/app/avo/resources/product.rb
@@ -7,7 +7,7 @@ class Avo::Resources::Product < Avo::BaseResource
       {
         cover_url: record.image.attached? ? main_app.url_for(record.image.variant(resize: "300x300")) : nil,
         title: record.title,
-        body: view_context.simple_format(record.description)
+        body: simple_format(record.description)
       }
     end,
     html: -> do


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2300

Delegating missing methods to view_context on Avo::ExecutionContext allow to direclty use `@view_context` methods without explicitly call it:

`body: simple_format(record.description)`

VS

`body: view_context.simple_format(record.description)`

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
