### PR TITLE
feature: informative development error when search misconfigured

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -26,7 +26,7 @@ module Avo
             raise_exception: false
           )
           # Filter out the models without a search_query
-          next if resource.search_query.nil?
+          raise "Please configure the search for #{resource}" if resource.search_query.nil?
 
           search_resource resource
         end

--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -212,7 +212,7 @@ export default class extends Controller {
   }
 
   handleOnSelect({ item }) {
-    if (this.isBelongsToSearch) {
+    if (this.isBelongsToSearch && !item._error) {
       this.updateFieldAttribute(this.hiddenIdTarget, 'value', item._id)
       this.updateFieldAttribute(this.buttonTarget, 'value', this.removeHTMLTags(item._label))
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3091

Related PR: https://github.com/avo-hq/avo-pro/pull/85

Raises an informative error (is displayed only on development) whenever a field has `searchable: true` but the target resource doesn't have the search configured.

https://github.com/user-attachments/assets/b8e3dd7f-0f6c-4ba0-a107-64b6521223e6

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
