### PR TITLE
🐛 Bypass protocol when using full link

### DIFF
--- a/app/components/avo/fields/text_field/index_component.html.erb
+++ b/app/components/avo/fields/text_field/index_component.html.erb
@@ -2,7 +2,11 @@
   <% if @field.as_html %>
     <%== @field.value %>
   <% elsif @field.protocol.present? %>
-    <%= link_to @field.value, "#{@field.protocol}:#{@field.value}" %>
+    <% if @field.protocol.to_sym == :link %>
+      <%= link_to @field.value, @field.value %>
+    <% else %>
+      <%= link_to @field.value, "#{@field.protocol}:#{@field.value}" %>
+    <% end %>
   <% else %>
     <%= link_to_if @field.link_to_record, @field.value, resource_view_path %>
   <% end %>

--- a/app/components/avo/fields/text_field/show_component.html.erb
+++ b/app/components/avo/fields/text_field/show_component.html.erb
@@ -2,7 +2,11 @@
   <% if @field.as_html %>
     <%== @field.value %>
   <% elsif @field.protocol.present? %>
-    <%= link_to @field.value, "#{@field.protocol}:#{@field.value}" %>
+    <% if @field.protocol.to_sym == :link %>
+      <%= link_to @field.value, @field.value %>
+    <% else %>
+      <%= link_to @field.value, "#{@field.protocol}:#{@field.value}" %>
+    <% end %>
   <% else %>
     <%= @field.value %>
   <% end %>


### PR DESCRIPTION
# Description
Adding `protocol: :link` to fields

Fixes # (issue)
Using a field with full url will never work unless we do a custom `as_html` ; adding `protocol: :link` should fix it