### PR TITLE
fix: fetch cards only when necessary

### DIFF
--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -287,8 +287,15 @@ module Avo
       fields
     end
 
-    def fields
-      # blank fields method
+    def fetch_cards
+      cards
+    end
+
+    # def fields / def cards
+    [:fields, :cards].each do |method_name|
+      define_method method_name do
+        # Empty method
+      end
     end
 
     [:action, :filter, :scope].each do |entity|


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Apply same logic that we use to fetch fields but on cards. We should fetch cards only when visiting a dashboard.

Related PR https://github.com/avo-hq/avo-dashboards/pull/31