### PR TITLE
feature: callable `default_view_type`

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -335,7 +335,12 @@ module Avo
       elsif available_view_types.size == 1
         available_view_types.first
       else
-        @resource.default_view_type || Avo.configuration.default_view_type
+        Avo::ExecutionContext.new(
+          target: @resource.default_view_type || Avo.configuration.default_view_type,
+          resource: @resource,
+          record: @record,
+          view: @view
+        ).handle
       end
 
       if available_view_types.exclude? @index_params[:view_type].to_sym

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -338,7 +338,6 @@ module Avo
         Avo::ExecutionContext.new(
           target: @resource.default_view_type || Avo.configuration.default_view_type,
           resource: @resource,
-          record: @record,
           view: @view
         ).handle
       end

--- a/spec/dummy/app/avo/resources/post.rb
+++ b/spec/dummy/app/avo/resources/post.rb
@@ -8,7 +8,11 @@ class Avo::Resources::Post < Avo::BaseResource
   }
 
   self.includes = [:user]
-  self.default_view_type = :grid
+  self.default_view_type = -> {
+    mobile_user = request.user_agent =~ /Mobile/
+
+    mobile_user ? :table : :grid
+  }
   self.find_record_method = -> {
     # When using friendly_id, we need to check if the id is a slug or an id.
     # If it's a slug, we need to use the find_by_slug method.


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This enables the possibility to define a proc on `default_view_type` option. It's useful when we want different default view types according to the user or used device.

```ruby
class Avo::Resources::Post < Avo::BaseResource
  self.default_view_type = -> {
    mobile_user = request.user_agent =~ /Mobile/

    mobile_user ? :table : :grid
  }
end
```

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
  - https://github.com/avo-hq/avodocs/pull/188
- [ ] I have added tests that prove my fix is effective or that my feature works
