### PR TITLE
[#2996] - Change boolean field to show dash when null

### DIFF
--- a/app/components/avo/fields/boolean_field/index_component.html.erb
+++ b/app/components/avo/fields/boolean_field/index_component.html.erb
@@ -1,3 +1,3 @@
-<%= index_field_wrapper **field_wrapper_args, dash_if_blank: false, flush: true do %>
+<%= index_field_wrapper **field_wrapper_args, dash_if_blank: true, flush: true do %>
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>

--- a/app/components/avo/fields/boolean_field/index_component.html.erb
+++ b/app/components/avo/fields/boolean_field/index_component.html.erb
@@ -1,3 +1,3 @@
-<%= index_field_wrapper **field_wrapper_args, dash_if_blank: true, flush: true do %>
+<%= index_field_wrapper **field_wrapper_args, flush: true do %>
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>

--- a/app/components/avo/fields/boolean_field/show_component.html.erb
+++ b/app/components/avo/fields/boolean_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args, dash_if_blank: true do %>
+<%= field_wrapper **field_wrapper_args do %>
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>

--- a/app/components/avo/fields/boolean_field/show_component.html.erb
+++ b/app/components/avo/fields/boolean_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args, dash_if_blank: false do %>
+<%= field_wrapper **field_wrapper_args, dash_if_blank: true do %>
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>

--- a/spec/system/avo/boolean_field_spec.rb
+++ b/spec/system/avo/boolean_field_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "BooleanField", type: :system do
+  describe "with regular input" do
+    let!(:post) { create :post, name: "My Post", is_featured: nil }
+
+    context "show" do
+      it "displays the post values" do
+        visit "/admin/resources/posts/#{post.id}"
+
+        expect(page).to have_text "IS FEATURED"
+
+        expect(find_field_value_element("is_featured")).to have_text empty_dash
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description
When a boolean field is nullable, it shows false as a red X instead of a dash.
Fixes #2996.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
