### PR TITLE
fix: Get to_param instead of id for preview hover

### DIFF
--- a/app/components/avo/fields/preview_field/index_component.html.erb
+++ b/app/components/avo/fields/preview_field/index_component.html.erb
@@ -3,7 +3,7 @@
     title: t('avo.view_item', item: @resource.name).humanize,
     data: {
       controller: "preview",
-      preview_url_value: helpers.preview_resource_path(record: @record, resource: @resource, resource_id: @resource.record_id, turbo_frame: :preview_modal),
+      preview_url_value: helpers.preview_resource_path(resource: @resource,  turbo_frame: :preview_modal),
     } do %>
     <%= helpers.svg("magnifying-glass-circle", class: "block h-6 text-gray-600") %>
   <% end %>

--- a/app/helpers/avo/url_helpers.rb
+++ b/app/helpers/avo/url_helpers.rb
@@ -36,19 +36,10 @@ module Avo
     end
 
     def preview_resource_path(
-      record:,
       resource:,
-      resource_id: nil,
-      keep_query_params: false,
       **args
     )
-      if record.respond_to? resource.id_attribute
-        id = record
-      elsif resource_id.present?
-        id = resource_id
-      end
-
-      avo.send :"preview_resources_#{resource.singular_route_key}_path", id, **args
+      avo.send :"preview_resources_#{resource.singular_route_key}_path", resource.record, **args
     end
 
     def new_resource_path(resource:, **args)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
