### PR TITLE
chore: rails 7.1 warning

### DIFF
--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -153,7 +153,8 @@ module Avo
                     - Dashboards\n\r
                     - Ordering\n\r
                     - Dynamic filters\n\r
-                    We recommend you upgrade to Rails 7.2"
+                    We recommend you upgrade to Rails 7.2\n\r
+                    Click banner for more information."
         })
       end
     end

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -149,10 +149,11 @@ module Avo
         Avo.error_manager.add({
           url: "https://docs.avohq.io/3.0/upgrade.html#upgrade-from-3-7-4-to-3-9-1",
           target: "_blank",
-          message: "Due a Rails 7.1 bug the following features may present issues:\n\r
+          message: "Due to a Rails 7.1 bug the following features won't work:\n\r
                     - Dashboards\n\r
                     - Ordering\n\r
-                    - Dynamic filters\n\r"
+                    - Dynamic filters\n\r
+                    We recommend you upgrade to Rails 7.2"
         })
       end
     end

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -72,6 +72,7 @@ module Avo
     # Runs on each request
     def init
       Avo::Current.error_manager = Avo::ErrorManager.build
+      check_rails_version_issues
       Avo::Current.resource_manager = Avo::Resources::ResourceManager.build
       Avo::Current.tool_manager = Avo::Tools::ToolManager.build
 
@@ -141,6 +142,19 @@ module Avo
 
     def eager_load_actions
       Rails.autoloaders.main.eager_load_namespace(Avo::Actions) if defined?(Avo::Actions)
+    end
+
+    def check_rails_version_issues
+      if Rails.version.start_with?("7.1") && Avo.configuration.license.in? ["pro", "advanced"]
+        Avo.error_manager.add({
+          url: "https://docs.avohq.io/3.0/upgrade.html#upgrade-from-3-7-4-to-3-9-1",
+          target: "_blank",
+          message: "Due a Rails 7.1 bug the following features may present issues:\n\r
+                    - Dashboards\n\r
+                    - Ordering\n\r
+                    - Dynamic filters\n\r"
+        })
+      end
     end
   end
 end

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -145,7 +145,7 @@ module Avo
     end
 
     def check_rails_version_issues
-      if Rails.version.start_with?("7.1") && Avo.configuration.license.in? ["pro", "advanced"]
+      if Rails.version.start_with?("7.1") && Avo.configuration.license.in?(["pro", "advanced"])
         Avo.error_manager.add({
           url: "https://docs.avohq.io/3.0/upgrade.html#upgrade-from-3-7-4-to-3-9-1",
           target: "_blank",


### PR DESCRIPTION
Fixes #2962 

A short informative message with a redirect to [a more detailed documentation](https://docs.avohq.io/3.0/upgrade.html#upgrade-from-3-7-4-to-3-9-1) about a rails 7.1 path helpers issue.
![image](https://github.com/avo-hq/avo/assets/69730720/a54e3d2a-8c7b-4fac-92b3-d607b5bccb87)
