### PR TITLE
performance: don't fetch fields on action's initialization

### DIFF
--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -19,6 +19,9 @@ module Avo
       @view = Avo::ViewInquirer.new("new")
 
       @resource.hydrate(record: @record, view: @view, user: _current_user, params: params)
+
+      # Fetch action's fields
+      @action.fields
       @fields = @action.get_fields
 
       build_background_url

--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -19,9 +19,6 @@ module Avo
       @view = Avo::ViewInquirer.new("new")
 
       @resource.hydrate(record: @record, view: @view, user: _current_user, params: params)
-
-      # Fetch action's fields
-      @action.fields
       @fields = @action.get_fields
 
       build_background_url
@@ -78,6 +75,9 @@ module Avo
         view: :new, # force the action view to in order to render new-related fields (hidden field)
         arguments: BaseAction.decode_arguments(params[:arguments] || params.dig(:fields, :arguments)) || {}
       )
+
+      # Fetch action's fields
+      @action.fields
     end
 
     def action_class

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -120,7 +120,6 @@ module Avo
       self.class.cancel_button_label ||= I18n.t("avo.cancel")
 
       self.items_holder = Avo::Resources::Items::Holder.new
-      fields
 
       @response ||= {}
       @response[:messages] = []

--- a/spec/dummy/app/avo/actions/sub/dummy_action.rb
+++ b/spec/dummy/app/avo/actions/sub/dummy_action.rb
@@ -11,6 +11,7 @@ class Avo::Actions::Sub::DummyAction < Avo::BaseAction
   end
 
   def fields
+    TestBuddy.hi("Dummy action fields")
     field :keep_modal_open, as: :boolean
     field :persistent_text, as: :text
     field :parent_id,

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -276,6 +276,19 @@ RSpec.describe "Actions", type: :system do
     end
   end
 
+  describe "fetch fields" do
+    it "don't fetch when load index" do
+      expect(TestBuddy).not_to receive(:hi).with("Dummy action fields")
+      visit avo.resources_users_path
+    end
+
+    it "fetch when click on action" do
+      expect(TestBuddy).to receive(:hi).with("Dummy action fields").at_least :once
+      visit avo.resources_users_path
+      open_panel_action(action_name: "Dummy action")
+    end
+  end
+
   #   let!(:roles) { { admin: false, manager: false, writer: false } }
   #   let!(:user) { create :user, active: true, roles: roles }
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3025 

Fetch fields on each action request instead of on each action initialization.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
