### PR TITLE
Fix pager button CSS on mobile devices

### DIFF
--- a/app/assets/stylesheets/css/pagination.css
+++ b/app/assets/stylesheets/css/pagination.css
@@ -101,3 +101,11 @@
     }
   }
 }
+
+/* Media queries for mobile devices */
+@media (max-width: 640px) {
+  .pagy.nav a,
+  .pagy.nav span {
+    @apply px-2 py-1 text-xs;
+  }
+}


### PR DESCRIPTION
Related to #2344

This pull request introduces media queries for mobile devices to the pagination CSS, ensuring the pager button fits within the screen on mobile devices.

- Adds media queries specifically targeting screens with a maximum width of 640px.
- Adjusts the padding and font size of the pager buttons for better visibility and interaction on smaller screens.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/avo-hq/avo/issues/2344?shareId=3fef42a0-5145-4749-9e82-e9b9cacd9b88).