### PR TITLE
fix: code mirror does not disconnect properly

### DIFF
--- a/app/javascript/js/controllers/fields/code_field_controller.js
+++ b/app/javascript/js/controllers/fields/code_field_controller.js
@@ -42,4 +42,8 @@ export default class extends Controller {
       })
     }, 1)
   }
+
+  disconnect() {
+    this.element.querySelector('.CodeMirror').CodeMirror.toTextArea()
+  }
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where the `code` field might be duplicated in some navigation scenarios.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
