### PR TITLE
fix: Trix field disable_attachments option unexpected behaviour

### DIFF
--- a/lib/avo/fields/trix_field.rb
+++ b/lib/avo/fields/trix_field.rb
@@ -15,8 +15,6 @@ module Avo
 
         @always_show = args[:always_show] || false
         @attachment_key = args[:attachment_key]
-        # If we don't have an attachment_key, we disable attachments.  There's no point in having
-        # attachments if we can't store them.
         @attachments_disabled = disable_attachments?(args)
         @hide_attachment_filename = args[:hide_attachment_filename] || false
         @hide_attachment_filesize = args[:hide_attachment_filesize] || false
@@ -26,6 +24,8 @@ module Avo
       private
 
       def disable_attachments?(args)
+        # If we don't have an attachment_key, we disable attachments. There's no point in having
+        # attachments if we can't store them.
         return false if args[:attachment_key].present?
 
         args[:attachments_disabled] == true

--- a/lib/avo/fields/trix_field.rb
+++ b/lib/avo/fields/trix_field.rb
@@ -17,11 +17,18 @@ module Avo
         @attachment_key = args[:attachment_key]
         # If we don't have an attachment_key, we disable attachments.  There's no point in having
         # attachments if we can't store them.
-        @attachments_disabled = args[:attachments_disabled] || true
-        @attachments_disabled = false unless @attachment_key.present?
+        @attachments_disabled = disable_attachments?(args)
         @hide_attachment_filename = args[:hide_attachment_filename] || false
         @hide_attachment_filesize = args[:hide_attachment_filesize] || false
         @hide_attachment_url = args[:hide_attachment_url] || false
+      end
+
+      private
+
+      def disable_attachments?(args)
+        return false if args[:attachment_key].present?
+
+        args[:attachments_disabled] == true
       end
     end
   end


### PR DESCRIPTION
# Description
This PR comes in order to fix a critical regression introduced by #2429 which changed 
```ruby
@attachments_disabled = args[:attachments_disabled] || false
```
by
```ruby
@attachments_disabled = args[:attachments_disabled] || true
@attachments_disabled = false unless @attachment_key.present?
```

Unfortunately this created an unexpected behaviour making `@attachments_disabled` always defaulting to `true`. Here is why:
```ruby
irb(main):001> args = {}
=> {}
irb(main):002> args[:attachments_disabled] = false
=> false
irb(main):003> @attachments_disabled = args[:attachments_disabled] || true
=> true
```
This has the side effect of breaking the attachment feature by always disabling it even when specifying an attachment key or manually set the `attachments_disabled` option to `false`.

This PR comes with a simple fix extracting the logic in a private method and validating if the boolean value is set to `true` or `false`.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
There's  multiple ways to reproduce it:

- Add a `trix` field with an `attachment_key` and try to add an attachment to the content
- Add a `trix` field and explicitely set the `attachments_disabled` to true, the button to add an attachment will show up anyway