### PR TITLE
feature: action name as proc

### DIFF
--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -61,7 +61,15 @@ module Avo
     end
 
     def action_name
-      return name if name.present?
+      if name.present?
+        return Avo::ExecutionContext.new(
+          target: name,
+          resource: @resource,
+          record: @record,
+          view: @view,
+          arguments: @arguments
+        ).handle
+      end
 
       self.class.to_s.demodulize.underscore.humanize(keep_id_suffix: true)
     end

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -105,7 +105,13 @@ module Avo
     end
 
     def get_message
-      Avo::ExecutionContext.new(target: self.class.message, record: @record, resource: @resource).handle
+      Avo::ExecutionContext.new(
+        target: self.class.message,
+        resource: @resource,
+        record: @record,
+        view: @view,
+        arguments: @arguments
+      ).handle
     end
 
     def handle_action(**args)

--- a/spec/dummy/app/avo/actions/sub/dummy_action.rb
+++ b/spec/dummy/app/avo/actions/sub/dummy_action.rb
@@ -1,5 +1,5 @@
 class Avo::Actions::Sub::DummyAction < Avo::BaseAction
-  self.name = "Dummy action"
+  self.name = -> { "Dummy action#{arguments[:test_action_name]}" }
   self.standalone = true
   # self.turbo = false
   self.visible = -> do

--- a/spec/dummy/app/avo/resources/city.rb
+++ b/spec/dummy/app/avo/resources/city.rb
@@ -100,5 +100,6 @@ class Avo::Resources::City < Avo::BaseResource
   def actions
     action Avo::Actions::City::PreUpdate
     action Avo::Actions::City::Update
+    action Avo::Actions::Sub::DummyAction, arguments: { test_action_name: " city resource" }
   end
 end

--- a/spec/dummy/app/avo/resources/city.rb
+++ b/spec/dummy/app/avo/resources/city.rb
@@ -100,6 +100,6 @@ class Avo::Resources::City < Avo::BaseResource
   def actions
     action Avo::Actions::City::PreUpdate
     action Avo::Actions::City::Update
-    action Avo::Actions::Sub::DummyAction, arguments: { test_action_name: " city resource" }
+    action Avo::Actions::Sub::DummyAction, arguments: {test_action_name: " city resource"}
   end
 end

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -199,6 +199,24 @@ RSpec.describe "Actions", type: :system do
     end
   end
 
+  describe "flexibility" do
+    context "index" do
+      it "finds same action on index with different name" do
+        visit "/admin/resources/users"
+
+        click_on "Actions"
+
+        expect(page.find("a", text: "Dummy action")["data-disabled"]).to eq "false"
+
+        visit "/admin/resources/cities"
+
+        click_on "Actions"
+
+        expect(page.find("a", text: "Dummy action city resource")["data-disabled"]).to eq "false"
+      end
+    end
+  end
+
   #   let!(:roles) { { admin: false, manager: false, writer: false } }
   #   let!(:user) { create :user, active: true, roles: roles }
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2496

Action name accept now procs as input: `self.name = -> { "Dummy action #{arguments[:some_argument]}" }`

Also the `self.message` has now context of arguments and view.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
  - https://github.com/avo-hq/avodocs/pull/176
- [x] I have added tests that prove my fix is effective or that my feature works

