### PR TITLE
refactor: conditional fill field

### DIFF
--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -191,7 +191,7 @@ module Avo
 
       # Fills the record with the received value on create and update actions.
       def fill_field(record, key, value, params)
-        return record unless has_attribute?(key)
+        return record unless has_attribute?(record, key)
 
         if @update_using.present?
           value = Avo::ExecutionContext.new(
@@ -210,7 +210,7 @@ module Avo
         record
       end
 
-      def has_attribute?(attribute)
+      def has_attribute?(record, attribute)
         record.methods.include? attribute.to_sym
       end
 

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -191,7 +191,7 @@ module Avo
 
       # Fills the record with the received value on create and update actions.
       def fill_field(record, key, value, params)
-        return record unless record.methods.include? key.to_sym
+        return record unless has_attribute?(key)
 
         if @update_using.present?
           value = Avo::ExecutionContext.new(
@@ -205,9 +205,13 @@ module Avo
           ).handle
         end
 
-        record.public_send("#{key}=", value)
+        record.public_send(:"#{key}=", value)
 
         record
+      end
+
+      def has_attribute?(attribute)
+        record.methods.include? attribute.to_sym
       end
 
       # Try to see if the field has a different database ID than it's name


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR enables users to override the `has_attribute?` method in order to get access to setters when there are no getters.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
