### PR TITLE
fix: searchable belongs_to field keep html tags on selected option

### DIFF
--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -208,7 +208,7 @@ export default class extends Controller {
   handleOnSelect({ item }) {
     if (this.isBelongsToSearch) {
       this.updateFieldAttribute(this.hiddenIdTarget, 'value', item._id)
-      this.updateFieldAttribute(this.buttonTarget, 'value', item._label)
+      this.updateFieldAttribute(this.buttonTarget, 'value', this.removeHTMLTags(item._label))
 
       document.querySelector('.aa-DetachedOverlay').remove()
 
@@ -315,5 +315,11 @@ export default class extends Controller {
   updateFieldAttribute(target, attribute, value) {
     target.setAttribute(attribute, value)
     target.dispatchEvent(new Event('input'))
+  }
+
+  removeHTMLTags(str) {
+    const doc = new DOMParser().parseFromString(str, 'text/html')
+
+    return doc.body.textContent || ''
   }
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2416

Clear all HTML tags before updating the belongs_to searchable field with selected option.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording

### Before
![before](https://github.com/avo-hq/avo/assets/69730720/d095009d-0b2c-4b02-93fc-dc050d53f055)


### After
![after](https://github.com/avo-hq/avo/assets/69730720/c1a3070e-07eb-4644-b9cb-417563a5b6d0)

