### PR TITLE
fix: resource on action handle

### DIFF
--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -25,7 +25,7 @@ module Avo
       performed_action = @action.handle_action(
         fields: action_params[:fields].except(:avo_resource_ids, :avo_selected_query),
         current_user: _current_user,
-        resource: resource,
+        resource: @resource,
         query: decrypted_query ||
           (resource_ids.any? ? @resource.find_record(resource_ids, params: params) : [])
       )


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2399

On handle action now `resource == @resource`

Before this PR `resource == @resource.class` because we were targeting it wrong when calling the handle method.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~