### PR TITLE
feature: heading target

### DIFF
--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Avo::FieldWrapperComponent < ViewComponent::Base
+  include Avo::Concerns::HasResourceStimulusControllers
+
   attr_reader :dash_if_blank
   attr_reader :compact
   attr_reader :field
@@ -111,13 +113,5 @@ class Avo::FieldWrapperComponent < ViewComponent::Base
 
   def full_width?
     @full_width
-  end
-
-  private
-
-  def add_stimulus_attributes_for(entity, attributes)
-    entity.get_stimulus_controllers.split(" ").each do |controller|
-      attributes["#{controller}-target"] = "#{@field.id.to_s.underscore}_#{@field.type.to_s.underscore}_wrapper".camelize(:lower)
-    end
   end
 end

--- a/app/components/avo/fields/common/heading_component.html.erb
+++ b/app/components/avo/fields/common/heading_component.html.erb
@@ -1,9 +1,9 @@
-<div class="flex items-start py-1 leading-tight bg-gray-100 text-gray-500 text-xs">
+<%= content_tag :div, class: "flex items-start py-1 leading-tight bg-gray-100 text-gray-500 text-xs", data: @data do %>
   <div class="py-2 px-6 h-full w-full">
-    <% if as_html %>
-      <%= sanitize value %>
+    <% if @field.as_html %>
+      <%= sanitize @field.value %>
     <% else %>
-      <div class="font-semibold uppercase"><%= value %></div>
+      <div class="font-semibold uppercase"><%= @field.value %></div>
     <% end %>
   </div>
-</div>
+<% end %>

--- a/app/components/avo/fields/common/heading_component.rb
+++ b/app/components/avo/fields/common/heading_component.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 class Avo::Fields::Common::HeadingComponent < ViewComponent::Base
-  attr_reader :value
-  attr_reader :as_html
+  include Avo::Concerns::HasResourceStimulusControllers
 
-  def initialize(value:, as_html:)
-    @value = value
-    @as_html = as_html
+  def initialize(field:)
+    @field = field
+    @view = field.resource.view
+
+    @data = stimulus_data_attributes
+    add_stimulus_attributes_for(field.resource, @data)
   end
 end

--- a/app/components/avo/fields/heading_field/edit_component.html.erb
+++ b/app/components/avo/fields/heading_field/edit_component.html.erb
@@ -1,3 +1,3 @@
 <div <% if @index == 0 %> class="overflow-hidden rounded-t" <% end %> data-field-id="<%= @field.id %>">
-  <%= render Avo::Fields::Common::HeadingComponent.new value: @field.value, as_html: @field.as_html %>
+  <%= render Avo::Fields::Common::HeadingComponent.new field: @field %>
 </div>

--- a/app/components/avo/fields/heading_field/show_component.html.erb
+++ b/app/components/avo/fields/heading_field/show_component.html.erb
@@ -1,3 +1,3 @@
 <div <% if @index == 0 %> class="overflow-hidden rounded-t" <% end %> data-field-id="<%= @field.id %>">
-  <%= render Avo::Fields::Common::HeadingComponent.new value: @field.value, as_html: @field.as_html %>
+  <%= render Avo::Fields::Common::HeadingComponent.new field: @field %>
 </div>

--- a/lib/avo/concerns/has_resource_stimulus_controllers.rb
+++ b/lib/avo/concerns/has_resource_stimulus_controllers.rb
@@ -8,11 +8,11 @@ module Avo
       end
 
       def get_stimulus_controllers
-        return "" if view.nil?
+        return "" if @view.nil?
 
         controllers = []
 
-        case view.to_sym
+        case @view.to_sym
         when :show
           controllers << "resource-show"
         when :new, :edit
@@ -32,10 +32,16 @@ module Avo
         }
 
         get_stimulus_controllers.split(" ").each do |controller|
-          attributes["#{controller}-view-value"] = view
+          attributes["#{controller}-view-value"] = @view
         end
 
         attributes
+      end
+
+      def add_stimulus_attributes_for(entity, attributes)
+        entity.get_stimulus_controllers.split(" ").each do |controller|
+          attributes["#{controller}-target"] = "#{@field.id.to_s.underscore}_#{@field.type.to_s.underscore}_wrapper".camelize(:lower)
+        end
       end
     end
   end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Add stimulus target for heading fields.

```ruby
field :user_information, as: :heading

# Generates on show (same for other views)
<div class="..." data-controller="resource-show " data-resource-show-view-value="show" data-resource-show-target="headingUserInformationHeadingWrapper">
   ...
</div>
```

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
