### PR TITLE
Stop file field from hiding filename

### DIFF
--- a/app/components/avo/fields/common/files/view_type/grid_item_component.html.erb
+++ b/app/components/avo/fields/common/files/view_type/grid_item_component.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= dom_id file %>" class="relative min-h-full max-w-full flex-1 flex flex-col justify-between space-y-2">
   <% if file.present? %>
-    <div class="flex h-full">
+    <div class="flex flex-col h-full">
       <% if file.representable? && is_image? %>
         <%= image_tag helpers.main_app.url_for(file), class: "rounded-lg max-w-full #{@extra_classes}" %>
       <% elsif is_audio? %>


### PR DESCRIPTION

# Description

On main, even if you choose to display filenames, filenames are hidden for file fields on avo 3.x. This is happening because the parent flexbox is set to flex row and truncate css class was truncating the text down to 0 width.

To fix this I've made the parent flexbox use flex-col, which puts the filename underneath the image (as it was in avo 2.x) so it doesn't get truncated and can be seen.

Fixes # (issue)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

Before it looks like this:

![Screenshot 2024-01-30 at 16 37 58](https://github.com/avo-hq/avo/assets/111963/5f3c0308-5311-43b9-bddf-a429a68365a8)

On this branch it looks like this:

![Screenshot 2024-01-30 at 16 39 01](https://github.com/avo-hq/avo/assets/111963/9bdbda73-c348-441c-8b73-d35e26f4db99)

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Find a resource with a files component and set `display_filename: true` is set to `true`
2. View it in the browser and confirm that the filename isn't visible
3. Switch to this branch
4. Confirm that the filename is visible now.

Manual reviewer: please leave a comment with output from the test if that's the case.
