### PR TITLE
Use Rails.application.secret_key_base directly

### DIFF
--- a/lib/avo/services/encryption_service.rb
+++ b/lib/avo/services/encryption_service.rb
@@ -28,28 +28,7 @@ module Avo
       private
 
       def encryption_key
-        secret_key_base[0..31]
-      end
-
-      def secret_key_base
-        # Try to fetch the secret key base from ENV or the credentials file
-        key = ENV["SECRET_KEY_BASE"] || Rails.application.credentials.secret_key_base
-
-        # If key is blank and Rails version is less than 7.2.0
-        # Try to fetch the secret key base from the secrets file
-        # Rails 7.2.0 made secret_key_base from secrets obsolete
-        if key.blank? && (Gem::Version.new(Rails.gem_version) < Gem::Version.new("7.2.0"))
-          key = Rails.application.secrets.secret_key_base
-        end
-
-        return key if key.present?
-
-        # Avoid breaking in production
-        # All features relying on encryption will not work properly without a configured secret key base
-        return SecureRandom.random_bytes(32) if Rails.env.production?
-
-        raise "Unable to fetch secret key base. Please set it in your credentials or environment variables\n" \
-          "For more information check https://docs.avohq.io/3.0/encryption-service.html#secret-key-base"
+        Rails.application.secret_key_base[0..31]
       end
     end
   end


### PR DESCRIPTION
# Description
Port of https://github.com/avo-hq/avo/pull/2417 to the main branch

Fixes # (issue)

Removes the deprecation message output when running tests:
```
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from secret_key_base at /Users/jpawlyn/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/avo-3.10.6/lib/avo/services/encryption_service.rb:42)
```

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

