### PR TITLE
fix: date_time fields timezone

### DIFF
--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -204,18 +204,22 @@ export default class extends Controller {
       return
     }
 
+    let timezonedDate = DateTime.fromISO(selectedDates[0].toISOString())
+      .setZone(this.displayTimezone, { keepLocalTime: true })
+      .setZone('UTC', { keepLocalTime: !this.relativeValue })
+
     let value
     switch (this.fieldTypeValue) {
       case 'time':
         // For time values, we should maintain the real value and format it to a time-friendly format.
-        value = DateTime.fromISO(selectedDates[0].toISOString()).setZone('UTC', { keepLocalTime: !this.relativeValue }).toFormat(RAW_TIME_FORMAT)
+        value = timezonedDate.toFormat(RAW_TIME_FORMAT)
         break
       case 'date':
-        value = DateTime.fromISO(selectedDates[0].toISOString()).setZone('UTC', { keepLocalTime: true }).toFormat(RAW_DATE_FORMAT)
+        value = timezonedDate.toFormat(RAW_DATE_FORMAT)
         break
       default:
       case 'dateTime':
-        value = DateTime.fromISO(selectedDates[0].toISOString()).setZone('UTC', { keepLocalTime: !this.relativeValue }).toISO()
+        value = timezonedDate.toISO()
         break
     }
 

--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -204,7 +204,7 @@ export default class extends Controller {
       return
     }
 
-    let timezonedDate = DateTime.fromISO(selectedDates[0].toISOString())
+    const timezonedDate = DateTime.fromISO(selectedDates[0].toISOString())
       .setZone(this.displayTimezone, { keepLocalTime: true })
       .setZone('UTC', { keepLocalTime: !this.relativeValue })
 

--- a/lib/avo/fields/date_time_field.rb
+++ b/lib/avo/fields/date_time_field.rb
@@ -56,7 +56,7 @@ module Avo
         timezone = Avo::ExecutionContext.new(target: @timezone, record: resource.record, resource: resource, view: view).handle
 
         # Fix for https://github.com/moment/luxon/issues/1358#issuecomment-2017477897
-        return "Etc/UTC" if timezone.downcase == "utc" && view.form?
+        return "Etc/UTC" if timezone&.downcase == "utc" && view.form?
 
         timezone
       end

--- a/lib/avo/fields/date_time_field.rb
+++ b/lib/avo/fields/date_time_field.rb
@@ -53,7 +53,12 @@ module Avo
       end
 
       def timezone
-        Avo::ExecutionContext.new(target: @timezone, record: resource.record, resource: resource, view: view).handle
+        timezone = Avo::ExecutionContext.new(target: @timezone, record: resource.record, resource: resource, view: view).handle
+
+        # Fix for https://github.com/moment/luxon/issues/1358#issuecomment-2017477897
+        return "Etc/UTC" if timezone.downcase == "utc" && view.form?
+
+        timezone
       end
     end
   end

--- a/lib/avo/fields/date_time_field.rb
+++ b/lib/avo/fields/date_time_field.rb
@@ -43,8 +43,10 @@ module Avo
       end
 
       def utc_time(value)
-        if timezone.present?
-          ActiveSupport::TimeZone.new(timezone).local_to_utc(Time.parse(value))
+        time = Time.parse(value)
+
+        if timezone.present? && !time.utc?
+          ActiveSupport::TimeZone.new(timezone).local_to_utc(time)
         else
           value
         end

--- a/spec/system/avo/date_time_fields/timezone_spec.rb
+++ b/spec/system/avo/date_time_fields/timezone_spec.rb
@@ -68,7 +68,6 @@ RSpec.describe "timezone", type: :system do
     end
   end
 
-
   describe "On Romania (EET) with UTC timezone configured", tz: "Europe/Bucharest" do
     before do
       Avo::Resources::Project.with_temporary_items do

--- a/spec/system/avo/date_time_fields/timezone_spec.rb
+++ b/spec/system/avo/date_time_fields/timezone_spec.rb
@@ -67,4 +67,63 @@ RSpec.describe "timezone", type: :system do
       end
     end
   end
