### PR TITLE
refactor: Prefer Model.reflections over private Model#_reflections.

### DIFF
--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -114,7 +114,7 @@ module Avo
       end
 
       def get_record_associations(record)
-        record._reflections
+        record.class.reflections
       end
 
       def valid_association_name(record, association_name)
@@ -382,7 +382,7 @@ module Avo
 
           if field.type == "belongs_to"
 
-            reflection = @model._reflections[@params[:via_relation]]
+            reflection = @model.class.reflections[@params[:via_relation]]
 
             if field.polymorphic_as.present? && field.types.map(&:to_s).include?(@params[:via_relation_class])
               # set the value to the actual record

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -245,10 +245,10 @@ module Avo
 
         reflection_key = polymorphic_as || id
 
-        if @model.class.reflections[reflection_key.to_s].klass.present?
-          App.get_resource_by_model_name @model.class.reflections[reflection_key.to_s].klass.to_s
-        elsif @model.class.reflections[reflection_key.to_s].options[:class_name].present?
-          App.get_resource_by_model_name @model.class.reflections[reflection_key.to_s].options[:class_name]
+        if @model.class.reflect_on_association(reflection_key).klass.present?
+          App.get_resource_by_model_name @model.class.reflect_on_association(reflection_key).klass.to_s
+        elsif @model.class.reflect_on_association(reflection_key).options[:class_name].present?
+          App.get_resource_by_model_name @model.class.reflect_on_association(reflection_key).options[:class_name]
         else
           App.get_resource_by_name reflection_key.to_s
         end

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -245,10 +245,10 @@ module Avo
 
         reflection_key = polymorphic_as || id
 
-        if @model._reflections[reflection_key.to_s].klass.present?
-          App.get_resource_by_model_name @model._reflections[reflection_key.to_s].klass.to_s
-        elsif @model._reflections[reflection_key.to_s].options[:class_name].present?
-          App.get_resource_by_model_name @model._reflections[reflection_key.to_s].options[:class_name]
+        if @model.class.reflections[reflection_key.to_s].klass.present?
+          App.get_resource_by_model_name @model.class.reflections[reflection_key.to_s].klass.to_s
+        elsif @model.class.reflections[reflection_key.to_s].options[:class_name].present?
+          App.get_resource_by_model_name @model.class.reflections[reflection_key.to_s].options[:class_name]
         else
           App.get_resource_by_name reflection_key.to_s
         end

--- a/lib/avo/fields/has_base_field.rb
+++ b/lib/avo/fields/has_base_field.rb
@@ -59,10 +59,10 @@ module Avo
       end
 
       def target_resource
-        if @model.class.reflections[id.to_s].klass.present?
-          Avo::App.get_resource_by_model_name @model.class.reflections[id.to_s].klass.to_s
-        elsif @model.class.reflections[id.to_s].options[:class_name].present?
-          Avo::App.get_resource_by_model_name @model.class.reflections[id.to_s].options[:class_name]
+        if @model.class.reflect_on_association(id).klass.present?
+          Avo::App.get_resource_by_model_name @model.class.reflect_on_association(id).klass.to_s
+        elsif @model.class.reflect_on_association(id).options[:class_name].present?
+          Avo::App.get_resource_by_model_name @model.class.reflect_on_association(id).options[:class_name]
         else
           Avo::App.get_resource_by_name id.to_s
         end

--- a/lib/avo/fields/has_base_field.rb
+++ b/lib/avo/fields/has_base_field.rb
@@ -59,10 +59,10 @@ module Avo
       end
 
       def target_resource
-        if @model._reflections[id.to_s].klass.present?
-          Avo::App.get_resource_by_model_name @model._reflections[id.to_s].klass.to_s
-        elsif @model._reflections[id.to_s].options[:class_name].present?
-          Avo::App.get_resource_by_model_name @model._reflections[id.to_s].options[:class_name]
+        if @model.class.reflections[id.to_s].klass.present?
+          Avo::App.get_resource_by_model_name @model.class.reflections[id.to_s].klass.to_s
+        elsif @model.class.reflections[id.to_s].options[:class_name].present?
+          Avo::App.get_resource_by_model_name @model.class.reflections[id.to_s].options[:class_name]
         else
           Avo::App.get_resource_by_name id.to_s
         end


### PR DESCRIPTION
:construction: This targets 2.x branch.

- `_reflections` returns different key type per Rails version

:information_source: Model.reflections seems supported for 6.0+ (I have not checked earlier versions since those seems unsupported).

:bulb: This fixes issues at RubyGems.org with Rails 7.2 beta compatibility.