### PR TITLE
fix: double download with turbo_temporary

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -63,8 +63,9 @@ module Avo
 
       # Create resources for each record
       # Duplicate the @resource before hydration to avoid @resource keeping last record.
+      @resource.hydrate(params: params)
       @resources = @records.map do |record|
-        @resource.dup.hydrate(record: record, params: params)
+        @resource.dup.hydrate(record: record)
       end
 
       set_component_for __method__

--- a/app/helpers/avo/turbo_stream_actions_helper.rb
+++ b/app/helpers/avo/turbo_stream_actions_helper.rb
@@ -13,7 +13,7 @@ module Avo
     def close_action_modal
       turbo_stream_action_tag :replace,
         target: Avo::ACTIONS_TURBO_FRAME_ID,
-        html: @view_context.turbo_frame_tag(Avo::ACTIONS_TURBO_FRAME_ID)
+        template: @view_context.turbo_frame_tag(Avo::ACTIONS_TURBO_FRAME_ID, data: {turbo_temporary: 1})
     end
   end
 end

--- a/app/helpers/avo/turbo_stream_actions_helper.rb
+++ b/app/helpers/avo/turbo_stream_actions_helper.rb
@@ -11,7 +11,9 @@ module Avo
     end
 
     def close_action_modal
-      turbo_stream_action_tag :refresh, target: Avo::ACTIONS_TURBO_FRAME_ID
+      turbo_stream_action_tag :replace,
+        target: Avo::ACTIONS_TURBO_FRAME_ID,
+        html: @view_context.turbo_frame_tag(Avo::ACTIONS_TURBO_FRAME_ID)
     end
   end
 end

--- a/app/helpers/avo/turbo_stream_actions_helper.rb
+++ b/app/helpers/avo/turbo_stream_actions_helper.rb
@@ -11,9 +11,7 @@ module Avo
     end
 
     def close_action_modal
-      turbo_stream_action_tag :replace,
-        target: Avo::ACTIONS_TURBO_FRAME_ID,
-        html: @view_context.turbo_frame_tag(Avo::ACTIONS_TURBO_FRAME_ID)
+      turbo_stream_action_tag :refresh, target: Avo::ACTIONS_TURBO_FRAME_ID
     end
   end
 end

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -12,7 +12,6 @@
       data: {
         action_target: :form,
         **@action.class.form_data_attributes,
-        turbo_frame: Avo::ACTIONS_TURBO_FRAME_ID,
       } do |form|
     %>
     <%= render Avo::ModalComponent.new do |c| %>

--- a/app/views/layouts/avo/application.html.erb
+++ b/app/views/layouts/avo/application.html.erb
@@ -50,7 +50,7 @@
         </div>
       </div>
     </div>
-    <%= turbo_frame_tag Avo::ACTIONS_TURBO_FRAME_ID, data: {turbo_temporary: 1} %>
+    <%= turbo_frame_tag Avo::ACTIONS_TURBO_FRAME_ID %>
     <%= turbo_frame_tag 'attach_modal' %>
     <%= turbo_frame_tag 'alerts', class: "fixed inset-0 bottom-0 flex flex-col space-y-4 items-end justify-right px-4 py-6 sm:p-6 justify-end z-[100] pointer-events-none" do %>
       <%= render Avo::FlashAlertsComponent.new flashes: flash %>

--- a/app/views/layouts/avo/application.html.erb
+++ b/app/views/layouts/avo/application.html.erb
@@ -50,7 +50,7 @@
         </div>
       </div>
     </div>
-    <%= turbo_frame_tag Avo::ACTIONS_TURBO_FRAME_ID %>
+    <%= turbo_frame_tag Avo::ACTIONS_TURBO_FRAME_ID, data: {turbo_temporary: 1} %>
     <%= turbo_frame_tag 'attach_modal' %>
     <%= turbo_frame_tag 'alerts', class: "fixed inset-0 bottom-0 flex flex-col space-y-4 items-end justify-right px-4 py-6 sm:p-6 justify-end z-[100] pointer-events-none" do %>
       <%= render Avo::FlashAlertsComponent.new flashes: flash %>

--- a/spec/dummy/app/avo/actions/toggle_inactive.rb
+++ b/spec/dummy/app/avo/actions/toggle_inactive.rb
@@ -8,7 +8,10 @@ class Avo::Actions::ToggleInactive < Avo::BaseAction
       as: :tags,
       mode: :select,
       close_on_select: true,
