### PR TITLE
refactor: new tool paths

### DIFF
--- a/lib/generators/avo/tool_generator.rb
+++ b/lib/generators/avo/tool_generator.rb
@@ -33,17 +33,25 @@ module Generators
         # Add view file
         template "tool/view.tt", "app/views/avo/tools/#{file_name}.html.erb"
 
-        if ::Avo.configuration.root_path == ""
-          route <<-ROUTE
-  get "#{file_name}", to: "avo/tools##{file_name}"
-          ROUTE
-        else
-          route <<-ROUTE
-scope :#{::Avo.configuration.namespace} do
-  get "#{file_name}", to: "avo/tools##{file_name}"
+        # Add the route in the `routes.rb` file.
+        # The route should be defined inside the Avo engine.
+        # The new tool has a dedicated path helper.
+        # EX:
+        #   bin/rails generate avo:tool lolo
+        #   will generate the avo.lolo_path helper
+        # THe fact that it will always generate the definded? and Avo::Engine.routes.draw wraps is unfortunate. We'd love a PR to fix that.
+        route_contents = <<-ROUTE
+
+if defined? ::Avo
+  Avo::Engine.routes.draw do
+    get "#{file_name}", to: "avo/tools##{file_name}", as: :#{file_name}
+  end
 end
-          ROUTE
-        end
+        ROUTE
+        append_to_file "config/routes.rb", route_contents
+
+        # Restart the server so the new routes go into effect.
+        Rails::Command.invoke "restart"
       end
 
       no_tasks do

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   authenticate :user, ->(user) { user.is_admin? } do
     scope :admin do
-      get "custom_tool", to: "avo/tools#custom_tool"
+      get "custom_tool", to: "avo/tools#custom_tool", as: :custom_tool
     end
 
     mount Avo::Engine, at: Avo.configuration.root_path


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR changes the way the tool paths are generated. Instead of nesting inside the app's routes, we add them outside inside the Avo routes.

Now the tools have the proper path helpers too.

`bin/rails generate avo:tool lol` will generate the `avo.lol_path` helper.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
