### PR TITLE
fix: Update error message in MissingResourceError class

### DIFF
--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -39,7 +39,7 @@ module Avo
     private
 
     def missing_resource_message(resource_name)
-      name = resource_name.to_s.gsub(/([a-z])([A-Z])/, '\1_\2').downcase
+      name = resource_name.to_s.underscore.downcase
 
       "Failed to find a resource while rendering the :#{name} field.\n" \
       "You may generate a resource for it by running 'rails generate avo:resource #{name.singularize}'.\n" \

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -39,7 +39,7 @@ module Avo
     private
 
     def missing_resource_message(resource_name)
-      name = resource_name.to_s.downcase
+      name = resource_name.to_s.gsub(/([a-z])([A-Z])/, '\1_\2').downcase
 
       "Failed to find a resource while rendering the :#{name} field.\n" \
       "You may generate a resource for it by running 'rails generate avo:resource #{name.singularize}'.\n" \

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -39,7 +39,7 @@ module Avo
     private
 
     def missing_resource_message(resource_name)
-      name = resource_name.to_s.underscore.downcase
+      name = resource_name.to_s.underscore
 
       "Failed to find a resource while rendering the :#{name} field.\n" \
       "You may generate a resource for it by running 'rails generate avo:resource #{name.singularize}'.\n" \


### PR DESCRIPTION
# Description
The error message now correctly converts camel case resource names to snake case before displaying the message

Fixes [2515](https://github.com/avo-hq/avo/issues/2515)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
