### PR TITLE
fix: boolean group field on actions

### DIFF
--- a/app/components/avo/fields/boolean_group_field/edit_component.html.erb
+++ b/app/components/avo/fields/boolean_group_field/edit_component.html.erb
@@ -8,7 +8,7 @@
               class: @classes,
               data: @data,
               disabled: disabled?,
-              id: @field.id,
+              id: "#{@form_scope}_#{@field.id}_#{id}",
               style: @style,
               multiple: true,
               checked: checked?(id),

--- a/app/components/avo/fields/boolean_group_field/edit_component.html.erb
+++ b/app/components/avo/fields/boolean_group_field/edit_component.html.erb
@@ -3,7 +3,7 @@
     <div class="space-y-2">
       <% @field.options.each do |id, label| %>
         <label class="block">
-          <%= form.check_box @field.id,
+          <%= @form.check_box @field.id,
             {
               class: @classes,
               data: @data,
@@ -11,10 +11,10 @@
               id: "#{@form_scope}_#{@field.id}_#{id}",
               style: @style,
               multiple: true,
-              checked: checked?(id),
-              include_hidden: false
+              checked: checked?(id)
             },
-            id
+            id,
+            ""
           %>
           <%= label %>
         </label>

--- a/app/components/avo/fields/boolean_group_field/edit_component.html.erb
+++ b/app/components/avo/fields/boolean_group_field/edit_component.html.erb
@@ -1,29 +1,22 @@
 <%= field_wrapper **field_wrapper_args do %>
   <div class="flex items-center">
     <div class="space-y-2">
-      <% model_param_key = model_name_from_record_or_class(@resource.record).param_key %>
-      <%= check_box_tag "#{model_param_key}[#{@field.id}][]", '', true, { class: "hidden" } %>
       <% @field.options.each do |id, label| %>
-        <%
-          checked = false
-
-          # Get the state of the checkboxes from either the form that returns a validation error or from the model itself.
-          if params[model_param_key].present? && params[model_param_key][@field.id.to_s].present?
-            checked = params[model_param_key][@field.id.to_s].include?(id.to_s)
-          else
-            if @field.value.present?
-              checked = @field.value[id.to_s]
-            end
-          end
-        %>
         <label class="block">
-          <%= check_box_tag "#{model_param_key}[#{@field.id}][]", id, checked, {
-              class: "w-4 h-4 rounded checked:bg-primary-400 focus:checked:!bg-primary-400 #{@field.get_html(:classes, view: view, element: :input)}",
-              data: @field.get_html(:data, view: view, element: :input),
+          <%= form.check_box @field.id,
+            {
+              class: @classes,
+              data: @data,
               disabled: disabled?,
-              id: "#{model_param_key}_#{@field.id}_#{id}",
-              style: @field.get_html(:style, view: view, element: :input)
-            } %> <%= label %>
+              id: @field.id,
+              style: @style,
+              multiple: true,
+              checked: checked?(id),
+              include_hidden: false
+            },
+            id
+          %>
+          <%= label %>
         </label>
       <% end %>
     </div>

--- a/app/components/avo/fields/boolean_group_field/edit_component.rb
+++ b/app/components/avo/fields/boolean_group_field/edit_component.rb
@@ -9,13 +9,13 @@ class Avo::Fields::BooleanGroupField::EditComponent < Avo::Fields::EditComponent
       "#{@field.get_html(:classes, view: view, element: :input)}"
     @data = @field.get_html(:data, view: view, element: :input)
     @style = @field.get_html(:style, view: view, element: :input)
-    @model_param_key = model_name_from_record_or_class(@resource.record).param_key
+    @form_scope = form.object_name
   end
 
   # Get the state of each checkboxe from either the form that returns a validation error or from the model itself.
   def checked?(id)
