### PR TITLE
Make default of `:attachments_disabled` context-aware.

### DIFF
--- a/lib/avo/fields/trix_field.rb
+++ b/lib/avo/fields/trix_field.rb
@@ -14,8 +14,8 @@ module Avo
         hide_on :index
 
         @always_show = args[:always_show] || false
-        @attachments_disabled = args[:attachments_disabled] || false
         @attachment_key = args[:attachment_key]
+        @attachments_disabled = args[:attachments_disabled] || !@attachment_key.present?
         @hide_attachment_filename = args[:hide_attachment_filename] || false
         @hide_attachment_filesize = args[:hide_attachment_filesize] || false
         @hide_attachment_url = args[:hide_attachment_url] || false

--- a/lib/avo/fields/trix_field.rb
+++ b/lib/avo/fields/trix_field.rb
@@ -15,7 +15,10 @@ module Avo
 
         @always_show = args[:always_show] || false
         @attachment_key = args[:attachment_key]
-        @attachments_disabled = args[:attachments_disabled] || !@attachment_key.present?
+        # If we don't have an attachment_key, we disable attachments.  There's no point in having
+        # attachments if we can't store them.
+        @attachments_disabled = args[:attachments_disabled] || true
+        @attachments_disabled = false unless @attachment_key.present?
         @hide_attachment_filename = args[:hide_attachment_filename] || false
         @hide_attachment_filesize = args[:hide_attachment_filesize] || false
         @hide_attachment_url = args[:hide_attachment_url] || false


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2389 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

