### PR TITLE
Use correct policy class in search controller

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -20,7 +20,11 @@ module Avo
       resources
         .map do |resource|
           # Apply authorization
-          next unless @authorization.set_record(resource.model_class).authorize_action(:search, raise_exception: false)
+          next unless @authorization.set_record(resource.model_class).authorize_action(
+            :search,
+            policy_class: resource.authorization_policy,
+            raise_exception: false
+          )
           # Filter out the models without a search_query
           next if resource.search_query.nil?
 


### PR DESCRIPTION
# Description

The authorization_policy on the resource should be used when set in the search controller.

Fixes something similar to #2799 (related to #2805)

#2805 fixed most of the test failures for us, but this PR is still necessary to get them all passing.

Here's the [test run](https://github.com/rubygems/rubygems.org/actions/runs/9325667018/job/25673035487?pr=4745) that failed.
This is the commit without the fix applied that fails: https://github.com/rubygems/rubygems.org/pull/4745/commits/4726858ea8a102e3ecf3bec3c43a4c5d412048b0

Specifically, the search controller test failure is caused in [test/integration/avo/gem_name_reservations_controller_test.rb:15](https://github.com/rubygems/rubygems.org/blob/8c6080fbc313712c134b3f433297695640209f2b/test/integration/avo/gem_name_reservations_controller_test.rb#L15)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. This change was necessary to get rubygems.org tests working with a custom authorization policy.

Manual reviewer: please leave a comment with output from the test if that's the case.
