### PR TITLE
fix: rename instantclick to instant_click

### DIFF
--- a/app/views/layouts/avo/application.html.erb
+++ b/app/views/layouts/avo/application.html.erb
@@ -3,7 +3,7 @@
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <% if !Avo.configuration.turbo[:instantclick] %>
+    <% if !Avo.configuration.turbo[:instant_click] %>
       <meta name="turbo-prefetch" content="false">
     <% end %>
     <%= display_meta_tags site: Avo.configuration.app_name, reverse: true, separator: "—" %>

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -228,7 +228,7 @@ module Avo
     def default_turbo
       -> do
         {
-          instantclick: true
+          instant_click: true
         }
       end
     end

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -68,7 +68,7 @@ Avo.configure do |config|
   ## == Turbo options ==
   # config.turbo = -> do
   #   {
-  #     instantclick: true
+  #     instant_click: true
   #   }
   # end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Rename `instantclick` to `instant_click` on `turbo` configuration.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
  - https://github.com/avo-hq/avodocs/pull/178
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
