### PR TITLE
fix: generators can run without prior migrations

### DIFF
--- a/lib/generators/avo/all_resources_generator.rb
+++ b/lib/generators/avo/all_resources_generator.rb
@@ -1,0 +1,40 @@
+require_relative "base_generator"
+
+module Generators
+  module Avo
+    class AllResourcesGenerator < BaseGenerator
+      namespace "avo:all_resources"
+
+      def task
+        # Rails.application.eager_load!
+        # get all models
+        models = fetch_models
+
+        models
+          .reject do |model|
+            model.in?(%w[ApplicationRecord])
+          end
+          .each do |model|
+            begin
+              invoke "avo:resource", [model.underscore], {}
+            rescue => e
+              puts "Error: #{e.message}"
+            end
+          end
+      end
+
+      no_tasks do
+        def fetch_models
+          model_files = Dir[Rails.root.join('app/models/**/*.rb')]
+          model_files.map do |file|
+            model_name = file.sub(Rails.root.join('app/models/').to_s, '').sub('.rb', '')
+            model_name.camelize.constantize
+            model_name.camelize
+          rescue NameError
+          nil
+          end.compact
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/avo/all_resources_generator.rb
+++ b/lib/generators/avo/all_resources_generator.rb
@@ -13,23 +13,21 @@ module Generators
 
         models
           .each do |model|
-            begin
-              Rails::Generators.invoke "avo:resource", [model.underscore], {}
-            rescue => e
-              puts "Error: #{e.message}"
-            end
+            Rails::Generators.invoke "avo:resource", [model.underscore], {}
+          rescue => e
+            puts "Error: #{e.message}"
           end
       end
 
       no_tasks do
         def fetch_models
-          model_files = Dir[Rails.root.join('app/models/**/*.rb')]
+          model_files = Dir[Rails.root.join("app/models/**/*.rb")]
           model_files.map do |file|
-            model_name = file.sub(Rails.root.join('app/models/').to_s, '').sub('.rb', '')
+            model_name = file.sub(Rails.root.join("app/models/").to_s, "").sub(".rb", "")
             model_name.camelize.constantize
             model_name.camelize
           rescue NameError
-          nil
+            nil
           end.compact
         end
       end

--- a/lib/generators/avo/all_resources_generator.rb
+++ b/lib/generators/avo/all_resources_generator.rb
@@ -9,14 +9,12 @@ module Generators
         # Rails.application.eager_load!
         # get all models
         models = fetch_models
+        models.delete("ApplicationRecord")
 
         models
-          .reject do |model|
-            model.in?(%w[ApplicationRecord])
-          end
           .each do |model|
             begin
-              invoke "avo:resource", [model.underscore], {}
+              Rails::Generators.invoke "avo:resource", [model.underscore], {}
             rescue => e
               puts "Error: #{e.message}"
             end

--- a/lib/generators/avo/install_generator.rb
+++ b/lib/generators/avo/install_generator.rb
@@ -13,12 +13,15 @@ module Generators
         route "mount Avo::Engine, at: Avo.configuration.root_path"
 
         template "initializer/avo.tt", "config/initializers/avo.rb"
+
         create_resources
       end
 
-      def create_resources
-        if defined?(User).present?
-          Rails::Generators.invoke("avo:resource", ["user", "-q"], {destination_root: Rails.root })
+      no_tasks do
+        def create_resources
+          if defined?(User).present?
+            Rails::Generators.invoke("avo:resource", ["user", "-q"], {destination_root: Rails.root })
+          end
         end
 
         if defined?(Account) && Account.is_a?(ActiveRecord::Base)

--- a/lib/generators/avo/install_generator.rb
+++ b/lib/generators/avo/install_generator.rb
@@ -20,7 +20,7 @@ module Generators
       no_tasks do
         def create_resources
           if defined?(User).present?
-            Rails::Generators.invoke("avo:resource", ["user", "-q"], {destination_root: Rails.root })
+            Rails::Generators.invoke("avo:resource", ["user", "-q"], {destination_root: Rails.root})
           end
         end
 