-    if params[@model_param_key].present? && params[@model_param_key][@field.id.to_s].present?
-      params[@model_param_key][@field.id.to_s].include?(id.to_s)
+    if params[@form_scope].present? && params[@form_scope][@field.id.to_s].present?
+      params[@form_scope][@field.id.to_s].include?(id.to_s)
     else
       if @field.value.present?
         @field.value[id.to_s]

--- a/app/components/avo/fields/boolean_group_field/edit_component.rb
+++ b/app/components/avo/fields/boolean_group_field/edit_component.rb
@@ -9,7 +9,7 @@ class Avo::Fields::BooleanGroupField::EditComponent < Avo::Fields::EditComponent
       "#{@field.get_html(:classes, view: view, element: :input)}"
     @data = @field.get_html(:data, view: view, element: :input)
     @style = @field.get_html(:style, view: view, element: :input)
-    @form_scope = form.object_name
+    @form_scope = @form.object_name
   end
 
   # Get the state of each checkboxe from either the form that returns a validation error or from the model itself.

--- a/app/components/avo/fields/boolean_group_field/edit_component.rb
+++ b/app/components/avo/fields/boolean_group_field/edit_component.rb
@@ -15,10 +15,10 @@ class Avo::Fields::BooleanGroupField::EditComponent < Avo::Fields::EditComponent
   # Get the state of each checkboxe from either the form that returns a validation error or from the model itself.
   def checked?(id)
     if params[@model_param_key].present? && params[@model_param_key][@field.id.to_s].present?
-      return params[@model_param_key][@field.id.to_s].include?(id.to_s)
+      params[@model_param_key][@field.id.to_s].include?(id.to_s)
     else
       if @field.value.present?
-        return @field.value[id.to_s]
+        @field.value[id.to_s]
       end
     end
   end

--- a/app/components/avo/fields/boolean_group_field/edit_component.rb
+++ b/app/components/avo/fields/boolean_group_field/edit_component.rb
@@ -1,4 +1,25 @@
 # frozen_string_literal: true
 
 class Avo::Fields::BooleanGroupField::EditComponent < Avo::Fields::EditComponent
+  def initialize(...)
+    super(...)
+
+    # Initilize here to avoid multiple calls to @field.get_html for each option.
+    @classes = "w-4 h-4 rounded checked:bg-primary-400 focus:checked:!bg-primary-400" \
+      "#{@field.get_html(:classes, view: view, element: :input)}"
+    @data = @field.get_html(:data, view: view, element: :input)
+    @style = @field.get_html(:style, view: view, element: :input)
+    @model_param_key = model_name_from_record_or_class(@resource.record).param_key
+  end
+
+  # Get the state of each checkboxe from either the form that returns a validation error or from the model itself.
+  def checked?(id)
+    if params[@model_param_key].present? && params[@model_param_key][@field.id.to_s].present?
+      return params[@model_param_key][@field.id.to_s].include?(id.to_s)
+    else
+      if @field.value.present?
+        return @field.value[id.to_s]
+      end
+    end
+  end
 end

--- a/app/components/avo/fields/boolean_group_field/edit_component.rb
+++ b/app/components/avo/fields/boolean_group_field/edit_component.rb
@@ -16,10 +16,8 @@ class Avo::Fields::BooleanGroupField::EditComponent < Avo::Fields::EditComponent
   def checked?(id)
     if params[@form_scope].present? && params[@form_scope][@field.id.to_s].present?
       params[@form_scope][@field.id.to_s].include?(id.to_s)
-    else
-      if @field.value.present?
-        @field.value[id.to_s]
-      end
+    elsif @field.value.present?
+      @field.value[id.to_s]
     end
   end
 end

--- a/lib/avo/fields/boolean_group_field.rb
+++ b/lib/avo/fields/boolean_group_field.rb
@@ -21,23 +21,20 @@ module Avo
         ["#{id}": []]
       end
 
-      def fill_field(model, key, value, params)
+      def fill_field(record, _, values, _)
         new_value = {}
 
-        # Filter out the empty ("") value boolean group generates
-        value = value.filter do |arr_value|
-          arr_value.present?
-        end
+        # Reject empty values passed by hidden inputs
+        values.reject! { |value| value == "" }
 
