### PR TITLE
Don't affect unspecified options in boolean group

### DIFF
--- a/lib/avo/fields/boolean_group_field.rb
+++ b/lib/avo/fields/boolean_group_field.rb
@@ -26,7 +26,8 @@ module Avo
           new_value[id] = value.include? id.to_s
         end
 
-        model[id] = new_value
+        # Don't override existing values unless specified in options
+        model[id] = (model[id] || {}).merge(new_value)
 
         model
       end

--- a/spec/system/avo/boolean_group_field_spec.rb
+++ b/spec/system/avo/boolean_group_field_spec.rb
@@ -63,6 +63,21 @@ RSpec.describe "BooleanGroupField", type: :system do
         expect(page.all(".tippy-content svg")[1][:class]).to have_text "text-red-500"
         expect(page.all(".tippy-content svg")[2][:class]).to have_text "text-red-500"
       end
+
+      it "doesn't affect unspecified options" do
+        user.update(roles: user.roles.merge({publisher: true}))
+
+        visit "/admin/resources/users/#{user.id}/edit"
+
+        uncheck "user_roles_admin"
+        uncheck "user_roles_manager"
+        uncheck "user_roles_writer"
+
+        save
+
+        user.reload
+        expect(user.roles).to eql({admin: false, manager: false, publisher: true, writer: false}.with_indifferent_access)
+      end
     end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2603. If this is fine, I will create a PR to [revert the warning](https://github.com/avo-hq/avodocs/commit/87f7b96a114263bb0f568b1c5599ebab21a6d020) in the docs (or better describing the updated behavior).

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs): avo-hq/avodocs#194
- [x] I have added tests that prove my fix is effective or that my feature works

