### PR TITLE
enhancement: full-width fields when sidebar present

### DIFF
--- a/app/components/avo/field_wrapper_component.html.erb
+++ b/app/components/avo/field_wrapper_component.html.erb
@@ -20,7 +20,7 @@
   <%= content_tag :div, class: class_names("flex-1 flex flex-row md:min-h-inherit py-2 px-6", @field.get_html(:classes, view: view, element: :content), {
     "pb-4": stacked?,
   }), data: {slot: "value"} do %>
-    <div class="self-center w-full <% unless full_width? || compact? || stacked? %> md:w-8/12 <% end %>">
+    <div class="self-center w-full <% unless full_width? || compact? || stacked? %> md:w-8/12 has-sidebar:w-full <% end %>">
       <% if on_show? %>
         <% if field.value.blank? and dash_if_blank %>
           —

--- a/app/components/avo/panel_component.html.erb
+++ b/app/components/avo/panel_component.html.erb
@@ -31,7 +31,7 @@
     </div>
   <% end %>
   <% if body? %>
-    <div data-target="panel-body" class="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:gap-4 w-full">
+    <div data-target="panel-body" class="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:gap-4 w-full <% if sidebar? %> has-sidebar <% end %>">
       <div class="relative flex-1 w-full <% if sidebar? %> sm:w-2/3 <% end %>">
         <% # The body is wrapped inside another div in order to avoid long & tall panels next to sidebars when the sidebar taller. %>
         <div class="relative <%= white_panel_classes %> <%= @body_classes %>">
@@ -51,7 +51,7 @@
     </div>
   <% end %>
   <% if bare_content? %>
-    <div data-target="panel-bare-content" class="relative">
+    <div data-target="panel-bare-content" class="relative <% if sidebar? %> has-sidebar <% end %>">
       <%= bare_content %>
     </div>
   <% end %>

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -136,13 +136,13 @@ module Avo
         @reflection = @record._reflections[params[:via_relation]]
         # Figure out what kind of association does the record have with the parent record
 
-        # Fills in the required infor for belongs_to and has_many
+        # Fills in the required info for belongs_to and has_many
         # Get the foreign key and set it to the id we received in the params
         if @reflection.is_a?(ActiveRecord::Reflection::BelongsToReflection) || @reflection.is_a?(ActiveRecord::Reflection::HasManyReflection)
           related_resource = Avo.resource_manager.get_resource_by_model_class params[:via_relation_class]
           related_record = related_resource.find_record params[:via_record_id], params: params
 
-          @record.send("#{@reflection.foreign_key}=", related_record.id)
+          @record.send(:"#{@reflection.foreign_key}=", related_record.id)
         end
 
         # For when working with has_one, has_one_through, has_many_through, has_and_belongs_to_many, polymorphic

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -471,11 +471,13 @@ module Avo
     end
 
     def cache_hash(parent_record)
+      result = [record, file_hash]
+
       if parent_record.present?
-        [record, file_hash, parent_record]
-      else
-        [record, file_hash]
+        result << parent_record
       end
+
+      result
     end
 
     # We will not overwrite any attributes that come pre-filled in the record.

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   # config.assets.debug = true
 
   # Suppress logger output for asset requests.
-  # config.assets.quiet = true
+  config.assets.quiet = true
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true

--- a/tailwind.preset.js
+++ b/tailwind.preset.js
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 const plugin = require('tailwindcss/plugin')
 const colors = require('tailwindcss/colors')
 const defaultTheme = require('tailwindcss/defaultTheme')
@@ -139,13 +140,15 @@ module.exports = {
   plugins: [
     require('@tailwindcss/forms'),
     require('@tailwindcss/typography'),
-    plugin(({ addUtilities }) => {
+    plugin(({ addUtilities, addVariant }) => {
       const newUtilities = {
         '.backface-hidden': {
           backfaceVisibility: 'hidden',
         },
       }
 
+      // Add has-sidebar variant to make it easier to target fields in panels and use the full-width
+      addVariant('has-sidebar', '.has-sidebar & ')
       addUtilities(newUtilities, ['group-hover'])
     }),
   ],


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR makes the value section of the field take up all the space it can when there is a sidebar present.

#### Before

![CleanShot 2024-04-12 at 21 22 47@2x](https://github.com/avo-hq/avo/assets/1334409/cc3b33dc-988a-42fc-aedb-6e5575bca378)

#### After
![CleanShot 2024-04-12 at 21 23 10@2x](https://github.com/avo-hq/avo/assets/1334409/f382cc1b-92b8-429a-a213-b36a3ccb623a)



<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
