### PR TITLE
fix: tags fetch_labels overriding DB values

### DIFF
--- a/lib/avo/fields/tags_field.rb
+++ b/lib/avo/fields/tags_field.rb
@@ -100,9 +100,7 @@ module Avo
 
         # Return computed array of hashes for forms
         # [{value: 1, label: "One"}, {value: 2, label: "Two"}, {value: 3, label: "Three"}]
-        value.map.with_index do |value, index|
-          { value: value, label: labels[index] }
-        end
+        value.map.with_index do { |value, index| {value: value, label: labels[index]} }
       end
 
       def act_as_taggable_attribute(key)

--- a/lib/avo/fields/tags_field.rb
+++ b/lib/avo/fields/tags_field.rb
@@ -100,7 +100,7 @@ module Avo
 
         # Return computed array of hashes for forms
         # [{value: 1, label: "One"}, {value: 2, label: "Two"}, {value: 3, label: "Three"}]
-        value.map.with_index do { |value, index| {value: value, label: labels[index]} }
+        value.map.with_index { |value, index| {value: value, label: labels[index]} }
       end
 
       def act_as_taggable_attribute(key)

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@tiptap/extension-text": "^2.3.0",
     "@tiptap/extension-underline": "^2.3.0",
     "@tiptap/pm": "^2.3.0",
-    "@yaireo/tagify": "^4.24.0",
+    "@yaireo/tagify": "^4.26.6",
     "autoprefixer": "^10.4.19",
     "chart.js": "^3.9.1",
     "chartkick": "^4.2.0",

--- a/spec/dummy/app/avo/resources/course.rb
+++ b/spec/dummy/app/avo/resources/course.rb
@@ -67,6 +67,14 @@ class Avo::Resources::Course < Avo::BaseResource
             end
           end
         end
+
+      # Coment above tags field and uncomment below to test fetch_values_from with fetch_labels
+      # field :skills,
+      #   as: :tags,
+      #   fetch_values_from: "/admin/resources/users/get_users?hey=you&record_id=1",
+      #   fetch_labels: -> {
+      #     values.map { |id| User.find(id).name }
+      #   }
     end
 
     field :starting_at,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1807,10 +1807,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@yaireo/tagify@^4.24.0":
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/@yaireo/tagify/-/tagify-4.24.0.tgz#5e7dcf6b421178dd15bf79dce98db4078879785e"
-  integrity sha512-Q124iBwTsVgmCG1/LezRf13CGcmRqed3Jy5EZ0lE0QhnUzmwXZ0YBnYeO0Ic8DkFnZSzK2XJ7ESNwXBohs8uMw==
+"@yaireo/tagify@^4.26.6":
+  version "4.26.6"
+  resolved "https://registry.yarnpkg.com/@yaireo/tagify/-/tagify-4.26.6.tgz#ee7e7b6e7c4641770d5d892a0d87599159ad4082"
+  integrity sha512-+WFHvdXAXwIrMH/5KcRcnixyYKYyE4ca3fhR9aljKB0N3Vgt+N5ilnZ1whPqdkmUzOs3fpW5k7nEDdLToJx2jA==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2836

Changes:
`fetch_labels` receive `values` and must return an array of labels that match the same values position.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
[fetch_labels_with_fetch_values_from.webm](https://github.com/avo-hq/avo/assets/69730720/b6538122-64f6-4409-8a92-bc5512503f14)