+
+
+  describe "On Romania (EET) with UTC timezone configured", tz: "Europe/Bucharest" do
+    before do
+      Avo::Resources::Project.with_temporary_items do
+        field :started_at, as: :date_time, timezone: "UTC", time_24hr: true, format: "MMMM dd, y HH:mm:ss z"
+      end
+    end
+
+    it { reset_browser }
+
+    context "index" do
+      it "displays the date in UTC tz" do
+        visit "/admin/resources/projects"
+
+        expect(index_field_value(id: :started_at, record_id: project.id)).to eq "March 25, 2024 08:23:00 UTC"
+      end
+    end
+
+    context "show" do
+      it "displays the date in UTC tz" do
+        visit "/admin/resources/projects/#{project.id}"
+
+        expect(show_field_value(id: :started_at)).to eq "March 25, 2024 08:23:00 UTC"
+      end
+    end
+
+    context "edit" do
+      describe "when keeping the value" do
+        it "saves the valid date" do
+          visit "/admin/resources/projects/#{project.id}/edit"
+
+          expect(text_input.value).to eq "2024-03-25 08:23:00"
+
+          save
+
+          expect(show_field_value(id: :started_at)).to eq "March 25, 2024 08:23:00 UTC"
+        end
+      end
+
+      describe "when changing the value" do
+        it "saves the valid date" do
+          visit "/admin/resources/projects/#{project.id}/edit"
+
+          expect(text_input.value).to eq "2024-03-25 08:23:00"
+
+          open_picker
+          set_picker_minute 24
+          set_picker_second 17
+
+          close_picker
+
+          save
+
+          expect(show_field_value(id: :started_at)).to eq "March 25, 2024 08:24:17 UTC"
+        end
+      end
+    end
+  end
 end

--- a/spec/system/avo/date_time_fields/timezone_spec.rb
+++ b/spec/system/avo/date_time_fields/timezone_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+# Please use the reset_browser helpers before the first and after the last spec.
+RSpec.describe "timezone", type: :system do
+  let!(:project) { create :project, started_at: Time.new(2024, 3, 25, 8, 23, 0, "UTC") } # "March 25, 2024 08:23:00 UTC"
+
+  subject(:text_input) { find '[data-field-id="started_at"] [data-controller="date-field"] input[type="text"]' }
+
+  after do
+    Avo::Resources::Project.restore_items_from_backup
+  end
+
+  describe "On Romania (EET) with CET timezone configured", tz: "Europe/Bucharest" do
+    before do
+      Avo::Resources::Project.with_temporary_items do
+        field :started_at, as: :date_time, timezone: "CET", time_24hr: true, format: "MMMM dd, y HH:mm:ss z"
+      end
+    end
+
+    it { reset_browser }
+
+    context "index" do
+      it "displays the date in CET tz" do
+        visit "/admin/resources/projects"
+
+        expect(index_field_value(id: :started_at, record_id: project.id)).to eq "March 25, 2024 09:23:00 CET"
+      end
+    end
+
+    context "show" do
+      it "displays the date in CET tz" do
+        visit "/admin/resources/projects/#{project.id}"
+
+        expect(show_field_value(id: :started_at)).to eq "March 25, 2024 09:23:00 CET"
+      end
+    end
+
+    context "edit" do
+      describe "when keeping the value" do
+        it "saves the valid date" do
+          visit "/admin/resources/projects/#{project.id}/edit"
+
+          expect(text_input.value).to eq "2024-03-25 09:23:00"
+
+          save
+
+          expect(show_field_value(id: :started_at)).to eq "March 25, 2024 09:23:00 CET"
+        end
+      end
+
+      describe "when changing the value" do
+        it "saves the valid date" do
+          visit "/admin/resources/projects/#{project.id}/edit"
+
+          expect(text_input.value).to eq "2024-03-25 09:23:00"
+
+          open_picker
+          set_picker_minute 24
+          set_picker_second 17
+
+          close_picker
+
+          save
+
+          expect(show_field_value(id: :started_at)).to eq "March 25, 2024 09:24:17 CET"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2510 

Flatpickr is always using the local timezone when editing. If `timezone` option is present it will ignore it. With this PR we change the timezone of the selected input keeping the date and time values before converting it to UTC.

Force timezone option when `UTC` to `Etc/UTC` on edit due this issue https://github.com/moment/luxon/issues/1358
<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works
