### PR TITLE
fix: disable turbo_prefetch on belongs_to creation link

### DIFF
--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -71,8 +71,11 @@
             <% create_href = create_path(Avo.resource_manager.get_resource_by_model_class(type.to_s)) %>
             <% if !disabled && create_href.present? %>
               <%= link_to t("avo.create_new_item", item: type.to_s.downcase),
-                          create_href,
-                          class: "text-sm"
+                    create_href,
+                    class: "text-sm",
+                    data: {
+                      turbo_prefetch: false
+                    }
               %>
             <% end %>
           <% end %>
@@ -115,7 +118,13 @@
     <% end %>
     <% if field.can_create? %>
       <% if !disabled && create_path.present? %>
-        <%= link_to t("avo.create_new_item", item: @field.name.downcase), create_path, class: "text-sm" %>
+        <%= link_to t("avo.create_new_item", item: @field.name.downcase),
+              create_path,
+              class: "text-sm",
+              data: {
+                turbo_prefetch: false
+              }
+        %>
       <% end %>
     <% end %>
   <% end %>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2539

Disables instant click on `belongs_to` new link.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
