### PR TITLE
fix: search highlight

### DIFF
--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import * as Mousetrap from 'mousetrap'
+import * as DOMPurify from 'dompurify'
 import { Controller } from '@hotwired/stimulus'
 import { Turbo } from '@hotwired/turbo-rails'
 import { autocomplete } from '@algolia/autocomplete-js'
@@ -21,11 +22,11 @@ export default class extends Controller {
     'visibleLabel',
     'clearValue',
     'clearButton',
-  ];
+  ]
 
-  debouncedFetch = debouncePromise(fetch, this.searchDebounce);
+  debouncedFetch = debouncePromise(fetch, this.searchDebounce)
 
-  destroyMethod;
+  destroyMethod
 
   get dataset() {
     return this.autocompleteTarget.dataset
@@ -157,15 +158,29 @@ export default class extends Controller {
             )
           }
 
-          const labelChildren = [item._label]
+          const label = DOMPurify.sanitize(item._label)
+
+          const labelChildren = [
+            createElement(
+              'div',
+              {
+                dangerouslySetInnerHTML: { __html: label },
+              },
+              label,
+            ),
+          ]
+
           if (item._description) {
+            const description = DOMPurify.sanitize(item._description)
+
             labelChildren.push(
               createElement(
                 'div',
                 {
                   class: 'aa-ItemDescription',
+                  dangerouslySetInnerHTML: { __html: description },
                 },
-                item._description,
+                description,
               ),
             )
           }

--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-underscore-dangle */
 import * as Mousetrap from 'mousetrap'
-import * as DOMPurify from 'dompurify'
 import { Controller } from '@hotwired/stimulus'
 import { Turbo } from '@hotwired/turbo-rails'
 import { autocomplete } from '@algolia/autocomplete-js'
+import { sanitize } from 'dompurify'
 import URI from 'urijs'
 import debouncePromise from '../helpers/debounce_promise'
 
@@ -158,7 +158,7 @@ export default class extends Controller {
             )
           }
 
-          const label = DOMPurify.sanitize(item._label)
+          const label = sanitize(item._label)
 
           const labelChildren = [
             createElement(
@@ -171,7 +171,7 @@ export default class extends Controller {
           ]
 
           if (item._description) {
-            const description = DOMPurify.sanitize(item._description)
+            const description = sanitize(item._description)
 
             labelChildren.push(
               createElement(


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Allows usage of html tags inside search results labels and descriptions. 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
`W<mark>rap</mark>safe`:
![image](https://github.com/avo-hq/avo/assets/69730720/af4f5870-64cb-47a7-9d01-417009273cb9)
