### PR TITLE
fix: collect errors from record without exception

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -245,9 +245,14 @@ module Avo
       end
 
       # Add the errors from the record
-      @errors = @record.errors.full_messages.reject { |error| exception_message.include? error }.unshift exception_message
+      @errors = @record.errors.full_messages
 
-      succeeded
+      # Remove duplicated errors
+      if exception_message.present?
+        @errors.reject { |error| exception_message.include? error }.unshift exception_message
+      end
+
+      @errors.any? ? false : succeeded
     end
 
     def model_params

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -249,7 +249,7 @@ module Avo
 
       # Remove duplicated errors
       if exception_message.present?
-        @errors.reject { |error| exception_message.include? error }.unshift exception_message
+        @errors = @errors.reject { |error| exception_message.include? error }.unshift exception_message
       end
 
       @errors.any? ? false : succeeded

--- a/spec/system/model_errors_spec.rb
+++ b/spec/system/model_errors_spec.rb
@@ -6,8 +6,6 @@ RSpec.feature "ModelErrors", type: :system do
   around do |example|
     Comment.before_destroy do
       errors.add(:base, "Some Errors")
-
-      throw(:abort)
     end
 
     example.run


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2602 

Collect errors from record even if nothing is raised. Errors can be added on callbacks without raising exception. Action fail if any error is present

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)~
- [x] I have added tests that prove my fix is effective or that my feature works