### PR TITLE
✨ feat. reload table / relationships

### DIFF
--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -282,6 +282,18 @@ class Avo::ResourceComponent < Avo::BaseComponent
     end
   end
 
+  def render_reload_button(control)
+    # return unless can_see_the_create_button?
+
+    a_button color: :primary,
+      style: :text,
+      type: :button,
+      onclick: "this.closest('turbo-frame').reload()",
+      icon: "heroicons/outline/arrow-path" do
+      control.label
+    end
+  end
+
   def render_link_to(link)
     a_link link.path,
       color: link.color,

--- a/lib/avo/concerns/has_controls.rb
+++ b/lib/avo/concerns/has_controls.rb
@@ -20,7 +20,10 @@ module Avo
       end
 
       def render_index_controls(item:)
-        [AttachButton.new(item: item), ActionsList.new(as_index_control: true), CreateButton.new(item: item)]
+        [
+          AttachButton.new(item: item), ActionsList.new(as_index_control: true),
+          ReloadButton.new(item: item), CreateButton.new(item: item)
+        ]
       end
 
       def render_row_controls(item:)

--- a/lib/avo/resources/controls/reload_button.rb
+++ b/lib/avo/resources/controls/reload_button.rb
@@ -1,0 +1,15 @@
+module Avo
+  module Resources
+    module Controls
+      class ReloadButton < BaseControl
+        def initialize(**args)
+          super(**args)
+
+          if args[:item].present?
+            @label = I18n.t("avo.reload_items", item: args[:item].humanize(capitalize: false)) if label.nil?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/avo/templates/locales/avo.ar.yml
+++ b/lib/generators/avo/templates/locales/avo.ar.yml
@@ -10,6 +10,7 @@ ar:
     attach: ربط
     attach_and_attach_another: ربط وربط آخر
     attach_item: ربط %{item}
+    reload_items: إعادة تحميل %{item}
     attachment_class_attached: "%{attachment_class} تم ربط"
     attachment_class_detached: "%{attachment_class} تم فصل"
     attachment_destroyed: تم حذف المرفق

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -10,6 +10,7 @@ en:
     attach: Attach
     attach_and_attach_another: Attach & Attach another
     attach_item: Attach %{item}
+    reload_items: Reload %{item}
     attachment_class_attached: "%{attachment_class} attached."
     attachment_class_detached: "%{attachment_class} detached."
     attachment_destroyed: Attachment destroyed

--- a/lib/generators/avo/templates/locales/avo.es.yml
+++ b/lib/generators/avo/templates/locales/avo.es.yml
@@ -10,6 +10,7 @@ es:
     attach: Adjuntar
     attach_and_attach_another: Adjuntar y adjuntar otro
     attach_item: Adjuntar %{item}
+    reload_items: Recargar %{item}
     attachment_class_attached: "%{attachment_class} adjuntado/a."
     attachment_class_detached: "%{attachment_class} adjuntado/a."
     attachment_destroyed: Adjunto eliminado

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -10,6 +10,7 @@ fr:
     attach: Attacher
     attach_and_attach_another: joindre et joindre un autre
     attach_item: Attacher %{item}
+    reload_items: Recharger %{item}
     attachment_class_attached: "%{attachment_class} attaché."
     attachment_class_detached: "%{attachment_class} détaché."
     attachment_destroyed: Pièce jointe détruite

--- a/lib/generators/avo/templates/locales/avo.ja.yml
+++ b/lib/generators/avo/templates/locales/avo.ja.yml
@@ -9,6 +9,7 @@ ja:
     attach: 添付
     attach_and_attach_another: アタッチして別のものをアタッチ
     attach_item: "%{item}をアタッチ"
+    reload_items: "%{item} リロード"
     attachment_class_attached: "%{attachment_class}をアタッチしました。"
     attachment_class_detached: "%{attachment_class}をデタッチしました。"
     attachment_destroyed: アタッチは削除されました

--- a/lib/generators/avo/templates/locales/avo.nb.yml
+++ b/lib/generators/avo/templates/locales/avo.nb.yml
@@ -10,6 +10,7 @@ nb:
     attach: Legg til
     attach_and_attach_another: Legg til & Legg til ny
     attach_item: Legg til %{item}
+    reload_items: Last inn på nytt %{item}
     attachment_class_attached: "%{attachment_class} lagt til."
     attachment_class_detached: "%{attachment_class} fjernet."
     attachment_destroyed: Vedlett slettet

--- a/lib/generators/avo/templates/locales/avo.nn.yml
+++ b/lib/generators/avo/templates/locales/avo.nn.yml
@@ -10,6 +10,7 @@ nn:
     attach: Legg til
     attach_and_attach_another: Legg til & Legg til ny
     attach_item: Legg til %{item}
+    reload_items: Last inn på nytt %{item}
     attachment_class_attached: "%{attachment_class} lagt til."
     attachment_class_detached: "%{attachment_class} fjerna."
     attachment_destroyed: Vedlegg sletta

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -10,6 +10,7 @@ pt-BR:
     attach: Anexar
     attach_and_attach_another: Anexar & anexar outro
     attach_item: Anexar %{item}
+    reload_items: Recarregar %{item}
     attachment_class_attached: "%{attachment_class} anexado."
     attachment_class_detached: "%{attachment_class} separado."
     attachment_destroyed: Anexo destruído

--- a/lib/generators/avo/templates/locales/avo.pt.yml
+++ b/lib/generators/avo/templates/locales/avo.pt.yml
@@ -10,6 +10,7 @@ pt:
     attach: Anexar
     attach_and_attach_another: Anexar & anexar outro
     attach_item: Anexar %{item}
+    reload_items: Recarregar %{item}
     attachment_class_attached: "%{attachment_class} anexado."
     attachment_class_detached: "%{attachment_class} separado."
     attachment_destroyed: Anexo destruído

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -10,6 +10,7 @@ ro:
     attach: Atașează
     attach_and_attach_another: Atașează și atașează inca unul
     attach_item: Atașează %{item}
+    reload_items: Reîncărcați %{item}
     attachment_class_attached: "%{attachment_class} anexat."
     attachment_class_detached: "%{attachment_class} separat."
     attachment_destroyed: Atașamentul a fost distrus

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -10,6 +10,7 @@ tr:
     attach: İlişkilendir
     attach_and_attach_another: İlişkilendir & Bir başka daha İlişkilendir
     attach_item: "%{item} öğesini ilişkilendir"
+    reload_items: "%{item} tekrar yükle"
     attachment_class_attached: "%{attachment_class} ilişkilendirildi."
     attachment_class_detached: "%{attachment_class} ilişkisi kesildi."
     attachment_destroyed: Ek silindi


### PR DESCRIPTION
# Description
I've added a button to reload the content of a specific frame.
For example, I'm doing updates via console, or the user did something on his end, and I was to reload this specific relationship or table without refreshing the whole page; the button will find the nearest frame and reload it.

# Checklist:
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

# Notes:
I know that you guys prefer using stimulus controllers for these type of things, but I was not able to make it run with a controller looking like this:

```js
import { Controller } from '@hotwired/stimulus'
export default class extends Controller {
  get parentTurboFrame() {
    return this.context.scope.element.closest('turbo-frame')
  }

  refresh() {
    if (!this.parentTurboFrame.src) return
    this.parentTurboFrame.reload()
  }
}
```