### PR TITLE
feature: load concerns to Avo's controllers & aid multitenancy

### DIFF
--- a/RELEASE.MD
+++ b/RELEASE.MD
@@ -1,15 +1,15 @@
 # Release schedule
 
-A new Avo version is released every two weeks, usually on Tuesday. The versioning scheme does not follow semver but a series release.
+A new Avo version is released every four-ish weeks, usually on Tuesday. The versioning scheme does not follow semver but a series release.
 
-The current series is series 2 (version `2.1`, `2.2`, `2.9`, etc). Every two weeks we'll increment the minor version number (from `2.7` to `2.8`).
+The current series is series 3 (version `3.1`, `3.2`, `3.9`, etc). Every second Tuesday of the month we'll increment the minor version number (from `3.7` to `3.8`).
 
 ## Patch releases
 
-In-between that release cycle we might release patches (`2.7.1` or `2.9.5`) that address particular bugs or issues that are more urgent and can't wait for the next release cycle.
+In-between that release cycle we might release patches (`3.7.1` or `3.9.5`) that address particular bugs or issues that are more urgent and can't wait for the next release cycle.
 
 ## Pre-releases
 
-Sometimes I publish pre-releases (`2.7.1.pre.1` or `2.5.2.pre.7`).
+Sometimes we publish pre-releases (`3.7.1.pre.1` or `3.5.2.pre.7`).
 
-The pre-releases are usually built on my machine and will be builds from a specific branch, so they don't follow any particular convention. The `pre.2` might contain a fix, but the `pre.3` might not containt tht fix because they might be built from different branches. I usually mention on a PR or issue to the bug reporter if they should or shouldn't use pre-releases. They won't get installed in regular `bundle update avo` commands, unless you instruct it in the `Gemfile`.
+The pre-releases are usually built on our machines and will be builds from a specific branch, so they don't follow any particular convention. The `pre.2` might contain a fix, but the `pre.3` might not contain that fix because they might be built from different branches. We usually mention on a PR or issue to the bug reporter if they should or shouldn't use pre-releases. They won't get installed in regular `bundle update avo` commands, unless you specify it in the `Gemfile`.

--- a/app/views/avo/partials/_header.html.erb
+++ b/app/views/avo/partials/_header.html.erb
@@ -1,1 +1,11 @@
-<%= link_to Avo.configuration.app_name, '/', class: 'text-primary-500 font-semibold', target: :_blank %>
+<div class="flex">
+  <%= link_to Avo.configuration.app_name, '/', class: 'text-primary-500 font-semibold', target: :_blank %>
+
+  <% if false %>
+    <div class="ml-12">
+      <% current_user.accounts.each do |account| %>
+        <%= link_to account.name, switch_account_path(account.id), class: class_names({"underline": session[:tenant_id].to_s == account.id.to_s}), data: {turbo_method: :put} %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -56,7 +56,7 @@ module Avo
 
     delegate :license, :app, :error_manager, :tool_manager, :resource_manager, to: Avo::Current
 
-    # Run when the app boots up
+    # Runs when the app boots up
     def boot
       @logger = Avo.configuration.logger
       @field_manager = Avo::Fields::FieldManager.build
@@ -79,7 +79,7 @@ module Avo
       end
     end
 
-    # Run on each request
+    # Runs on each request
     def init
       Avo::Current.error_manager = Avo::ErrorManager.build
       Avo::Current.resource_manager = Avo::Resources::ResourceManager.build

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -56,14 +56,30 @@ module Avo
 
     delegate :license, :app, :error_manager, :tool_manager, :resource_manager, to: Avo::Current
 
+    # Run when the app boots up
     def boot
       @logger = Avo.configuration.logger
       @field_manager = Avo::Fields::FieldManager.build
       @cache_store = Avo.configuration.cache_store
       plugin_manager.boot_plugins
       Avo.run_load_hooks(:boot, self)
+
+      Rails.configuration.to_prepare do
+        Avo.configuration.extend_controllers_with.each do |concern|
+          concern = concern.safe_constantize
+          Avo::ApplicationController.include concern
+
+          # Add the concern to all of Avo's engines
+          Avo.extra_gems.each do |gem_name|
+            if defined?("Avo::#{gem_name.capitalize}::Engine".safe_constantize)
+              "Avo::#{gem_name}::ApplicationController".safe_constantize.include concern
+            end
+          end
+        end
+      end
     end
 
