### PR TITLE
fix: bad animation for menu on reload

### DIFF
--- a/app/javascript/js/controllers/menu_controller.js
+++ b/app/javascript/js/controllers/menu_controller.js
@@ -49,19 +49,27 @@ export default class extends Controller {
 
   updateDom() {
     if (this.collapsed) {
-      this.markCollapsed()
+      this.markCollapsed(true)
     } else {
-      this.markExpanded()
+      this.markExpanded(true)
     }
   }
 
-  markCollapsed() {
+  markCollapsed(animate = false) {
     this.svgTarget.classList.add('rotate-90')
-    leave(this.itemsTarget)
+    if (animate) {
+      leave(this.itemsTarget)
+    } else {
+      this.itemsTarget.classList.add('hidden')
+    }
   }
 
-  markExpanded() {
+  markExpanded(animate = false) {
     this.svgTarget.classList.remove('rotate-90')
-    enter(this.itemsTarget)
+    if (animate) {
+      enter(this.itemsTarget)
+    } else {
+      this.itemsTarget.classList.remove('hidden')
+    }
   }
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where the sidebar section and group would animate in on page refresh.
Related to https://github.com/avo-hq/avo/pull/2695

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
