### PR TITLE
fix: keep original view after run update or create actions

### DIFF
--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -161,13 +161,22 @@ module Avo
       @resource.class.find_scope
     end
 
+    # Force actions to have specific view
+    VIEW_ACTION_MAPPING = {
+      update: :edit,
+      create: :new
+    } unless defined? VIEW_ACTION_MAPPING
+
     def set_view
-      @view = Avo::ViewInquirer.new(action_name.to_s)
+      @view = Avo::ViewInquirer.new(VIEW_ACTION_MAPPING[action_name.to_sym] || action_name)
     end
 
     def set_record_to_fill
-      @record_to_fill = @resource.model_class.new if @view.create?
-      @record_to_fill = @record if @view.update?
+      @record_to_fill = if @view.new?
+        @resource.model_class.new
+      elsif @view.edit?
+        @record
+      end
 
       # If resource.record is nil, most likely the user is creating a new record.
       # In that case, to access resource.record in visible and readonly blocks we hydrate the resource with a new record.

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -162,10 +162,12 @@ module Avo
     end
 
     # Force actions to have specific view
-    VIEW_ACTION_MAPPING = {
-      update: :edit,
-      create: :new
-    } unless defined? VIEW_ACTION_MAPPING
+    unless defined? VIEW_ACTION_MAPPING
+      VIEW_ACTION_MAPPING = {
+        update: :edit,
+        create: :new
+      }
+    end
 
     def set_view
       @view = Avo::ViewInquirer.new(VIEW_ACTION_MAPPING[action_name.to_sym] || action_name)

--- a/spec/features/avo/controller_action_spec.rb
+++ b/spec/features/avo/controller_action_spec.rb
@@ -31,13 +31,15 @@ RSpec.describe Avo::UsersController, type: :controller do
     it "assigns the @widget" do
       post :create, params: {user: {name: "Adrian"}}
 
-      assert assigns(:view).create?
+      assert assigns(:view).new?
+      assert assigns(:view).form?
     end
 
     it "assigns the @widget" do
       put :update, params: {id: user.id, user: {name: "Adrian"}}
 
-      assert assigns(:view).update?
+      assert assigns(:view).edit?
+      assert assigns(:view).form?
     end
 
     it "assigns the @widget" do


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2605

Keep original `new` / `edit` views when `create` / `update` actions are executed.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->