### PR TITLE
Set z-index for navbar to the highest value, equal only to flash alerts

### DIFF
--- a/app/views/avo/partials/_navbar.html.erb
+++ b/app/views/avo/partials/_navbar.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag :div, class: class_names("fixed bg-white p-2 w-full flex flex-shrink-0 items-center z-50 px-4 lg:px-4 border-b space-x-4 lg:space-x-0 h-16", {"print:hidden": Avo.configuration.hide_layout_when_printing}) do %>
+<%= content_tag :div, class: class_names("fixed bg-white p-2 w-full flex flex-shrink-0 items-center z-[100] px-4 lg:px-4 border-b space-x-4 lg:space-x-0 h-16", {"print:hidden": Avo.configuration.hide_layout_when_printing}) do %>
   <div class="flex items-center space-x-2 w-auto lg:w-64 flex-shrink-0 h-full">
     <div>
       <%= a_button class: 'lg:hidden', icon: 'menu', size: :xs, compact: true, style: :text, data: { action: 'click->sidebar#toggleSidebarOnMobile' } %>


### PR DESCRIPTION
# Description

The problem is that our warning from `_custom_tools_alert.html.erb` is currently having an equal precedence (z-index = 50) as the navbar (z-index = 50) which results in this:

![image](https://github.com/avo-hq/avo/assets/12682792/1c4ba77f-4ecd-4781-919b-30cccb8a8b56)

I'm setting the z-index of the navbar to 100, which is the same value as flash alerts and modals currently have. Meaning that only those components are allowed to be displayed over the navbar.

After the fix:

![image](https://github.com/avo-hq/avo/assets/12682792/eccd4a6d-0f50-423f-a01a-8a3e3db919b3)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Manual review steps

1. Run the dummy app and scroll a bit