-      fetch_values_from: -> { "/admin/resources/users/get_users?hey=you&record_id=#{resource.record.id}" },
+      fetch_values_from: -> {
+        # record is nil when selecting on index
+        "/admin/resources/users/get_users?hey=you&record_id=#{resource&.record&.id}"
+      },
       suggestions: -> do
         User.take(5).map do |user|
           {
@@ -24,12 +27,11 @@ class Avo::Actions::ToggleInactive < Avo::BaseAction
     # for testing purposes
     TestBuddy.hi(fields["user_id"])
 
+    puts ["query->", query].inspect
     query.each do |record|
-      if record.active
-        record.update active: false
-      else
-        record.update active: true
-      end
+      puts ["record.active->", record.active].inspect
+      record.update! active: !record.active
+      puts ["record.active->", record.active].inspect
 
       record.notify fields[:message] if fields[:notify_user]
     end

--- a/spec/dummy/app/avo/actions/toggle_inactive.rb
+++ b/spec/dummy/app/avo/actions/toggle_inactive.rb
@@ -27,11 +27,8 @@ class Avo::Actions::ToggleInactive < Avo::BaseAction
     # for testing purposes
     TestBuddy.hi(fields["user_id"])
 
-    puts ["query->", query].inspect
     query.each do |record|
-      puts ["record.active->", record.active].inspect
       record.update! active: !record.active
-      puts ["record.active->", record.active].inspect
 
       record.notify fields[:message] if fields[:notify_user]
     end

--- a/spec/dummy/app/avo/resources/user.rb
+++ b/spec/dummy/app/avo/resources/user.rb
@@ -26,9 +26,11 @@ class Avo::Resources::User < Avo::BaseResource
     # If it's an id, we need to use the find method.
     # If the id is an array, we need to use the where method in order to return a collection.
     if id.is_a?(Array)
-      (id.first.to_i == 0) ? query.where(slug: id) : query.where(id: id)
+      first_is_number = true if Float(id.first, exception: false)
+      first_is_number ? query.where(id: id) : query.where(slug: id)
     else
-      (id.to_i == 0) ? query.find_by_slug(id) : query.find(id)
+      first_is_number = true if Float(id, exception: false)
+      first_is_number ? query.find(id) : query.find_by_slug(id)
     end
   }
   self.includes = [:posts, :post]

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe "Actions", type: :system do
 
   # Double download action should keep page
   describe "turbo" do
-    let!(:projects) { create_list :project, 4}
+    let!(:projects) { create_list :project, 4 }
     context "double action" do
       it "page persist" do
         visit "/admin/resources/projects"

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -217,6 +217,26 @@ RSpec.describe "Actions", type: :system do
     end
   end
 
+  # Double download action should keep page
+  describe "turbo" do
+    let!(:projects) { create_list :project, 4}
+    context "double action" do
+      it "page persist" do
+        visit "/admin/resources/projects"
+        expect(page).to have_css('[data-component-name="avo/views/resource_index_component"]')
+
+        check_select_all
+        open_panel_action(action_name: "Export CSV")
+        run_action
+        expect(page).to have_css('[data-component-name="avo/views/resource_index_component"]')
+
+        open_panel_action(action_name: "Export CSV")
+        run_action
+        expect(page).to have_css('[data-component-name="avo/views/resource_index_component"]')
+      end
+    end
+  end
+
   #   let!(:roles) { { admin: false, manager: false, writer: false } }
   #   let!(:user) { create :user, active: true, roles: roles }
 

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -192,8 +192,9 @@ RSpec.describe "Actions", type: :system do
       click_on "Actions"
       click_on "Close modal"
       expect(page).to have_css('turbo-frame#actions_show')
+      expect(page).to have_selector(modal = "[role='dialog']")
       click_on "Run"
-      expect(page).not_to have_css('turbo-frame#actions_show')
+      expect(page).not_to have_selector(modal)
       expect(page).to have_text "Modal closed!!"
       expect(page).to have_field('user_first_name', with: 'First name should persist after action.')
     end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://discord.com/channels/740892036978442260/1029406999227666483/1212776480925290589

`turbo_stream_action_tag` doesn't support the `html` option. It is being replaced with the proper `template` option
<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)~
- [x] I have added tests that prove my fix is effective or that my feature works
