### PR TITLE
refactor: sidebar remember scroll move to controller

### DIFF
--- a/app/javascript/avo.base.js
+++ b/app/javascript/avo.base.js
@@ -51,50 +51,13 @@ function initTippy() {
   })
 }
 
-// Detect whether an element is in view inside a parent element.
-// Original here: https://gist.github.com/jjmu15/8646226
-function isInViewport(element, parentElement) {
-  const rect = element.getBoundingClientRect()
-  const html = document.documentElement
-  const parent = parentElement.getBoundingClientRect()
-
-  return (
-    rect.top >= 0
-    && rect.left >= 0
-    && rect.bottom <= (parent.height || window.innerHeight || html.clientHeight)
-    && rect.right <= (parent.width || window.innerWidth || html.clientWidth)
-  )
-}
-
-// Used on initial page load to scroll to the first active sidebar item if it's not in view.
-function scrollSidebarMenuItemIntoView() {
-  const activeSidebarItem = document.querySelector('.avo-sidebar .mac-styled-scrollbar a.active')
-  const sidebarScrollingArea = document.querySelector('.avo-sidebar .mac-styled-scrollbar')
-  if (!isInViewport(activeSidebarItem, sidebarScrollingArea)) {
-    activeSidebarItem.scrollIntoView({ block: 'end', inline: 'nearest' })
-  }
-}
-
 window.initTippy = initTippy
 
 ActiveStorage.start()
 
-let sidebarScrollPosition = null
-
 document.addEventListener('turbo:load', () => {
   initTippy()
   isMac()
-  if (window.Avo.configuration.focus_sidebar_menu_item) {
-    scrollSidebarMenuItemIntoView()
-  }
-
-  // Restore sidebar scroll position
-  if (sidebarScrollPosition && window.Avo.configuration.preserve_sidebar_scroll) {
-    document.querySelector('.avo-sidebar .mac-styled-scrollbar').scrollTo({
-      top: sidebarScrollPosition,
-      behavior: 'instant',
-    })
-  }
 
   // Restore scroll position after r r r turbo reload
   if (scrollTop) {
@@ -124,9 +87,6 @@ document.addEventListener('turbo:before-fetch-response', async (e) => {
 })
 
 document.addEventListener('turbo:visit', () => {
-  // Remeber sidebar scroll position before changing pages.
-  sidebarScrollPosition = document.querySelector('.avo-sidebar .mac-styled-scrollbar').scrollTop
-
   document.body.classList.add('turbo-loading')
 })
 document.addEventListener('turbo:submit-start', () => document.body.classList.add('turbo-loading'))

--- a/app/javascript/js/controllers/sidebar_controller.js
+++ b/app/javascript/js/controllers/sidebar_controller.js
@@ -2,6 +2,30 @@ import { Controller } from '@hotwired/stimulus'
 import { enter, leave, toggle } from 'el-transition'
 import Cookies from 'js-cookie'
 
+// Detect whether an element is in view inside a parent element.
+// Original here: https://gist.github.com/jjmu15/8646226
+function isInViewport(element, parentElement) {
+  const rect = element.getBoundingClientRect()
+  const html = document.documentElement
+  const parent = parentElement.getBoundingClientRect()
+
+  return (
+    rect.top >= 0
+    && rect.left >= 0
+    && rect.bottom <= (parent.height || window.innerHeight || html.clientHeight)
+    && rect.right <= (parent.width || window.innerWidth || html.clientWidth)
+  )
+}
+
+// Used on initial page load to scroll to the first active sidebar item if it's not in view.
+function scrollSidebarMenuItemIntoView() {
+  const activeSidebarItem = document.querySelector('.avo-sidebar .mac-styled-scrollbar a.active')
+  const sidebarScrollingArea = document.querySelector('.avo-sidebar .mac-styled-scrollbar')
+  if (!isInViewport(activeSidebarItem, sidebarScrollingArea)) {
+    activeSidebarItem.scrollIntoView({ block: 'end', inline: 'nearest' })
+  }
+}
+
 export default class extends Controller {
   static targets = ['sidebar', 'mobileSidebar', 'mainArea']
 
@@ -17,8 +41,48 @@ export default class extends Controller {
     return Cookies.get(this.cookieKey) === '1'
   }
 
+  get sidebarScrollPosition() {
+    return window.Avo.localStorage.get('sidebar.sidebarScrollPosition')
+  }
+
+  set sidebarScrollPosition(value) {
+    window.Avo.localStorage.set('sidebar.sidebarScrollPosition', value)
+  }
+
   set cookie(state) {
     Cookies.set(this.cookieKey, state === true ? 1 : 0)
+  }
+
+  initialize() {
+    this.rememberScrollPosition = this.rememberScrollPosition.bind(this)
+  }
+
+  connect() {
+    this.attachScrollVisibilityAnchor()
+
+    // Restore sidebar scroll position
+    if (this.sidebarScrollPosition && window.Avo.configuration.preserve_sidebar_scroll) {
+      document.querySelector('.avo-sidebar .mac-styled-scrollbar').scrollTo({
+        top: this.sidebarScrollPosition,
+        behavior: 'instant',
+      })
+    }
+    document.addEventListener('turbo:visit', this.rememberScrollPosition)
+  }
+
+  disconnect() {
+    document.removeEventListener('turbo:visit', this.rememberScrollPosition)
+  }
+
+  rememberScrollPosition() {
+    // Remeber sidebar scroll position before changing pages.
+    this.sidebarScrollPosition = document.querySelector('.avo-sidebar .mac-styled-scrollbar').scrollTop
+  }
+
+  attachScrollVisibilityAnchor() {
+    if (window.Avo.configuration.focus_sidebar_menu_item) {
+      scrollSidebarMenuItemIntoView()
+    }
   }
 
   markSidebarClosed() {

--- a/app/javascript/js/controllers/sidebar_controller.js
+++ b/app/javascript/js/controllers/sidebar_controller.js
@@ -53,10 +53,6 @@ export default class extends Controller {
     Cookies.set(this.cookieKey, state === true ? 1 : 0)
   }
 
-  initialize() {
-    this.rememberScrollPosition = this.rememberScrollPosition.bind(this)
-  }
-
   connect() {
     this.attachScrollVisibilityAnchor()
 
@@ -67,16 +63,18 @@ export default class extends Controller {
         behavior: 'instant',
       })
     }
-    document.addEventListener('turbo:visit', this.rememberScrollPosition)
-  }
-
-  disconnect() {
-    document.removeEventListener('turbo:visit', this.rememberScrollPosition)
+    this.rememberScrollPosition()
   }
 
   rememberScrollPosition() {
-    // Remeber sidebar scroll position before changing pages.
-    this.sidebarScrollPosition = document.querySelector('.avo-sidebar .mac-styled-scrollbar').scrollTop
+    let handler
+
+    document.addEventListener('turbo:visit', handler = () => {
+      // Remeber sidebar scroll position before changing pages.
+      this.sidebarScrollPosition = document.querySelector('.avo-sidebar .mac-styled-scrollbar').scrollTop
+      // remove event handler after disconnection
+      document.removeEventListener('turbo:visit', handler)
+    })
   }
 
   attachScrollVisibilityAnchor() {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/2414

This is mainly a refactor to move some global JS code to a StimulusJS controller.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

