### PR TITLE
feature: added a preview when editing/creating images, video or audio

### DIFF
--- a/app/components/avo/fields/common/files/view_type/grid_item_component.html.erb
+++ b/app/components/avo/fields/common/files/view_type/grid_item_component.html.erb
@@ -2,11 +2,11 @@
   <% if file.present? %>
     <div class="flex h-full">
       <% if file.representable? && is_image? %>
-        <%= image_tag helpers.main_app.url_for(file), class: "rounded-lg max-w-full #{@extra_classes}" %>
+        <%= image_tag helpers.main_app.url_for(file), "data-file-field-target": "preview", class: "rounded-lg max-w-full #{@extra_classes}" %>
       <% elsif is_audio? %>
-        <%= audio_tag(helpers.main_app.url_for(file), controls: true, preload: false, class: 'w-full') %>
+        <%= audio_tag(helpers.main_app.url_for(file), "data-file-field-target": "preview", controls: true, preload: false, class: 'w-full') %>
       <% elsif is_video? %>
-        <%= video_tag(helpers.main_app.url_for(file), controls: true, preload: false, class: 'w-full') %>
+        <%= video_tag(helpers.main_app.url_for(file), "data-file-field-target": "preview", controls: true, preload: false, class: 'w-full') %>
       <% else %>
         <div class="relative flex flex-col justify-evenly items-center px-2 rounded-lg border bg-white border-gray-500 min-h-24">
           <div class="flex flex-col justify-center items-center w-full">

--- a/app/components/avo/fields/file_field/edit_component.html.erb
+++ b/app/components/avo/fields/file_field/edit_component.html.erb
@@ -1,20 +1,33 @@
 <%= field_wrapper **field_wrapper_args do %>
-  <% if @field.value.present? %>
+  <%= content_tag :div, data: {
+    controller: "file-field",
+  } do %>
     <div class="mb-2">
-      <%= render Avo::Fields::Common::Files::ViewType::GridItemComponent.new resource: @resource, field: @field %>
+      <% if @field.value.present? %>
+        <%= render Avo::Fields::Common::Files::ViewType::GridItemComponent.new resource: @resource, field: @field %>
+      <% elsif @field.is_image %>
+        <%= image_tag "", "data-file-field-target": "preview", class: "rounded-lg max-w-full" %>
+      <% elsif @field.is_audio %>
+        <%= audio_tag("", "data-file-field-target": "preview", controls: true, preload: false, class: 'w-full') %>
+      <% elsif @field.is_video %>
+        <%= video_tag("", "data-file-field-target": "preview", controls: true, preload: false, class: 'w-full') %>
+      <% end %>
     </div>
-  <% end %>
 
-  <% if can_upload_file? %>
-    <%= @form.file_field @field.id,
-      accept: @field.accept,
-      data: @field.get_html(:data, view: view, element: :input),
-      direct_upload: @field.direct_upload,
-      disabled: disabled?,
-      style: @field.get_html(:style, view: view, element: :input),
-      class: "w-full"
-    %>
-  <% else %>
-    —
+    <% if can_upload_file? %>
+      <%= @form.file_field @field.id,
+        accept: @field.accept,
+        data: {
+          action: "input->file-field#update",
+          **@field.get_html(:data, view: view, element: :input),
+        },
+        direct_upload: @field.direct_upload,
+        disabled: disabled?,
+        style: @field.get_html(:style, view: view, element: :input),
+        class: "w-full"
+      %>
+    <% else %>
+      —
+    <% end %>
   <% end %>
 <% end %>

--- a/app/javascript/js/controllers.js
+++ b/app/javascript/js/controllers.js
@@ -11,6 +11,7 @@ import CopyToClipboardController from './controllers/copy_to_clipboard_controlle
 import DashboardCardController from './controllers/dashboard_card_controller'
 import DateFieldController from './controllers/fields/date_field_controller'
 import EasyMdeController from './controllers/fields/easy_mde_controller'
+import FileFieldController from './controllers/fields/file_field_controller'
 import FilterController from './controllers/filter_controller'
 import HiddenInputController from './controllers/hidden_input_controller'
 import InputAutofocusController from './controllers/input_autofocus_controller'
@@ -76,6 +77,7 @@ application.register('belongs-to-field', BelongsToFieldController)
 application.register('code-field', CodeFieldController)
 application.register('date-field', DateFieldController)
 application.register('easy-mde', EasyMdeController)
+application.register('file-field', FileFieldController)
 application.register('key-value', KeyValueController)
 application.register('progress-bar-field', ProgressBarFieldController)
 application.register('reload-belongs-to-field', ReloadBelongsToFieldController)

--- a/app/javascript/js/controllers/fields/file_field_controller.js
+++ b/app/javascript/js/controllers/fields/file_field_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['preview']
+
+  update(e) {
+    const reader = new FileReader()
+    reader.onload = () => {
+      this.previewTarget.src = reader.result
+    }
+    reader.readAsDataURL(e.target.files[0])
+  }
+}

--- a/lib/avo/fields/file_field.rb
+++ b/lib/avo/fields/file_field.rb
@@ -5,6 +5,7 @@ module Avo
       attr_accessor :is_avatar
       attr_accessor :is_image
       attr_accessor :is_audio
+      attr_accessor :is_video
       attr_accessor :direct_upload
       attr_accessor :accept
       attr_reader :display_filename
@@ -15,6 +16,7 @@ module Avo
         @link_to_record = args[:link_to_record].present? ? args[:link_to_record] : false
         @is_avatar = args[:is_avatar].present? ? args[:is_avatar] : false
         @is_image = args[:is_image].present? ? args[:is_image] : @is_avatar
+        @is_video = args[:is_video].present? ? args[:is_video] : false
         @is_audio = args[:is_audio].present? ? args[:is_audio] : false
         @direct_upload = args[:direct_upload].present? ? args[:direct_upload] : false
         @accept = args[:accept].present? ? args[:accept] : nil


### PR DESCRIPTION
# Description

It adds a preview when adding an image/video/audio to a "file" field.

Note: a preview already exists when the record is created, but does not automatically update when you select another file. While my code works, I don't think it's the cleanest.

Some logic is duplicated between edit_component.html.erb (file field) and grid_item_component.html.erb.
grid_item_component references file_field_controller and I don't know if it's a bad practice. I also cannot think of a better way to do this as I don't use stimulus in my projects

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording

https://github.com/avo-hq/avo/assets/377682/f6d3cc4c-cfac-4595-b4a8-d967b52f122f

