### PR TITLE
fix: keep avo.custom.js template on build

### DIFF
--- a/avo.gemspec
+++ b/avo.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.post_install_message = "Thank you for using Avo 💪  Docs are available at https://docs.avohq.io"
 
   spec.files = Dir["{bin,app,config,db,lib,public}/**/*", "MIT-LICENSE", "Rakefile", "README.md", "avo.gemspec", "Gemfile", "Gemfile.lock", "tailwind.preset.js", "tailwind.custom.js"]
-  spec.files.reject! { |file_name| %w[application.js application.js.map avo.custom.js avo.custom.js.map].any? { |rejected_file| file_name.include? rejected_file } }
+  spec.files.reject! { |file_name| %w[application.js application.js.map spec/dummy/app/javascript/avo.custom.js avo.custom.js.map].any? { |rejected_file| file_name.include? rejected_file } }
 
   spec.add_dependency "activerecord", ">= 6.1"
   spec.add_dependency "activesupport", ">= 6.1"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2411 

Keep `avo.custom.js` template on build, remove only the dummy app `avo.custom.js` file.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
