### PR TITLE
chore: move scopes from pro to advanced

### DIFF
--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -159,7 +159,7 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
   end
 
   def scopes_list
-    Avo::Pro::Scopes::ListComponent.new(
+    Avo::Advanced::Scopes::ListComponent.new(
       scopes: scopes,
       resource: resource,
       turbo_frame: turbo_frame,
@@ -169,7 +169,7 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
   end
 
   def can_render_scopes?
-    defined?(Avo::Pro)
+    defined?(Avo::Advanced)
   end
 
   private


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Call scopes from `avo-advanced` instead `avo-pro` 