### PR TITLE
fix: action link_arguments compact params

### DIFF
--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -49,7 +49,13 @@ module Avo
       def link_arguments(resource:, arguments: {}, **args)
         path = Avo::Services::URIService.parse(resource.record&.persisted? ? resource.record_path : resource.records_path)
           .append_paths("actions")
-          .append_query(action_id: to_param, arguments: encode_arguments(arguments), **args)
+          .append_query(
+            **{
+              action_id: to_param,
+              arguments: encode_arguments(arguments),
+              **args
+            }.compact
+          )
           .to_s
 
         data = {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When using `link_arguments` all params should be compact and don't pass empty params like: `?arguments=&etc...`

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

