### PR TITLE
fix: hydrate resource with record when detect_fields on new

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -8,6 +8,7 @@ module Avo
     before_action :set_resource
     before_action :set_applied_filters, only: :index
     before_action :set_record, only: [:show, :edit, :destroy, :update, :preview]
+    before_action :set_new_record, only: :new
     before_action :detect_fields
     before_action :set_record_to_fill
     before_action :set_edit_title_and_breadcrumbs, only: [:edit, :update]
@@ -102,9 +103,6 @@ module Avo
     end
 
     def new
-      @record = @resource.model_class.new
-      @resource = @resource.hydrate(record: @record, view: :new, user: _current_user)
-
       # Handle special cases when creating a new record via a belongs_to relationship
       if params[:via_belongs_to_resource_class].present?
         return render turbo_stream: turbo_stream.append('attach_modal', partial: 'avo/base/new_via_belongs_to')
@@ -603,6 +601,11 @@ module Avo
 
     def apply_pagination
       @pagy, @records = @resource.apply_pagination(index_params: @index_params, query: pagy_query)
+    end
+
+    def set_new_record
+      @record = @resource.model_class.new
+      @resource.hydrate(record: @record, view: :new, user: _current_user)
     end
   end
 end

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -8,7 +8,7 @@ module Avo
     before_action :set_resource
     before_action :set_applied_filters, only: :index
     before_action :set_record, only: [:show, :edit, :destroy, :update, :preview]
-    before_action :set_record_to_fill
+    before_action :set_record_to_fill, only: [:new, :edit]
     before_action :detect_fields
     before_action :set_edit_title_and_breadcrumbs, only: [:edit, :update]
     before_action :fill_record, only: [:create, :update]

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -8,9 +8,8 @@ module Avo
     before_action :set_resource
     before_action :set_applied_filters, only: :index
     before_action :set_record, only: [:show, :edit, :destroy, :update, :preview]
-    before_action :set_new_record, only: :new
-    before_action :detect_fields
     before_action :set_record_to_fill
+    before_action :detect_fields
     before_action :set_edit_title_and_breadcrumbs, only: [:edit, :update]
     before_action :fill_record, only: [:create, :update]
     # Don't run base authorizations for associations
@@ -103,6 +102,10 @@ module Avo
     end
 
     def new
+      # Record is already hydrated on set_record_to_fill method
+      @record = @resource.record
+      @resource.hydrate(view: :new, user: _current_user)
+
       # Handle special cases when creating a new record via a belongs_to relationship
       if params[:via_belongs_to_resource_class].present?
         return render turbo_stream: turbo_stream.append('attach_modal', partial: 'avo/base/new_via_belongs_to')
@@ -601,11 +604,6 @@ module Avo
 
     def apply_pagination
       @pagy, @records = @resource.apply_pagination(index_params: @index_params, query: pagy_query)
-    end
-
-    def set_new_record
-      @record = @resource.model_class.new
-      @resource.hydrate(record: @record, view: :new, user: _current_user)
     end
   end
 end

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -8,7 +8,7 @@ module Avo
     before_action :set_resource
     before_action :set_applied_filters, only: :index
     before_action :set_record, only: [:show, :edit, :destroy, :update, :preview]
-    before_action :set_record_to_fill, only: [:new, :edit]
+    before_action :set_record_to_fill, only: [:new, :edit, :create, :update]
     before_action :detect_fields
     before_action :set_edit_title_and_breadcrumbs, only: [:edit, :update]
     before_action :fill_record, only: [:create, :update]


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://discord.com/channels/740892036978442260/1201874761546735636/1225395037047619664

Ensure that record is present when `detect_fields` is called on `new` action.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
