### PR TITLE
Make all components inherit from `Avo::BaseComponent`

### DIFF
--- a/app/components/avo/actions_component.rb
+++ b/app/components/avo/actions_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::ActionsComponent < ViewComponent::Base
+class Avo::ActionsComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
   attr_reader :label, :size, :as_row_control
 

--- a/app/components/avo/alert_component.rb
+++ b/app/components/avo/alert_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::AlertComponent < ViewComponent::Base
+class Avo::AlertComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
 
   attr_reader :type

--- a/app/components/avo/asset_manager/javascript_component.rb
+++ b/app/components/avo/asset_manager/javascript_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::AssetManager::JavascriptComponent < ViewComponent::Base
+class Avo::AssetManager::JavascriptComponent < Avo::BaseComponent
   attr_reader :asset_manager
 
   def initialize(asset_manager:)

--- a/app/components/avo/asset_manager/stylesheet_component.rb
+++ b/app/components/avo/asset_manager/stylesheet_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::AssetManager::StylesheetComponent < ViewComponent::Base
+class Avo::AssetManager::StylesheetComponent < Avo::BaseComponent
   attr_reader :asset_manager
 
   def initialize(asset_manager:)

--- a/app/components/avo/blank_field_component.rb
+++ b/app/components/avo/blank_field_component.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-class Avo::BlankFieldComponent < ViewComponent::Base
+class Avo::BlankFieldComponent < Avo::BaseComponent
 end

--- a/app/components/avo/button_component.rb
+++ b/app/components/avo/button_component.rb
@@ -3,7 +3,7 @@
 # A button/link can have the following settings:
 # style: primary/outline/text
 # size: :xs :sm, :md, :lg
-class Avo::ButtonComponent < ViewComponent::Base
+class Avo::ButtonComponent < Avo::BaseComponent
   def initialize(path = nil, size: :md, style: :outline, color: :gray, icon: nil, icon_class: "", is_link: false, rounded: true, compact: false, aria: {}, **args)
     # Main settings
     @size = size

--- a/app/components/avo/divider_component.rb
+++ b/app/components/avo/divider_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::DividerComponent < ViewComponent::Base
+class Avo::DividerComponent < Avo::BaseComponent
   attr_reader :label
 
   def initialize(label = nil, **args)

--- a/app/components/avo/empty_state_component.rb
+++ b/app/components/avo/empty_state_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::EmptyStateComponent < ViewComponent::Base
+class Avo::EmptyStateComponent < Avo::BaseComponent
   attr_reader :message, :view_type, :add_background, :by_association
 
   def initialize(message: nil, view_type: :table, add_background: false, by_association: false)

--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::FieldWrapperComponent < ViewComponent::Base
+class Avo::FieldWrapperComponent < Avo::BaseComponent
   include Avo::Concerns::HasResourceStimulusControllers
 
   attr_reader :dash_if_blank

--- a/app/components/avo/fields/common/badge_viewer_component.rb
+++ b/app/components/avo/fields/common/badge_viewer_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Fields::Common::BadgeViewerComponent < ViewComponent::Base
+class Avo::Fields::Common::BadgeViewerComponent < Avo::BaseComponent
   def initialize(value:, options:)
     @value = value
     @options = options

--- a/app/components/avo/fields/common/boolean_check_component.rb
+++ b/app/components/avo/fields/common/boolean_check_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Fields::Common::BooleanCheckComponent < ViewComponent::Base
+class Avo::Fields::Common::BooleanCheckComponent < Avo::BaseComponent
   def initialize(checked: false)
     @icon = checked ? "heroicons/outline/check-circle" : "heroicons/outline/x-circle"
     @classes = "h-6 #{checked ? "text-green-600" : "text-red-500"}"

--- a/app/components/avo/fields/common/boolean_group_component.rb
+++ b/app/components/avo/fields/common/boolean_group_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Fields::Common::BooleanGroupComponent < ViewComponent::Base
+class Avo::Fields::Common::BooleanGroupComponent < Avo::BaseComponent
   def initialize(options: {}, value: nil)
     @options = options
     @value = value

--- a/app/components/avo/fields/common/files/controls_component.rb
+++ b/app/components/avo/fields/common/files/controls_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Fields::Common::Files::ControlsComponent < ViewComponent::Base
+class Avo::Fields::Common::Files::ControlsComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
   include Avo::Fields::Concerns::FileAuthorization
 

--- a/app/components/avo/fields/common/files/list_viewer_component.rb
+++ b/app/components/avo/fields/common/files/list_viewer_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Fields::Common::Files::ListViewerComponent < ViewComponent::Base
+class Avo::Fields::Common::Files::ListViewerComponent < Avo::BaseComponent
   include Turbo::FramesHelper
 
   attr_reader :field, :resource

