### PR TITLE
fix: detach when using view *_fields api

### DIFF
--- a/app/components/avo/index/resource_controls_component.rb
+++ b/app/components/avo/index/resource_controls_component.rb
@@ -182,7 +182,7 @@ class Avo::Index::ResourceControlsComponent < Avo::ResourceComponent
     hidden = {}
 
     hidden[:view_type] = params[:view_type] if params[:view_type]
-    hidden[:view] = resource.view.to_s
+    hidden[:view] = parent_resource&.view&.to_s
 
     if params[:turbo_frame]
       hidden[:turbo_frame] = params[:turbo_frame]

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -101,7 +101,7 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
   def attach_path
     current_path = CGI.unescape(request.env["PATH_INFO"]).split("/").select(&:present?)
 
-    Avo.root_path(paths: [*current_path, "new"])
+    Avo.root_path(paths: [*current_path, "new"], query: { view: @parent_resource&.view&.to_s })
   end
 
   def singular_resource_name

--- a/spec/dummy/app/avo/resources/course.rb
+++ b/spec/dummy/app/avo/resources/course.rb
@@ -6,12 +6,24 @@ class Avo::Resources::Course < Avo::BaseResource
   self.stimulus_controllers = "city-in-country toggle-fields"
 
 
-  def display_fields
+  def links
+    field :links, as: :has_many, searchable: true, placeholder: "Click to choose a link",
+      discreet_pagination: true
+  end
+
+  def show_fields
+    fields_bag
+    links
+  end
+
+  def index_fields
     fields_bag
   end
 
   def form_fields
     fields_bag
+    # TODO: figure out why links should be here to attach
+    links
   end
 
   def fields_bag
@@ -93,9 +105,6 @@ class Avo::Resources::Course < Avo::BaseResource
       as: :select,
       options: Course.cities.values.flatten.map { |city| [city, city] }.to_h,
       display_value: false
-
-    field :links, as: :has_many, searchable: true, placeholder: "Click to choose a link",
-      discreet_pagination: true
 
     if params[:show_location_field] == '1'
       # Example for error message when resource is missing

--- a/spec/dummy/app/avo/resources/course.rb
+++ b/spec/dummy/app/avo/resources/course.rb
@@ -22,8 +22,6 @@ class Avo::Resources::Course < Avo::BaseResource
 
   def form_fields
     fields_bag
-    # TODO: figure out why links should be here to attach
-    links
   end
 
   def fields_bag

--- a/spec/dummy/app/avo/resources/course.rb
+++ b/spec/dummy/app/avo/resources/course.rb
@@ -5,15 +5,10 @@ class Avo::Resources::Course < Avo::BaseResource
   self.keep_filters_panel_open = true
   self.stimulus_controllers = "city-in-country toggle-fields"
 
-
-  def links
-    field :links, as: :has_many, searchable: true, placeholder: "Click to choose a link",
-      discreet_pagination: true
-  end
-
   def show_fields
     fields_bag
-    links
+    field :links, as: :has_many, searchable: true, placeholder: "Click to choose a link",
+      discreet_pagination: true
   end
 
   def index_fields

--- a/spec/features/avo/discreet_pagination_spec.rb
+++ b/spec/features/avo/discreet_pagination_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "DiscreetPagination", type: :feature do
 
       describe "with one page" do
         it "should not have pagination" do
-          visit "/admin/resources/courses/#{course_with_one_page_of_links.id}/links?turbo_frame=has_many_field_show_links"
+          visit "/admin/resources/courses/#{course_with_one_page_of_links.id}/links?turbo_frame=has_many_field_show_links&view=show"
           wait_for_loaded
 
           expect(current_path).to eql "/admin/resources/courses/#{course_with_one_page_of_links.id}/links"
@@ -22,7 +22,7 @@ RSpec.describe "DiscreetPagination", type: :feature do
 
       describe "with two pages" do
         it "should have pagination" do
