### PR TITLE
feature: html classes for heading wrapper

### DIFF
--- a/app/components/avo/fields/common/heading_component.html.erb
+++ b/app/components/avo/fields/common/heading_component.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag :div, class: "flex items-start py-1 leading-tight bg-gray-100 text-gray-500 text-xs", data: @data do %>
+<%= content_tag :div, class: @classes, data: @data do %>
   <div class="py-2 px-6 h-full w-full">
     <% if @field.as_html %>
       <%= sanitize @field.value %>

--- a/app/components/avo/fields/common/heading_component.rb
+++ b/app/components/avo/fields/common/heading_component.rb
@@ -6,6 +6,7 @@ class Avo::Fields::Common::HeadingComponent < ViewComponent::Base
   def initialize(field:)
     @field = field
     @view = field.resource.view
+    @classes = "flex items-start py-1 leading-tight bg-gray-100 text-gray-500 text-xs #{@field.get_html(:classes, view: @view, element: :wrapper)}"
 
     @data = stimulus_data_attributes
     add_stimulus_attributes_for(field.resource, @data)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Allow html option classes for heading field wrapper:

```ruby
      field :user_information, as: :heading, html: -> {
        edit do
          wrapper do
            classes do
              record.something? ? "hidden" : ""
            end
          end
        end
      }
```

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
