### PR TITLE
Drag and drop reordering: Tailwind classes, reverting HashWithIndifferentAccess

### DIFF
--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -77,14 +77,6 @@ module Avo
       delegate :t, to: ::I18n
       delegate :context, to: ::Avo::Current
 
-      alias_method :_ordering=, :ordering=
-      private :_ordering=
-      def ordering= value
-        # Using HashWithIndifferentAccess removes the need to intern
-        # user input, and thus protects from symbol DoS.
-        self._ordering = value&.with_indifferent_access
-      end
-
       def action(action_class, arguments: {})
         deprecated_dsl_api __method__, "actions"
       end

--- a/scripts/export-tailwind-safelist.js
+++ b/scripts/export-tailwind-safelist.js
@@ -41,7 +41,10 @@ ignoredDynamicClasses.push(
   'font-sans',
   'font-serif',
   'font-mono',
-  '!bg-gray-100', // avo-pro drag and drop feature
+  // avo-pro drag and drop feature:
+  '!bg-gray-100',
+  'opacity-50',
+  'select-none'
 )
 
 const content = `# This file was auto-generated using the \`yarn export:tailwind-safelist\` command in \`export-tailwind-safelist.js\`\n${ignoredDynamicClasses.flat().join(' ')}`


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

* Added necessary Tailwind classes to the whitelist. It's needed for avo-pro#46.
* Reverted the use of HashWithIndifferentAccess. No specific tests needed (the functionality is already covered by tests here and in avo-pro).

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

Not applicable.