### PR TITLE
Feature: Add back button to association pages

### DIFF
--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -190,6 +190,8 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
   end
 
   def back_path
+    # Show Go Back link only when association page is opened
+    # as a standalone page
     if @reflection.present? && !helpers.turbo_frame_request?
       helpers.resource_path(record: @parent_record, resource: @parent_resource)
     end

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -189,6 +189,12 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
     defined?(Avo::Advanced)
   end
 
+  def back_path
+    if @reflection.present? && !helpers.turbo_frame_request?
+      helpers.resource_path(record: @parent_record, resource: @parent_resource)
+    end
+  end
+
   private
 
   def reflection_model_class

--- a/lib/avo/concerns/has_controls.rb
+++ b/lib/avo/concerns/has_controls.rb
@@ -21,7 +21,7 @@ module Avo
       end
 
       def render_index_controls(item:)
-        [AttachButton.new(item: item), ActionsList.new(as_index_control: true), CreateButton.new(item: item)]
+        [BackButton.new, AttachButton.new(item: item), ActionsList.new(as_index_control: true), CreateButton.new(item: item)]
       end
 
       def render_row_controls(item:)

--- a/spec/features/avo/breadcrumbs_spec.rb
+++ b/spec/features/avo/breadcrumbs_spec.rb
@@ -26,42 +26,57 @@ RSpec.feature "Breadcrumbs", type: :feature do
     let!(:user) { create(:user) }
     let!(:team) { create(:team) }
 
-    it "displays breadcrumbs" do
-      url = "/admin/resources/users/#{user.slug}/teams?view=show"
-      visit url
+    context "when HTML request" do
+      it "displays breadcrumbs" do
+        url = "/admin/resources/users/#{user.slug}/teams?view=show"
+        visit url
 
-      expect(page).to have_selector ".breadcrumbs"
-      expect(page.find(".breadcrumbs").text).to eq "Home Users #{user.name} Teams"
+        expect(page).to have_selector ".breadcrumbs"
+        expect(page.find(".breadcrumbs").text).to eq "Home Users #{user.name} Teams"
 
-      breadcrumbs = find(".breadcrumbs")
-      expect(breadcrumbs).to have_link "Home"
-      expect(breadcrumbs).to have_link "Users"
-      expect(breadcrumbs).to have_link user.name.to_s
-      expect(breadcrumbs).to_not have_link "Teams"
+        breadcrumbs = find(".breadcrumbs")
+        expect(breadcrumbs).to have_link "Home"
+        expect(breadcrumbs).to have_link "Users"
+        expect(breadcrumbs).to have_link user.name.to_s
+        expect(breadcrumbs).to_not have_link "Teams"
+      end
+
+      it "displays breadcrumbs" do
+        url = "/admin/resources/teams/#{team.id}/team_members?view=show"
+        visit url
+
+        expect(page).to have_selector ".breadcrumbs"
+        expect(page.find(".breadcrumbs").text).to eq "Home Teams #{team.name} Users"
+
+        breadcrumbs = find(".breadcrumbs")
+        expect(breadcrumbs).to have_link "Home"
+        expect(breadcrumbs).to have_link "Teams"
+        expect(breadcrumbs).to have_link team.name.to_s
+        expect(breadcrumbs).to_not have_link "Users"
+      end
+
+      it "displays a back button" do
+        url = "/admin/resources/teams/#{team.id}/team_members?view=show"
+        visit url
+
+        expect(page).to have_selector "div[data-target='panel-tools'] a[href='/admin/resources/teams/#{team.id}']", text: "Go back"
+      end
     end
 
-    it "displays breadcrumbs" do
-      url = "/admin/resources/teams/#{team.id}/team_members?view=show"
-      visit url
+    context "when Turbo request" do
+      before(:example) do
+        url = "/admin/resources/teams/#{team.id}/team_members?view=show"
+        page.driver.browser.header("Turbo-Frame", true)
+        visit url
+      end
 
-      expect(page).to have_selector ".breadcrumbs"
-      expect(page.find(".breadcrumbs").text).to eq "Home Teams #{team.name} Users"
+      it "does not display breadcrumbs" do
+        expect(page).to_not have_selector ".breadcrumbs"
+      end
 
-      breadcrumbs = find(".breadcrumbs")
-      expect(breadcrumbs).to have_link "Home"
-      expect(breadcrumbs).to have_link "Teams"
-      expect(breadcrumbs).to have_link team.name.to_s
-      expect(breadcrumbs).to_not have_link "Users"
-    end
-
-    it "has a back button" do
-      url = "/admin/resources/teams/#{team.id}/team_members?view=show"
-      visit url
-
-      expect(page).to have_link "Go back"
-      click_link "Go back"
-      expect(current_path).to eq "/admin/resources/teams/#{team.id}"
-      expect(page).to have_link "Go back", count: 1
+      it "does not display a back button" do
+        expect(page).to_not have_selector "div[data-target='panel-tools'] a", text: "Go back"
+      end
     end
   end
 end

--- a/spec/features/avo/breadcrumbs_spec.rb
+++ b/spec/features/avo/breadcrumbs_spec.rb
@@ -53,5 +53,15 @@ RSpec.feature "Breadcrumbs", type: :feature do
       expect(breadcrumbs).to have_link team.name.to_s
       expect(breadcrumbs).to_not have_link "Users"
     end
+
+    it "has a back button" do
+      url = "/admin/resources/teams/#{team.id}/team_members?view=show"
+      visit url
+
+      expect(page).to have_link "Go back"
+      click_link "Go back"
+      expect(current_path).to eq "/admin/resources/teams/#{team.id}"
+      expect(page).to have_link "Go back", count: 1
+    end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR adds a back button when association pages are opened in their own window.

Fixes #3061

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

https://github.com/user-attachments/assets/09ce786c-9c5b-40ab-b5e9-6159106db373



## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