--- a/lib/generators/avo/resource_generator.rb
+++ b/lib/generators/avo/resource_generator.rb
@@ -24,344 +24,367 @@ module Generators
         invoke "avo:controller", [resource_name], options
       end
 
-      def resource_class
-        class_name.remove(":").to_s
-      end
+      no_tasks do
+        def can_connect_to_the_database?
+          result = false
+          begin
+            ActiveRecord::Migration.check_all_pending!
 
-      def controller_class
-        "Avo::#{class_name.remove(":").pluralize}Controller"
-      end
+            result = true
 
-      def resource_name
-        model_resource_name.to_s
-      end
+            # If all migrations were completed, try to generate some resource files
+          rescue ActiveRecord::ConnectionNotEstablished => e
+            puts error_message("Connection not established.\nRun 'rails db:setup' to resolve.")
+          rescue ActiveRecord::PendingMigrationError => e
+            puts error_message("Migrations are pending.\nRun 'rails db:migrate' to resolve.")
+          rescue => e
+            puts "Something went wrong while trying to geenrate an Avo resource: #{e}"
+          end
 
-      def controller_name
-        "#{model_resource_name.pluralize}_controller"
-      end
-
-      def current_models
-        ActiveRecord::Base.connection.tables.map do |model|
-          model.capitalize.singularize.camelize
-        end
-      rescue ActiveRecord::NoDatabaseError
-        puts "Database not found, please create your database and regenerate the resource."
-        []
-      rescue ActiveRecord::ConnectionNotEstablished
-        puts "Database connection error, please create your database and regenerate the resource."
-        []
-      end
-
-      def class_from_args
-        @class_from_args ||= options["model-class"]&.camelize || (class_name if class_name.include?("::"))
-      end
-
-      def model_class_from_args
-        if class_from_args.present? || class_name.include?("::")
-          "\n  self.model_class = ::#{class_from_args || class_name}"
-        end
-      end
-
-      private
-
-      def model_class
-        @model_class ||= class_from_args || singular_name
-      end
-
-      def model
-        @model ||= model_class.classify.safe_constantize
-      end
-
-      def model_db_columns
-        @model_db_columns ||= model.columns_hash.except(*db_columns_to_ignore)
-      rescue ActiveRecord::NoDatabaseError
-        puts "Database not found, please create your database and regenerate the resource."
-        []
-      rescue ActiveRecord::ConnectionNotEstablished
-        puts "Database connection error, please create your database and regenerate the resource."
-        []
-      end
-
-      def db_columns_to_ignore
-        %w[id encrypted_password reset_password_token reset_password_sent_at remember_created_at created_at updated_at password_digest]
-      end
-
-      def reflections
-        @reflections ||= model.reflections.reject do |name, _|
-          reflections_sufixes_to_ignore.include?(name.split("_").pop) || reflections_to_ignore.include?(name)
-        end
-      end
-
-      def reflections_sufixes_to_ignore
-        %w[blob blobs tags]
-      end
-
-      def reflections_to_ignore
-        %w[taggings]
-      end
-
-      def attachments
-        @attachments ||= reflections.select do |_, reflection|
-          reflection.options[:class_name] == "ActiveStorage::Attachment"
-        end
-      end
-
-      def rich_texts
-        @rich_texts ||= reflections.select do |_, reflection|
-          reflection.options[:class_name] == "ActionText::RichText"
-        end
-      end
-
-      def tags
-        @tags ||= reflections.select { |_, reflection| reflection.options[:as] == :taggable }
-      end
-
-      def associations
-        @associations ||= reflections.reject do |key|
-          attachments.key?(key) || tags.key?(key) || rich_texts.key?(key)
-        end
-      end
-
-      def fields
-        @fields ||= {}
-      end
-
-      def invoked_by_model_generator?
-        @options.dig("from_model_generator")
-      end
-
-      def generate_fields
-        return generate_fields_from_args if invoked_by_model_generator?
-
-        if model.blank?
-          puts "Can't generate fields from model. '#{model_class}.rb' not found!"
-          return
+          result
         end
 