--- a/app/components/avo/fields/common/files/view_type/grid_item_component.rb
+++ b/app/components/avo/fields/common/files/view_type/grid_item_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Fields::Common::Files::ViewType::GridItemComponent < ViewComponent::Base
+class Avo::Fields::Common::Files::ViewType::GridItemComponent < Avo::BaseComponent
   attr_reader :field, :resource
 
   def initialize(field:, resource:, file: nil, extra_classes: nil)

--- a/app/components/avo/fields/common/gravatar_viewer_component.rb
+++ b/app/components/avo/fields/common/gravatar_viewer_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Fields::Common::GravatarViewerComponent < ViewComponent::Base
+class Avo::Fields::Common::GravatarViewerComponent < Avo::BaseComponent
   def initialize(md5: nil, link: nil, default: nil, size: nil, rounded: false, link_to_record: false, title: nil)
     @md5 = md5
     @link = link

--- a/app/components/avo/fields/common/heading_component.rb
+++ b/app/components/avo/fields/common/heading_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Fields::Common::HeadingComponent < ViewComponent::Base
+class Avo::Fields::Common::HeadingComponent < Avo::BaseComponent
   include Avo::Concerns::HasResourceStimulusControllers
 
   def initialize(field:)

--- a/app/components/avo/fields/common/key_value_component.rb
+++ b/app/components/avo/fields/common/key_value_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Fields::Common::KeyValueComponent < ViewComponent::Base
+class Avo::Fields::Common::KeyValueComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
 
   attr_reader :view

--- a/app/components/avo/fields/common/progress_bar_component.rb
+++ b/app/components/avo/fields/common/progress_bar_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Fields::Common::ProgressBarComponent < ViewComponent::Base
+class Avo::Fields::Common::ProgressBarComponent < Avo::BaseComponent
   attr_reader :value
   attr_reader :display_value
   attr_reader :value_suffix

--- a/app/components/avo/fields/common/status_viewer_component.rb
+++ b/app/components/avo/fields/common/status_viewer_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Fields::Common::StatusViewerComponent < ViewComponent::Base
+class Avo::Fields::Common::StatusViewerComponent < Avo::BaseComponent
   def initialize(status:, label:)
     @status = status
     @label = label

--- a/app/components/avo/fields/edit_component.rb
+++ b/app/components/avo/fields/edit_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Fields::EditComponent < ViewComponent::Base
+class Avo::Fields::EditComponent < Avo::BaseComponent
   include Avo::ResourcesHelper
 
   attr_reader :compact

--- a/app/components/avo/fields/show_component.rb
+++ b/app/components/avo/fields/show_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Fields::ShowComponent < ViewComponent::Base
+class Avo::Fields::ShowComponent < Avo::BaseComponent
   include Avo::ResourcesHelper
 
   attr_reader :compact

--- a/app/components/avo/fields/tags_field/tag_component.rb
+++ b/app/components/avo/fields/tags_field/tag_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Fields::TagsField::TagComponent < ViewComponent::Base
+class Avo::Fields::TagsField::TagComponent < Avo::BaseComponent
   attr_reader :label
   attr_reader :title
 

--- a/app/components/avo/filters_component.rb
+++ b/app/components/avo/filters_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::FiltersComponent < ViewComponent::Base
+class Avo::FiltersComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
 
   def initialize(filters: [], resource: nil, applied_filters: [], parent_record: nil)

--- a/app/components/avo/flash_alerts_component.rb
+++ b/app/components/avo/flash_alerts_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::FlashAlertsComponent < ViewComponent::Base
+class Avo::FlashAlertsComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
 
   def initialize(flashes: [])

--- a/app/components/avo/index/field_wrapper_component.rb
+++ b/app/components/avo/index/field_wrapper_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Index::FieldWrapperComponent < ViewComponent::Base
+class Avo::Index::FieldWrapperComponent < Avo::BaseComponent
   attr_reader :view
 
   def initialize(field: nil, resource: nil, dash_if_blank: true, center_content: false, flush: false, **args)

--- a/app/components/avo/index/grid_cover_empty_state_component.rb
+++ b/app/components/avo/index/grid_cover_empty_state_component.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-class Avo::Index::GridCoverEmptyStateComponent < ViewComponent::Base
+class Avo::Index::GridCoverEmptyStateComponent < Avo::BaseComponent
 end

--- a/app/components/avo/items/visible_items_component.rb
+++ b/app/components/avo/items/visible_items_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Items::VisibleItemsComponent < ViewComponent::Base
+class Avo::Items::VisibleItemsComponent < Avo::BaseComponent
   def initialize(resource:, item:, view:, form:, field_component_extra_args: {})
     @resource = resource
     @item = item

--- a/app/components/avo/loading_component.rb
+++ b/app/components/avo/loading_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::LoadingComponent < ViewComponent::Base
+class Avo::LoadingComponent < Avo::BaseComponent
   def initialize(title: nil)
     @title = title
   end

