### PR TITLE
fix: MissingResourceError on polymorphic field

### DIFF
--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -47,7 +47,7 @@ module Avo
       field_name ||= model_name
 
       "Failed to find a resource while rendering the :#{field_name} field.\n" \
-      "You may generate a resource for it by running 'rails generate avo:resource #{model_name}'.\n" \
+      "You may generate a resource for it by running 'rails generate avo:resource #{model_name.singularize}'.\n" \
       "\n" \
       "Alternatively add the 'use_resource' option to the :#{field_name} field to specify a custom resource to be used.\n" \
       "More info on https://docs.avohq.io/#{Avo::VERSION[0]}.0/resources.html."

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -36,19 +36,20 @@ module Avo
   class DeprecatedAPIError < StandardError; end
 
   class MissingResourceError < StandardError
-    def initialize(resource_name)
-      super(missing_resource_message(resource_name))
+    def initialize(model_class, field_name = nil)
+      super(missing_resource_message(model_class, field_name))
     end
 
     private
 
-    def missing_resource_message(resource_name)
-      name = resource_name.to_s.underscore
+    def missing_resource_message(model_class, field_name)
+      model_name = model_class.to_s.underscore
+      field_name ||= model_name
 
-      "Failed to find a resource while rendering the :#{name} field.\n" \
-      "You may generate a resource for it by running 'rails generate avo:resource #{name.singularize}'.\n" \
+      "Failed to find a resource while rendering the :#{field_name} field.\n" \
+      "You may generate a resource for it by running 'rails generate avo:resource #{model_name}'.\n" \
       "\n" \
-      "Alternatively add the 'use_resource' option to the :#{name} field to specify a custom resource to be used.\n" \
+      "Alternatively add the 'use_resource' option to the :#{field_name} field to specify a custom resource to be used.\n" \
       "More info on https://docs.avohq.io/#{Avo::VERSION[0]}.0/resources.html."
     end
   end
@@ -75,7 +76,7 @@ module Avo
       Avo::Current.error_manager = Avo::ErrorManager.build
       # Check rails version issues only on NON Production environments
       unless Rails.env.production?
-        check_rails_version_issues 
+        check_rails_version_issues
         display_menu_editor_warning
       end
       Avo::Current.resource_manager = Avo::Resources::ResourceManager.build

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -313,7 +313,7 @@ module Avo
       def get_resource_by_model_class(model_class)
         resource = Avo.resource_manager.get_resource_by_model_class(model_class)
 
-        resource || (raise Avo::MissingResourceError.new(model_class))
+        resource || (raise Avo::MissingResourceError.new(model_class, id))
       end
     end
   end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3068 

When rendering a polymorphic field and one of the types doesn't have a valid resource the custom error is confusing:

```ruby
field :reviewable,
      as: :belongs_to,
      polymorphic_as: :reviewable,
      types: [::Fish, ::Post, ::Project, ::Team]
```

I deleted the `Avo::Resources::Team` to generate the errors.

#### Before
```
Failed to find a resource while rendering the :team field.
You may generate a resource for it by running 'rails generate avo:resource team'.

Alternatively add the 'use_resource' option to the :team field to specify a custom resource to be used.
More info on https://docs.avohq.io/3.0/resources.html.
```

#### After
```
Failed to find a resource while rendering the :reviewable field.
You may generate a resource for it by running 'rails generate avo:resource team'.

Alternatively add the 'use_resource' option to the :reviewable field to specify a custom resource to be used.
More info on https://docs.avohq.io/3.0/resources.html.
```



<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works