### PR TITLE
security: sanitize key_value field content

### DIFF
--- a/app/javascript/js/controllers/fields/key_value_controller.js
+++ b/app/javascript/js/controllers/fields/key_value_controller.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-len */
+import * as DOMPurify from 'dompurify'
 import { Controller } from '@hotwired/stimulus'
 import { castBoolean } from '../../helpers/cast_boolean'
 
@@ -80,7 +81,7 @@ export default class extends Controller {
     let index = 0
     this.fieldValue.forEach((row) => {
       const [key, value] = row
-      result += this.interpolatedRow(key, value, index)
+      result += this.interpolatedRow(DOMPurify.sanitize(key), DOMPurify.sanitize(value), index)
       index++
     })
     this.rowsTarget.innerHTML = result

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "codemirror": "5.59.1",
     "core-js": "^3.35.0",
     "css-loader": "^6.9.0",
+    "dompurify": "^3.0.8",
     "easymde": "^2.18.0",
     "el-transition": "^0.0.7",
     "esbuild": "^0.14.54",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2090,6 +2090,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dompurify@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.0.8.tgz#e0021ab1b09184bc8af7e35c7dd9063f43a8a437"
+  integrity sha512-b7uwreMYL2eZhrSCRC4ahLTeZcPZxSmYfmcQGXGkXiZSNW1X85v+SDM5KsWcpivIiUBH47Ji7NtyUdpLeF5JZQ==
+
 easymde@^2.18.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/easymde/-/easymde-2.18.0.tgz#ff1397d07329b1a7b9187d2d0c20766fa16b3b1b"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Addresses https://github.com/avo-hq/avo/security/advisories/GHSA-ghjv-mh6x-7q6h

Fixes a security issue where the output for the `key_value` field is not sanitized.


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots
<!-- Does the PR introduce any visual changes? Can you show us before and after? -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Follow the steps in the CVE to test.

Manual reviewer: please leave a comment with output from the test if that's the case.
