### PR TITLE
fix: preserve page when go back from resource show page (#1555)

### DIFF
--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -117,8 +117,8 @@ class Avo::ResourceComponent < Avo::BaseComponent
     (params[:via_resource_class].present? || params[:via_relation_class].present?) && params[:via_record_id].present?
   end
 
-  def via_page?
-    referrer_params["page"].present?
+  def keep_referrer_params
+    { page: referrer_params["page"] }.compact
   end
 
   def render_back_button(control)

--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -118,7 +118,7 @@ class Avo::ResourceComponent < Avo::BaseComponent
   end
 
   def keep_referrer_params
-    { page: referrer_params["page"] }.compact
+    {page: referrer_params["page"]}.compact
   end
 
   def render_back_button(control)

--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -1,5 +1,6 @@
 class Avo::ResourceComponent < Avo::BaseComponent
   include Avo::Concerns::ChecksAssocAuthorization
+  include Avo::Concerns::RequestMethods
 
   attr_reader :fields_by_panel
   attr_reader :has_one_panels
@@ -114,6 +115,10 @@ class Avo::ResourceComponent < Avo::BaseComponent
 
   def via_resource?
     (params[:via_resource_class].present? || params[:via_relation_class].present?) && params[:via_record_id].present?
+  end
+
+  def via_page?
+    referrer_params["page"].present?
   end
 
   def render_back_button(control)

--- a/app/components/avo/views/resource_edit_component.rb
+++ b/app/components/avo/views/resource_edit_component.rb
@@ -23,14 +23,14 @@ class Avo::Views::ResourceEditComponent < Avo::ResourceComponent
     return resources_path if via_index?
 
     if is_edit? && Avo.configuration.resource_default_view.show? # via resource show or edit page
-      return helpers.resource_path(record: @resource.record, resource: @resource)
+      return helpers.resource_path(record: @resource.record, resource: @resource, **keep_referrer_params)
     end
 
     resources_path
   end
 
   def resources_path
-    helpers.resources_path(resource: @resource)
+    helpers.resources_path(resource: @resource, **keep_referrer_params)
   end
 
   def resource_view_path

--- a/app/components/avo/views/resource_show_component.rb
+++ b/app/components/avo/views/resource_show_component.rb
@@ -30,7 +30,9 @@ class Avo::Views::ResourceShowComponent < Avo::ResourceComponent
     if via_resource?
       helpers.resource_path(record: association_resource.model_class, resource: association_resource, resource_id: params[:via_record_id])
     else
-      helpers.resources_path(resource: @resource)
+      via_page? ?
+        helpers.resources_path(resource: @resource, page: referrer_params["page"]) :
+        helpers.resources_path(resource: @resource)
     end
   end
 

--- a/app/components/avo/views/resource_show_component.rb
+++ b/app/components/avo/views/resource_show_component.rb
@@ -30,9 +30,7 @@ class Avo::Views::ResourceShowComponent < Avo::ResourceComponent
     if via_resource?
       helpers.resource_path(record: association_resource.model_class, resource: association_resource, resource_id: params[:via_record_id])
     else
-      via_page? ?
-        helpers.resources_path(resource: @resource, page: referrer_params["page"]) :
-        helpers.resources_path(resource: @resource)
+      helpers.resources_path(resource: @resource, **keep_referrer_params)
     end
   end
 

--- a/lib/avo/concerns/request_methods.rb
+++ b/lib/avo/concerns/request_methods.rb
@@ -1,0 +1,13 @@
+module Avo
+  module Concerns
+    module RequestMethods
+      def referrer_params
+        @referrer_params ||= begin
+          Rack::Utils.parse_query(URI(request.referrer).query)
+        rescue ArgumentError => _e
+          {}
+        end
+      end
+    end
+  end
+end

--- a/spec/components/avo/views/resource_show_component_spec.rb
+++ b/spec/components/avo/views/resource_show_component_spec.rb
@@ -1,12 +1,37 @@
 require "rails_helper"
 
 RSpec.describe Avo::Views::ResourceShowComponent, type: :component do
+  describe "back link" do
+    let(:user) { create :user }
+    let(:params) { {} }
+    let(:resource) { Avo::Resources::User.new(record: user, view: Avo::ViewInquirer.new("show")) }
+    let(:component) { described_class.new(resource: resource) }
+    let(:test_request) do
+      ActionDispatch::TestRequest.create
+        .tap do |req|
+          req.env["HTTP_REFERER"] = "/admin/resources/users?" + Rack::Utils.build_query(params)
+        end
+    end
+    let(:test_controller) do
+      Avo::UsersController.new
+        .tap { |c| c.request = test_request }
+        .extend(Rails.application.routes.url_helpers)
+    end
 
-  # it "renders something useful" do
-  #   expect(
-  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
-  #   ).to include(
-  #     "Hello, components!"
-  #   )
-  # end
+    it "returns the correct path" do
+      test_controller.view_context.render(component)
+
+      expect(component.back_path).to eq("/admin/resources/users")
+    end
+
+    context "when the resource is accessed via some page" do
+      let(:params) { {page: 42} }
+
+      it "returns path with page" do
+        test_controller.view_context.render(component)
+
+        expect(component.back_path).to eq("/admin/resources/users?page=42")
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Preserve page number when going back from resource show page.
Page number is fetched from referral url by parsing its query params.

Another approach can be using pagination data from index page as a parameter for generated links and then just checking `params` for `back_path`. The problem with this option is not that we will have to pass `@pagy` down through components tree, but that page number will be present in show links as well, which seems redundant.

Fixes [#1555](https://github.com/orgs/avo-hq/projects/8?pane=issue&itemId=47768610)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Run local dummy app
2. Open project list and go to page 2
3. Select some project and open show page
4. Click 'Go back'
5. Make sure you are on page 2 

Manual reviewer: please leave a comment with output from the test if that's the case.
