### PR TITLE
fix: tags delimiters

### DIFF
--- a/app/javascript/js/controllers/fields/tags_field_controller.js
+++ b/app/javascript/js/controllers/fields/tags_field_controller.js
@@ -64,7 +64,7 @@ export default class extends Controller {
       })
     } else {
       options = merge(options, {
-        originalInputValueFormat: (valuesArr) => valuesArr.map((item) => item.value).join(','),
+        originalInputValueFormat: (valuesArr) => valuesArr.map((item) => item.value).join(this.delimitersValue[0]),
       })
     }
 

--- a/lib/avo/fields/tags_field.rb
+++ b/lib/avo/fields/tags_field.rb
@@ -54,7 +54,7 @@ module Avo
         return fill_acts_as_taggable(record, key, value, params) if acts_as_taggable_on.present?
 
         value = if value.is_a?(String)
-          value.split(",")
+          value.split Regexp.union(delimiters)
         else
           value
         end

--- a/lib/avo/fields/tags_field.rb
+++ b/lib/avo/fields/tags_field.rb
@@ -54,7 +54,7 @@ module Avo
         return fill_acts_as_taggable(record, key, value, params) if acts_as_taggable_on.present?
 
         value = if value.is_a?(String)
-          value.split Regexp.union(delimiters)
+          value.split(delimiters[0])
         else
           value
         end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2922 

Properly apply `delimiters` on the tags field.

Format tags' param value using the first delimiter then split them using the same delimiter.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works