### PR TITLE
fix: Remove field_translations and resource_translations key

### DIFF
--- a/lib/generators/avo/templates/locales/avo.ar.yml
+++ b/lib/generators/avo/templates/locales/avo.ar.yml
@@ -38,15 +38,6 @@ ar:
     failed: فشل
     failed_to_find_attachment: فشل في العثور على المرفق
     failed_to_load: فشل التحميل
-    field_translations:
-      file:
-        one: ملف
-        other: ملفات
-        zero: ملفات
-      people:
-        one: شخص
-        other: أشخاص
-        zero: أشخاص
     filter_by: تصفية حسب
     filters: مرشحات
     go_back: العودة للخلف
@@ -86,15 +77,6 @@ ar:
     reset_filters: إعادة تعيين الفلاتر
     resource_created: تم إنشاء السجل
     resource_destroyed: تم حذف السجل
-    resource_translations:
-      team_members:
-        one: عضو فريق
-        other: أعضاء الفريق
-        zero: أعضاء الفريق
-      user:
-        one: مستخدم
-        other: مستخدمين
-        zero: مستخدمين
     resource_updated: تم تحديث السجل
     resources: المصادر
     run: تشغيل

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -38,15 +38,6 @@ en:
     failed: Failed
     failed_to_find_attachment: Failed to find attachment
     failed_to_load: Failed to load
-    field_translations:
-      file:
-        one: file
-        other: files
-        zero: files
-      people:
-        one: person
-        other: people
-        zero: people
     filter_by: Filter by
     filters: Filters
     go_back: Go back
@@ -86,15 +77,6 @@ en:
     reset_filters: Reset filters
     resource_created: Record created
     resource_destroyed: Record destroyed
-    resource_translations:
-      team_members:
-        one: team member
-        other: team memberz
-        zero: team memberz
-      user:
-        one: user
-        other: users
-        zero: users
     resource_updated: Record updated
     resources: Resources
     run: Run

--- a/lib/generators/avo/templates/locales/avo.es.yml
+++ b/lib/generators/avo/templates/locales/avo.es.yml
@@ -38,15 +38,6 @@ es:
     failed: Fallo
     failed_to_find_attachment: No se ha encontrado el archivo adjunto
     failed_to_load: No se ha podido cargar
-    field_translations:
-      file:
-        one: fichero
-        other: ficheros
-        zero: ficheros
-      people:
-        one: persona
-        other: personas
-        zero: personas
     filter_by: Filtrar por
     filters: Filtros
     go_back: Volver
@@ -86,15 +77,6 @@ es:
     reset_filters: Reiniciar filtros
     resource_created: Recurso creado
     resource_destroyed: Recurso eliminado
-    resource_translations:
-      team_members:
-        one: miembro del equipo
-        other: miembros del equipo
-        zero: miembros del equipo
-      user:
-        one: usuario/a
-        other: usuarios/as
-        zero: usuarios/as
     resource_updated: Recurso actualizado
     resources: Recursos
     run: Ejecutar

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -38,15 +38,6 @@ fr:
     failed: Échec
     failed_to_find_attachment: Impossible de trouver la pièce jointe
     failed_to_load: Impossible de charger
-    field_translations:
-      file:
-        one: fichier
-        other: fichiers
-        zero: fichier
-      people:
-        one: personne
-        other: personnes
-        zero: personne
     filter_by: Filtrer par
     filters: Filtres
     go_back: Retourner en arrière
@@ -86,11 +77,6 @@ fr:
     reset_filters: Réinitialiser les filtres
     resource_created: Ressource créee
     resource_destroyed: Ressource détruite
-    resource_translations:
-      user:
-        one: utilisateurs
-        other: utilisateurs
-        zero: utilisateur
     resource_updated: Ressource mise à jour
     resources: Ressources
     run: Exécuter

--- a/lib/generators/avo/templates/locales/avo.ja.yml
+++ b/lib/generators/avo/templates/locales/avo.ja.yml
@@ -37,15 +37,6 @@ ja:
     failed: 失敗
     failed_to_find_attachment: アタッチメントを見つけるのに失敗
     failed_to_load: 読み込みに失敗
-    field_translations:
-      file:
-        one: ファイル
-        other: ファイル
-        zero: ファイル
-      people:
-        one: 人
-        other: 人々
-        zero: 人々
     filter_by: フィルター条件
     filters: フィルター
     go_back: 戻る
@@ -85,15 +76,6 @@ ja:
     reset_filters: フィルターをリセット
     resource_created: レコードが作成されました
     resource_destroyed: レコードが破棄されました
-    resource_translations:
-      team_members:
-        one: チームメンバー
-        other: チームメンバー
-        zero: チームメンバー
-      user:
-        one: ユーザー
-        other: ユーザー
-        zero: ユーザー
     resource_updated: レコードが更新されました
     resources: リソース
     run: 実行

--- a/lib/generators/avo/templates/locales/avo.nb.yml
+++ b/lib/generators/avo/templates/locales/avo.nb.yml
@@ -38,15 +38,6 @@ nb:
     failed: Feilet
     failed_to_find_attachment: Fant ikke vedlegg
     failed_to_load: Lasting feilet
