### PR TITLE
fix: `set_record` when fetching `fields` on actions' `handle`

### DIFF
--- a/app/components/avo/actions_component.rb
+++ b/app/components/avo/actions_component.rb
@@ -46,19 +46,6 @@ class Avo::ActionsComponent < Avo::BaseComponent
     end
   end
 
-  # When running an action for one record we should do it on a special path.
-  # We do that so we get the `record` param inside the action so we can prefill fields.
-  def action_path(action)
-    return single_record_path(action) if @as_row_control
-    return many_records_path(action) unless @resource.has_record_id?
-
-    if on_record_page?
-      single_record_path action
-    else
-      many_records_path action
-    end
-  end
-
   # How should the action be displayed by default
   def is_disabled?(action)
     return false if action.standalone || @as_row_control
@@ -74,25 +61,6 @@ class Avo::ActionsComponent < Avo::BaseComponent
 
   def on_index_page?
     !on_record_page?
-  end
-
-  def single_record_path(action)
-    action_url(action, @resource.record_path)
-  end
-
-  def many_records_path(action)
-    action_url(action, @resource.records_path)
-  end
-
-  def action_url(action, path)
-    Avo::Services::URIService.parse(path)
-      .append_paths("actions")
-      .append_query(
-        {
-          action_id: action.to_param,
-          arguments: Avo::BaseAction.encode_arguments(action.arguments)
-        }.compact
-      ).to_s
   end
 
   def icon(action)
@@ -116,7 +84,7 @@ class Avo::ActionsComponent < Avo::BaseComponent
   end
 
   def render_action_link(action)
-    link_to action_path(action),
+    link_to action.link_arguments(resource: @resource).first,
       data: action_data_attributes(action),
       title: action.action_name,
       class: action_css_class(action) do

--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -4,7 +4,7 @@ module Avo
   class ActionsController < ApplicationController
     before_action :set_resource_name
     before_action :set_resource
-    before_action :set_record, only: :show, if: ->(request) do
+    before_action :set_record, only: [:show, :handle], if: ->(request) do
       # Try to se the record only if the user is on the record page.
       # set_record will fail if it's tried to be used from the Index page.
       request.params[:id].present?

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -11,7 +11,7 @@
     class="hidden text-slate-800"
   >
     <%= form_with scope: 'fields',
-      url: Avo::Services::URIService.parse(@resource.records_path).append_paths("actions").to_s,
+      url: @action.link_arguments(resource: @resource).first,
       local: true,
       html: {
         novalidate: true,
@@ -29,7 +29,6 @@
       <div class="flex-1 flex">
         <%= @action.get_message %>
       </div>
-      <%= hidden_field_tag :action_id, @action.to_param %>
       <%= form.hidden_field :avo_resource_ids, value: params[:id] || params[:resource_ids], 'data-action-target': 'resourceIds' %>
       <%= form.hidden_field :avo_selected_query, 'data-action-target': 'selectedAllQuery' %>
       <%= form.hidden_field :arguments, value: params[:arguments] %>

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -33,6 +33,7 @@ module Avo
     delegate :avo, to: :view_context
     delegate :main_app, to: :view_context
     delegate :to_param, to: :class
+    delegate :link_arguments, to: :class
 
     class << self
       delegate :context, to: ::Avo::Current


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3021

`set_record` on `handle` request (only on show pages) to make it available while fetching fields.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
