### PR TITLE
feature: expose resource in resource tools intializers

### DIFF
--- a/lib/avo/base_resource_tool.rb
+++ b/lib/avo/base_resource_tool.rb
@@ -5,17 +5,24 @@ module Avo
     include Avo::Concerns::HasItemType
     include Avo::Concerns::IsVisible
     include Avo::Concerns::VisibleInDifferentViews
+    include Avo::Concerns::Hydration
 
     class_attribute :name
     class_attribute :partial
 
     attr_accessor :params
+    attr_accessor :parent
+    attr_accessor :resource
+    attr_accessor :view
 
     def initialize(**args)
       # Set the visibility
       only_on Avo.configuration.resource_default_view
 
       @args = args
+      @parent = args[:parent]
+      @resource = args[:parent]
+      @view = args[:view]
 
       post_initialize if respond_to?(:post_initialize)
     end

--- a/lib/avo/concerns/has_items.rb
+++ b/lib/avo/concerns/has_items.rb
@@ -192,24 +192,6 @@ module Avo
         end
       end
 
-      def tools
-        return [] if self.class.tools.blank?
-
-        items
-          .select do |item|
-            next if item.nil?
-
-            item.is_tool?
-          end
-          .map do |tool|
-            tool.hydrate view: view
-            tool
-          end
-          .select do |item|
-            item.visible_in_view?(view: view)
-          end
-      end
-
       def get_items
         # Each group is built only by standalone items or items that have their own panel, keeping the items order
         grouped_items = visible_items.slice_when do |prev, curr|

--- a/lib/avo/resources/items/holder.rb
+++ b/lib/avo/resources/items/holder.rb
@@ -1,5 +1,5 @@
 class Avo::Resources::Items::Holder
-  attr_reader :tools, :from
+  attr_reader :tools, :from, :parent
   attr_accessor :items
   attr_accessor :invalid_fields
 
@@ -54,7 +54,7 @@ class Avo::Resources::Items::Holder
   end
 
   def tool(klass, **args)
-    add_item klass.new(**args)
+    add_item klass.new(**args, view: self.parent.view, parent: self.parent)
   end
 
   def panel(panel_name = nil, **args, &block)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avodocs/issues/163

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Try to use the `resource`, `parent`, and `view` in a resource tool initializer.

```ruby
class Avo::ResourceTools::FishInformation < Avo::BaseResourceTool
  def initialize(**kwargs)
    super(**kwargs)

    abort [parent.class, resource.class, view].inspect # 👈 these objects are available in the initializer
  end
end
```

Manual reviewer: please leave a comment with output from the test if that's the case.
