### PR TITLE
feature: keep query params while searching

### DIFF
--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -247,6 +247,7 @@ export default class extends Controller {
 
   searchParams(query) {
     let params = {
+      ...Object.fromEntries(new URLSearchParams(window.location.search)),
       q: query,
       global: false,
     }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2471

Now there is guaranteed access to the current params while searching. 

When on `/admin/resources/projects?some_param=first&another=second` and searching now this is possible:

```ruby
self.search = {
  query: -> {
    if params[:some_param].present?
      query...
    else
      query...
    end
  }
}
```

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

