### PR TITLE
fix: wrong label on `belongs_to`field

### DIFF
--- a/app/components/avo/field_wrapper_component.html.erb
+++ b/app/components/avo/field_wrapper_component.html.erb
@@ -11,7 +11,7 @@
     "md:w-64": !compact?,
   }), data: {slot: "label"} do %>
     <% if form.present? %>
-      <%= form.label field.id, label %>
+      <%= form.label field.form_field_label, label %>
     <% else %>
       <%= field.name %>
     <% end %>

--- a/lib/avo/concerns/breadcrumbs.rb
+++ b/lib/avo/concerns/breadcrumbs.rb
@@ -85,10 +85,10 @@ module Avo
       end
 
       module HelperMethods
-        def render_avo_breadcrumbs(options = {}, &block)
+        def render_avo_breadcrumbs(options = {}, &)
           builder = Builder.new(self, options)
           content = builder.render.html_safe
-          block_given? ? capture(content, &block) : content
+          block_given? ? capture(content, &) : content
         end
       end
     end

--- a/lib/avo/concerns/can_replace_items.rb
+++ b/lib/avo/concerns/can_replace_items.rb
@@ -24,8 +24,8 @@ module Avo
         end
       end
 
-      def with_new_items(&block)
-        self.class.with_new_items(&block)
+      def with_new_items(&)
+        self.class.with_new_items(&)
       end
     end
   end

--- a/lib/avo/concerns/checks_assoc_authorization.rb
+++ b/lib/avo/concerns/checks_assoc_authorization.rb
@@ -8,7 +8,7 @@ module Avo
         policy_result = true
 
         if @reflection.present?
-          # Fetch the appropiate resource
+          # Fetch the appropriate resource
           reflection_resource = field.resource
           # Fetch the record
           # Hydrate the resource with the record if we have one
@@ -23,7 +23,7 @@ module Avo
             service = reflection_resource.authorization
 
             if service.has_method?(method_name, raise_exception: false)
-              # Some policy methods should get the parent record in order to have the necessarry information to do the authorization
+              # Some policy methods should get the parent record in order to have the necessary information to do the authorization
               # Example: Post->has_many->Comments
               #
               # When you want to authorize the creation/attaching of a Comment, you don't have the Comment instance.

--- a/lib/avo/concerns/has_items.rb
+++ b/lib/avo/concerns/has_items.rb
@@ -84,7 +84,14 @@ module Avo
         items.each do |item|
           next if item.nil?
 
-          unless only_root
+          if only_root
+            # When `item.is_main_panel? == true` then also `item.is_panel? == true`
+            # But when only_root == true we want to extract main_panel items
+            # In all other circumstances items will get extracted when checking for `item.is_panel?`
+            if item.is_main_panel?
+              fields << extract_fields(item)
+            end
+          else
             # Dive into panels to fetch their fields
             if item.is_panel?
               fields << extract_fields(item)
@@ -99,13 +106,6 @@ module Avo
 
             # Dive into sidebar to fetch their fields
             if item.is_sidebar?
-              fields << extract_fields(item)
-            end
-          else
-            # When `item.is_main_panel? == true` then also `item.is_panel? == true`
-            # But when only_root == true we want to extract main_panel items
-            # In all other circumstances items will get extracted when checking for `item.is_panel?`
-            if item.is_main_panel?
               fields << extract_fields(item)
             end
           end
@@ -308,8 +308,6 @@ module Avo
             item
           elsif extractable_structure?(item)
             extract_fields(item)
-          else
-            nil
           end
         end.compact
       end

--- a/lib/avo/concerns/visible_in_different_views.rb
+++ b/lib/avo/concerns/visible_in_different_views.rb
@@ -32,7 +32,7 @@ module Avo
       def visible_in_view?(view:)
         raise "No view specified on visibility check." if view.blank?
 
-        send "show_on_#{view}"
+        send :"show_on_#{view}"
       end
 
       def show_on(*where)
@@ -78,11 +78,11 @@ module Avo
       private
 
       def show_on_view(view)
-        send("show_on_#{view}=", true)
+        send(:"show_on_#{view}=", true)
       end
 
       def hide_on_view(view)
-        send("show_on_#{view}=", false)
+        send(:"show_on_#{view}=", false)
       end
 
       def only_on_view(view)

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -277,6 +277,10 @@ module Avo
         end
       end
 
+      def form_field_label
+        id
+      end
+
       private
 
       def model_or_class(model)

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -265,6 +265,10 @@ module Avo
         @can_create
       end
 
+      def form_field_label
+        id
+      end
+
       private
 
       def get_model_class(record)

--- a/lib/avo/fields/concerns/frame_loading.rb
+++ b/lib/avo/fields/concerns/frame_loading.rb
@@ -11,4 +11,3 @@ module Avo
     end
   end
 end
-


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/1929

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
