### PR TITLE
Use human model name when creating new polymorphic association

### DIFF
--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -70,7 +70,7 @@
           <% if field.can_create? %>
             <% create_href = create_path(Avo.resource_manager.get_resource_by_model_class(type.to_s)) %>
             <% if !disabled && create_href.present? %>
-              <%= link_to t("avo.create_new_item", item: type.to_s.downcase),
+              <%= link_to t("avo.create_new_item", item: type.model_name.human.downcase),
                     create_href,
                     class: "text-sm",
                     data: {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Use the human model name in the link for creating a new polymorphic association, instead of the class name

Fixes # (issue)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

Right now, when you have a polymorphic belongs to field and you specify the types argument (so the field shows a useful select menu allowing you to choose from the different polymorphic types) it has a link below the select menu saying "Create new <classname>". However, the name it uses for the resource is the class name used in the code, which isn't very user-friendly.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

This is what it looks like before (note the class name with modules in the link):

![Screenshot 2024-03-08 at 12 36 13](https://github.com/avo-hq/avo/assets/111963/dab6a2a0-155f-44f1-9f99-3e2dc66aacbe)

This is what it looks like after:

![Screenshot 2024-03-08 at 12 35 36](https://github.com/avo-hq/avo/assets/111963/7233f589-c2e4-46ba-966a-8404c22c7917)


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Find a polymorphic belongs to field that uses types, eg. https://main.avodemo.com/avo/resources/comments/549/edit
1. Switch to this branch
1. Confirm that the "create new <classname>" hasn't changed
2. Change the human name for the polymorphic class in the rails translations file
3. Reload avo and confirm that the name has updated to use the new translation

Manual reviewer: please leave a comment with output from the test if that's the case.
