### PR TITLE
fix: select boolean false value

### DIFF
--- a/app/components/avo/fields/select_field/show_component.html.erb
+++ b/app/components/avo/fields/select_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args do %>
-  <%= @field.label %>
+<%= field_wrapper **field_wrapper_args.merge(dash_if_blank: false) do %>
+  <%= @field.value.nil? ? "—" : @field.label %>
 <% end %>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes select field on boolean attributes when value is false.

```ruby
field :is_capital,
  as: :select,
  options: {
    'Yes': true,
    'No': false
  }
```

1 - Before
2 - After

![image](https://github.com/avo-hq/avo/assets/69730720/c0ceb12c-b755-4b73-a7bf-3c4b16d449f1)


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