-          visit "/admin/resources/courses/#{course_with_two_pages_of_links.id}/links?turbo_frame=has_many_field_show_links"
+          visit "/admin/resources/courses/#{course_with_two_pages_of_links.id}/links?turbo_frame=has_many_field_show_links&view=show"
           wait_for_loaded
 
           expect(current_path).to eql "/admin/resources/courses/#{course_with_two_pages_of_links.id}/links"

--- a/spec/features/avo/fields_methods_for_views_spec.rb
+++ b/spec/features/avo/fields_methods_for_views_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature "Fields methods for each view", type: :feature do
-  let!(:course) { create :course }
+  let!(:links) { create_list :course_link, 3 }
+  let!(:course) { create :course, links: links }
 
   context "with `fields` declaration" do
     it "shows all the fields" do
@@ -158,6 +159,14 @@ RSpec.feature "Fields methods for each view", type: :feature do
       Avo::Resources::Course.class_eval do
         define_method(:form_fields, original_form_fields)
       end
+    end
+
+    it "detach works using show and index fields api" do
+      visit "#{Avo::Engine.routes.url_helpers.resources_course_path(course)}/links?turbo_frame=has_many_field_links&view=show"
+
+      expect {
+        find("tr[data-resource-id='#{course.links.first.to_param}'] [data-control='detach']").click
+      }.to change(course.links, :count).by(-1)
     end
   end
 end

--- a/spec/features/avo/fields_methods_for_views_spec.rb
+++ b/spec/features/avo/fields_methods_for_views_spec.rb
@@ -20,6 +20,8 @@ RSpec.feature "Fields methods for each view", type: :feature do
 
   context "with `view_fields` declaration" do
     it "shows only the specified fields for show view" do
+      original_show_fields = Avo::Resources::Course.instance_method(:show_fields)
+
       Avo::Resources::Course.class_eval do
         def show_fields
           field :name, as: :text
@@ -40,11 +42,13 @@ RSpec.feature "Fields methods for each view", type: :feature do
       expect(page).not_to have_selector 'turbo-frame[id="has_many_field_show_links"]'
 
       Avo::Resources::Course.class_eval do
-        remove_method :show_fields
+        define_method(:show_fields, original_show_fields)
       end
     end
 
     it "shows only the specified fields for index view" do
+      original_index_fields = Avo::Resources::Course.instance_method(:index_fields)
+
       Avo::Resources::Course.class_eval do
         def index_fields
           field :id, as: :id
@@ -64,15 +68,19 @@ RSpec.feature "Fields methods for each view", type: :feature do
       expect(page).not_to have_selector 'turbo-frame[id="has_many_field_show_links"]'
 
       Avo::Resources::Course.class_eval do
-        remove_method :index_fields
+        define_method(:index_fields, original_index_fields)
       end
     end
 
     it "shows only the specified fields for display views" do
       # Store the original method
-      original_display_fields = Avo::Resources::Course.instance_method(:display_fields)
+      original_show_fields = Avo::Resources::Course.instance_method(:show_fields)
+      original_index_fields = Avo::Resources::Course.instance_method(:index_fields)
 
       Avo::Resources::Course.class_eval do
+        remove_method :show_fields
+        remove_method :index_fields
+
         def display_fields
           field :id, as: :id
           field :name, as: :text
@@ -107,7 +115,8 @@ RSpec.feature "Fields methods for each view", type: :feature do
 
       # Restore the original method
       Avo::Resources::Course.class_eval do
-        define_method(:display_fields, original_display_fields)
+        define_method(:show_fields, original_show_fields)
+        define_method(:index_fields, original_index_fields)
       end
     end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2403

[This PR](https://github.com/avo-hq/avo/pull/2415) is fetching the view from the `resource` when it should fetch the view from the `parent_resource` because fields will be evaluated on the parent resource when detaching.

It also fixes the need to add a association field on `form_fields` in order to attach.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