-    field_translations:
-      file:
-        one: fil
-        other: filer
-        zero: filer
-      people:
-        one: person
-        other: personer
-        zero: personer
     filter_by: Filtrer etter
     filters: Filter
     go_back: Gå tilbake
@@ -86,11 +77,6 @@ nb:
     reset_filters: Nullstill filter
     resource_created: Ressurs generert
     resource_destroyed: Ressurs slettet
-    resource_translations:
-      user:
-        one: bruker
-        other: brukere
-        zero: brukere
     resource_updated: Ressurs oppdatert
     resources: Ressurser
     run: Kjør

--- a/lib/generators/avo/templates/locales/avo.nn.yml
+++ b/lib/generators/avo/templates/locales/avo.nn.yml
@@ -38,15 +38,6 @@ nn:
     failed: Feila
     failed_to_find_attachment: Fann ikkje vedlegg
     failed_to_load: Lasting feila
-    field_translations:
-      file:
-        one: fil
-        other: filer
-        zero: filer
-      people:
-        one: person
-        other: personar
-        zero: personar
     filter_by: Filtrer etter
     filters: Filter
     go_back: Gå tilbake
@@ -86,11 +77,6 @@ nn:
     reset_filters: Nullstill filter
     resource_created: Ressurs generert
     resource_destroyed: Ressurs sletta
-    resource_translations:
-      user:
-        one: brukar
-        other: brukarar
-        zero: brukarar
     resource_updated: Ressurs oppdatert
     resources: Ressursar
     run: Køyr

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -38,15 +38,6 @@ pt-BR:
     failed: Falhou
     failed_to_find_attachment: Falhou ao achar anexo
     failed_to_load: Falha ao carregar
-    field_translations:
-      file:
-        one: arquivo
-        other: arquivos
-        zero: arquivos
-      people:
-        one: pessoa
-        other: pessoas
-        zero: ninguém
     filter_by: Filtrar por
     filters: Filtros
     go_back: Voltar
@@ -86,11 +77,6 @@ pt-BR:
     reset_filters: Limpar filtros
     resource_created: Recurso criado
     resource_destroyed: Recurso destruído
-    resource_translations:
-      user:
-        one: usuário
-        other: usuários
-        zero: usuários
     resource_updated: Recurso atualizado
     resources: Recursos
     run: Executar

--- a/lib/generators/avo/templates/locales/avo.pt.yml
+++ b/lib/generators/avo/templates/locales/avo.pt.yml
@@ -38,15 +38,6 @@ pt:
     failed: Falhou
     failed_to_find_attachment: Falha ao encontrar anexo
     failed_to_load: Falhou ao carregar
-    field_translations:
-      file:
-        one: ficheiro
-        other: ficheiros
-        zero: ficheiros
-      people:
-        one: pessoa
-        other: pessoas
-        zero: ninguém
     filter_by: Filtrar por
     filters: Filtros
     go_back: Voltar
@@ -86,11 +77,6 @@ pt:
     reset_filters: Limpar filtros
     resource_created: Recurso criado
     resource_destroyed: Recurso destruído
-    resource_translations:
-      user:
-        one: utilizador
-        other: utilizadores
-        zero: utilizadores
     resource_updated: Recurso atualizado
     resources: Recursos
     run: Executar

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -38,15 +38,6 @@ ro:
     failed: A eșuat
     failed_to_find_attachment: Atașamentul nu a fost găsit
     failed_to_load: Încărcarea a eșuat
-    field_translations:
-      file:
-        one: fișier
-        other: fișiere
-        zero: fișiere
-      people:
-        one: persoana
-        other: persoane
-        zero: persoane
     filter_by: Filtează după
     filters: Filtre
     go_back: Înapoi
@@ -86,11 +77,6 @@ ro:
     reset_filters: Resetați filtrele
     resource_created: Resursă creata
     resource_destroyed: Resursă ștearsă
-    resource_translations:
-      user:
-        one: utilizator
-        other: utilizatori
-        zero: utilizatori
     resource_updated: Resursă actualizată
     resources: Resurse
     run: Rulează

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -38,15 +38,6 @@ tr:
     failed: Başarısız
     failed_to_find_attachment: Ek bulunamadı
     failed_to_load: Yüklenemedi
-    field_translations:
-      file:
-        one: dosya
-        other: dosya
-        zero: dosya
-      people:
-        one: kişi
-        other: kişi
-        zero: kişi
     filter_by: Tarafından filtre
     filters: Filtreler
     go_back: Geri dön
@@ -86,11 +77,6 @@ tr:
     reset_filters: Filtreleri sıfırla
     resource_created: Kayıt oluşturuldu
     resource_destroyed: Kayıt silindi
-    resource_translations:
-      user:
-        one: kullanıcı
-        other: kullanıcı
-        zero: kullanıcı
     resource_updated: Kayıt güncellendi
     resources: Kaynaklar
     run: Başlat


### PR DESCRIPTION
# Description
This PR removes field and resource translations from the default locale file

Fixes [#2494](https://github.com/avo-hq/avo/issues/2494)
<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
