### PR TITLE
feature: hide empty menu groups and sections

### DIFF
--- a/app/components/avo/sidebar/base_item_component.rb
+++ b/app/components/avo/sidebar/base_item_component.rb
@@ -8,7 +8,6 @@ class Avo::Sidebar::BaseItemComponent < Avo::BaseComponent
     @item = item
   end
 
-
   def render?
     items.any?
   end

--- a/app/components/avo/sidebar/base_item_component.rb
+++ b/app/components/avo/sidebar/base_item_component.rb
@@ -2,7 +2,7 @@
 
 class Avo::Sidebar::BaseItemComponent < Avo::BaseComponent
   attr_reader :item
-  delegate :items, :collapsable, :collapsed, to: :item
+  delegate :items, :collapsable, :collapsed, to: :@item
 
   def initialize(item: nil)
     @item = item
@@ -14,10 +14,10 @@ class Avo::Sidebar::BaseItemComponent < Avo::BaseComponent
   end
 
   def key
-    result = "avo.#{request.host}.main_menu.#{item.name.to_s.underscore}"
+    result = "avo.#{request.host}.main_menu.#{@item.name.to_s.underscore}"
 
-    if item.icon.present?
-      result += ".#{item.icon.parameterize.underscore}"
+    if @item.icon.present?
+      result += ".#{@item.icon.parameterize.underscore}"
     end
 
     result

--- a/app/components/avo/sidebar/base_item_component.rb
+++ b/app/components/avo/sidebar/base_item_component.rb
@@ -2,21 +2,22 @@
 
 class Avo::Sidebar::BaseItemComponent < Avo::BaseComponent
   attr_reader :item
-  delegate :items, :collapsable, :collapsed, :icon, :name, to: :item
+  delegate :items, :collapsable, :collapsed, to: :item
 
   def initialize(item: nil)
     @item = item
   end
+
 
   def render?
     items.any?
   end
 
   def key
-    result = "avo.#{request.host}.main_menu.#{name.to_s.underscore}"
+    result = "avo.#{request.host}.main_menu.#{item.name.to_s.underscore}"
 
-    if icon.present?
-      result += ".#{icon.parameterize.underscore}"
+    if item.icon.present?
+      result += ".#{item.icon.parameterize.underscore}"
     end
 
     result

--- a/app/components/avo/sidebar/base_item_component.rb
+++ b/app/components/avo/sidebar/base_item_component.rb
@@ -2,31 +2,24 @@
 
 class Avo::Sidebar::BaseItemComponent < Avo::BaseComponent
   attr_reader :item
+  delegate :items, :collapsable, :collapsed, :icon, :name, to: :item
 
   def initialize(item: nil)
     @item = item
   end
 
-  def items
-    item.items
+  def render?
+    items.any?
   end
 
   def key
-    result = "avo.#{request.host}.main_menu.#{item.name.to_s.underscore}"
+    result = "avo.#{request.host}.main_menu.#{name.to_s.underscore}"
 
-    if item.icon.present?
-      result += ".#{item.icon.parameterize.underscore}"
+    if icon.present?
+      result += ".#{icon.parameterize.underscore}"
     end
 
     result
-  end
-
-  def collapsable
-    item.collapsable
-  end
-
-  def collapsed
-    item.collapsed
   end
 
   def section_collapse_data_animation


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2833

This feature hides all empty menu groups and sections.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
