### PR TITLE
Fix: css based solution for sidebar without js dependency

### DIFF
--- a/app/assets/stylesheets/css/sidebar.css
+++ b/app/assets/stylesheets/css/sidebar.css
@@ -14,7 +14,7 @@
     /* Add padding to the main area to allow for the sidebar to expand. */
     .main-content-area {
       @apply lg:pl-64;
-      transition: padding .1s ease;
+      transition: padding 0.1s ease;
     }
   }
 }

--- a/app/assets/stylesheets/css/sidebar.css
+++ b/app/assets/stylesheets/css/sidebar.css
@@ -7,12 +7,24 @@
   /* remove the left padding. */
   .main-content-area {
     @apply lg:pl-0;
+    transition: padding 0.5s ease;
   }
 
   &.sidebar-open {
     /* Add padding to the main area to allow for the sidebar to expand. */
     .main-content-area {
       @apply lg:pl-64;
+      transition: padding .5s ease;
     }
   }
+}
+.sidebar-open {
+  .avo-sidebar {
+    transform: translateX(0);
+    transition: transform 0.5s ease, opacity 0.5s ease;
+  }
+}
+.avo-sidebar {
+  transform: translateX(-100%);
+  transition: transform 0.5s ease, opacity 0.5s ease;
 }

--- a/app/assets/stylesheets/css/sidebar.css
+++ b/app/assets/stylesheets/css/sidebar.css
@@ -18,6 +18,7 @@
     }
   }
 }
+
 .sidebar-open {
   .avo-sidebar {
     transform: translateX(0);

--- a/app/assets/stylesheets/css/sidebar.css
+++ b/app/assets/stylesheets/css/sidebar.css
@@ -7,24 +7,24 @@
   /* remove the left padding. */
   .main-content-area {
     @apply lg:pl-0;
-    transition: padding 0.5s ease;
+    transition: padding 0.1s ease;
   }
 
   &.sidebar-open {
     /* Add padding to the main area to allow for the sidebar to expand. */
     .main-content-area {
       @apply lg:pl-64;
-      transition: padding .5s ease;
+      transition: padding .1s ease;
     }
   }
 }
 .sidebar-open {
   .avo-sidebar {
     transform: translateX(0);
-    transition: transform 0.5s ease, opacity 0.5s ease;
+    transition: transform 0.1s ease;
   }
 }
 .avo-sidebar {
   transform: translateX(-100%);
-  transition: transform 0.5s ease, opacity 0.5s ease;
+  transition: transform 0.1s ease;
 }

--- a/app/components/avo/sidebar_component.html.erb
+++ b/app/components/avo/sidebar_component.html.erb
@@ -1,12 +1,6 @@
 <div
-  class="avo-sidebar fixed z-[60] t-0 application-sidebar w-64 flex-1 border-r lg:border-none bg-none h-[calc(100vh-4rem)] bg-application lg:bg-transparent <%= 'print:hidden' if Avo.configuration.hide_layout_when_printing %> <%= @sidebar_open ? 'flex' : 'hidden' %>"
+  class="avo-sidebar fixed z-[60] t-0 application-sidebar w-64 flex-1 border-r lg:border-none bg-none h-[calc(100vh-4rem)] bg-application lg:bg-transparent <%= 'print:hidden' if Avo.configuration.hide_layout_when_printing %>"
   data-sidebar-target="<%= stimulus_target %>"
-  data-transition-enter="transition ease-out duration-100"
-  data-transition-enter-start="transform opacity-0 -translate-x-full"
-  data-transition-enter-end="transform opacity-100 translate-x-0"
-  data-transition-leave="transition ease-in duration-75"
-  data-transition-leave-start="transform opacity-100 translate-x-0"
-  data-transition-leave-end="transform opacity-0 -translate-x-full"
 >
   <div class="flex flex-col w-full h-full">
     <div class="flex-1 flex flex-col justify-between overflow-auto h-full pt-3 mac-styled-scrollbar">

--- a/app/javascript/js/controllers/sidebar_controller.js
+++ b/app/javascript/js/controllers/sidebar_controller.js
@@ -82,23 +82,8 @@ export default class extends Controller {
     }
   }
 
