### PR TITLE
fix: assets outputted multiple times

### DIFF
--- a/app/components/avo/turbo_frame_wrapper_component.html.erb
+++ b/app/components/avo/turbo_frame_wrapper_component.html.erb
@@ -4,7 +4,7 @@
   # We're appending it back if it's a turbo_frame_request.
 %>
 <% if helpers.turbo_frame_request? %>
-  <%= helpers.turbo_stream_action_tag :append, target: 'alerts', template: render(Avo::FlashAlertsComponent.new(flashes: helpers.flash)) %>
+  <%= helpers.turbo_stream_action_tag :append, target: "alerts", template: render(Avo::FlashAlertsComponent.new(flashes: helpers.flash)) %>
 <% end %>
 <%= content %>
 <% if name.present? %></turbo-frame><% end %>

--- a/lib/avo/asset_manager.rb
+++ b/lib/avo/asset_manager.rb
@@ -2,9 +2,6 @@ module Avo
   class AssetManager
     include ActionView::Helpers::AssetTagHelper
 
-    attr_reader :stylesheets
-    attr_reader :javascripts
-
     def initialize
       @stylesheets = []
       @javascripts = []
@@ -21,6 +18,14 @@ module Avo
 
     def add_javascript(path)
       @javascripts.push path
+    end
+
+    def stylesheets
+      @stylesheets.uniq
+    end
+
+    def javascripts
+      @javascripts.uniq
     end
   end
 

--- a/lib/generators/avo/eject_generator.rb
+++ b/lib/generators/avo/eject_generator.rb
@@ -146,7 +146,7 @@ module Generators
             [dest_rb, dest_erb].each do |path|
               if component.starts_with?("avo/views/")
                 modified_content = File.read(path).gsub("Avo::Views::", "Avo::Views::#{options[:scope].camelize}::")
-              elsif component.starts_with?("avo/fields/")
+              elsif component.starts_with?("avo/fields/") && options["field-components"].present?
                 modified_content = File.read(path).gsub("#{options["field-components"].camelize}Field", "#{options[:scope].camelize}::#{options["field-components"].camelize}Field")
               end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where, sometimes, the asset files would be added multiple times.
Also fixes https://github.com/avo-hq/avo/issues/2978

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

