### PR TITLE
fix: index destroy

### DIFF
--- a/app/components/avo/index/resource_controls_component.rb
+++ b/app/components/avo/index/resource_controls_component.rb
@@ -189,6 +189,6 @@ class Avo::Index::ResourceControlsComponent < Avo::ResourceComponent
       hidden[:referrer] = referrer_path
     end
 
-    hidden
+    hidden.compact
   end
 end

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -107,7 +107,7 @@ module Avo
     def set_resource
       raise ActionController::RoutingError.new "No route matches" if resource.nil?
 
-      @resource = resource.new(view: params[:view] || action_name.to_s, user: _current_user, params: params)
+      @resource = resource.new(view: params[:view].presence || action_name.to_s, user: _current_user, params: params)
 
       set_authorization
     end
@@ -130,7 +130,7 @@ module Avo
       view = if action_view.in?([:index, :show, :new, :edit, :create])
         action_view
       else
-        params[:view] || action_view
+        params[:view].presence || action_view
       end
 
       @related_resource = related_resource.new(

--- a/spec/system/avo/app_spec.rb
+++ b/spec/system/avo/app_spec.rb
@@ -55,5 +55,15 @@ RSpec.describe "App", type: :system do
 
       expect(page).to have_text("Record destroyed").once
     end
+
+    it "destroy from index page" do
+      visit "/admin/resources/projects"
+
+      expect {
+        find("[data-resource-id='#{project.id}'] [data-control='destroy']").click
+        confirm_alert
+        wait_for_loaded
+      }.to change(Project, :count).by(-1)
+    end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes a regression (broken index destroy action) introduced here https://github.com/avo-hq/avo/pull/2436

`params[:view]` was passed as empty string `""` and we were doing `params[:view] || action_name.to_s` which would result in empty string `""` since:

```
irb(main):001> "" || "value"
=> ""
```

A resource with the `view` value as `nil` breaks fetching fields. This is fixed now and resource's `view` have the propper value

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)~
- [x] I have added tests that prove my fix is effective or that my feature works

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Go to any resource's index
2. Destroy any record