-  markSidebarClosed() {
-    Cookies.set(this.cookieKey, '0')
-    this.openValue = false
-    this.mainAreaTarget.classList.remove('sidebar-open')
-  }
-
-  markSidebarOpen() {
-    Cookies.set(this.cookieKey, '1')
-    this.openValue = true
-    this.mainAreaTarget.classList.add('sidebar-open')
-  }
-
   toggleSidebar() {
-    if (this.openValue) {
-      this.markSidebarClosed()
-    } else {
-      this.markSidebarOpen()
-    }
+    this.mainAreaTarget.classList.toggle('sidebar-open')
+    Cookies.set(this.cookieKey, this.cookieKey === '1' ? '0' : '1')
   }
 }

--- a/app/javascript/js/controllers/sidebar_controller.js
+++ b/app/javascript/js/controllers/sidebar_controller.js
@@ -1,5 +1,4 @@
 import { Controller } from '@hotwired/stimulus'
-import { enter, leave, toggle } from 'el-transition'
 import Cookies from 'js-cookie'
 
 // Detect whether an element is in view inside a parent element.
@@ -86,14 +85,12 @@ export default class extends Controller {
   markSidebarClosed() {
     Cookies.set(this.cookieKey, '0')
     this.openValue = false
-    leave(this.sidebarTarget)
     this.mainAreaTarget.classList.remove('sidebar-open')
   }
 
   markSidebarOpen() {
     Cookies.set(this.cookieKey, '1')
     this.openValue = true
-    enter(this.sidebarTarget)
     this.mainAreaTarget.classList.add('sidebar-open')
   }
 

--- a/app/javascript/js/controllers/sidebar_controller.js
+++ b/app/javascript/js/controllers/sidebar_controller.js
@@ -101,8 +101,4 @@ export default class extends Controller {
       this.markSidebarOpen()
     }
   }
-
-  toggleSidebarOnMobile() {
-    toggle(this.mobileSidebarTarget)
-  }
 }

--- a/app/views/avo/partials/_navbar.html.erb
+++ b/app/views/avo/partials/_navbar.html.erb
@@ -1,8 +1,7 @@
 <%= content_tag :div, class: class_names("fixed bg-white p-2 w-full flex flex-shrink-0 items-center z-[100] px-4 lg:px-4 border-b space-x-4 lg:space-x-0 h-16", {"print:hidden": Avo.configuration.hide_layout_when_printing}) do %>
   <div class="flex items-center space-x-2 w-auto lg:w-64 flex-shrink-0 h-full">
     <div>
-      <%= a_button class: 'lg:hidden', icon: 'avo/menu', size: :xs, compact: true, style: :text, data: { action: 'click->sidebar#toggleSidebarOnMobile' }, aria: {label: "Toggle sidebar"} %>
-      <%= a_button class: 'hidden lg:block', icon: 'avo/menu', size: :xs, compact: true, style: :text, data: { action: 'click->sidebar#toggleSidebar' }, aria: {label: "Toggle sidebar"} %>
+      <%= a_button icon: 'avo/menu', size: :xs, compact: true, style: :text, data: { action: 'click->sidebar#toggleSidebar' }, aria: {label: "Toggle sidebar"} %>
     </div>
     <%= render partial: "avo/partials/logo" %>
   </div>


### PR DESCRIPTION
# Description
Currently the functionality for the show/hide of the sidebar uses 'el-transition' for the sidebare ease-in/out but nothing for the main body. It looks uneven. I've changed them both to use css transitions and have removed some unneccesary code. Works on all viewport sizes

Fixes # No Issue

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
**Old functionality:**
https://github.com/user-attachments/assets/0004757a-f44c-4d13-bdb3-76392d0ee49e

**New functionality**
https://github.com/user-attachments/assets/4fcef603-1bc1-4f46-a19a-fcfeeb12118f



## Manual review steps
Click on the hamburge icon on any viewport size
