### PR TITLE
feature: add visible option to tab

### DIFF
--- a/lib/avo/resources/items/tab.rb
+++ b/lib/avo/resources/items/tab.rb
@@ -4,6 +4,7 @@ class Avo::Resources::Items::Tab
   include Avo::Concerns::HasItems
   include Avo::Concerns::HasItemType
   include Avo::Concerns::VisibleItems
+  include Avo::Concerns::IsVisible
   include Avo::Concerns::VisibleInDifferentViews
 
   delegate :items, :add_item, to: :items_holder
@@ -16,6 +17,7 @@ class Avo::Resources::Items::Tab
     @items_holder = Avo::Resources::Items::Holder.new
     @view = Avo::ViewInquirer.new view
     @args = args
+    @visible = args[:visible]
 
     post_initialize if respond_to?(:post_initialize)
   end

--- a/spec/features/avo/tabs_panels_and_sidebar_visibility_spec.rb
+++ b/spec/features/avo/tabs_panels_and_sidebar_visibility_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe "TabsPanelsAndSidebarVisibility", type: :feature do
             }
           end
         end
+
+        tab "Conditional hidden tab inside tabs", visible: -> { resource.record.name == "RSpec TabsPanelAndSidebarVisibility" } do
+          field :hidden_field_inside_tabs_inside_conditional_tab, as: :text
+        end
       end
     end
   end
@@ -60,6 +64,9 @@ RSpec.describe "TabsPanelsAndSidebarVisibility", type: :feature do
         expect(page).to have_text "Hidden field inside tabs inside tab"
         expect(page).to have_text "Hidden field inside tabs inside tab inside panel"
         expect(page).to have_text "Hidden field inside sidebar"
+
+        expect(page).to have_text "Conditional hidden tab inside tabs"
+        expect(page).to have_text "Hidden field inside tabs inside conditional tab"
       end
     end
 
@@ -71,6 +78,9 @@ RSpec.describe "TabsPanelsAndSidebarVisibility", type: :feature do
         expect(page).not_to have_text "Hidden field inside tabs inside tab"
         expect(page).not_to have_text "Hidden field inside tabs inside tab inside panel"
         expect(page).not_to have_text "Hidden field inside sidebar"
+
+        expect(page).not_to have_text "Conditional hidden tab inside tabs"
+        expect(page).not_to have_text "Hidden field inside tabs inside conditional tab"
       end
     end
   end


### PR DESCRIPTION
# Description
This PR adds a `visible` option to Tab, which should hide all the contained fields as well as the tab itself.

This new option shouldn't affect `tabs` only `tab`

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

https://github.com/user-attachments/assets/92d3e602-de77-42b8-83c8-6956ff38a2a3

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Add `visible: -> { false }` to a `tab`
2. Make sure it hides all the tab header and all fields contained
3. Move set it back to true and they should reappear
5. Ensure it doesn't hide anything when visible isn't set

Manual reviewer: please leave a comment with output from the test if that's the case.
