### PR TITLE
fix: select_first_result_in_search selenium compatible

### DIFF
--- a/lib/avo/test_helpers.rb
+++ b/lib/avo/test_helpers.rb
@@ -128,6 +128,10 @@ module Avo
     #   select_first_result_in_search
     def select_first_result_in_search
       type :down, :enter
+    rescue
+      find(".aa-Input").send_keys :arrow_down
+      find(".aa-Input").send_keys :enter
+    ensure
       wait_for_search_loaded
     end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When using selenium the `type` helper don't work:

```ruby
1.1) Failure/Error: select_first_result_in_search

          NoMethodError:
            undefined method `keyboard' for an instance of Selenium::WebDriver::Chrome::Driver
```