### PR TITLE
fix: exclude rails 7.1 version error from production

### DIFF
--- a/app/views/avo/partials/_custom_tools_alert.html.erb
+++ b/app/views/avo/partials/_custom_tools_alert.html.erb
@@ -5,7 +5,7 @@
     </a>
   </div>
 <% end %>
-<% if Avo.error_manager.render? %>
+<% if Avo.error_manager.has_errors? %>
   <% Avo.error_manager.all.each do |error| %>
     <% if error.is_a? Hash %>
       <%

--- a/app/views/avo/partials/_custom_tools_alert.html.erb
+++ b/app/views/avo/partials/_custom_tools_alert.html.erb
@@ -5,7 +5,7 @@
     </a>
   </div>
 <% end %>
-<% if Avo.error_manager.has_errors?.present? %>
+<% if Avo.error_manager.render? %>
   <% Avo.error_manager.all.each do |error| %>
     <% if error.is_a? Hash %>
       <%

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -73,7 +73,8 @@ module Avo
     # Runs on each request
     def init
       Avo::Current.error_manager = Avo::ErrorManager.build
-      check_rails_version_issues
+      # Check rails version issues only on NON Production environments
+      check_rails_version_issues unless Rails.env.production?
       Avo::Current.resource_manager = Avo::Resources::ResourceManager.build
       Avo::Current.tool_manager = Avo::Tools::ToolManager.build
 

--- a/lib/avo/error_manager.rb
+++ b/lib/avo/error_manager.rb
@@ -15,11 +15,17 @@ module Avo
     end
 
     def add(error)
-      errors << error
+      @errors << error
     end
 
     def has_errors?
-      errors.present?
+      @errors.present?
+    end
+
+    def render?
+      return false if Rails.env.production?
+
+      has_errors?
     end
   end
 end

--- a/lib/avo/error_manager.rb
+++ b/lib/avo/error_manager.rb
@@ -23,8 +23,6 @@ module Avo
     end
 
     def render?
-      return false if Rails.env.production?
-
       has_errors?
     end
   end

--- a/lib/avo/error_manager.rb
+++ b/lib/avo/error_manager.rb
@@ -21,9 +21,5 @@ module Avo
     def has_errors?
       @errors.present?
     end
-
-    def render?
-      has_errors?
-    end
   end
 end

--- a/spec/dummy/app/avo/resource_tools/team_membership_tool_playground.rb
+++ b/spec/dummy/app/avo/resource_tools/team_membership_tool_playground.rb
@@ -1,4 +1,4 @@
-class TeamMembershipToolPlayground < Avo::BaseResourceTool
+class Avo::ResourceTools::TeamMembershipToolPlayground < Avo::BaseResourceTool
   self.name = "Team membership tool playground"
   # self.partial = "avo/resource_tools/team_membership_tool_playground"
 end

--- a/spec/dummy/app/avo/resources/membership.rb
+++ b/spec/dummy/app/avo/resources/membership.rb
@@ -34,5 +34,5 @@ class Avo::Resources::Membership < Avo::BaseResource
     field :team, as: :belongs_to
   end
 
-  # tool TeamMembershipToolPlayground, show_on: :all
+  # tool Avo::ResourceTools::TeamMembershipToolPlayground, show_on: :all
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3030

Hide rails 7.1 version error on production.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

