### PR TITLE
fix: double download action

### DIFF
--- a/app/helpers/avo/turbo_stream_actions_helper.rb
+++ b/app/helpers/avo/turbo_stream_actions_helper.rb
@@ -11,7 +11,7 @@ module Avo
     end
 
     def close_action_modal
-      turbo_stream_action_tag :replace, target: "actions_show", html: @view_context.turbo_frame_tag('actions_show')
+      turbo_stream_action_tag :replace, target: "actions_show", html: @view_context.turbo_frame_tag("actions_show")
     end
   end
 end

--- a/app/helpers/avo/turbo_stream_actions_helper.rb
+++ b/app/helpers/avo/turbo_stream_actions_helper.rb
@@ -11,7 +11,7 @@ module Avo
     end
 
     def close_action_modal
-      turbo_stream_action_tag :remove , target: "actions_show"
+      turbo_stream_action_tag :update , target: "actions_show"
     end
   end
 end

--- a/app/helpers/avo/turbo_stream_actions_helper.rb
+++ b/app/helpers/avo/turbo_stream_actions_helper.rb
@@ -11,7 +11,7 @@ module Avo
     end
 
     def close_action_modal
-      turbo_stream_action_tag :update , target: "actions_show"
+      turbo_stream_action_tag :update, target: "actions_show"
     end
   end
 end

--- a/app/helpers/avo/turbo_stream_actions_helper.rb
+++ b/app/helpers/avo/turbo_stream_actions_helper.rb
@@ -11,7 +11,7 @@ module Avo
     end
 
     def close_action_modal
-      turbo_stream_action_tag :update, target: "actions_show"
+      turbo_stream_action_tag :replace, target: "actions_show", html: @view_context.turbo_frame_tag('actions_show')
     end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2385 

`close_action_modal` now updates the `actions_show` to be empty instead removing the frame, keeping the frame there for a new action request.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~

## Screenshots & recording

### Before
[before.webm](https://github.com/avo-hq/avo/assets/69730720/1115fbaf-5ac9-4a73-927a-dd3f643c54d1)

### After
[after.webm](https://github.com/avo-hq/avo/assets/69730720/b9874784-589c-4f63-9902-9ec3928ce3f2)
