### PR TITLE
Feature: alias close_modal action response to do_nothing

### DIFF
--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -238,7 +238,7 @@ module Avo
       self
     end
 
-    alias do_nothing close_modal
+    alias_method :do_nothing, :close_modal
 
     # Add a placeholder silent message from when a user wants to do a redirect action or something similar
     def silent

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -238,6 +238,8 @@ module Avo
       self
     end
 
+    alias do_nothing close_modal
+
     # Add a placeholder silent message from when a user wants to do a redirect action or something similar
     def silent
       add_message nil, :silent

--- a/spec/dummy/app/avo/actions/test/do_nothing.rb
+++ b/spec/dummy/app/avo/actions/test/do_nothing.rb
@@ -1,0 +1,13 @@
+class Avo::Actions::Test::DoNothing < Avo::BaseAction
+  self.name = "Do Nothing"
+  self.standalone = true
+  self.visible = -> {
+    true
+  }
+
+  def handle(**args)
+    TestBuddy.hi "Hello from Avo::Actions::Test::DoNothing handle method"
+    succeed "Nothing Done!!"
+    do_nothing
+  end
+end

--- a/spec/dummy/app/avo/resources/user.rb
+++ b/spec/dummy/app/avo/resources/user.rb
@@ -73,6 +73,7 @@ class Avo::Resources::User < Avo::BaseResource
     divider
     action Avo::Actions::Test::NoConfirmationRedirect
     action Avo::Actions::Test::CloseModal
+    action Avo::Actions::Test::DoNothing
     action Avo::Actions::DetachUser
   end
 

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -179,8 +179,30 @@ RSpec.describe "Actions", type: :system do
     end
   end
 
+
+  describe "do_nothing" do
+    it "closes the modal and flashes messages" do
+      allow(TestBuddy).to receive(:hi).and_call_original
+      expect(TestBuddy).to receive(:hi).with("Hello from Avo::Actions::Test::DoNothing handle method").at_least :once
+
+      visit "/admin/resources/users/new"
+
+      fill_in "user_first_name", with: "First name should persist after action."
+
+
+      click_on "Actions"
+      click_on "Do Nothing"
+      expect(page).to have_css('turbo-frame#actions_show')
+      expect(page).to have_selector(modal = "[role='dialog']")
+      click_on "Run"
+      expect(page).not_to have_selector(modal)
+      expect(page).to have_text "Nothing Done!!"
+      expect(page).to have_field('user_first_name', with: 'First name should persist after action.')
+    end
+  end
+
   describe "close_modal" do
-    it "closes the modal and flahses messages" do
+    it "closes the modal and flashes messages" do
       allow(TestBuddy).to receive(:hi).and_call_original
       expect(TestBuddy).to receive(:hi).with("Hello from Avo::Actions::Test::CloseModal handle method").at_least :once
 


### PR DESCRIPTION
# Description
Added `do_nothing` alias for `close_modal` as described in issue #2944

Fixes #2944

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs) https://github.com/avo-hq/docs.avohq.io/pull/233
- [x] I have added tests that prove my fix is effective or that my feature works

<img width="1905" alt="do_nothing" src="https://github.com/avo-hq/avo/assets/174844386/04bca628-fede-4bec-8748-dc2ab45c2f69">


## Manual review steps

1. head to http://localhost:3030/admin/resources/users/new
2. click "Actions"
3. click "Do nothing"
4. click "Run" 

Manual reviewer: please leave a comment with output from the test if that's the case.
