### PR TITLE
Fix: filtering badge field not working

### DIFF
--- a/lib/avo/fields/badge_field.rb
+++ b/lib/avo/fields/badge_field.rb
@@ -3,13 +3,24 @@ module Avo
     class BadgeField < BaseField
       attr_reader :options
 
-      def initialize(id, **args, &block)
-        super(id, **args, &block)
+      def initialize(id, **args, &)
+        super
 
         hide_on [:edit, :new]
 
         default_options = {info: :info, success: :success, danger: :danger, warning: :warning, neutral: :neutral}
         @options = args[:options].present? ? default_options.merge(args[:options]) : default_options
+        @enum = args[:enum]
+
+        if @enum
+          @options_for_filter = options.transform_values do |value|
+            if value.is_a? Array
+              value.map { |v| @enum[v.to_s] }
+            else
+              @enum[value.to_s] || value
+            end
+          end
+        end
       end
     end
   end

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -264,7 +264,7 @@ module Avo
       end
 
       def options_for_filter
-        options
+        @options_for_filter || options
       end
 
       def updatable


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Filtering badge fields did not work because we passed string values of enums into ransack. Ransack does not convert these strings into the appropriate numbers like they are stored in the database which is why filtering badge fields didn't work.
These changes pass in appropriate values into ransack when filtering badge fields.

Fixes #2822

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
