### PR TITLE
fix: remove duplicate create method

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -123,10 +123,6 @@ module Avo
     end
 
     def create
-      # record gets instantiated and filled in the fill_record method
-      saved = save_record
-      @resource.hydrate(record: @record, view: :new, user: _current_user)
-
       # This means that the record has been created through another parent record and we need to attach it somehow.
       if params[:via_record_id].present? && params[:via_belongs_to_resource_class].nil?
         @reflection = @record._reflections[params[:via_relation]]
@@ -139,7 +135,6 @@ module Avo
           related_record = related_resource.find_record params[:via_record_id], params: params
 
           @record.send("#{@reflection.foreign_key}=", related_record.id)
-          @record.save
         end
 
         # For when working with has_one, has_one_through, has_many_through, has_and_belongs_to_many, polymorphic
@@ -157,6 +152,10 @@ module Avo
           end
         end
       end
+
+      # record gets instantiated and filled in the fill_record method
+      saved = save_record
+      @resource.hydrate(record: @record, view: :new, user: _current_user)
 
       add_breadcrumb @resource.plural_name.humanize, resources_path(resource: @resource)
       add_breadcrumb t("avo.new").humanize


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1944

Save record only once on creation after applying the associations logic.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
