### PR TITLE
Layout tweaks to Resource header area

### DIFF
--- a/app/components/avo/panel_component.html.erb
+++ b/app/components/avo/panel_component.html.erb
@@ -1,12 +1,12 @@
 <%= content_tag :div, data: data_attributes, class: classes do %>
   <% if render_header? %>
     <div data-target="panel-header" class="mb-4">
-        <% if display_breadcrumbs? %>
-          <div class="breadcrumbs mb-2">
-            <%= helpers.render_avo_breadcrumbs(separator: helpers.svg('chevron-right', class: 'inline-block h-3 stroke-current relative top-[-1px] ml-1' )) if Avo.configuration.display_breadcrumbs %>
-          </div>
-        <% end %>
-        <div class="flex-1 flex flex-col xl:flex-row justify-between gap-1">
+      <% if display_breadcrumbs? %>
+        <div class="breadcrumbs mb-2">
+          <%= helpers.render_avo_breadcrumbs(separator: helpers.svg('chevron-right', class: 'inline-block h-3 stroke-current relative top-[-1px] ml-1' )) if Avo.configuration.display_breadcrumbs %>
+        </div>
+      <% end %>
+      <div class="flex-1 flex flex-col xl:flex-row justify-between gap-1">
         <div class="overflow-hidden flex flex-col">
           <div class="text-2xl tracking-normal font-semibold text-gray-800 items-center flex flex-1" data-target="title">
             <span><%= @name %></span>

--- a/app/components/avo/panel_component.html.erb
+++ b/app/components/avo/panel_component.html.erb
@@ -1,31 +1,33 @@
 <%= content_tag :div, data: data_attributes, class: classes do %>
   <% if render_header? %>
-    <div data-target="panel-header" class="flex-1 flex flex-col xl:flex-row justify-between mb-4">
-      <div class="overflow-hidden flex flex-col">
+    <div data-target="panel-header" class="mb-4">
         <% if display_breadcrumbs? %>
-          <div class="breadcrumbs truncate mb-2">
+          <div class="breadcrumbs mb-2">
             <%= helpers.render_avo_breadcrumbs(separator: helpers.svg('chevron-right', class: 'inline-block h-3 stroke-current relative top-[-1px] ml-1' )) if Avo.configuration.display_breadcrumbs %>
           </div>
         <% end %>
-        <div class="text-2xl tracking-normal font-semibold text-gray-800 truncate items-center flex flex-1" data-target="title">
-          <span><%= @name %></span>
-          <% if @reloadable %>
-            <%= button_tag data: { controller: "panel-refresh", action: "click->panel-refresh#refresh" } do %>
-              <%= svg "heroicons/outline/arrow-path", class: "ml-2 text-2xl h-6 " %>
+        <div class="flex-1 flex flex-col xl:flex-row justify-between gap-1">
+        <div class="overflow-hidden flex flex-col">
+          <div class="text-2xl tracking-normal font-semibold text-gray-800 items-center flex flex-1" data-target="title">
+            <span><%= @name %></span>
+            <% if @reloadable %>
+              <%= button_tag data: { controller: "panel-refresh", action: "click->panel-refresh#refresh" } do %>
+                <%= svg "heroicons/outline/arrow-path", class: "ml-2 text-2xl h-6 " %>
+              <% end %>
             <% end %>
+          </div>
+          <% if description.present? %>
+            <div class="text-sm tracking-normal font-medium text-gray-600" data-target="description">
+              <%== description %>
+            </div>
           <% end %>
         </div>
-        <% if description.present? %>
-          <div class="text-sm tracking-normal font-medium text-gray-600" data-target="description">
-            <%== description %>
+        <% if tools.present? %>
+          <div class="flex-1 w-full flex flex-col sm:flex-row xl:justify-end sm:items-end gap-2 mt-4 xl:mt-0" data-target="panel-tools">
+            <%= tools %>
           </div>
         <% end %>
       </div>
-      <% if tools.present? %>
-        <div class="flex-1 w-full flex flex-wrap flex-col sm:flex-row xl:justify-end sm:items-end gap-2 mt-4 xl:mt-0" data-target="panel-tools">
-          <%= tools %>
-        </div>
-      <% end %>
     </div>
   <% end %>
   <% if body? %>


### PR DESCRIPTION
- Ensure Resource titles are always visible.
- Action buttons don’t wrap to new lines
- Breadcrumb always spans full width

# Description
Makes a few changes to the layout of the Resource header.  Mainly it always ensures that no data is obscured or cut off. 

Yes, it does make pages longer but i feel it's more important to be able to see the content than have shorter pages. 

## Screenshots & recording
Before:
<img width="1517" alt="Screenshot 2024-04-07 at 17 10 38" src="https://github.com/avo-hq/avo/assets/774459/554fc263-eb4a-4a17-a0d8-dcb3530cf829">
<img width="449" alt="Screenshot 2024-04-07 at 17 32 28" src="https://github.com/avo-hq/avo/assets/774459/a92cfa10-67dc-4987-8d98-1ceee5ec7d75">


After:
<img width="1511" alt="Screenshot 2024-04-07 at 17 28 54" src="https://github.com/avo-hq/avo/assets/774459/7b50eeed-af82-483f-a7be-9f5a57ebb605">
<img width="847" alt="Screenshot 2024-04-07 at 17 29 01" src="https://github.com/avo-hq/avo/assets/774459/7d82a16d-2d10-4f61-951f-c371383cee30">
<img width="446" alt="Screenshot 2024-04-07 at 17 31 40" src="https://github.com/avo-hq/avo/assets/774459/e8a9c611-a4c4-41b1-8659-b52e3c9b62ae">


