### PR TITLE
fix: check proper dir for internal controller override

### DIFF
--- a/lib/generators/avo/concerns/override_controller.rb
+++ b/lib/generators/avo/concerns/override_controller.rb
@@ -12,7 +12,7 @@ module Generators
         end
 
         def controllers_list
-          Dir["app/controllers/avo/*.rb"].map { |file_path| File.basename(file_path, ".rb") }
+          Dir[::Avo::Engine.root.join("app", "controllers", "avo", "*.rb")].map { |file_path| File.basename(file_path, ".rb") }
         end
       end
     end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2710

Check proper directory for internal controller override. Engine dir instead app one.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

![image](https://github.com/avo-hq/avo/assets/69730720/171b0950-cd12-4283-8de2-30364f818502)
