### PR TITLE
Backport #2431 to 2.x branch

### DIFF
--- a/app/components/avo/fields/common/files/view_type/grid_item_component.html.erb
+++ b/app/components/avo/fields/common/files/view_type/grid_item_component.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= dom_id file %>" class="relative min-h-full max-w-full flex-1 flex flex-col justify-between space-y-2">
   <% if file.present? %>
-    <div class="flex h-full">
+    <div class="flex flex-col h-full">
       <% if file.representable? && is_image? %>
         <%= image_tag helpers.main_app.url_for(file), class: "rounded-lg max-w-full #{@extra_classes}" %>
       <% elsif is_audio? %>


### PR DESCRIPTION


# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In #2431 I fixed a bug where (at some point) the filename on a file field was hidden. The fix was only applied to the 3.x branch but I'd like to use it in 2.x as well.

Fixes # (issue)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

The filename on a file input is hidden.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Find a file input on an avo 2.x app
2. Upload a file
3. Confirm that the filename is visible (it should be with this patch, but wasn't before)

Manual reviewer: please leave a comment with output from the test if that's the case.
