### PR TITLE
add visible option for tabs

### DIFF
--- a/lib/avo/resources/items/tab_group.rb
+++ b/lib/avo/resources/items/tab_group.rb
@@ -18,6 +18,7 @@ class Avo::Resources::Items::TabGroup
     @id = id
     @name = name
     @args = args
+    @visible = args[:visible]
 
     post_initialize if respond_to?(:post_initialize)
   end
@@ -66,8 +67,8 @@ class Avo::Resources::Items::TabGroup
       @items_holder.tabs tab
     end
 
-    def initialize(name:, id:, parent:, style: nil)
-      @group = Avo::Resources::Items::TabGroup.new(name: name, id: id, style: style)
+    def initialize(name:, id:, parent:, style: nil, **args)
+      @group = Avo::Resources::Items::TabGroup.new(name: name, id: id, style: style, **args)
       @items_holder = Avo::Resources::Items::Holder.new(parent: parent, from: self)
     end
 

--- a/spec/dummy/app/avo/resources/fish.rb
+++ b/spec/dummy/app/avo/resources/fish.rb
@@ -34,7 +34,7 @@ class Avo::Resources::Fish < Avo::BaseResource
 
     tool Avo::ResourceTools::NestedFishReviews, only_on: :new
     tool Avo::ResourceTools::FishInformation, show_on: :forms
-    tabs do
+    tabs visible: true do
       tab "big useless tab here" do
         panel do
           field :id, as: :id

--- a/spec/features/avo/tabs_panels_and_sidebar_visibility_spec.rb
+++ b/spec/features/avo/tabs_panels_and_sidebar_visibility_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe "TabsPanelsAndSidebarVisibility", type: :feature do
       panel "Hidden panel", visible: -> { resource.record.name == "RSpec PanelVisibility" } do
         field :hidden_field_inside_panel, as: :text
       end
+
+      tabs visible: -> { resource.record.name == "RSpec TabsPanelAndSidebarVisibility" } do
+        field :hidden_field_inside_hidden_tabs, as: :text
+      end
     end
   end
 
@@ -69,6 +73,8 @@ RSpec.describe "TabsPanelsAndSidebarVisibility", type: :feature do
         expect(page).to have_text "Hidden field inside tabs inside tab inside panel"
         expect(page).to have_text "Hidden field inside sidebar"
 
+        expect(page).to have_text "Hidden field inside hidden tabs"
+
         expect(page).to have_text "Conditional hidden tab inside tabs"
         expect(page).to have_text "Hidden field inside tabs inside conditional tab"
       end
@@ -82,6 +88,8 @@ RSpec.describe "TabsPanelsAndSidebarVisibility", type: :feature do
         expect(page).not_to have_text "Hidden field inside tabs inside tab"
         expect(page).not_to have_text "Hidden field inside tabs inside tab inside panel"
         expect(page).not_to have_text "Hidden field inside sidebar"
+
+        expect(page).not_to have_text "Hidden field inside hidden tabs"
 
         expect(page).not_to have_text "Conditional hidden tab inside tabs"
         expect(page).not_to have_text "Hidden field inside tabs inside conditional tab"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds a `visible` option to tabs, which should hide all the contained tabs and their fields.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

https://github.com/user-attachments/assets/f4ec6cfa-e2d3-401b-a050-1c91d8767107

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Add `visible: -> { false }` to a `tabs`
2. Make sure it hides all the tabs inside of it and their fields
3. Move set it back to true and they should reappear
5. Ensure it doesn't hide anything when visible isn't set

