### PR TITLE
Get rid of const_defined? check which led to issues with zeitwerk

### DIFF
--- a/lib/avo/version.rb
+++ b/lib/avo/version.rb
@@ -1,3 +1,3 @@
 module Avo
-  VERSION = "3.4.0" unless const_defined?(:VERSION)
+  VERSION = "3.4.0"
 end


### PR DESCRIPTION
# Description

For some reason during zeitwerk load Avo failed to add VERSION constant.

Here's traceback:
```
/myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/helpers.rb:136:in `const_get': uninitialized constant Avo::VERSION (NameError)

    parent.const_get(cname, false)
          ^^^^^^^^^^
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/helpers.rb:136:in `cget'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/eager_load.rb:175:in `block in actual_eager_load_dir'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/helpers.rb:40:in `block in ls'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/helpers.rb:25:in `each'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/helpers.rb:25:in `ls'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/eager_load.rb:170:in `actual_eager_load_dir'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/eager_load.rb:17:in `block (2 levels) in eager_load'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/eager_load.rb:16:in `each'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/eager_load.rb:16:in `block in eager_load'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/eager_load.rb:10:in `synchronize'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/eager_load.rb:10:in `eager_load'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/avo-3.4.0/lib/avo.rb:139:in `<main>'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:34:in `require'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:34:in `require'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.4.19/lib/bundler/runtime.rb:60:in `block (2 levels) in require'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.4.19/lib/bundler/runtime.rb:55:in `each'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.4.19/lib/bundler/runtime.rb:55:in `block in require'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.4.19/lib/bundler/runtime.rb:44:in `each'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.4.19/lib/bundler/runtime.rb:44:in `require'
        from /myhome/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.4.19/lib/bundler.rb:187:in `require'
        from /myhome/myapp/config/application.rb:7:in `<main>'
```

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works
