### PR TITLE
fix: persist values after validation errors on tags fields that acts as taggable on

### DIFF
--- a/lib/avo/fields/tags_field.rb
+++ b/lib/avo/fields/tags_field.rb
@@ -32,11 +32,19 @@ module Avo
       end
 
       def json_value
-        value.map do |item|
-          {
-            value: item.name
-          }
-        end.as_json
+        acts_as_taggable_on_values.map { |value| { value: } }.as_json
+      end
+
+      def acts_as_taggable_on_values
+        # When record is DB persistent the values are fetched from the DB
+        # Else the array values are fetched from the record using the tag_list_on helper
+        # values_array examples: ["1", "2"]
+        #                        ["example suggestion","example tag"]
+        if record.persisted?
+          value.map { |item| item.name }
+        else
+          record.tag_list_on(acts_as_taggable_on)
+        end
       end
 
       def fill_field(model, key, value, params)

--- a/lib/avo/fields/tags_field.rb
+++ b/lib/avo/fields/tags_field.rb
@@ -32,7 +32,7 @@ module Avo
       end
 
       def json_value
-        acts_as_taggable_on_values.map { |value| { value: } }.as_json
+        acts_as_taggable_on_values.map { |value| {value:} }.as_json
       end
 
       def acts_as_taggable_on_values

--- a/spec/system/avo/tabs_spec.rb
+++ b/spec/system/avo/tabs_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Tabs", type: :system do
         find('[aria-label="February 9, 1988"]').click
         save
 
-        expect(current_path).to eq avo.resources_user_path user
+        expect(page).to have_current_path avo.resources_user_path(user)
         expect(find_field_value_element("birthday")).to have_text "Tuesday, 9 February 1988"
       end
 

--- a/spec/system/avo/tags_spec.rb
+++ b/spec/system/avo/tags_spec.rb
@@ -87,6 +87,21 @@ RSpec.describe "Tags", type: :system do
         expect(post.reload.tag_list.sort).to eq ["1", "2"].sort
       end
     end
+
+    context "new" do
+      it "keeps acts as taggable tags on validation errors" do
+        visit avo.new_resources_post_path
+
+        add_tag(field: :tags, tag: "one")
+        add_tag(field: :tags, tag: "two")
+        add_tag(field: :tags, tag: "five")
+
+        save
+
+        expect(page).to have_text("Validation failed: Name can't be blank")
+        expect(page.all(".tagify__tag-text").map(&:text)).to eq ["one", "two"]
+      end
+    end
   end
 
   describe 'without acts_as_taggable' do


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2724

Acts as taggable on stores the tags values through DB tables. When the record is not DB persistent (on a new unsaved record) the tags values only can be accessed directly from the record's tag list. `tag_list_on(acts_as_taggable_on_option)` helper does the trick.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
[acts_as_taggable_on_fix.webm](https://github.com/avo-hq/avo/assets/69730720/e7bc27af-36f0-46b1-9726-f41889ea6b56)
