### PR TITLE
feature: edit has one associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ Avo is a beautiful next-generation framework that empowers you, the developer, t
   - **Mobile interface** - Check your data on the go from any mobile device.
   - **Tabbed interface** - Conditionally show the data you need
   - **Menu builder** - Group and surface information as you need to
-  - **Branding** - Make it look
+  - **Branding** - Make it look like your brand
+  - **Scopes** - Segment your records
+  - **Dynamic filters** - Enable your users to take control of record filtering
 
 ## Some of the things we're going to focus on next
 
-Theming ⭐️  &nbsp;notifications ⭐️  &nbsp;Resource segmentation ⭐️  &nbsp;filterable fields ⭐️  &nbsp;inline editing ⭐️  &nbsp;multilingual records ⭐️  &nbsp;keyboard shortcuts ⭐️  &nbsp;track resource changes ⭐️  &nbsp;smart resource generation ⭐️  &nbsp;live resources ⭐️  &nbsp;columns view ⭐️  &nbsp;list view ⭐️  &nbsp;custom action items ⭐️  &nbsp;command bar ⭐️  &nbsp; use fields DSL in your custom views
+Theming ⭐️  &nbsp;notifications ⭐️  &nbsp;inline editing ⭐️  &nbsp;multilingual records ⭐️  &nbsp;keyboard shortcuts ⭐️  &nbsp;track resource changes ⭐️  &nbsp;live resources ⭐️  &nbsp;columns view ⭐️  &nbsp;list view ⭐️  &nbsp;command bar
 
 For more up-to-date info check out our 🗺 [Roadmap](https://github.com/orgs/avo-hq/projects/3).
 

--- a/app/components/avo/fields/has_one_field/edit_component.html.erb
+++ b/app/components/avo/fields/has_one_field/edit_component.html.erb
@@ -1,0 +1,40 @@
+
+!!!!!!!!!
+
+<% # import the form from that resource %>
+
+<%#= abort [form, field, resource].inspect %>
+<%
+resource_user = field.target_resource.new(record: field.value, view: field.view, user: field.user).detect_fields
+ %>
+<% resource_user.only_fields(only_root: true).inspect %>
+<%#= field.target_resource.only_fields(only_root: true).inspect %>
+      <% resource_user.only_fields(only_root: true).each_with_index do |item, index| %>
+        <%= render Avo::Items::SwitcherComponent.new(
+          resource: @resource,
+          reflection: @reflection,
+          item: item,
+          index: index + 1,
+          view: @view,
+          parent_resource: @parent_resource,
+          parent_record: @parent_record,
+          form: form,
+          parent_component: self,
+          actions: @actions
+        ) %>
+      <% end %>
+<%# Avo::Views::ResourceEditComponent.new(resource: resource, record: resource.record, actions: [], view: "edit", display_breadcrumbs: true) %>
+
+<%#= field.component_for_view(:edit).new(
+  resource: resource,
+  record: resource.record,
+  actions: [],
+  view: "edit",
+  display_breadcrumbs: true,
+  field: field,
+  index: 0,
+  # form: form,
+  # compact: false,
+  # stacked: nil,
+  # multiple: false
+  ) %>

--- a/app/components/avo/fields/has_one_field/edit_component.rb
+++ b/app/components/avo/fields/has_one_field/edit_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Avo::Fields::HasOneField::EditComponent < Avo::Fields::EditComponent
+end

--- a/lib/avo/fields/has_base_field.rb
+++ b/lib/avo/fields/has_base_field.rb
@@ -77,13 +77,14 @@ module Avo
         false
       end
 
+      # TODO: mind this. we might need to bring it back
       # Adds the view override component
       # has_one, has_many, has_and_belongs_to_many fields don't have edit views
-      def component_for_view(view = Avo::ViewInquirer.new("index"))
-        view = Avo::ViewInquirer.new("show") if view.in? %w[new create update edit]
+      # def component_for_view(view = Avo::ViewInquirer.new("index"))
+      #   # view = Avo::ViewInquirer.new("show") if view.in? %w[new create update edit]
 
-        super view
-      end
+      #   super view
+      # end
 
       def authorized?
         method = "view_#{id}?".to_sym

--- a/lib/avo/fields/has_one_field.rb
+++ b/lib/avo/fields/has_one_field.rb
@@ -4,7 +4,7 @@ module Avo
       attr_accessor :relation_method
 
       def initialize(id, **args, &block)
-        hide_on :forms
+        # hide_on :forms
 
         super(id, **args, &block)
 

--- a/spec/dummy/app/avo/resources/team.rb
+++ b/spec/dummy/app/avo/resources/team.rb
@@ -68,22 +68,22 @@ class Avo::Resources::Team < Avo::BaseResource
       end
     end
 
-    field :memberships,
-      as: :has_many,
-      searchable: true,
-      filterable: true,
-      attach_scope: -> do
-        query.where.not(user_id: parent.id).or(query.where(user_id: nil))
-      end
-
     field :admin, as: :has_one
-    field :team_members, as: :has_many, through: :memberships, translation_key: "avo.resource_translations.team_members"
-    field :reviews, as: :has_many
+    # field :memberships,
+    #   as: :has_many,
+    #   searchable: true,
+    #   filterable: true,
+    #   attach_scope: -> do
+    #     query.where.not(user_id: parent.id).or(query.where(user_id: nil))
+    #   end
 
-    if params[:show_location_field] == '1'
-      # Example for error message when resource is missing
-      field :locations, as: :has_many
-    end
+    # field :team_members, as: :has_many, through: :memberships, translation_key: "avo.resource_translations.team_members"
+    # field :reviews, as: :has_many
+
+    # if params[:show_location_field] == '1'
+    #   # Example for error message when resource is missing
+    #   field :locations, as: :has_many
+    # end
   end
 
   def filters

--- a/spec/dummy/app/models/team.rb
+++ b/spec/dummy/app/models/team.rb
@@ -19,6 +19,7 @@ class Team < ApplicationRecord
 
   has_one :admin_membership, -> { where level: :admin }, class_name: "TeamMembership", dependent: :destroy
   has_one :admin, through: :admin_membership, source: :user, inverse_of: :teams
+  accepts_nested_attributes_for :admin
 
   has_many :reviews, as: :reviewable
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This is an exploration of how we could edit one association from the parent edit screen.
Useful for those `User->has_one->Profile` scenarios.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

https://github.com/avo-hq/avo/assets/1334409/b27039e2-b503-4828-92f0-5e30cd0f7fcb


