### PR TITLE
Use Rails.application.secret_key_base directly

### DIFF
--- a/lib/avo/services/encryption_service.rb
+++ b/lib/avo/services/encryption_service.rb
@@ -32,15 +32,11 @@ module Avo
       private
 
       def encryption_key
-        secret_key_base[0..31]
+        Rails.application.secret_key_base[0..31]
       rescue
         # This will fail the decryption process.
         # It's here only to keep Avo from crashing
         SecureRandom.random_bytes(32)
-      end
-
-      def secret_key_base
-        ENV["SECRET_KEY_BASE"] || Rails.application.credentials.secret_key_base || Rails.application.secrets.secret_key_base
       end
     end
   end


### PR DESCRIPTION
This helps avoid the rails 7.1 deprecation warning about using `Rails.application.secrets` when no secret key base is explicitly configured, when `Rails.env.local? || ENV["SECRET_KEY_BASE_DUMMY"]`

# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
