### PR TITLE
Add URL acronym

### DIFF
--- a/app/components/avo/tab_switcher_component.rb
+++ b/app/components/avo/tab_switcher_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::TabSwitcherComponent < Avo::BaseComponent
-  include Avo::UrlHelpers
+  include Avo::URLHelpers
   include Avo::ApplicationHelper
 
   attr_reader :active_tab_name

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -8,7 +8,7 @@ module Avo
 
     include Avo::InitializesAvo
     include Avo::ApplicationHelper
-    include Avo::UrlHelpers
+    include Avo::URLHelpers
     include Avo::Concerns::Breadcrumbs
 
     protect_from_forgery with: :exception

--- a/app/helpers/avo/url_helpers.rb
+++ b/app/helpers/avo/url_helpers.rb
@@ -1,5 +1,5 @@
 module Avo
-  module UrlHelpers
+  module URLHelpers
     def resources_path(resource:, keep_query_params: false, **args)
       return if resource.nil?
 

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,0 +1,3 @@
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "URL"
+end

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -6,7 +6,6 @@ loader = Zeitwerk::Loader.for_gem
 loader.inflector.inflect(
   "html" => "HTML",
   "uri_service" => "URIService",
-  "url_helpers" => "URLHelpers",
   "has_html_attributes" => "HasHTMLAttributes"
 )
 loader.ignore("#{__dir__}/generators")

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -6,6 +6,7 @@ loader = Zeitwerk::Loader.for_gem
 loader.inflector.inflect(
   "html" => "HTML",
   "uri_service" => "URIService",
+  "url_helpers" => "URLHelpers",
   "has_html_attributes" => "HasHTMLAttributes"
 )
 loader.ignore("#{__dir__}/generators")

--- a/spec/features/avo/native_fields_spec.rb
+++ b/spec/features/avo/native_fields_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "NativeFields", type: :feature do
     expect(find_field('Features').value).to eq "\"#{city.features}\""
 
     expect(page).to have_css 'img[src="https://images.unsplash.com/photo-1660061993776-098c0ee403ac?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8fHx8fHx8MTY2MDMxMzc4NA&ixlib=rb-1.2.1&q=80&w=1080"]'
-    expect(find_field('Image url').value).to eq city.image_url
+    expect(find_field('Image URL').value).to eq city.image_url
 
     expect(page).to have_css 'trix-editor'
     expect(find_field('city[description]', visible: false).value).to include city.description.to_plain_text


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds acronym for `URL` so that [`URLHelpers`](https://github.com/avo-hq/avo/blob/main/app/helpers/avo/url_helpers.rb) can be renamed from `UrlHelpers`, as it is already done for [`URIServices`](https://github.com/avo-hq/avo/blob/main/lib/avo/services/uri_service.rb).

Unfortunately this requires adding `config/initializers/inflections.rb` which I'm not sure if it is a correct approach in this case.

However tests pass and dummy app also seems to be working fine.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
