### PR TITLE
Hide search input when avo_search? policy is not defined

### DIFF
--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -135,10 +135,8 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
 
   def authorized_to_search?
     # Hide the search if the authorization prevents it
-    # return false unless resource.authorization.respond_to?(:avo_search?)
-    return false unless resource.authorization.respond_to?(:has_action_method?)
+    return true unless resource.authorization.respond_to?(:has_action_method?)
     return false unless resource.authorization.has_action_method?("search")
-    return false unless resource.authorization.has_action_method?("avo_search?")
 
     resource.authorization.authorize_action("search", raise_exception: false)
   end

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -135,8 +135,10 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
 
   def authorized_to_search?
     # Hide the search if the authorization prevents it
-    return true unless resource.authorization.respond_to?(:has_action_method?)
-    return true unless resource.authorization.has_action_method?("search")
+    # return false unless resource.authorization.respond_to?(:avo_search?)
+    return false unless resource.authorization.respond_to?(:has_action_method?)
+    return false unless resource.authorization.has_action_method?("search")
+    return false unless resource.authorization.has_action_method?("avo_search?")
 
     resource.authorization.authorize_action("search", raise_exception: false)
   end


### PR DESCRIPTION
# Description
Modified the authorized_to_search? method in the ResourceIndexComponent to hide the search input if the avo_search? policy method is not defined for the resource.

Fixes [#2283](https://github.com/avo-hq/avo/issues/2283)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
