### PR TITLE
fix: cache_table_rows

### DIFF
--- a/app/components/avo/index/resource_table_component.rb
+++ b/app/components/avo/index/resource_table_component.rb
@@ -4,6 +4,8 @@ class Avo::Index::ResourceTableComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
   attr_reader :pagy, :query
 
+  def before_render = cache_table_rows
+
   def initialize(resources: nil, resource: nil, reflection: nil, parent_record: nil, parent_resource: nil, pagy: nil, query: nil, actions: nil)
     @resources = resources
     @resource = resource
@@ -13,7 +15,6 @@ class Avo::Index::ResourceTableComponent < Avo::BaseComponent
     @pagy = pagy
     @query = query
     @actions = actions
-    cache_table_rows
   end
 
   def encrypted_query


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2732

Caching before render instead inside initializer to avoid:

```
ActionView::Template::Error (`#controller` can't be used during initialization, as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.

It's sometimes possible to fix this issue by moving code dependent on `#controller` to a [`#before_render` method](https://viewcomponent.org/api.html#before_render--void).):
```

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
