### PR TITLE
fix: visible block

### DIFF
--- a/app/components/avo/actions_component.html.erb
+++ b/app/components/avo/actions_component.html.erb
@@ -32,16 +32,16 @@
   >
     <div data-target="actions-list" class="w-full space divide-y">
       <% actions.each_with_index do |action, index| %>
-        <% link, data = action.class.link_arguments(resource: @resource, arguments: action.arguments) %>
-        <%= link_to link,
+        <%= link_to action_path(action),
           data: {
             action_name: action.action_name,
+            'turbo-frame': Avo::ACTIONS_TURBO_FRAME_ID,
             'action': 'click->actions-picker#visitAction',
             'actions-picker-target': action.standalone ? 'standaloneAction' : 'resourceAction',
             'disabled': is_disabled?(action),
             # for some reason InstantClick fetches the URL even if it's prefetched.
             turbo_prefetch: false,
-          }.merge(data),
+          },
           title: action.action_name,
           class: "flex items-center px-4 py-3 w-full font-semibold text-sm hover:bg-primary-100 #{is_disabled?(action) ? 'text-gray-500' : 'text-black'}" do %>
           <%= svg 'play', class: 'h-5 mr-1 inline pointer-events-none' %> <%= action.action_name %>

--- a/app/components/avo/actions_component.rb
+++ b/app/components/avo/actions_component.rb
@@ -31,6 +31,19 @@ class Avo::ActionsComponent < ViewComponent::Base
     end
   end
 
+  # When running an action for one record we should do it on a special path.
+  # We do that so we get the `record` param inside the action so we can prefill fields.
+  def action_path(action)
+    return single_record_path(action) if as_row_control
+    return many_records_path(action) unless @resource.has_record_id?
+
+    if on_record_page?
+      single_record_path action
+    else
+      many_records_path action
+    end
+  end
+
   # How should the action be displayed by default
   def is_disabled?(action)
     return false if action.standalone || as_row_control
@@ -46,5 +59,24 @@ class Avo::ActionsComponent < ViewComponent::Base
 
   def on_index_page?
     !on_record_page?
+  end
+
+  def single_record_path(action)
+    action_url(action, @resource.record_path)
+  end
+
+  def many_records_path(action)
+    action_url(action, @resource.records_path)
+  end
+
+  def action_url(action, path)
+    Avo::Services::URIService.parse(path)
+      .append_paths("actions")
+      .append_query(
+        {
+          action_id: action.to_param,
+          arguments: Avo::BaseAction.encode_arguments(action.arguments)
+        }.compact
+      ).to_s
   end
 end

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -68,6 +68,11 @@ module Avo
         @resource.dup.hydrate(record: record)
       end
 
+      # Temporary fix for visible blocks when geting fields for header
+      # Hydrating with last record so resource.record != nil
+      # This is keeping same behavior from <= 3.4.1
+      @resource.hydrate(record: @records.last)
+
       set_component_for __method__
     end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2544 

Reverting to same behavior as versions `<= 3.4.1` where index `@resource` keep last record hydrated. This avoid breaks while evaluating table header and there are fields using `visible: -> { resource.record.... }` checks on a visible field.

Also reverting the usage of `link_arguments` helper internally for generating actions path since it would generate the links always for the last record on the table.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
