### PR TITLE
feature: apply target resource policy on belongs_to field create new link

### DIFF
--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -66,8 +66,9 @@
                 <%= @form.hidden_field @field.id_input_foreign_key %>
               <% end %>
             <% end %>
-            <% if field.can_create? %>
-              <% create_href = create_path(Avo.resource_manager.get_resource_by_model_class(type.to_s)) %>
+            <% target_resource_for_type = Avo.resource_manager.get_resource_by_model_class(type.to_s) %>
+            <% if field.can_create?(target_resource_for_type) %>
+              <% create_href = create_path(target_resource_for_type) %>
               <% if !disabled && create_href.present? %>
                 <%= link_to t("avo.create_new_item", item: type.model_name.human.downcase),
                       create_href,

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -281,8 +281,12 @@ module Avo
         end
       end
 
+      # field :user, as: :belongs_to, can_create: true
+      # Only can create when:
+      #   - `can_create: true` option is present
+      #   - target resource's policy allow creation (UserPolicy in this example)
       def can_create?
-        @can_create
+        @can_create && target_resource.authorization.authorize_action(:create, raise_exception: false)
       end
 
       def form_field_label

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -285,8 +285,10 @@ module Avo
       # Only can create when:
       #   - `can_create: true` option is present
       #   - target resource's policy allow creation (UserPolicy in this example)
-      def can_create?
-        @can_create && target_resource.authorization.authorize_action(:create, raise_exception: false)
+      def can_create?(forced_target_resource)
+        return unless @can_create
+
+        (forced_target_resource || target_resource).authorization.authorize_action(:create, raise_exception: false)
       end
 
       def form_field_label

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -285,10 +285,8 @@ module Avo
       # Only can create when:
       #   - `can_create: true` option is present
       #   - target resource's policy allow creation (UserPolicy in this example)
-      def can_create?(forced_target_resource)
-        return unless @can_create
-
-        (forced_target_resource || target_resource).authorization.authorize_action(:create, raise_exception: false)
+      def can_create?(final_target_resource = target_resource)
+        @can_create && final_target_resource.authorization.authorize_action(:create, raise_exception: false)
       end
 
       def form_field_label


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2723

Apply the target resource policy on the belongs_to field create new link.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
  - https://github.com/avo-hq/docs.avohq.io/pull/232
- [ ] I have added tests that prove my fix is effective or that my feature works
