### PR TITLE
feature: Add `default_url_options` support

### DIFF
--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -277,11 +277,21 @@ module Avo
     end
 
     def default_url_options
+      result = super
+
       if params[:force_locale].present?
-        {**super, force_locale: params[:force_locale]}
-      else
-        super
+        result[:force_locale] = params[:force_locale]
       end
+
+      extra_options = get_extra_default_url_options
+
+      if extra_options.present?
+        extra_options.each do |param_name|
+          result[param_name] = params[param_name]
+        end
+      end
+
+      result
     end
 
     def set_sidebar_open
@@ -310,6 +320,18 @@ module Avo
         "/avo-assets/avo.base"
       else
         "avo.base"
+      end
+    end
+
+    private
+
+    def get_extra_default_url_options
+      block_or_array = Avo.configuration.default_url_options
+
+      if block_or_array.respond_to?(:call)
+        instance_eval(&block_or_array)
+      else
+        block_or_array
       end
     end
   end

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -47,6 +47,7 @@ module Avo
     attr_accessor :resource_parent_controller
     attr_accessor :mount_avo_engines
     attr_accessor :extend_controllers_with
+    attr_accessor :default_url_options
 
     def initialize
       @root_path = "/avo"
@@ -101,6 +102,7 @@ module Avo
       @extend_controllers_with = []
       @cache_store = computed_cache_store
       @logger = default_logger
+      @default_url_options = []
     end
 
     def current_user_method(&block)

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -3,6 +3,9 @@ Avo.configure do |config|
   config.root_path = "/admin"
   config.app_name = -> { "Avocadelicious #{params[:app_name_suffix]}" }
   config.home_path = -> { "/admin/resources/projects" }
+  config.home_path = -> { avo.resources_projects_path }
+  # config.mount_avo_engines = false
+  # config.default_url_options = [:tenant_id]
 
   # Use this to test root_path_without_url helper
   # Also enable in config.ru & application.rb


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Enable adding to the `default_url_options` method.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
