### PR TITLE
fix: detach action record

### DIFF
--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -128,8 +128,8 @@ module Avo
       klass
     end
 
-    def authorize_if_defined(method)
-      @authorization.set_record(@record)
+    def authorize_if_defined(method, record = @record)
+      @authorization.set_record(record)
 
       if @authorization.has_method?(method.to_sym)
         @authorization.authorize_action method.to_sym
@@ -145,7 +145,7 @@ module Avo
     end
 
     def authorize_detach_action
-      authorize_if_defined "detach_#{@field.id}?"
+      authorize_if_defined "detach_#{@field.id}?", @attachment_record
     end
 
     def set_related_authorization


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2568

`record` variable on `detach_...` method was actually the parent record instead the detached record as expected and documented.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
please leave a comment with output from the test if that's the case.
