### PR TITLE
Create button to nullify date_time fields

### DIFF
--- a/app/components/avo/fields/date_time_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_time_field/edit_component.html.erb
@@ -1,5 +1,5 @@
 <%= field_wrapper **field_wrapper_args do %>
-  <%= content_tag :div, class: 'flex', data: {
+  <%= content_tag :div, class: "flex relative", data: {
       controller: "date-field",
       date_field_view_value: @view,
       date_field_enable_time_value: true,
@@ -16,7 +16,7 @@
       value: @field.edit_formatted_value,
       class: classes("w-full #{"hidden" unless params[:avo_show_hidden_inputs]}"),
       data: {
-        'date-field-target': 'input',
+        date_field_target: :input,
         placeholder: @field.placeholder,
         **@field.get_html(:data, view: view, element: :input)
       },
@@ -28,7 +28,7 @@
       value: @field.edit_formatted_value,
       class: classes("w-full"),
       data: {
-        'date-field-target': 'fakeInput',
+        date_field_target: :fakeInput,
         placeholder: @field.placeholder,
         **@field.get_html(:data, view: view, element: :input)
       },
@@ -36,11 +36,16 @@
       placeholder: @field.placeholder,
       style: @field.get_html(:style, view: view, element: :input)
     %>
-    <%= content_tag :button, id: :reset, type: :button,
-                    title: "Reset Date",
-                    data: {action: "click->date-field#clear",
-                           tippy: :tooltip } do %>
-      <%= render Avo::Fields::Common::BooleanCheckComponent.new %>
+    <%= content_tag :button,
+      class: "absolute right-0 self-center mr-4 uppercase font-semibold text-xs",
+      id: :reset,
+      type: :button,
+      title: t("avo.reset").capitalize,
+      data: {
+        action: "click->date-field#clear",
+        tippy: :tooltip
+      } do %>
+      <%= helpers.svg "avo/times", class: "h-4" %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/avo/fields/date_time_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_time_field/edit_component.html.erb
@@ -36,9 +36,9 @@
       placeholder: @field.placeholder,
       style: @field.get_html(:style, view: view, element: :input)
     %>
-    <%= content_tag :button, type: :button, 
-                    title: "Reset Date", 
-                    data: {action: "click->date-field#clear", 
+    <%= content_tag :button, id: :reset, type: :button,
+                    title: "Reset Date",
+                    data: {action: "click->date-field#clear",
                            tippy: :tooltip } do %>
       <%= render Avo::Fields::Common::BooleanCheckComponent.new %>
     <% end %>

--- a/app/components/avo/fields/date_time_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_time_field/edit_component.html.erb
@@ -36,5 +36,8 @@
       placeholder: @field.placeholder,
       style: @field.get_html(:style, view: view, element: :input)
     %>
+  <button type="button" data-action="click->date-field#clear">
+    <%= render Avo::Fields::Common::BooleanCheckComponent.new %>
+  </button>
   <% end %>
 <% end %>

--- a/app/components/avo/fields/date_time_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_time_field/edit_component.html.erb
@@ -1,5 +1,5 @@
 <%= field_wrapper **field_wrapper_args do %>
-  <%= content_tag :div, data: {
+  <%= content_tag :div, class: 'flex', data: {
       controller: "date-field",
       date_field_view_value: @view,
       date_field_enable_time_value: true,
@@ -36,8 +36,11 @@
       placeholder: @field.placeholder,
       style: @field.get_html(:style, view: view, element: :input)
     %>
-  <button type="button" data-action="click->date-field#clear">
-    <%= render Avo::Fields::Common::BooleanCheckComponent.new %>
-  </button>
+    <%= content_tag :button, type: :button, 
+                    title: "Reset Date", 
+                    data: {action: "click->date-field#clear", 
+                           tippy: :tooltip } do %>
+      <%= render Avo::Fields::Common::BooleanCheckComponent.new %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/avo/fields/time_field/edit_component.html.erb
+++ b/app/components/avo/fields/time_field/edit_component.html.erb
@@ -1,5 +1,5 @@
 <%= field_wrapper **field_wrapper_args do %>
-  <%= content_tag :div, data: {
+  <%= content_tag :div, class: "flex", data: {
       controller: "date-field",
       date_field_view_value: @view,
       date_field_enable_time_value: true,
@@ -36,5 +36,11 @@
       placeholder: @field.placeholder,
       style: @field.get_html(:style, view: view, element: :input)
     %>
+    <%= content_tag :button, type: :button, 
+                    title: "Reset Time", 
+                    data: {action: "click->date-field#clear", 
+                           tippy: :tooltip } do %>
+      <%= render Avo::Fields::Common::BooleanCheckComponent.new %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/avo/fields/time_field/edit_component.html.erb
+++ b/app/components/avo/fields/time_field/edit_component.html.erb
@@ -1,5 +1,5 @@
 <%= field_wrapper **field_wrapper_args do %>
-  <%= content_tag :div, class: "flex", data: {
+  <%= content_tag :div, class: "flex relative", data: {
       controller: "date-field",
       date_field_view_value: @view,
       date_field_enable_time_value: true,
@@ -16,7 +16,7 @@
       value: @field.edit_formatted_value,
       class: classes("w-full #{"hidden" unless params[:avo_show_hidden_inputs]}"),
       data: {
-        'date-field-target': 'input',
+        date_field_target: :input,
         placeholder: @field.placeholder,
         **@field.get_html(:data, view: view, element: :input)
       },
@@ -28,7 +28,7 @@
       value: @field.edit_formatted_value,
       class: classes("w-full"),
       data: {
-        'date-field-target': 'fakeInput',
+        date_field_target: :fakeInput,
         placeholder: @field.placeholder,
         **@field.get_html(:data, view: view, element: :input)
       },
@@ -36,11 +36,16 @@
       placeholder: @field.placeholder,
       style: @field.get_html(:style, view: view, element: :input)
     %>
-    <%= content_tag :button, id: :reset, type: :button,
-                    title: "Reset Time",
-                    data: {action: "click->date-field#clear",
-                           tippy: :tooltip } do %>
-      <%= render Avo::Fields::Common::BooleanCheckComponent.new %>
+    <%= content_tag :button,
+      class: "absolute right-0 self-center mr-4 uppercase font-semibold text-xs",
+      id: :reset,
+      type: :button,
+      title: t("avo.reset").capitalize,
+      data: {
+        action: "click->date-field#clear",
+        tippy: :tooltip
+      } do %>
+      <%= helpers.svg "avo/times", class: "h-4" %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/avo/fields/time_field/edit_component.html.erb
+++ b/app/components/avo/fields/time_field/edit_component.html.erb
@@ -36,9 +36,9 @@
       placeholder: @field.placeholder,
       style: @field.get_html(:style, view: view, element: :input)
     %>
-    <%= content_tag :button, type: :button, 
-                    title: "Reset Time", 
-                    data: {action: "click->date-field#clear", 
+    <%= content_tag :button, id: :reset, type: :button,
+                    title: "Reset Time",
+                    data: {action: "click->date-field#clear",
                            tippy: :tooltip } do %>
       <%= render Avo::Fields::Common::BooleanCheckComponent.new %>
     <% end %>

--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -230,4 +230,8 @@ export default class extends Controller {
   updateRealInput(value) {
     this.inputTarget.value = value
   }
+
+  clear() {
+    this.fakeInputTarget._flatpickr.clear();
+  }
 }

--- a/lib/generators/avo/templates/locales/avo.ar.yml
+++ b/lib/generators/avo/templates/locales/avo.ar.yml
@@ -92,6 +92,7 @@ ar:
     records_selected_from_all_pages_html: جميع السجلات مختارة من جميع الصفحات
     remove_selection: إزالة التحديد
     reset_filters: إعادة تعيين الفلاتر
+    reset: اعاده تعيين
     resource_created: تم إنشاء السجل
     resource_destroyed: تم حذف السجل
     resource_updated: تم تحديث السجل

--- a/lib/generators/avo/templates/locales/avo.ar.yml
+++ b/lib/generators/avo/templates/locales/avo.ar.yml
@@ -91,8 +91,8 @@ ar:
     prev_page: الصفحة السابقة
     records_selected_from_all_pages_html: جميع السجلات مختارة من جميع الصفحات
     remove_selection: إزالة التحديد
-    reset_filters: إعادة تعيين الفلاتر
     reset: اعاده تعيين
+    reset_filters: إعادة تعيين الفلاتر
     resource_created: تم إنشاء السجل
     resource_destroyed: تم حذف السجل
     resource_updated: تم تحديث السجل

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -82,6 +82,7 @@ en:
     records_selected_from_all_pages_html: All records selected from all pages
     remove_selection: Remove selection
     reset_filters: Reset filters
+    reset: reset
     resource_created: Record created
     resource_destroyed: Record destroyed
     resource_updated: Record updated

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -81,8 +81,8 @@ en:
     prev_page: Previous page
     records_selected_from_all_pages_html: All records selected from all pages
     remove_selection: Remove selection
-    reset_filters: Reset filters
     reset: reset
+    reset_filters: Reset filters
     resource_created: Record created
     resource_destroyed: Record destroyed
     resource_updated: Record updated

--- a/lib/generators/avo/templates/locales/avo.es.yml
+++ b/lib/generators/avo/templates/locales/avo.es.yml
@@ -83,8 +83,8 @@ es:
     prev_page: Página anterior
     records_selected_from_all_pages_html: Todos los registros seleccionados de todas las páginas.
     remove_selection: Quitar la selección
-    reset_filters: Reiniciar filtros
     reset: Restablecer
+    reset_filters: Reiniciar filtros
     resource_created: Recurso creado
     resource_destroyed: Recurso eliminado
     resource_updated: Recurso actualizado

--- a/lib/generators/avo/templates/locales/avo.es.yml
+++ b/lib/generators/avo/templates/locales/avo.es.yml
@@ -84,6 +84,7 @@ es:
     records_selected_from_all_pages_html: Todos los registros seleccionados de todas las páginas.
     remove_selection: Quitar la selección
     reset_filters: Reiniciar filtros
+    reset: Restablecer
     resource_created: Recurso creado
     resource_destroyed: Recurso eliminado
     resource_updated: Recurso actualizado

--- a/lib/generators/avo/templates/locales/avo.es.yml
+++ b/lib/generators/avo/templates/locales/avo.es.yml
@@ -83,7 +83,7 @@ es:
     prev_page: Página anterior
     records_selected_from_all_pages_html: Todos los registros seleccionados de todas las páginas.
     remove_selection: Quitar la selección
-    reset: Restablecer
+    reset: restablecer
     reset_filters: Reiniciar filtros
     resource_created: Recurso creado
     resource_destroyed: Recurso eliminado

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -83,8 +83,8 @@ fr:
     prev_page: Page précédente
     records_selected_from_all_pages_html: tous les éléments sélectionnés de toutes les pages
     remove_selection: Supprimer la sélection
-    reset_filters: Réinitialiser les filtres
     reset: réinitialiser
+    reset_filters: Réinitialiser les filtres
     resource_created: Ressource créee
     resource_destroyed: Ressource détruite
     resource_updated: Ressource mise à jour

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -84,6 +84,7 @@ fr:
     records_selected_from_all_pages_html: tous les éléments sélectionnés de toutes les pages
     remove_selection: Supprimer la sélection
     reset_filters: Réinitialiser les filtres
+    reset: réinitialiser
     resource_created: Ressource créee
     resource_destroyed: Ressource détruite
     resource_updated: Ressource mise à jour

--- a/lib/generators/avo/templates/locales/avo.ja.yml
+++ b/lib/generators/avo/templates/locales/avo.ja.yml
@@ -84,6 +84,7 @@ ja:
     records_selected_from_all_pages_html: 全ページから選択された全レコード
     remove_selection: 選択を解除
     reset_filters: フィルターをリセット
+    reset: リセット
     resource_created: レコードが作成されました
     resource_destroyed: レコードが破棄されました
     resource_updated: レコードが更新されました

--- a/lib/generators/avo/templates/locales/avo.ja.yml
+++ b/lib/generators/avo/templates/locales/avo.ja.yml
@@ -83,8 +83,8 @@ ja:
     prev_page: 前のページ
     records_selected_from_all_pages_html: 全ページから選択された全レコード
     remove_selection: 選択を解除
-    reset_filters: フィルターをリセット
     reset: リセット
+    reset_filters: フィルターをリセット
     resource_created: レコードが作成されました
     resource_destroyed: レコードが破棄されました
     resource_updated: レコードが更新されました

--- a/lib/generators/avo/templates/locales/avo.nb.yml
+++ b/lib/generators/avo/templates/locales/avo.nb.yml
@@ -84,6 +84,7 @@ nb:
     records_selected_from_all_pages_html: Alle poster valgt fra alle sider
     remove_selection: Fjern valg
     reset_filters: Nullstill filter
+    reset: Nullstille
     resource_created: Ressurs generert
     resource_destroyed: Ressurs slettet
     resource_updated: Ressurs oppdatert

--- a/lib/generators/avo/templates/locales/avo.nb.yml
+++ b/lib/generators/avo/templates/locales/avo.nb.yml
@@ -83,8 +83,8 @@ nb:
     prev_page: Forrige side
     records_selected_from_all_pages_html: Alle poster valgt fra alle sider
     remove_selection: Fjern valg
-    reset_filters: Nullstill filter
     reset: Nullstille
+    reset_filters: Nullstill filter
     resource_created: Ressurs generert
     resource_destroyed: Ressurs slettet
     resource_updated: Ressurs oppdatert

--- a/lib/generators/avo/templates/locales/avo.nb.yml
+++ b/lib/generators/avo/templates/locales/avo.nb.yml
@@ -83,7 +83,7 @@ nb:
     prev_page: Forrige side
     records_selected_from_all_pages_html: Alle poster valgt fra alle sider
     remove_selection: Fjern valg
-    reset: Nullstille
+    reset: nullstille
     reset_filters: Nullstill filter
     resource_created: Ressurs generert
     resource_destroyed: Ressurs slettet

--- a/lib/generators/avo/templates/locales/avo.nn.yml
+++ b/lib/generators/avo/templates/locales/avo.nn.yml
@@ -84,6 +84,7 @@ nn:
     records_selected_from_all_pages_html: Alle poster valgt fra alle sider
     remove_selection: Fjern val
     reset_filters: Nullstill filter
+    reset: Nullstille
     resource_created: Ressurs generert
     resource_destroyed: Ressurs sletta
     resource_updated: Ressurs oppdatert

--- a/lib/generators/avo/templates/locales/avo.nn.yml
+++ b/lib/generators/avo/templates/locales/avo.nn.yml
@@ -83,8 +83,8 @@ nn:
     prev_page: Førre side
     records_selected_from_all_pages_html: Alle poster valgt fra alle sider
     remove_selection: Fjern val
-    reset_filters: Nullstill filter
     reset: Nullstille
+    reset_filters: Nullstill filter
     resource_created: Ressurs generert
     resource_destroyed: Ressurs sletta
     resource_updated: Ressurs oppdatert

--- a/lib/generators/avo/templates/locales/avo.nn.yml
+++ b/lib/generators/avo/templates/locales/avo.nn.yml
@@ -83,7 +83,7 @@ nn:
     prev_page: Førre side
     records_selected_from_all_pages_html: Alle poster valgt fra alle sider
     remove_selection: Fjern val
-    reset: Nullstille
+    reset: nullstille
     reset_filters: Nullstill filter
     resource_created: Ressurs generert
     resource_destroyed: Ressurs sletta

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -83,8 +83,8 @@ pt-BR:
     prev_page: Página anterior
     records_selected_from_all_pages_html: Todos os registros de todas as páginas selecionados
     remove_selection: Remover seleção
-    reset_filters: Limpar filtros
     reset: Resetar
+    reset_filters: Limpar filtros
     resource_created: Recurso criado
     resource_destroyed: Recurso destruído
     resource_updated: Recurso atualizado

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -84,6 +84,7 @@ pt-BR:
     records_selected_from_all_pages_html: Todos os registros de todas as páginas selecionados
     remove_selection: Remover seleção
     reset_filters: Limpar filtros
+    reset: Resetar
     resource_created: Recurso criado
     resource_destroyed: Recurso destruído
     resource_updated: Recurso atualizado

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -83,7 +83,7 @@ pt-BR:
     prev_page: Página anterior
     records_selected_from_all_pages_html: Todos os registros de todas as páginas selecionados
     remove_selection: Remover seleção
-    reset: Resetar
+    reset: resetar
     reset_filters: Limpar filtros
     resource_created: Recurso criado
     resource_destroyed: Recurso destruído

--- a/lib/generators/avo/templates/locales/avo.pt.yml
+++ b/lib/generators/avo/templates/locales/avo.pt.yml
@@ -83,8 +83,8 @@ pt:
     prev_page: Página anterior
     records_selected_from_all_pages_html: Todos os itens de todas as páginas selecionados
     remove_selection: Remover seleção
-    reset_filters: Limpar filtros
     reset: Restaurar
+    reset_filters: Limpar filtros
     resource_created: Recurso criado
     resource_destroyed: Recurso destruído
     resource_updated: Recurso atualizado

--- a/lib/generators/avo/templates/locales/avo.pt.yml
+++ b/lib/generators/avo/templates/locales/avo.pt.yml
@@ -83,7 +83,7 @@ pt:
     prev_page: Página anterior
     records_selected_from_all_pages_html: Todos os itens de todas as páginas selecionados
     remove_selection: Remover seleção
-    reset: Restaurar
+    reset: restaurar
     reset_filters: Limpar filtros
     resource_created: Recurso criado
     resource_destroyed: Recurso destruído

--- a/lib/generators/avo/templates/locales/avo.pt.yml
+++ b/lib/generators/avo/templates/locales/avo.pt.yml
@@ -84,6 +84,7 @@ pt:
     records_selected_from_all_pages_html: Todos os itens de todas as páginas selecionados
     remove_selection: Remover seleção
     reset_filters: Limpar filtros
+    reset: Restaurar
     resource_created: Recurso criado
     resource_destroyed: Recurso destruído
     resource_updated: Recurso atualizado

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -86,6 +86,7 @@ ro:
     records_selected_from_all_pages_html: Toate selectate din toate paginile
     remove_selection: Șterge selecția
     reset_filters: Resetați filtrele
+    reset: Resetare
     resource_created: Resursă creata
     resource_destroyed: Resursă ștearsă
     resource_updated: Resursă actualizată

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -85,7 +85,7 @@ ro:
     prev_page: Pagina anterioara
     records_selected_from_all_pages_html: Toate selectate din toate paginile
     remove_selection: Șterge selecția
-    reset: Resetare
+    reset: resetare
     reset_filters: Resetați filtrele
     resource_created: Resursă creata
     resource_destroyed: Resursă ștearsă

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -85,8 +85,8 @@ ro:
     prev_page: Pagina anterioara
     records_selected_from_all_pages_html: Toate selectate din toate paginile
     remove_selection: Șterge selecția
-    reset_filters: Resetați filtrele
     reset: Resetare
+    reset_filters: Resetați filtrele
     resource_created: Resursă creata
     resource_destroyed: Resursă ștearsă
     resource_updated: Resursă actualizată

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -83,8 +83,8 @@ tr:
     prev_page: Önceki sayfa
     records_selected_from_all_pages_html: Tüm sayfalardan seçilen tüm kayıtlar
     remove_selection: Seçimi sil
-    reset_filters: Filtreleri sıfırla
     reset: Sıfırlama
+    reset_filters: Filtreleri sıfırla
     resource_created: Kayıt oluşturuldu
     resource_destroyed: Kayıt silindi
     resource_updated: Kayıt güncellendi

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -83,7 +83,7 @@ tr:
     prev_page: Önceki sayfa
     records_selected_from_all_pages_html: Tüm sayfalardan seçilen tüm kayıtlar
     remove_selection: Seçimi sil
-    reset: Sıfırlama
+    reset: sıfırlama
     reset_filters: Filtreleri sıfırla
     resource_created: Kayıt oluşturuldu
     resource_destroyed: Kayıt silindi

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -84,6 +84,7 @@ tr:
     records_selected_from_all_pages_html: Tüm sayfalardan seçilen tüm kayıtlar
     remove_selection: Seçimi sil
     reset_filters: Filtreleri sıfırla
+    reset: Sıfırlama
     resource_created: Kayıt oluşturuldu
     resource_destroyed: Kayıt silindi
     resource_updated: Kayıt güncellendi

--- a/spec/dummy/config/locales/avo.en.yml
+++ b/spec/dummy/config/locales/avo.en.yml
@@ -84,6 +84,7 @@ en:
     records_selected_from_all_pages_html: All records selected from all pages
     remove_selection: Remove selection
     reset_filters: Reset filters
+    reset: reset
     resource_created: Record created
     resource_destroyed: Record destroyed
     resource_updated: Record updated

--- a/spec/system/avo/date_time_fields/date_time_spec.rb
+++ b/spec/system/avo/date_time_fields/date_time_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Date field", type: :system do
 
           expect(text_input.value).to eq "2000-01-01 08:00:00"
 
-          click_button('reset')
+          click_button("reset")
 
           save
 

--- a/spec/system/avo/date_time_fields/date_time_spec.rb
+++ b/spec/system/avo/date_time_fields/date_time_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe "Date field", type: :system do
 
           expect(show_field_value(id: :started_at)).to eq "January 02, 2000 17:17:17 Europe/Bucharest"
         end
+
+        it "resets the date when reset button is clicked" do
+          visit "/admin/resources/projects/#{project.id}/edit"
+
+          expect(text_input.value).to eq "2000-01-01 08:00:00"
+
+          click_button('reset')
+
+          save
+
+          expect(show_field_value(id: :started_at)).to eq "—"
+        end
       end
     end
   end

--- a/spec/system/avo/date_time_fields/time_spec.rb
+++ b/spec/system/avo/date_time_fields/time_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Time field", type: :system do
 
         expect(text_input.value).to eq "16:30"
 
-        click_button('reset')
+        click_button("reset")
         save
 
         expect(find_field_value_element("starting_at").text).to eq "—"

--- a/spec/system/avo/date_time_fields/time_spec.rb
+++ b/spec/system/avo/date_time_fields/time_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe "Time field", type: :system do
 
         expect(find_field_value_element("starting_at").text).to eq "17:30"
       end
+
+      it "resets the time when reset button is clicked" do
+        visit "/admin/resources/courses/#{course.id}/edit"
+
+        expect(text_input.value).to eq "16:30"
+
+        click_button('reset')
+        save
+
+        expect(find_field_value_element("starting_at").text).to eq "—"
+      end
     end
   end
 


### PR DESCRIPTION
# Description
This PR adds a button to nullify date_time fields.

Fixes #2770

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
This is how it looks right now:
![crop](https://github.com/avo-hq/avo/assets/87677429/4d85070d-c9fc-4a3e-be67-51cb177e9281)
![image](https://github.com/avo-hq/avo/assets/87677429/a886c388-c98a-43f4-a21c-dbfc3953f9ed)
![reset](https://github.com/avo-hq/avo/assets/87677429/eab26b72-4f1a-4bf3-80cd-009c1c505edc)

Manual reviewer: please leave a comment with output from the test if that's the case.