-        fields_from_model_db_columns
-        fields_from_model_enums
-        fields_from_model_attachements
-        fields_from_model_associations
-        fields_from_model_rich_texts
-        fields_from_model_tags
-
-        generated_fields_template
-      end
-
-      def generated_fields_template
-        return if fields.blank?
-
-        fields_string = ""
-
-        fields.each do |field_name, field_options|
-          # if field_options are not available (likely a missing resource for an association), skip the field
-          fields_string += "\n    # Could not generate a field for #{field_name}" and next unless field_options
-
-          options = ""
-          field_options[:options].each { |k, v| options += ", #{k}: #{v}" } if field_options[:options].present?
-
-          fields_string += "\n    #{field_string field_name, field_options[:field], options}"
+        def error_message(extra)
+          "Avo will not attemmpt to create resources for you.\n#{extra}\nThen run 'rails generate avo:all_resources' to generate all your resources."
         end
 
-        fields_string
-      end
-
-      def field_string(name, type, options)
-        "field :#{name}, as: :#{type}#{options}"
-      end
-
-      def generate_fields_from_args
-        @args.each do |arg|
-          name, type = arg.split(":")
-          type = "string" if type.blank?
-          fields[name] = field(name, type.to_sym)
+        def resource_class
+          class_name.remove(":").to_s
         end
 
-        generated_fields_template
-      end
-
-      def fields_from_model_rich_texts
-        rich_texts.each do |name, _|
-          fields[name.delete_prefix("rich_text_")] = {field: "trix"}
+        def controller_class
+          "Avo::#{class_name.remove(":").pluralize}Controller"
         end
-      end
 
-      def fields_from_model_tags
-        tags.each do |name, _|
-          fields[(remove_last_word_from name).pluralize] = {field: "tags"}
+        def resource_name
+          model_resource_name.to_s
         end
-      end
 
-      def fields_from_model_associations
-        associations.each do |name, association|
-          fields[name] = if association.is_a? ActiveRecord::Reflection::ThroughReflection
-            field_from_through_association(association)
-          else
-            associations_mapping[association.class]
+        def controller_name
+          "#{model_resource_name.pluralize}_controller"
+        end
+
+        def current_models
+          ActiveRecord::Base.connection.tables.map do |model|
+            model.capitalize.singularize.camelize
+          end
+        rescue ActiveRecord::NoDatabaseError
+          puts "Database not found, please create your database and regenerate the resource."
+          []
+        rescue ActiveRecord::ConnectionNotEstablished
+          puts "Database connection error, please create your database and regenerate the resource."
+          []
+        end
+
+        def class_from_args
+          @class_from_args ||= options["model-class"]&.camelize || (class_name if class_name.include?("::"))
+        end
+
+        def model_class_from_args
+          if class_from_args.present? || class_name.include?("::")
+            "\n  self.model_class = ::#{class_from_args || class_name}"
           end
         end
-      end
 
