### PR TITLE
Update date param to global_range

### DIFF
--- a/app/javascript/js/controllers/card_filters_controller.js
+++ b/app/javascript/js/controllers/card_filters_controller.js
@@ -7,7 +7,9 @@ export default class extends Controller {
   updateCards(event) {
     this.cardsTargets.forEach((frame) => {
       // Add date param to the existing frame.src
-      frame.src = new URI(frame.src).setQuery('date', event.target.dataset.days).toString()
+      console.log(frame.src)
+      frame.src = new URI(frame.src).setQuery('global_range[date]', event.target.dataset.days).toString()
+      console.log(frame.src)
     })
   }
 }

--- a/app/javascript/js/controllers/card_filters_controller.js
+++ b/app/javascript/js/controllers/card_filters_controller.js
@@ -7,9 +7,7 @@ export default class extends Controller {
   updateCards(event) {
     this.cardsTargets.forEach((frame) => {
       // Add date param to the existing frame.src
-      console.log(frame.src)
       frame.src = new URI(frame.src).setQuery('global_range[date]', event.target.dataset.days).toString()
-      console.log(frame.src)
     })
   }
 }


### PR DESCRIPTION
# Description
Updated the query parameter in frame.src from `date` to `global_range[date]` in the updateCards method of card_filters_controller.js to reflect the new parameter naming convention.
Related to [dashboard-wide filters](https://github.com/avo-hq/avo-dashboards/pull/36)

Fixes # (issue)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
