### PR TITLE
fix: ensure Account is an ActiveRecord model before generating Avo resource

### DIFF
--- a/lib/generators/avo/install_generator.rb
+++ b/lib/generators/avo/install_generator.rb
@@ -21,7 +21,7 @@ module Generators
           Rails::Generators.invoke("avo:resource", ["user", "-q"], {destination_root: Rails.root })
         end
 
-        if defined?(Account).present?
+        if defined?(Account) && Account.is_a?(ActiveRecord::Base)
           Rails::Generators.invoke("avo:resource", ["account", "-q"], {destination_root: Rails.root })
         end
       end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2567

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
