### PR TITLE
fix: set_locale param not setting the locale properly

### DIFF
--- a/app/components/avo/divider_component.html.erb
+++ b/app/components/avo/divider_component.html.erb
@@ -1,7 +1,7 @@
-<div class="relative flex justify-center items-center w-full !border-b-2 border-gray-200 border-solid">
-  <div class="absolute inset-auto z-20 text-xs font-semibold uppercase leading-none text-gray-500 bg-white px-2">
-    <%if label.present?%>
-      <%=label%>
-    <%end%>
-  </div>
+<div class="relative flex justify-center items-center w-full !border-b-2 border-gray-200 border-solid" data-component-name="<%= self.class.to_s.underscore %>">
+  <% if label.present? %>
+    <div class="absolute inset-auto z-20 text-xs font-semibold uppercase leading-none text-gray-500 bg-white px-2 border py-1 rounded">
+      <%= label %>
+    </div>
+  <% end %>
 </div>

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -51,10 +51,6 @@ module Avo
       super
     end
 
-    def hello
-      puts "Nobody tested me :("
-    end
-
     private
 
     # Get the pluralized resource name for this request
@@ -280,15 +276,19 @@ module Avo
 
     # Sets the locale set in avo.rb initializer or if to something that the user set using the `?set_locale=pt-BR` param
     def set_avo_locale(&action)
-      locale = params[:set_locale] || Avo.configuration.locale || I18n.default_locale
-      I18n.default_locale = locale
+      locale = Avo.configuration.default_locale
+
+      if params[:set_locale].present?
+        locale = params[:set_locale]
+        Avo.configuration.locale = locale
+      end
+
       I18n.with_locale(locale, &action)
     end
 
     # Temporary set the locale and reverting at the end of the request.
     def set_force_locale(&action)
-      locale = params[:force_locale] || I18n.default_locale
-      I18n.with_locale(locale, &action)
+      I18n.with_locale(params[:force_locale], &action)
     end
 
     def set_sidebar_open
@@ -319,8 +319,6 @@ module Avo
         "avo.base"
       end
     end
-
-    private
 
     def choose_layout
       if turbo_frame_request?

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -15,7 +15,6 @@ module Avo
     protect_from_forgery with: :exception
     around_action :set_avo_locale
     around_action :set_force_locale, if: -> { params[:force_locale].present? }
-    before_action :set_default_locale, if: -> { params[:set_locale].present? }
     before_action :init_app
     before_action :set_active_storage_current_host
     before_action :set_resource_name
@@ -279,17 +278,11 @@ module Avo
       @resource.form_scope
     end
 
-    # Sets the locale set in avo.rb initializer
+    # Sets the locale set in avo.rb initializer or if to something that the user set using the `?set_locale=pt-BR` param
     def set_avo_locale(&action)
-      locale = Avo.configuration.locale || I18n.default_locale
-      I18n.with_locale(locale, &action)
-    end
-
-    # Enable the user to change the default locale with the `?set_locale=pt-BR` param
-    def set_default_locale
-      locale = params[:set_locale] || I18n.default_locale
-
+      locale = params[:set_locale] || Avo.configuration.locale || I18n.default_locale
       I18n.default_locale = locale
+      I18n.with_locale(locale, &action)
     end
 
     # Temporary set the locale and reverting at the end of the request.

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -558,7 +558,7 @@ module Avo
 
     # Set pagy locale from params or from avo configuration, if both nil locale = "en"
     def set_pagy_locale
-      @pagy_locale = locale.to_s || Avo.configuration.locale || "en"
+      @pagy_locale = locale.to_s || Avo.configuration.default_locale || "en"
     end
 
     def safe_call(method)

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -238,6 +238,10 @@ module Avo
     def pagination
       Avo::ExecutionContext.new(target: @pagination).handle
     end
+
+    def default_locale
+      @locale || I18n.default_locale
+    end
   end
 
   def self.configuration

--- a/spec/dummy/app/avo/resources/project.rb
+++ b/spec/dummy/app/avo/resources/project.rb
@@ -6,7 +6,7 @@ class Avo::Resources::Project < Avo::BaseResource
       query.ransack(id_eq: params[:q], name_cont: params[:q], country_cont: params[:q], m: "or").result(distinct: false)
     }
   }
-  self.includes = [:users, :files_attachments]
+  self.includes = [files_attachments: :blob, users: [:comments, :teams, post: [comments: :user]]]
   self.index_query = -> {
     query.unscoped
   }

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -27,6 +27,7 @@ Avo.configure do |config|
       params: request.params
     }
   end
+  config.locale = :en
   # config.raise_error_on_missing_policy = true
   # config.authorization_client = "Avo::Services::AuthorizationClients::ExtraPunditClient"
 

--- a/spec/features/action_icon_and_divider_spec.rb
+++ b/spec/features/action_icon_and_divider_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "action icon and divider", type: :feature do
       expect(page).to have_css("path[stroke-linecap='round'][stroke-linejoin='round'][d*='M3.055 11']")
       expect(page).to have_css("path[stroke-linecap='round'][stroke-linejoin='round'][d*='M10.5 19.5']")
 
-      expect(page).to have_css(".relative.col-span-full.border-t.border-gray-300.border-solid")
+      expect(page).to have_css("[data-component-name='avo/divider_component']")
     end
   end
 end

--- a/spec/features/avo/divider_spec.rb
+++ b/spec/features/avo/divider_spec.rb
@@ -10,15 +10,14 @@ RSpec.feature "Divider", type: :feature do
 
   describe "Divider in actions" do
     it "renders divider without label" do
-      dividers = page.all(".relative.col-span-full.border-t")
+      dividers = page.all("[data-component-name='avo/divider_component']")
       second_divider = dividers[1]
-      expect(second_divider).to have_css(".absolute", text: "")
+      expect(second_divider).not_to have_selector(".absolute.inset-auto.rounded")
     end
 
     it "renders divider with label" do
-      expect(page).to have_css ".relative.col-span-full.border-t"
-      dividers = page.all(".relative.col-span-full.border-t")
-      expect(dividers.first.find(".absolute").text.strip).to eq "Other actions"
+      dividers = page.all("[data-component-name='avo/divider_component']")
+      expect(dividers.first.find(".absolute.inset-auto.rounded").text.strip).to eq "Other actions"
       expect(page).to have_content "Other actions"
     end
   end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This fixes the way locales are being handled and a bug that required the user to run a URL with `set_locale` twice to actually have it visible.
This will enable to set the `config.locale` in the initializer and Avo will use that one independently of the apps locale.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
