### PR TITLE
require ostruct in case other gems are not doing so

### DIFF
--- a/lib/avo/menu/menu.rb
+++ b/lib/avo/menu/menu.rb
@@ -1,2 +1,4 @@
+require "ostruct"
+
 class Avo::Menu::Menu < OpenStruct
 end


### PR DESCRIPTION
# Description
When updating the `json` gem from 2.7.1 to [2.7.2](https://github.com/flori/json/blob/master/CHANGES.md#2024-04-04-272) in our Rails 7.1.3/Ruby 3.3.0 application we got the error
> NameError:
  uninitialized constant OpenStruct
 ./vendor/bundle/ruby/3.3.0/gems/avo-2.49.0/lib/avo/menu/menu.rb:1:in <main>

when running our rspec test suite. The error was resolved by adding `require "ostruct"`

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
