### PR TITLE
feature: popovers in action lists

### DIFF
--- a/app/components/avo/actions_component.html.erb
+++ b/app/components/avo/actions_component.html.erb
@@ -9,7 +9,7 @@
   <%= a_button style: @style,
     type: :button,
     color: @color,
-    size: size,
+    size: @size,
     class: "focus:outline-none",
     icon: @icon,
     data: {
@@ -18,7 +18,7 @@
       tippy: "tooltip",
       tippy_content: @title
     } do %>
-    <%= label %>
+    <%= @label %>
   <% end %>
   <div
     class="absolute flex inset-auto xl:right-0 top-full bg-white w-full sm:w-auto sm:min-w-[300px] mt-2 z-40 shadow-modal rounded overflow-hidden hidden"

--- a/app/components/avo/actions_component.html.erb
+++ b/app/components/avo/actions_component.html.erb
@@ -12,8 +12,12 @@
     size: size,
     class: "focus:outline-none",
     icon: @icon,
-    'data-action': "click->toggle#togglePanel",
-    'data-actions-dropdown-button': @resource.model_key do %>
+    data: {
+      action: "click->toggle#togglePanel",
+      actions_dropdown_button: @resource.model_key,
+      tippy: "tooltip",
+      tippy_content: @title
+    } do %>
     <%= label %>
   <% end %>
   <div

--- a/app/components/avo/actions_component.rb
+++ b/app/components/avo/actions_component.rb
@@ -4,7 +4,7 @@ class Avo::ActionsComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
   attr_reader :label, :size, :as_row_control
 
-  def initialize(actions: [], resource: nil, view: nil, exclude: [], include: [], style: :outline, color: :primary, label: nil, size: :md, as_row_control: false, icon: nil)
+  def initialize(actions: [], resource: nil, view: nil, exclude: [], include: [], style: :outline, color: :primary, label: nil, size: :md, as_row_control: false, icon: nil, title: nil)
     @actions = actions || []
     @resource = resource
     @view = view
@@ -16,6 +16,7 @@ class Avo::ActionsComponent < Avo::BaseComponent
     @size = size
     @icon = icon
     @as_row_control = as_row_control
+    @title = title
   end
 
   def render?

--- a/app/components/avo/actions_component.rb
+++ b/app/components/avo/actions_component.rb
@@ -4,20 +4,22 @@ class Avo::ActionsComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
   attr_reader :label, :size, :as_row_control
 
-  def initialize(actions: [], resource: nil, view: nil, exclude: [], include: [], style: :outline, color: :primary, label: nil, size: :md, as_row_control: false, icon: nil, title: nil)
-    @actions = actions || []
-    @resource = resource
-    @view = view
-    @exclude = Array(exclude)
-    @include = include
-    @color = color
-    @style = style
-    @label = label || I18n.t("avo.actions")
-    @size = size
-    @icon = icon
-    @as_row_control = as_row_control
-    @title = title
+  prop :as_row_control, _Boolean, default: false
+  prop :icon, _Nilable(String)
+  prop :size, Symbol, default: :md
+  prop :title, _Nilable(String)
+  prop :color, Symbol, default: :primary
+  prop :include, Array, default: [].freeze
+  prop :label, String do |label|
+    label || I18n.t("avo.actions")
   end
+  prop :style, Symbol, default: :outline
+  prop :actions, _Array(Avo::BaseAction), default: [].freeze
+  prop :exclude, Array, default: [].freeze do |exclude|
+    Array(exclude)
+  end
+  prop :resource, _Nilable(Avo::Resources::Base)
+  prop :view, _Nilable(Symbol), &:to_sym
 
   def render?
     actions.present?

--- a/app/components/avo/actions_component.rb
+++ b/app/components/avo/actions_component.rb
@@ -2,7 +2,6 @@
 
 class Avo::ActionsComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
-  attr_reader :label, :size, :as_row_control
 
   prop :as_row_control, _Boolean, default: false
   prop :icon, _Nilable(String)
@@ -38,7 +37,7 @@ class Avo::ActionsComponent < Avo::BaseComponent
   # When running an action for one record we should do it on a special path.
   # We do that so we get the `record` param inside the action so we can prefill fields.
   def action_path(action)
-    return single_record_path(action) if as_row_control
+    return single_record_path(action) if @as_row_control
     return many_records_path(action) unless @resource.has_record_id?
 
     if on_record_page?
@@ -50,7 +49,7 @@ class Avo::ActionsComponent < Avo::BaseComponent
 
   # How should the action be displayed by default
   def is_disabled?(action)
-    return false if action.standalone || as_row_control
+    return false if action.standalone || @as_row_control
 
     on_index_page?
   end
@@ -58,7 +57,7 @@ class Avo::ActionsComponent < Avo::BaseComponent
   private
 
   def on_record_page?
-    @view.in?(%w[show edit new])
+    @view.in?([:show, :edit, :new])
   end
 
   def on_index_page?

--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -149,6 +149,7 @@ class Avo::ResourceComponent < Avo::BaseComponent
       label: actions_list.label,
       size: actions_list.size,
       icon: actions_list.icon,
+      title: actions_list.title,
       as_row_control: instance_of?(Avo::Index::ResourceControlsComponent)
     )
   end

--- a/app/javascript/avo.base.js
+++ b/app/javascript/avo.base.js
@@ -49,6 +49,14 @@ function initTippy() {
 
       return title
     },
+    onShow(tooltipInstance) {
+      // Don't render tooltip if there is no content.
+      if (tooltipInstance.props.content === null || tooltipInstance.props.content.length === 0) {
+        return false
+      }
+
+      return tooltipInstance
+    },
   })
 }
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2975 

```ruby
class Avo::Resources::Fish < Avo::BaseResource
  # ...
  self.index_controls = -> do
    actions_list style: :primary, color: :slate, label: "", title: "Cool popover!"
  end
  # ...
end
```

![image](https://github.com/user-attachments/assets/c6414938-7983-478e-a5cd-4300e169689c)


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
