### PR TITLE
Feature: Set default scopes

### DIFF
--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -329,8 +329,8 @@ module Avo
         end
 
         # def action / def filter / def scope
-        define_method entity do |entity_class, arguments: {}, icon: nil|
-          entity_loader(entity).use({class: entity_class, arguments: arguments, icon: icon}.compact)
+        define_method entity do |entity_class, arguments: {}, icon: nil, default: nil|
+          entity_loader(entity).use({class: entity_class, arguments: arguments, icon: icon, default: default}.compact)
         end
 
         # def get_actions / def get_filters / def get_scopes


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This change makes in possible to use `default: true` when toggling a default scope without wrapping it into a arguments hash. Related comment: https://github.com/avo-hq/avo-advanced/pull/42

Fixes #2402

Related PR: https://github.com/avo-hq/avo-advanced/pull/42

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

(Tests are in the advanced repo. PR linked above)

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