--- a/app/components/avo/modal_component.rb
+++ b/app/components/avo/modal_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::ModalComponent < ViewComponent::Base
+class Avo::ModalComponent < Avo::BaseComponent
   renders_one :heading
   renders_one :controls
 

--- a/app/components/avo/paginator_component.rb
+++ b/app/components/avo/paginator_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::PaginatorComponent < ViewComponent::Base
+class Avo::PaginatorComponent < Avo::BaseComponent
   attr_reader :pagy
   attr_reader :turbo_frame
   attr_reader :index_params

--- a/app/components/avo/panel_component.rb
+++ b/app/components/avo/panel_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::PanelComponent < ViewComponent::Base
+class Avo::PanelComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
 
   attr_reader :title # deprecating title in favor of name

--- a/app/components/avo/panel_name_component.rb
+++ b/app/components/avo/panel_name_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::PanelNameComponent < ViewComponent::Base
+class Avo::PanelNameComponent < Avo::BaseComponent
   renders_one :body
 
   def initialize(name:, url: nil, target: :self, classes: "")

--- a/app/components/avo/profile_item_component.rb
+++ b/app/components/avo/profile_item_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::ProfileItemComponent < ViewComponent::Base
+class Avo::ProfileItemComponent < Avo::BaseComponent
   attr_reader :label
   attr_reader :icon
   attr_reader :path

--- a/app/components/avo/referrer_params_component.rb
+++ b/app/components/avo/referrer_params_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::ReferrerParamsComponent < ViewComponent::Base
+class Avo::ReferrerParamsComponent < Avo::BaseComponent
   attr_reader :back_path
 
   def initialize(back_path: nil)

--- a/app/components/avo/resource_sidebar_component.rb
+++ b/app/components/avo/resource_sidebar_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::ResourceSidebarComponent < ViewComponent::Base
+class Avo::ResourceSidebarComponent < Avo::BaseComponent
   attr_reader :resource
   attr_reader :params
   attr_reader :view

--- a/app/components/avo/row_component.rb
+++ b/app/components/avo/row_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::RowComponent < ViewComponent::Base
+class Avo::RowComponent < Avo::BaseComponent
   attr_reader :classes
 
   renders_one :body

--- a/app/components/avo/row_selector_component.rb
+++ b/app/components/avo/row_selector_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::RowSelectorComponent < ViewComponent::Base
+class Avo::RowSelectorComponent < Avo::BaseComponent
   def initialize(floating: false, size: :md)
     @floating = floating
     @size = size

--- a/app/components/avo/sidebar/base_item_component.rb
+++ b/app/components/avo/sidebar/base_item_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Sidebar::BaseItemComponent < ViewComponent::Base
+class Avo::Sidebar::BaseItemComponent < Avo::BaseComponent
   attr_reader :item
 
   def initialize(item: nil)

--- a/app/components/avo/sidebar/heading_component.rb
+++ b/app/components/avo/sidebar/heading_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Sidebar::HeadingComponent < ViewComponent::Base
+class Avo::Sidebar::HeadingComponent < Avo::BaseComponent
   attr_reader :collapsable
   attr_reader :collapsed
   attr_reader :icon

--- a/app/components/avo/sidebar/link_component.rb
+++ b/app/components/avo/sidebar/link_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::Sidebar::LinkComponent < ViewComponent::Base
+class Avo::Sidebar::LinkComponent < Avo::BaseComponent
   attr_reader :active
   attr_reader :target
   attr_reader :label

--- a/app/components/avo/sidebar_component.rb
+++ b/app/components/avo/sidebar_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::SidebarComponent < ViewComponent::Base
+class Avo::SidebarComponent < Avo::BaseComponent
   def initialize(sidebar_open: nil, for_mobile: false)
     @sidebar_open = sidebar_open
     @for_mobile = for_mobile

--- a/app/components/avo/sidebar_profile_component.rb
+++ b/app/components/avo/sidebar_profile_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::SidebarProfileComponent < ViewComponent::Base
+class Avo::SidebarProfileComponent < Avo::BaseComponent
   attr_reader :user
 
   def initialize(user:)

--- a/app/components/avo/turbo_frame_wrapper_component.rb
+++ b/app/components/avo/turbo_frame_wrapper_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Avo::TurboFrameWrapperComponent < ViewComponent::Base
+class Avo::TurboFrameWrapperComponent < Avo::BaseComponent
   attr_reader :name
 
   def initialize(name = nil)


### PR DESCRIPTION
# Description

This is a small find/replace maintenance PR to make all components inherit from `Avo::BaseComponent`. This will allow us to layer on component features, such as Literal properties in a way that makes them available to all Avo components. See #2891 

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works