### PR TITLE
fix: create and update when using `view.form?`

### DIFF
--- a/lib/avo/view_inquirer.rb
+++ b/lib/avo/view_inquirer.rb
@@ -3,7 +3,7 @@
 module Avo
   class ViewInquirer < ActiveSupport::StringInquirer
     DISPLAY_VIEWS = %w[index show].freeze unless defined? DISPLAY_VIEWS
-    FORM_VIEWS = %w[new edit].freeze unless defined? FORM_VIEWS
+    FORM_VIEWS = %w[new edit create update].freeze unless defined? FORM_VIEWS
 
     def initialize(view)
       super(view.to_s)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2478 

Fixes creating / updating a resource using:

```ruby
def fields
  if view.form?
    field :name, as: :text
  end
end
```

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)~
- [ ] I have added tests that prove my fix is effective or that my feature works~

