### PR TITLE
feature: configure custom save label per resource using localization

### DIFF
--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -177,22 +177,27 @@ module Avo
       end
 
       def name
-        default = class_name.underscore.humanize
-
-        if translation_key
-          t(translation_key, count: 1, default: default).humanize
-        else
-          default
-        end
+        name_from_translation_key(count: 1, default: class_name.underscore.humanize)
       end
       alias_method :singular_name, :name
 
       def plural_name
-        default = name.pluralize
+        name_from_translation_key(count: 2, default: name.pluralize)
+      end
 
-        if translation_key
-          t(translation_key, count: 2, default: default).humanize
-        else
+      # Get the name from the translation_key and fallback to default
+      # It can raise I18n::InvalidPluralizationData when using only resource_translation without pluralization keys like: one, two or other key
+      # Example:
+      # ---
+      # en:
+      #   avo:
+      #     resource_translations:
+      #       product:
+      #         save: "Save product"
+      def name_from_translation_key(count:, default:)
+        begin
+          t(translation_key, count:, default:).humanize
+        rescue I18n::InvalidPluralizationData
           default
         end
       end

--- a/lib/avo/concerns/has_controls.rb
+++ b/lib/avo/concerns/has_controls.rb
@@ -16,7 +16,7 @@ module Avo
       end
 
       def render_edit_controls
-        [BackButton.new(label: I18n.t("avo.cancel").capitalize), DeleteButton.new, ActionsList.new, SaveButton.new]
+        [BackButton.new(label: I18n.t("avo.cancel").capitalize), DeleteButton.new, ActionsList.new, SaveButton.new(resource: self)]
       end
 
       def render_index_controls(item:)

--- a/lib/avo/resources/controls/save_button.rb
+++ b/lib/avo/resources/controls/save_button.rb
@@ -5,7 +5,10 @@ module Avo
         def initialize(**args)
           super(**args)
 
-          @label = args[:label] || I18n.t("avo.save").capitalize
+          @label = args[:label] || I18n.t(
+            "#{args[:resource].translation_key}.save",
+            default: I18n.t("avo.save")
+          ).capitalize
         end
       end
     end

--- a/spec/dummy/config/locales/avo.en.yml
+++ b/spec/dummy/config/locales/avo.en.yml
@@ -1,0 +1,112 @@
+---
+en:
+  avo:
+    resource_translations:
+      product:
+        save: "Save the product!"
+    action_ran_successfully: Action ran successfully!
+    actions: Actions
+    and_x_other_resources: and %{count} other resources
+    are_you_sure: Are you sure?
+    are_you_sure_detach_item: Are you sure you want to detach this %{item}.
+    are_you_sure_you_want_to_run_this_option: Are you sure you want to run this action?
+    attach: Attach
+    attach_and_attach_another: Attach & Attach another
+    attach_item: Attach %{item}
+    attachment_class_attached: "%{attachment_class} attached."
+    attachment_class_detached: "%{attachment_class} detached."
+    attachment_destroyed: Attachment destroyed
+    cancel: Cancel
+    choose_a_country: Choose a country
+    choose_an_option: Choose an option
+    choose_item: Choose %{item}
+    clear_value: Clear value
+    click_to_reveal_filters: Click to reveal filters
+    confirm: Confirm
+    create_new_item: Create new %{item}
+    dashboard: Dashboard
+    dashboards: Dashboards
+    default_scope: All
+    delete: delete
+    delete_file: Delete file
+    delete_item: Delete %{item}
+    detach_item: detach %{item}
+    details: details
+    download: Download
+    download_file: Download file
+    download_item: Download %{item}
+    edit: edit
+    edit_item: edit %{item}
+    empty_dashboard_message: Add cards to this dashboard
+    failed: Failed
+    failed_to_find_attachment: Failed to find attachment
+    failed_to_load: Failed to load
+    filter_by: Filter by
+    filters: Filters
+    go_back: Go back
+    grid_view: Grid view
+    hide_content: Hide content
+    home: Home
+    key_value_field:
+      add_row: Add row
+      delete_row: Delete row
+      key: Key
+      value: Value
+    list_is_empty: List is empty
+    loading: Loading
+    more: More
+    new: new
+    next_page: Next page
+    no_cards_present: No cards present
+    no_item_found: No record found
+    no_options_available: No options available
+    no_related_item_found: No related record found
+    not_authorized: You are not authorized to perform this action.
+    number_of_items:
+      one: one %{item}
+      other: "%{count} %{item}"
+      zero: no %{item}
+    oops_nothing_found: Oops! Nothing found...
+    order:
+      higher: Move record higher
+      lower: Move record lower
+      reorder_record: Reorder record
+      to_bottom: Move record to bottom
+      to_top: Move record to top
+    per_page: Per page
+    prev_page: Previous page
+    records_selected_from_all_pages_html: All records selected from all pages
+    remove_selection: Remove selection
+    reset_filters: Reset filters
+    resource_created: Record created
+    resource_destroyed: Record destroyed
+    resource_updated: Record updated
+    resources: Resources
+    run: Run
+    save: Save
+    search:
+      cancel_button: Cancel
+      placeholder: Search
+    select_all: Select all
+    select_all_matching: Select all matching
+    select_item: Select item
+    show_content: Show content
+    sign_out: Sign out
+    switch_to_view: Switch to %{view_type} view
+    table_view: Table view
+    tools: Tools
+    type_to_search: Type to search.
+    unauthorized: Unauthorized
+    undo: undo
+    view: View
+    view_item: view %{item}
+    was_successfully_created: was successfully created
+    was_successfully_updated: was successfully updated
+    x_items_more:
+      one: one more item
+      other: "%{count} more items"
+      zero: no more items
+    x_records_selected_from_a_total_of_x_html: <span class="font-bold text-gray-700">%{selected}</span> records selected on this page from a total of <span class="font-bold text-gray-700">%{count}</span>
+    x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> records selected from all pages
+    x_records_selected_from_page_html: <span class="font-bold text-gray-700">%{selected}</span> records selected on this page
+    you_missed_something_check_form: You might have missed something. Please check the form.

--- a/spec/features/avo/i18n_spec.rb
+++ b/spec/features/avo/i18n_spec.rb
@@ -13,4 +13,12 @@ RSpec.feature "i18n", type: :feature do
       end
     end
   end
+
+  describe "save button" do
+    it "have custom text" do
+      visit avo.new_resources_product_path
+
+      expect(page).to have_button('Save the product!')
+    end
+  end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2594

Make possible to configure the save button label per each resource using localization

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
```yml
---
en:
  avo:
    resource_translations:
      product:
        save: "Save the product!"
```

![image](https://github.com/avo-hq/avo/assets/69730720/3b86847a-b045-4ba1-bf79-b189706fdc47)
