### PR TITLE
Add search_results_count to configuration

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -53,7 +53,7 @@ module Avo
       results_count = query.reselect(resource.model_class.primary_key).count
 
       # Get the results
-      query = query.limit(8)
+      query = query.limit(Avo.configuration.search_results_count)
 
       results = apply_search_metadata(query, resource)
 

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -50,6 +50,7 @@ module Avo
     attr_accessor :mount_avo_engines
     attr_accessor :default_url_options
     attr_accessor :alert_dismiss_time
+    attr_accessor :search_results_count
 
     def initialize
       @root_path = "/avo"
@@ -107,6 +108,7 @@ module Avo
       @default_url_options = []
       @pagination = {}
       @alert_dismiss_time = 5000
+      @search_results_count = 8
     end
 
     def current_user_method(&block)

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -61,6 +61,10 @@ Avo.configure do |config|
   ## == Response messages dismiss time ==
   # config.alert_dismiss_time = 5000
 
+
+  ## == Number of search results to display ==
+  # config.search_results_count = 8
+
   ## == Cache options ==
   ## Provide a lambda to customize the cache store used by Avo.
   ## We compute the cache store by default, this is NOT the default, just an example.

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -72,6 +72,7 @@ Avo.configure do |config|
   # ]
 
   config.alert_dismiss_time = 5000
+  config.search_results_count = 8
 
   ## == Menus ==
   config.main_menu = -> do


### PR DESCRIPTION
# Description
This PR adds a new configuration called search_results_count which lets the user specify the number of results to display after searching.

Currently this number is 8 and avo provides no way to change this number.

Fixes #2885

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps

1. Logged into avo. Typed 'a' in projects search box. Verified that 8 search results are displayed.
2. Changed the search_results_count variable to 10 in spec/dummy/config/initializers/avo.rb.
3. Typed 'a' in projects search box. Verified that 10 search results are displayed now.

Manual reviewer: please leave a comment with output from the test if that's the case.
