### PR TITLE
Support composite primary keys on show, edit, update and destroy actions

### DIFF
--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -146,7 +146,8 @@ module Avo
     end
 
     def set_record
-      @record = @resource.find_record(params[:id], query: model_scope, params: params)
+      id = @resource.model_class.primary_key.is_a?(Array) ? params.extract_value(:id) : params[:id]
+      @record = @resource.find_record(id, query: model_scope, params:)
       @resource.hydrate(record: @record)
     end
 

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -146,7 +146,12 @@ module Avo
     end
 
     def set_record
-      id = @resource.model_class.primary_key.is_a?(Array) ? params.extract_value(:id) : params[:id]
+      id = if @resource.model_class.primary_key.is_a?(Array) && params.respond_to?(:extract_value)
+        params.extract_value(:id)
+      else
+        params[:id]
+      end
+
       @record = @resource.find_record(id, query: model_scope, params:)
       @resource.hydrate(record: @record)
     end


### PR DESCRIPTION
Impressively, this seems to be all that's required to support composite primary keys in Rails 7.1

# Description
Support composite primary keys on show, edit, update and destroy actions on Rails 7.1.

`params.extract_values` was [introduced in Rails 7.1.0.beta1](https://github.com/rails/rails/commit/da7a6da4e7f5caf227420c550a8a13550dd9c682).

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording

Not really.

## Manual review steps

We do have a model that uses 3 enums as primary keys and I was able to view it's show page, edit and update it after the change. To implement the change in our codebase we have overwriting `set_record` on each resource that has a composite primary key.
