### PR TITLE
fix: check if ActionText::RichText is defined

### DIFF
--- a/lib/avo/fields/trix_field.rb
+++ b/lib/avo/fields/trix_field.rb
@@ -23,7 +23,7 @@ module Avo
 
       # Identify if field is bonded to a rich text model attribute
       def is_action_text?
-        return false if record.nil? || !record.respond_to?(id)
+        return false if !defined?(ActionText::RichText) || record.nil? || !record.respond_to?(id)
 
         record.send(id).is_a?(ActionText::RichText)
       end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Check if `ActionText::RichText` is defined before use it.

Fixes #2738

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