+    # Run on each request
     def init
       Avo::Current.error_manager = Avo::ErrorManager.build
       Avo::Current.resource_manager = Avo::Resources::ResourceManager.build
@@ -131,6 +147,10 @@ module Avo
         mount Avo::Dashboards::Engine, at: "/dashboards" if defined?(Avo::Dashboards::Engine)
         mount Avo::Pro::Engine, at: "/avo-pro" if defined?(Avo::Pro::Engine)
       }
+    end
+
+    def extra_gems
+      [:pro, :advanced, :menu, :dynamic_filters, :dashboards, :enterprise, :audits]
     end
   end
 end

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -46,6 +46,7 @@ module Avo
     attr_accessor :prefix_path
     attr_accessor :resource_parent_controller
     attr_accessor :mount_avo_engines
+    attr_accessor :extend_controllers_with
 
     def initialize
       @root_path = "/avo"
@@ -97,6 +98,7 @@ module Avo
       @resources = nil
       @resource_parent_controller = "Avo::ResourcesController"
       @mount_avo_engines = true
+      @extend_controllers_with = []
       @cache_store = computed_cache_store
       @logger = default_logger
     end

--- a/lib/avo/current.rb
+++ b/lib/avo/current.rb
@@ -1,30 +1,18 @@
 class Avo::Current < ActiveSupport::CurrentAttributes
-  # if Rails.env.development?
-  # singleton_class.attr_accessor :previous_attributes
-  # before_reset {
-  #   puts ["before_reset->", self.previous_attributes].inspect
-  #   if attributes.present?
-  #     puts ["has attributes->"].inspect
-  #     self.previous_attributes = attributes
-  #   end
-  #   puts ["before_reset->", self.previous_attributes].inspect
-  # }
-
-  # attr_accessor :previous_attributes
-
-  # def previous_attributes=(value)
-  #   @previous_attributes = value
-  # end
-  # end
-
   attribute :app
   attribute :license
-  attribute :context, :user, :view_context
+  attribute :context
+  attribute :user
+  attribute :view_context
   attribute :error_manager
   attribute :resource_manager
   attribute :tool_manager
   attribute :plugin_manager
   attribute :locale
+
+  # The tenant attributes are here so the user can add them on their own will
+  attribute :tenant_id
+  attribute :tenant
 
   # Protect from error #<RuntimeError: Missing rack.input> when request is ActionDispatch::Request.empty
   def params

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -18,8 +18,9 @@ Avo.configure do |config|
 
   ## == Set the context ==
   config.set_context do
-    # Return a context object that gets evaluated in Avo::ApplicationController
+    # Return a context object that gets evaluated within Avo::ApplicationController
   end
+  # config.extend_controllers_with = []
 
   ## == Authentication ==
   # config.current_user_method = {}

--- a/spec/dummy/app/controllers/avo/switch_accounts_controller.rb
+++ b/spec/dummy/app/controllers/avo/switch_accounts_controller.rb
@@ -1,0 +1,7 @@
+class Avo::SwitchAccountsController < Avo::ApplicationController
+  def update
+    session[:tenant_id] = params[:id]
+
+    redirect_back fallback_location: root_path
+  end
+end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -79,4 +79,9 @@ class User < ApplicationRecord
   def self.ransackable_attributes(auth_object = nil)
     ["active", "birthday", "created_at", "custom_css", "email", "encrypted_password", "first_name", "id", "last_name", "remember_created_at", "reset_password_sent_at", "reset_password_token", "roles", "slug", "team_id", "updated_at"]
   end
+
+  # Simulate accounts association
+  def accounts
+    [OpenStruct.new(id: 1, name: "Foo"), OpenStruct.new(id: 2, name: "Bar")]
+  end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -31,5 +31,7 @@ if defined? ::Avo
       get "courses/cities", to: "courses#cities"
       get "users/get_users", to: "users#get_users"
     end
+
+    put "switch_accounts/:id", to: "switch_accounts#update", as: :switch_account
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds the ability to add concerns to Avo's controllers natively.
This aids the mutitenancy feature.

Docs: https://docs.avohq.io/3.0/multitenancy.html

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
