### PR TITLE
fix: sign_out test

### DIFF
--- a/spec/system/avo/sign_out_dropdown_spec.rb
+++ b/spec/system/avo/sign_out_dropdown_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "SignOutDropdown", type: :system do
       expect(page.body).to have_css("form[data-controller='sign-out'][data-action='submit->sign-out#handle']", visible: true)
 
       # Test click away
-      page.find("body").click
+      all("div", text: "per page").first.click
       expect(page.body).to have_css("form[data-controller='sign-out'][data-action='submit->sign-out#handle']", visible: false)
 
       dots_link.click


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes sign-out test by clicking specifically on the "per page" text instead of randomly clicking on the body, as the random clicks were occasionally opening the search modal.