### PR TITLE
feature: override auto-generated data attributes

### DIFF
--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -72,6 +72,12 @@ class Avo::FieldWrapperComponent < ViewComponent::Base
       **@data
     }
 
+    # Fetch the data attributes off the html option
+    wrapper_data_attributes = @field.get_html :data, view: view, element: :wrapper
+    if wrapper_data_attributes.present?
+      attributes.merge! wrapper_data_attributes
+    end
+
     # Add the built-in stimulus integration data tags.
     if @resource.present?
       add_stimulus_attributes_for(@resource, attributes)
@@ -79,12 +85,6 @@ class Avo::FieldWrapperComponent < ViewComponent::Base
 
     if @action.present?
       add_stimulus_attributes_for(@action, attributes)
-    end
-
-    # Fetch the data attributes off the html option
-    wrapper_data_attributes = @field.get_html :data, view: view, element: :wrapper
-    if wrapper_data_attributes.present?
-      attributes.merge! wrapper_data_attributes
     end
 
     attributes


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

If a user added a `data` attribute to a wrapper that Avo already generated for it from the `slef.stimulus_controllers` DSL, it will not be used. Only Avo's will be displayed.

From [here](https://discord.com/channels/740892036978442260/740893011994738751/1201589913125146755)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. On a resource add the following
```ruby
self.stimulus_controllers = ["foo"]

field :name, as: :text, html: {
  edit: {
    wrapper: {
      data: {
        foo_target: "bar baz"
      }
    }
  }
```

2. Before the output on the wrapper element would have been `data-foo-target="nameTextWrapper"`, now it's `data-foo-target="bar baz"`.

Manual reviewer: please leave a comment with output from the test if that's the case.
