### PR TITLE
fix: remove client-side validation on action forms

### DIFF
--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -13,6 +13,9 @@
     <%= form_with scope: 'fields',
       url: Avo::Services::URIService.parse(@resource.records_path).append_paths("actions").to_s,
       local: true,
+      html: {
+        novalidate: true,
+      },
       data: {
         action_target: :form,
         **@action.class.form_data_attributes,

--- a/spec/system/avo/tabs_spec.rb
+++ b/spec/system/avo/tabs_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Tabs", type: :system do
         find('[aria-label="February 9, 1988"]').click
         save
 
-        expect(current_path).to eq avo.resources_user_path user
+        expect(page).to have_current_path avo.resources_user_path(user)
         expect(find_field_value_element("birthday")).to have_text "Tuesday, 9 February 1988"
       end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where the same field configuration would behave differently in a resource edit form and an action form.
Now, the behavior is more consitent.

From here: https://discord.com/channels/740892036978442260/1250828661314027540

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

