### PR TITLE
fix: truncate long action messages to avoid overflow

### DIFF
--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -292,6 +292,7 @@ module Avo
     private
 
     def add_message(body, type = :info)
+      body = body.truncate(320)
       response[:messages] << {
         type: type,
         body: body

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -294,7 +294,7 @@ module Avo
     def add_message(body, type = :info)
       response[:messages] << {
         type: type,
-        body: body&.truncate(321)
+        body: body&.truncate(320)
       }
     end
   end

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -292,10 +292,9 @@ module Avo
     private
 
     def add_message(body, type = :info)
-      body = body&.truncate(320)
       response[:messages] << {
         type: type,
-        body: body
+        body: body&.truncate(321)
       }
     end
   end

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -292,7 +292,7 @@ module Avo
     private
 
     def add_message(body, type = :info)
-      body = body.truncate(320)
+      body = body&.truncate(320)
       response[:messages] << {
         type: type,
         body: body


### PR DESCRIPTION
# Description
Implement message truncation to 320 characters on action.

Fixes https://github.com/avo-hq/avo/issues/2707

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
