### PR TITLE
feature: add option for create links in sidebar

### DIFF
--- a/app/components/avo/sidebar/link_component.html.erb
+++ b/app/components/avo/sidebar/link_component.html.erb
@@ -1,9 +1,14 @@
 <% if path.present? %>
-  <%= send link_method, path, class: classes, active: active, target: target, data: data do %>
-    <%= helpers.svg icon, class: "h-4 text-gray-700" if icon.present? %>
-    <%= label %>
-    <% if target == :_blank %>
-      <%= helpers.svg('heroicons/outline/external-link', class: 'self-center ml-auto h-3 mr-2') %>
+  <%= content_tag :div, class: "flex justify-between gap-1 mx-6" do %>
+    <%= send link_method, path, class: classes + " flex-1 flex gap-1", active: active, target: target, data: data do %>
+      <%= helpers.svg icon, class: "h-4 text-gray-700" if icon.present? %>
+      <%= label %>
+      <% if target == :_blank %>
+        <%= helpers.svg('heroicons/outline/external-link', class: 'self-center ml-auto h-3 mr-2') %>
+      <% end %>
+    <% end %>
+    <% if Avo.configuration.create_links_in_sidebar && new_path.present? %>
+      <%= link_to "+", new_path, class: classes + " hover:bg-gray-100 hover:opacity-100 opacity-25" %>
     <% end %>
   <% end %>
 <% else %>

--- a/app/components/avo/sidebar/link_component.rb
+++ b/app/components/avo/sidebar/link_component.rb
@@ -5,12 +5,14 @@ class Avo::Sidebar::LinkComponent < ViewComponent::Base
   attr_reader :target
   attr_reader :label
   attr_reader :path
+  attr_reader :new_path
   attr_reader :data
   attr_reader :icon
 
-  def initialize(label: nil, path: nil, active: :inclusive, target: nil, data: {}, icon: nil)
+  def initialize(label: nil, path: nil, new_path: nil, active: :inclusive, target: nil, data: {}, icon: nil)
     @label = label
     @path = path
+    @new_path = new_path
     @active = active
     @target = target
     @data = data
@@ -30,6 +32,6 @@ class Avo::Sidebar::LinkComponent < ViewComponent::Base
   end
 
   def classes
-    "px-4 pr-0 flex-1 flex mx-6 leading-none py-2 text-black rounded font-medium hover:bg-gray-100 gap-1"
+    "px-4 leading-none py-2 text-black rounded font-medium hover:bg-gray-100"
   end
 end

--- a/app/components/avo/sidebar_component.html.erb
+++ b/app/components/avo/sidebar_component.html.erb
@@ -36,7 +36,7 @@
 
             <div class="w-full space-y-1">
               <% resources.sort_by { |r| r.navigation_label }.each do |resource| %>
-                <%= render Avo::Sidebar::LinkComponent.new label: resource.navigation_label, path: helpers.resources_path(resource: resource) %>
+                <%= render Avo::Sidebar::LinkComponent.new label: resource.navigation_label, path: helpers.resources_path(resource: resource), new_path: helpers.new_resource_path(resource: resource) %>
               <% end %>
             </div>
           </div>

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -26,6 +26,7 @@ module Avo
     attr_accessor :cache_resource_filters
     attr_accessor :context
     attr_accessor :display_breadcrumbs
+    attr_accessor :create_links_in_sidebar
     attr_accessor :hide_layout_when_printing
     attr_accessor :initial_breadcrumbs
     attr_accessor :home_path
@@ -92,6 +93,7 @@ module Avo
       @buttons_on_form_footers = false
       @main_menu = nil
       @profile_menu = nil
+      @create_links_in_sidebar = true
       @model_resource_mapping = {}
       @resource_default_view = Avo::ViewInquirer.new("show")
       @authorization_client = :pundit


### PR DESCRIPTION
# Description
Adds "+" links next to resource links in sidebar. They can be disabled with `config.create_links_in_sidebar = false`

# Checklist
- [X] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<img width="250" alt="Screenshot 2024-03-29 at 20 34 56" src="https://github.com/avo-hq/avo/assets/774459/68a970fb-5b80-4576-84fe-53fd1e59c63c">
