### PR TITLE
fix: search when link_to_child_resource

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -9,7 +9,7 @@ module Avo
     before_action :set_resource, only: :show
 
     def show
-            render json: search_resources([resource])
+      render json: search_resources([resource])
     rescue => error
       render_search_error(error)
     end

--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -9,7 +9,7 @@ module Avo
     before_action :set_resource, only: :show
 
     def show
-      render json: search_resources([resource])
+            render json: search_resources([resource])
     rescue => error
       render_search_error(error)
     end
@@ -126,10 +126,16 @@ module Avo
       title = item&.dig(:title) || resource.record_title
       highlighted_title = highlight(title&.to_s, params[:q])
 
+      record_path = if resource.link_to_child_resource
+        Avo.resource_manager.get_resource_by_model_class(record.class).new(record: record).record_path
+      else
+        resource.record_path
+      end
+
       {
         _id: record.id,
         _label: highlighted_title,
-        _url: resource.class.fetch_search(:result_path, record: resource.record) || resource.record_path
+        _url: resource.class.fetch_search(:result_path, record: resource.record) || record_path
       }
     end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2581

On a STI situation when `self.link_to_child_resource = true` search results now respect the correct resource url.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~


https://github.com/avo-hq/avo/assets/69730720/151f5d21-ec3e-41a0-b24d-74932ee858ea
