### PR TITLE
fix: remove status field defaults and fix the neutral state

### DIFF
--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -45,14 +45,6 @@ module Avo
       end
     end
 
-    def _current_user
-      instance_eval(&Avo.configuration.current_user)
-    end
-
-    def context
-      instance_eval(&Avo.configuration.context)
-    end
-
     # This is coming from Turbo::Frames::FrameRequest module.
     # Exposing it as public method
     def turbo_frame_request?

--- a/lib/avo/fields/status_field.rb
+++ b/lib/avo/fields/status_field.rb
@@ -4,10 +4,10 @@ module Avo
       def initialize(id, **args, &block)
         super(id, **args, &block)
 
-        @loading_when = args[:loading_when].present? ? [args[:loading_when]].flatten.map(&:to_sym) : [:waiting, :running]
-        @failed_when = args[:failed_when].present? ? [args[:failed_when]].flatten.map(&:to_sym) : [:failed]
+        @loading_when = args[:loading_when].present? ? [args[:loading_when]].flatten.map(&:to_sym) : []
+        @failed_when = args[:failed_when].present? ? [args[:failed_when]].flatten.map(&:to_sym) : []
         @success_when = args[:success_when].present? ? [args[:success_when]].flatten.map(&:to_sym) : []
-        @neutral_when = args[:neutral_when].present? ? [args[:neutral_when]].flatten.map(&:to_sym) : nil
+        @neutral_when = args[:neutral_when].present? ? [args[:neutral_when]].flatten.map(&:to_sym) : []
       end
 
       def status

--- a/tailwind.preset.js
+++ b/tailwind.preset.js
@@ -10,7 +10,7 @@ function contentPaths(basePath) {
     `${basePath}/safelist.txt`,
     `${basePath}/lib/avo/**/*.rb`,
     `${basePath}/app/helpers/**/*.rb`,
-    `${basePath}/app/views/**/*.erb`,
+    `${basePath}/app/views/**/*.{html.erb,rb}`,
     `${basePath}/app/javascript/**/*.js`,
     `${basePath}/app/components/**/*.{html.erb,rb}`,
     `${basePath}/app/controllers/**/*.rb`,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where the default values in the status field would render inexistent options in dynamic filters.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

