### PR TITLE
Add link to record support to belongs to field

### DIFF
--- a/app/components/avo/fields/belongs_to_field/index_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/index_component.html.erb
@@ -1,4 +1,6 @@
 <%= index_field_wrapper **field_wrapper_args do %>
-  <%= link_to @field.label, helpers.resource_view_path(record: @field.value, resource: @field.target_resource)
- %>
+  <%= link_to @field.label, helpers.resource_view_path(
+    record: @field.index_link_to_record,
+    resource: @field.index_link_to_resource
+  ) %>
 <% end %>

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -68,6 +68,7 @@ module Avo
       attr_reader :allow_via_detaching
       attr_reader :attach_scope
       attr_reader :polymorphic_help
+      attr_reader :link_to_record
 
       def initialize(id, **args, &block)
         args[:placeholder] ||= I18n.t("avo.choose_an_option")
@@ -84,6 +85,7 @@ module Avo
         @target = args[:target]
         @use_resource = args[:use_resource] || nil
         @can_create = args[:can_create].nil? ? true : args[:can_create]
+        @link_to_record = args[:link_to_record].present? ? args[:link_to_record] : false
       end
 
       def value
@@ -261,6 +263,22 @@ module Avo
         return polymorphic_as.to_s.humanize if polymorphic_as.present?
 
         super
+      end
+
+      def index_link_to_resource
+        if @link_to_record.present?
+          @resource
+        else
+          target_resource
+        end
+      end
+
+      def index_link_to_record
+        if @link_to_record.present?
+          get_record
+        else
+          value
+        end
       end
 
       def can_create?

--- a/spec/dummy/app/avo/resources/comment.rb
+++ b/spec/dummy/app/avo/resources/comment.rb
@@ -18,7 +18,7 @@ class Avo::Resources::Comment < Avo::BaseResource
       as: :date_time,
       picker_format: "Y-m-d H:i:S",
       format: "cccc, d LLLL yyyy, HH:mm ZZZZ" # Wednesday, 10 February 1988, 16:00 GMT
-    field :user, as: :belongs_to, use_resource: Avo::Resources::CompactUser
+    field :user, as: :belongs_to, use_resource: Avo::Resources::CompactUser, link_to_record: true
     field :commentable, as: :belongs_to, polymorphic_as: :commentable, types: [::Post, ::Project]
   end
 

--- a/spec/dummy/app/avo/resources/post.rb
+++ b/spec/dummy/app/avo/resources/post.rb
@@ -48,7 +48,7 @@ class Avo::Resources::Post < Avo::BaseResource
     field :is_published, as: :boolean do
       record.published_at.present?
     end
-    field :user, as: :belongs_to, placeholder: "—", link_to_record: true
+    field :user, as: :belongs_to, placeholder: "—"
     field :status, as: :select, enum: ::Post.statuses, display_value: false
     field :slug, as: :text
     field :tags, as: :tags,

--- a/spec/dummy/app/avo/resources/post.rb
+++ b/spec/dummy/app/avo/resources/post.rb
@@ -48,7 +48,7 @@ class Avo::Resources::Post < Avo::BaseResource
     field :is_published, as: :boolean do
       record.published_at.present?
     end
-    field :user, as: :belongs_to, placeholder: "—"
+    field :user, as: :belongs_to, placeholder: "—", link_to_record: true
     field :status, as: :select, enum: ::Post.statuses, display_value: false
     field :slug, as: :text
     field :tags, as: :tags,

--- a/spec/features/avo/belongs_to_spec.rb
+++ b/spec/features/avo/belongs_to_spec.rb
@@ -19,6 +19,13 @@ RSpec.feature "belongs_to", type: :feature do
       let!(:post) { create :post, user: admin }
 
       it { is_expected.to have_text admin.name }
+      it { is_expected.to have_link admin.name, href: "/admin/resources/users/#{admin.slug}?via_record_id=#{post.slug}&via_resource_class=Avo%3A%3AResources%3A%3APost" }
+    end
+
+    describe "with a related user with link to record enabled" do
+      let!(:post) { create :post, user: admin }
+
+      it { is_expected.to have_link admin.name, href: "/admin/resources/posts/#{post.slug}" }
     end
 
     describe "without a related user" do

--- a/spec/features/avo/belongs_to_spec.rb
+++ b/spec/features/avo/belongs_to_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "belongs_to", type: :feature do
       let!(:post) { create :post, user: admin }
 
       it { is_expected.to have_text admin.name }
-      it { is_expected.to have_link admin.name, href: "/admin/resources/users/#{admin.slug}?via_record_id=#{post.slug}&via_resource_class=Avo%3A%3AResources%3A%3APost" }
+      it { is_expected.to have_link admin.name, href: "/admin/resources/users/#{admin.slug}" }
     end
 
     describe "with a related user with link to record enabled" do

--- a/spec/features/avo/belongs_to_spec.rb
+++ b/spec/features/avo/belongs_to_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "belongs_to", type: :feature do
       let!(:comment) { create :comment, body: "a comment", user: user }
 
       subject do
-        visit "/admin/resources/users/#{user.id}/comments"
+        visit "/admin/resources/comments"
         find("[data-resource-id='#{comment.to_param}'] [data-field-id='user']")
       end
 

--- a/spec/features/avo/belongs_to_spec.rb
+++ b/spec/features/avo/belongs_to_spec.rb
@@ -25,7 +25,6 @@ RSpec.feature "belongs_to", type: :feature do
     describe "with a related user with link to record enabled" do
       let!(:user) { create :user, first_name: "Alicia" }
       let!(:comment) { create :comment, body: "a comment", user: user }
-      let(:url) { "/admin/resources/posts?view_type=table" }
 
       subject do
         visit "/admin/resources/users/#{user.id}/comments"

--- a/spec/features/avo/belongs_to_spec.rb
+++ b/spec/features/avo/belongs_to_spec.rb
@@ -23,9 +23,16 @@ RSpec.feature "belongs_to", type: :feature do
     end
 
     describe "with a related user with link to record enabled" do
-      let!(:post) { create :post, user: admin }
+      let!(:user) { create :user, first_name: "Alicia" }
+      let!(:comment) { create :comment, body: "a comment", user: user }
+      let(:url) { "/admin/resources/posts?view_type=table" }
 
-      it { is_expected.to have_link admin.name, href: "/admin/resources/posts/#{post.slug}" }
+      subject do
+        visit "/admin/resources/users/#{user.id}/comments"
+        find("[data-resource-id='#{comment.to_param}'] [data-field-id='user']")
+      end
+
+      it { is_expected.to have_link user.name, href: "/admin/resources/comments/#{comment.slug}" }
     end
 
     describe "without a related user" do

--- a/spec/features/avo/belongs_to_spec.rb
+++ b/spec/features/avo/belongs_to_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "belongs_to", type: :feature do
         find("[data-resource-id='#{comment.to_param}'] [data-field-id='user']")
       end
 
-      it { is_expected.to have_link user.name, href: "/admin/resources/comments/#{comment.slug}" }
+      it { is_expected.to have_link user.name, href: "/admin/resources/comments/#{comment.id}" }
     end
 
     describe "without a related user" do


### PR DESCRIPTION
# Description

This adds support for `link_to_record` to `belongs_to` field, meaning on index view it will link to the record instead of the associated record.

Closes already closed #2689.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