-        # Cast values to booleans
-        options.each do |id, label|
-          new_value[id] = value.include? id.to_s
+        options.each do |key, _|
+          new_value[key] = values.include? key.to_s
         end
 
         # Don't override existing values unless specified in options
-        model[id] = (model[id] || {}).merge(new_value)
+        record[id] = (record[id] || {}).merge(new_value)
 
-        model
+        record
       end
     end
   end

--- a/lib/avo/fields/boolean_group_field.rb
+++ b/lib/avo/fields/boolean_group_field.rb
@@ -27,6 +27,7 @@ module Avo
         # Reject empty values passed by hidden inputs
         values.reject! { |value| value == "" }
 
+        # Cast values to booleans
         options.each do |key, _|
           new_value[key] = values.include? key.to_s
         end

--- a/spec/dummy/app/avo/actions/sub/dummy_action.rb
+++ b/spec/dummy/app/avo/actions/sub/dummy_action.rb
@@ -25,6 +25,14 @@ class Avo::Actions::Sub::DummyAction < Avo::BaseAction
         # get_type(Avo::App.request.referer) # strip the type from the referer string
         "users"
       end
+
+    field :fun_switch,
+      as: :boolean_group,
+      options: {
+        yes: "Yes",
+        sure: "Sure",
+        why_not: "Why not"
+      }
   end
 
   def handle(**args)
@@ -39,6 +47,8 @@ class Avo::Actions::Sub::DummyAction < Avo::BaseAction
 
     if arguments[:special_message]
       succeed "I love 🥑"
+    elsif (fun_switch = args[:fields][:fun_switch]).present?
+      succeed "#{fun_switch.map(&:humanize).join(",")}, I love 🥑"
     else
       succeed "Success response ✌️"
     end

--- a/spec/dummy/app/avo/actions/sub/dummy_action.rb
+++ b/spec/dummy/app/avo/actions/sub/dummy_action.rb
@@ -47,8 +47,8 @@ class Avo::Actions::Sub::DummyAction < Avo::BaseAction
 
     if arguments[:special_message]
       succeed "I love 🥑"
-    elsif (fun_switch = args[:fields][:fun_switch]).present?
-      succeed "#{fun_switch.map(&:humanize).join(",")}, I love 🥑"
+    elsif (fun_switch = args[:fields][:fun_switch].reject! { |option| option == "" }).any?
+      succeed "#{fun_switch.map(&:humanize).join(", ")}, I love 🥑"
     else
       succeed "Success response ✌️"
     end

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -241,10 +241,10 @@ RSpec.describe "Actions", type: :system do
   describe "fields" do
     context "boolean group fields" do
       it "pass through fields params" do
-        visit avo.resources_user_path(user)
+        visit avo.resources_users_path
 
         open_panel_action(action_name: "Dummy action")
-        find(:xpath, '(//input[@id="fun_switch"])[2]').check
+        check("fields_fun_switch_sure")
 
         run_action
         expect(page).to have_text "Sure, I love 🥑"

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -238,6 +238,20 @@ RSpec.describe "Actions", type: :system do
     end
   end
 
+  describe "fields" do
+    context "boolean group fields" do
+      it "pass through fields params" do
+        visit avo.resources_user_path(user)
+
+        open_panel_action(action_name: "Dummy action")
+        find(:xpath, '(//input[@id="fun_switch"])[2]').check
+
+        run_action
+        expect(page).to have_text "Sure, I love 🥑"
+      end
+    end
+  end
+
   #   let!(:roles) { { admin: false, manager: false, writer: false } }
   #   let!(:user) { create :user, active: true, roles: roles }
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2569

Boolean group field was not respecting the form scope. For this reason, on actions, it's values was getting passed through params outside `fields` scope behaving as unpermitted params.

This PR also drops `record` dependency for boolean group fields. Now it can be used for example on an action from index view.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works
