### PR TITLE
feature: add `default_sort_column` configuration option

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -305,8 +305,15 @@ module Avo
       # Sorting
       if params[:sort_by].present?
         @index_params[:sort_by] = params[:sort_by]
-      elsif @resource.model_class.present? && @resource.model_class.column_names.include?("created_at")
-        @index_params[:sort_by] = :created_at
+      elsif @resource.model_class.present?
+        available_columns = @resource.model_class.column_names
+        default_sort_column = @resource.default_sort_column
+
+        if available_columns.include?(default_sort_column.to_s)
+          @index_params[:sort_by] = default_sort_column
+        elsif available_columns.include?("created_at")
+          @index_params[:sort_by] = :created_at
+        end
       end
 
       @index_params[:sort_direction] = params[:sort_direction] || :desc

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -75,6 +75,7 @@ module Avo
       class_attribute :link_to_child_resource, default: false
       class_attribute :map_view
       class_attribute :components, default: {}
+      class_attribute :default_sort_column, default: :created_at
 
       # EXTRACT:
       class_attribute :ordering

--- a/spec/dummy/app/avo/resources/course.rb
+++ b/spec/dummy/app/avo/resources/course.rb
@@ -4,6 +4,7 @@ class Avo::Resources::Course < Avo::BaseResource
   }
   self.keep_filters_panel_open = true
   self.stimulus_controllers = "city-in-country toggle-fields"
+  # self.default_sort_column = :country
 
   def show_fields
     fields_bag

--- a/spec/features/avo/default_sort_column_spec.rb
+++ b/spec/features/avo/default_sort_column_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "DefaultSortColumn", type: :feature do
+  context "default_sort_column" do
+    let(:courses) do
+      create_list(:course, 3) do |course, i|
+        course.update(created_at: (i + 1).days.ago)
+      end
+    end
+    let(:course_index) { "/admin/resources/courses" }
+    let(:default_sort_column) { :created_at }
+
+    before(:all) do
+      Avo::Resources::Course.with_temporary_items do
+        field :id, as: :id
+        field :country, as: :text
+        field :created_at, as: :date_time
+      end
+    end
+
+    after(:all) do
+      Avo::Resources::Course.restore_items_from_backup
+    end
+
+    before do
+      Avo::Resources::Course.default_sort_column = default_sort_column
+    end
+
+    shared_examples "sorts by" do |expected_sort_column|
+      it "sorts index table by #{expected_sort_column} in desc" do
+        sorted_values = courses.sort_by(&expected_sort_column).reverse.map do |course|
+          value = course.send(expected_sort_column)
+          value.is_a?(Time) ? value.iso8601 : value
+        end
+        visit course_index
+
+        values = page.all("[data-field-id='#{expected_sort_column}']").map(&:text)
+        expect(values).to eq(sorted_values)
+      end
+    end
+
+    context "when default_sort_column is set" do
+      let(:default_sort_column) { :country }
+
+      include_examples "sorts by", :country
+
+      context "when default_sort_column does not exist" do
+        let(:default_sort_column) { :foo }
+
+        include_examples "sorts by", :created_at
+      end
+    end
+
+    context "when default_sort_column is not set" do
+      let(:default_sort_column) { nil }
+
+      include_examples "sorts by", :created_at
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR adds the ability to customize the default sorting attribute. The sorting column for the index view is `created_at` by default, but now the user can customize that by setting the `default_sort_column` option in the resource file to the desired default sorting column.

We still use `created_at` as the default sorting column if:
* `default_sort_column` is not set
* `default_sort_column` is set, but the model doesn't have that column

This also allow for backwards compatibility.

Fixes #2982

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording (**UPDATED**)
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

https://github.com/user-attachments/assets/0837ffdb-c4b6-40e0-984b-6a7dc73dc6a9


## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Tip: You can use the console log to see what column is being used for sorting when fetching the records (or just look at the UI)

1. Open any model's index page
2. Verify that it's sorting by `created_at`
3. Set the `default_sort_column` to another column
4. Ensure the query reflects the changes approximately

Manual reviewer: please leave a comment with output from the test if that's the case.