-      def field_from_through_association(association)
-        if association.through_reflection.is_a?(ActiveRecord::Reflection::HasManyReflection) || association.through_reflection.is_a?(ActiveRecord::Reflection::ThroughReflection)
+        def model_class
+          @model_class ||= class_from_args || singular_name
+        end
+
+        def model
+          @model ||= model_class.classify.safe_constantize
+        end
+
+        def model_db_columns
+          @model_db_columns ||= model.columns_hash.except(*db_columns_to_ignore)
+        rescue ActiveRecord::NoDatabaseError
+          puts "Database not found, please create your database and regenerate the resource."
+          []
+        rescue ActiveRecord::ConnectionNotEstablished
+          puts "Database connection error, please create your database and regenerate the resource."
+          []
+        end
+
+        def db_columns_to_ignore
+          %w[id encrypted_password reset_password_token reset_password_sent_at remember_created_at created_at updated_at password_digest]
+        end
+
+        def reflections
+          @reflections ||= model.reflections.reject do |name, _|
+            reflections_sufixes_to_ignore.include?(name.split("_").pop) || reflections_to_ignore.include?(name)
+          end
+        end
+
+        def reflections_sufixes_to_ignore
+          %w[blob blobs tags]
+        end
+
+        def reflections_to_ignore
+          %w[taggings]
+        end
+
+        def attachments
+          @attachments ||= reflections.select do |_, reflection|
+            reflection.options[:class_name] == "ActiveStorage::Attachment"
+          end
+        end
+
+        def rich_texts
+          @rich_texts ||= reflections.select do |_, reflection|
+            reflection.options[:class_name] == "ActionText::RichText"
+          end
+        end
+
+        def tags
+          @tags ||= reflections.select { |_, reflection| reflection.options[:as] == :taggable }
+        end
+
+        def associations
+          @associations ||= reflections.reject do |key|
+            attachments.key?(key) || tags.key?(key) || rich_texts.key?(key)
+          end
+        end
+
+        def fields
+          @fields ||= {}
+        end
+
+        def invoked_by_model_generator?
+          @options.dig("from_model_generator")
+        end
+
+        def field_string(name, type, options)
+          "field :#{name}, as: :#{type}#{options}"
+        end
+
+        def fields_from_model_rich_texts
+          rich_texts.each do |name, _|
+            fields[name.delete_prefix("rich_text_")] = {field: "trix"}
+          end
+        end
+
+        def fields_from_model_tags
+          tags.each do |name, _|
+            fields[(remove_last_word_from name).pluralize] = {field: "tags"}
+          end
+        end
+
+        def fields_from_model_associations
+          associations.each do |name, association|
+            fields[name] = if association.is_a? ActiveRecord::Reflection::ThroughReflection
+              field_from_through_association(association)
+            else
+              associations_mapping[association.class]
+            end
+          end
+        end
+
+        def field_from_through_association(association)
+          if association.through_reflection.is_a?(ActiveRecord::Reflection::HasManyReflection) || association.through_reflection.is_a?(ActiveRecord::Reflection::ThroughReflection)
+            {
+              field: "has_many",
+              options: {
+                through: ":#{association.options[:through]}"
+              }
+            }
+          else
+            # If the through_reflection is not a HasManyReflection, add it to the fields hash using the class of the through_reflection
+            # ex (team.rb): has_one :admin, through: :admin_membership, source: :user
+            # we use the class of the through_reflection (HasOneReflection -> has_one :admin) to generate the field
+            associations_mapping[association.through_reflection.class]
+          end
+        end
+
+        def fields_from_model_attachements
+          attachments.each do |name, attachment|
+            fields[remove_last_word_from name] = attachments_mapping[attachment.class]
+          end
+        end
+
+        # "hello_world_hehe".split('_') => ['hello', 'world', 'hehe']
+        # ['hello', 'world', 'hehe'].pop => ['hello', 'world']
+        # ['hello', 'world'].join('_') => "hello_world"
+        def remove_last_word_from(snake_case_string)
+          snake_case_string = snake_case_string.split("_")
+          snake_case_string.pop
+          snake_case_string.join("_")
+        end
+
+        def fields_from_model_enums
+          model.defined_enums.each_key do |enum|
+            fields[enum] = {
+              field: "select",
+              options: {
+                enum: "::#{model_class.classify}.#{enum.pluralize}"
+              }
+            }
+          end
+        end
+
+        def fields_from_model_db_columns
+          model_db_columns.each do |name, data|
+            fields[name] = field(name, data.type)
+          end
+        end
+
+        def associations_mapping
           {
-            field: "has_many",
-            options: {
-              through: ":#{association.options[:through]}"
-            }
-          }
-        else
-          # If the through_reflection is not a HasManyReflection, add it to the fields hash using the class of the through_reflection
-          # ex (team.rb): has_one :admin, through: :admin_membership, source: :user
-          # we use the class of the through_reflection (HasOneReflection -> has_one :admin) to generate the field
-          associations_mapping[association.through_reflection.class]
-        end
-      end
-
-      def fields_from_model_attachements
-        attachments.each do |name, attachment|
-          fields[remove_last_word_from name] = attachments_mapping[attachment.class]
-        end
-      end
-
-      # "hello_world_hehe".split('_') => ['hello', 'world', 'hehe']
-      # ['hello', 'world', 'hehe'].pop => ['hello', 'world']
-      # ['hello', 'world'].join('_') => "hello_world"
-      def remove_last_word_from(snake_case_string)
-        snake_case_string = snake_case_string.split("_")
-        snake_case_string.pop
-        snake_case_string.join("_")
-      end
-
-      def fields_from_model_enums
-        model.defined_enums.each_key do |enum|
-          fields[enum] = {
-            field: "select",
-            options: {
-              enum: "::#{model_class.classify}.#{enum.pluralize}"
+            ActiveRecord::Reflection::BelongsToReflection => {
+              field: "belongs_to"
+            },
+            ActiveRecord::Reflection::HasOneReflection => {
+              field: "has_one"
+            },
+            ActiveRecord::Reflection::HasManyReflection => {
+              field: "has_many"
+            },
+            ActiveRecord::Reflection::HasAndBelongsToManyReflection => {
+              field: "has_and_belongs_to_many"
             }
           }
         end
-      end
 
-      def fields_from_model_db_columns
-        model_db_columns.each do |name, data|
-          fields[name] = field(name, data.type)
+        def attachments_mapping
+          {
+            ActiveRecord::Reflection::HasOneReflection => {
+              field: "file"
+            },
+            ActiveRecord::Reflection::HasManyReflection => {
+              field: "files"
+            }
+          }
         end
-      end
 
-      def field(name, type)
-        names_mapping[name.to_sym] || fields_mapping[type&.to_sym] || {field: "text"}
-      end
-
-      def associations_mapping
-        {
-          ActiveRecord::Reflection::BelongsToReflection => {
-            field: "belongs_to"
-          },
-          ActiveRecord::Reflection::HasOneReflection => {
-            field: "has_one"
-          },
-          ActiveRecord::Reflection::HasManyReflection => {
-            field: "has_many"
-          },
-          ActiveRecord::Reflection::HasAndBelongsToManyReflection => {
-            field: "has_and_belongs_to_many"
+        def names_mapping
+          {
+            id: {
+              field: "id"
+            },
+            description: {
+              field: "textarea"
+            },
+            gravatar: {
+              field: "gravatar"
+            },
+            email: {
+              field: "text"
+            },
+            password: {
+              field: "password"
+            },
+            password_confirmation: {
+              field: "password"
+            },
+            stage: {
+              field: "select"
+            },
+            budget: {
+              field: "currency"
+            },
+            money: {
+              field: "currency"
+            },
+            country: {
+              field: "country"
+            }
           }
-        }
-      end
+        end
 
-      def attachments_mapping
-        {
-          ActiveRecord::Reflection::HasOneReflection => {
-            field: "file"
-          },
-          ActiveRecord::Reflection::HasManyReflection => {
-            field: "files"
+        def fields_mapping
+          {
+            primary_key: {
+              field: "id"
+            },
+            string: {
+              field: "text"
+            },
+            text: {
+              field: "textarea"
+            },
+            integer: {
+              field: "number"
+            },
+            float: {
+              field: "number"
+            },
+            decimal: {
+              field: "number"
+            },
+            datetime: {
+              field: "date_time"
+            },
+            timestamp: {
+              field: "date_time"
+            },
+            time: {
+              field: "date_time"
+            },
+            date: {
+              field: "date"
+            },
+            binary: {
+              field: "number"
+            },
+            boolean: {
+              field: "boolean"
+            },
+            references: {
+              field: "belongs_to"
+            },
+            json: {
+              field: "code"
+            }
           }
-        }
-      end
+        end
+        def generate_fields
+          return unless can_connect_to_the_database?
+          return generate_fields_from_args if invoked_by_model_generator?
 
-      def names_mapping
-        {
-          id: {
-            field: "id"
-          },
-          description: {
-            field: "textarea"
-          },
-          gravatar: {
-            field: "gravatar"
-          },
-          email: {
-            field: "text"
-          },
-          password: {
-            field: "password"
-          },
-          password_confirmation: {
-            field: "password"
-          },
-          stage: {
-            field: "select"
-          },
-          budget: {
-            field: "currency"
-          },
-          money: {
-            field: "currency"
-          },
-          country: {
-            field: "country"
-          }
-        }
-      end
+          if model.blank?
+            puts "Can't generate fields from model. '#{model_class}.rb' not found!"
+            return
+          end
 
-      def fields_mapping
-        {
-          primary_key: {
-            field: "id"
-          },
-          string: {
-            field: "text"
-          },
-          text: {
-            field: "textarea"
-          },
-          integer: {
-            field: "number"
-          },
-          float: {
-            field: "number"
-          },
-          decimal: {
-            field: "number"
-          },
-          datetime: {
-            field: "date_time"
-          },
-          timestamp: {
-            field: "date_time"
-          },
-          time: {
-            field: "date_time"
-          },
-          date: {
-            field: "date"
-          },
-          binary: {
-            field: "number"
-          },
-          boolean: {
-            field: "boolean"
-          },
-          references: {
-            field: "belongs_to"
-          },
-          json: {
-            field: "code"
-          }
-        }
+          fields_from_model_db_columns
+          fields_from_model_enums
+          fields_from_model_attachements
+          fields_from_model_associations
+          fields_from_model_rich_texts
+          fields_from_model_tags
+
+          generated_fields_template
+        end
+
+        def generated_fields_template
+          return if fields.blank?
+
+          fields_string = "lo"
+
+          fields.each do |field_name, field_options|
+            # if field_options are not available (likely a missing resource for an association), skip the field
+            fields_string += "\n    # Could not generate a field for #{field_name}" and next unless field_options
+
+            options = ""
+            field_options[:options].each { |k, v| options += ", #{k}: #{v}" } if field_options[:options].present?
+
+            fields_string += "\n    #{field_string field_name, field_options[:field], options}"
+          end
+
+          fields_string
+        end
+
+        def generate_fields_from_args
+          @args.each do |arg|
+            name, type = arg.split(":")
+            type = "string" if type.blank?
+            fields[name] = field(name, type.to_sym)
+          end
+
+          generated_fields_template
+        end
+
+        def field(name, type)
+          names_mapping[name.to_sym] || fields_mapping[type&.to_sym] || {field: "text"}
+        end
       end
     end
   end

--- a/lib/generators/avo/resource_generator.rb
+++ b/lib/generators/avo/resource_generator.rb
@@ -31,11 +31,10 @@ module Generators
             ActiveRecord::Migration.check_all_pending!
 
             result = true
-
             # If all migrations were completed, try to generate some resource files
-          rescue ActiveRecord::ConnectionNotEstablished => e
+          rescue ActiveRecord::ConnectionNotEstablished
             puts error_message("Connection not established.\nRun 'rails db:setup' to resolve.")
-          rescue ActiveRecord::PendingMigrationError => e
+          rescue ActiveRecord::PendingMigrationError
             puts error_message("Migrations are pending.\nRun 'rails db:migrate' to resolve.")
           rescue => e
             puts "Something went wrong while trying to geenrate an Avo resource: #{e}"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where the generators would fail if there were pending migrations.
This is common if you install rails, run the devise generator and then Avo's.

This PR also brings a new command `all_resources` which will generate all resources.

### Problem

We're now stuck at generating all the resources. The `all_resources` generator will not continue past the first resource it finds.

![CleanShot 2024-06-14 at 16 43 02@2x](https://github.com/avo-hq/avo/assets/1334409/d67ea26c-d5b5-479a-a362-b48a4aaa1c48)


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
