### PR TITLE
feature: close_modal_and_flash_alerts

### DIFF
--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -81,6 +81,11 @@ module Avo
               @response[:redirect_args][:turbo_frame],
               **@response[:redirect_args].except(:turbo_frame)
             )
+          when :close_modal_and_flash_alerts
+            render turbo_stream: [
+              turbo_stream.flash_alerts,
+              turbo_stream.remove("actions_show")
+            ]
           else
             # Reload the page
             redirect_back fallback_location: resources_path(resource: @resource)

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -189,6 +189,12 @@ module Avo
       self
     end
 
+    def close_modal_and_flash_alerts
+      response[:type] = :close_modal_and_flash_alerts
+
+      self
+    end
+
     # Add a placeholder silent message from when a user wants to do a redirect action or something similar
     def silent
       add_message nil, :silent


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2336 

Adds the `close_modal_and_flash_alerts` action's response option that flashes the alerts and closes the modal.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots
<!-- Does the PR introduce any visual changes? Can you show us before and after? -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
