### PR TITLE
fix: destroy when using forms and display fields API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    avo (3.3.1)
+    avo (3.3.2)
       actionview (>= 6.1)
       active_link_to
       activerecord (>= 6.1)

--- a/app/components/avo/index/resource_controls_component.rb
+++ b/app/components/avo/index/resource_controls_component.rb
@@ -182,7 +182,7 @@ class Avo::Index::ResourceControlsComponent < Avo::ResourceComponent
     hidden = {}
 
     hidden[:view_type] = params[:view_type] if params[:view_type]
-    hidden[:view] = params[:view]
+    hidden[:view] = resource.view.to_s
 
     if params[:turbo_frame]
       hidden[:turbo_frame] = params[:turbo_frame]

--- a/app/components/avo/index/resource_controls_component.rb
+++ b/app/components/avo/index/resource_controls_component.rb
@@ -182,6 +182,7 @@ class Avo::Index::ResourceControlsComponent < Avo::ResourceComponent
     hidden = {}
 
     hidden[:view_type] = params[:view_type] if params[:view_type]
+    hidden[:view] = params[:view]
 
     if params[:turbo_frame]
       hidden[:turbo_frame] = params[:turbo_frame]

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -119,7 +119,12 @@ module Avo
     def set_related_resource
       raise Avo::MissingResourceError.new(related_resource_name) if related_resource.nil?
 
-      @related_resource = related_resource.new(params: params, view: action_name.to_sym, user: _current_user, record: @related_record).detect_fields
+      @related_resource = related_resource.new(
+        params: params,
+        view: params[:view] || action_name.to_sym,
+        user: _current_user,
+        record: @related_record
+      ).detect_fields
     end
 
     def set_record

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -123,6 +123,10 @@ module Avo
 
       # Get view from params unless actions is index or show or forms...
       # Else, for example for detach action we want the view from params to can fetch the correct fields
+      # This logic avoid the following scenario:
+      # When a has many field is rendered the action is index and params[:view] is show or edit but we want to
+      # keep @view as index for the related_resource
+      # Same do not happen with other actions except the list below.
       view = if action_view.in?([:index, :show, :new, :edit, :create])
         action_view
       else

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -119,9 +119,19 @@ module Avo
     def set_related_resource
       raise Avo::MissingResourceError.new(related_resource_name) if related_resource.nil?
 
+      action_view = action_name.to_sym
+
+      # Get view from params unless actions is index or show or forms...
+      # Else, for example for detach action we want the view from params to can fetch the correct fields
+      view = if action_view.in?([:index, :show, :new, :edit, :create])
+        action_view
+      else
+        params[:view] || action_view
+      end
+
       @related_resource = related_resource.new(
         params: params,
-        view: params[:view] || action_name.to_sym,
+        view: view,
         user: _current_user,
         record: @related_record
       ).detect_fields

--- a/spec/dummy/app/avo/resources/course.rb
+++ b/spec/dummy/app/avo/resources/course.rb
@@ -10,7 +10,7 @@ class Avo::Resources::Course < Avo::BaseResource
     fields_bag
   end
 
-  def forms_fields
+  def form_fields
     fields_bag
   end
 

--- a/spec/dummy/app/avo/resources/course.rb
+++ b/spec/dummy/app/avo/resources/course.rb
@@ -5,7 +5,19 @@ class Avo::Resources::Course < Avo::BaseResource
   self.keep_filters_panel_open = true
   self.stimulus_controllers = "city-in-country toggle-fields"
 
-  def fields
+
+  def display_fields
+    fields_bag
+  end
+
+  def forms_fields
+    fields_bag
+  end
+
+  def fields_bag
+    field :links, as: :has_many, searchable: true, placeholder: "Click to choose a link",
+      discreet_pagination: true
+
     field :id, as: :id
     field :name, as: :text, html: {
       edit: {
@@ -85,8 +97,7 @@ class Avo::Resources::Course < Avo::BaseResource
       options: Course.cities.values.flatten.map { |city| [city, city] }.to_h,
       display_value: false
 
-    field :links, as: :has_many, searchable: true, placeholder: "Click to choose a link",
-      discreet_pagination: true
+
 
     if params[:show_location_field] == '1'
       # Example for error message when resource is missing

--- a/spec/dummy/app/avo/resources/course.rb
+++ b/spec/dummy/app/avo/resources/course.rb
@@ -15,9 +15,6 @@ class Avo::Resources::Course < Avo::BaseResource
   end
 
   def fields_bag
-    field :links, as: :has_many, searchable: true, placeholder: "Click to choose a link",
-      discreet_pagination: true
-
     field :id, as: :id
     field :name, as: :text, html: {
       edit: {
@@ -97,7 +94,8 @@ class Avo::Resources::Course < Avo::BaseResource
       options: Course.cities.values.flatten.map { |city| [city, city] }.to_h,
       display_value: false
 
-
+    field :links, as: :has_many, searchable: true, placeholder: "Click to choose a link",
+      discreet_pagination: true
 
     if params[:show_location_field] == '1'
       # Example for error message when resource is missing

--- a/spec/features/avo/fields_methods_for_views_spec.rb
+++ b/spec/features/avo/fields_methods_for_views_spec.rb
@@ -69,6 +69,9 @@ RSpec.feature "Fields methods for each view", type: :feature do
     end
 
     it "shows only the specified fields for display views" do
+      # Store the original method
+      original_display_fields = Avo::Resources::Course.instance_method(:display_fields)
+
       Avo::Resources::Course.class_eval do
         def display_fields
           field :id, as: :id
@@ -102,12 +105,16 @@ RSpec.feature "Fields methods for each view", type: :feature do
       expect(page).not_to have_selector 'turbo-frame[id="has_many_field_show_links"]'
 
 
+      # Restore the original method
       Avo::Resources::Course.class_eval do
-        remove_method :display_fields
+        define_method(:display_fields, original_display_fields)
       end
     end
 
     it "shows only the specified fields for form views" do
+      # Store the original method
+      original_form_fields = Avo::Resources::Course.instance_method(:form_fields)
+
       Avo::Resources::Course.class_eval do
         def form_fields
           field :name, as: :text
@@ -138,9 +145,9 @@ RSpec.feature "Fields methods for each view", type: :feature do
       expect(page).not_to have_css "[data-field-id='city']"
       expect(page).not_to have_selector 'turbo-frame[id="has_many_field_show_links"]'
 
-
+      # Restore the original method
       Avo::Resources::Course.class_eval do
-        remove_method :form_fields
+        define_method(:form_fields, original_form_fields)
       end
     end
   end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2403 

The detach button request has been updated to no longer hydrate the resource using the `destroy` view, as it was identified as a problematic approach when using `def display_fields` or `def form_fields` API since those methods wouldn't get called. 

To address this, we have modified the process to include passing the current view as parameters during the detach request. This ensures that the appropriate view is properly hydrated into the resource.


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)~
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

### Before
[before.webm](https://github.com/avo-hq/avo/assets/69730720/7696b801-fed5-4c8b-bdc4-dd69accbc923)

### After
[after.webm](https://github.com/avo-hq/avo/assets/69730720/4b12ce52-f9d0-4c3b-8a7c-cf1ee9a35cbb)

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Set a resource with an association field using only `def display_fields` and `def form_fields` API
2. Visit resource's show view
3. Detach a record from the association field
4. Before was raising error, notice that now it works.

