### PR TITLE
Change dummy photo service from unsplash to picsum

### DIFF
--- a/spec/dummy/db/seeds.rb
+++ b/spec/dummy/db/seeds.rb
@@ -168,10 +168,10 @@ puts "Creating posts"
   begin
     width = [1000, 1100, 1200, 1300].sample
     height = [1000, 1100, 1200, 1300].sample
-    url = "https://source.unsplash.com/random/#{width}x#{height}/?all"
+    url = "https://picsum.photos/#{width}/#{height}"
     io = URI.open(url) # standard:disable Security/Open
   rescue
-    puts "Failed to fetch cover photo from Unsplash"
+    puts "Failed to fetch cover photo from Picsum"
   end
   post.cover_photo.attach(io: io, filename: "cover.jpg") if io
 


### PR DESCRIPTION
# Description

I just noticed that [Unsplash](https://unsplash.com/) now requires a developer account, hence seeding the dummy app was broken.

I changed it to Picsum ✌



- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

