### PR TITLE
fix: leaky global default_url_options

### DIFF
--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -298,7 +298,7 @@ module Avo
     end
 
     def default_url_options
-      result = super
+      result = super.dup
 
       if params[:force_locale].present?
         result[:force_locale] = params[:force_locale]

--- a/spec/system/avo/reload_button_spec.rb
+++ b/spec/system/avo/reload_button_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe "Reload button", type: :system do
 
         expect(page).to have_content("Initial review body")
 
-        find("button[data-controller='panel-refresh']").click
+        within('[data-resource-name="Avo::Resources::Review"]') do
+          find("button[data-controller='panel-refresh']").click
+        end
 
         expect(page).to have_content("Updated review body")
       end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/2687

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
