### PR TITLE
chore: gh actions' concurrency

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: '35 21 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/feature-tests.yml
+++ b/.github/workflows/feature-tests.yml
@@ -12,6 +12,10 @@ on:
       - 1.x
       - 2.x
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   RAILS_ENV: test
   PGHOST: localhost

--- a/.github/workflows/i18n-tests.yml
+++ b/.github/workflows/i18n-tests.yml
@@ -12,6 +12,11 @@ on:
       - 1.x
       - 2.x
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   RAILS_ENV: test
   PGHOST: localhost

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,10 @@ name: Lint
 on:
   - pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     uses: avo-hq/support/.github/workflows/lint.yml@main

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -12,6 +12,10 @@ on:
       - 1.x
       - 2.x
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   RAILS_ENV: test
   PGHOST: localhost

--- a/.github/workflows/test-tailwindcss-integration.yml
+++ b/.github/workflows/test-tailwindcss-integration.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tailwindcss_integration_test:
     runs-on: ubuntu-latest

--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -98,7 +98,7 @@
         resource: @resource,
         disabled: disabled,
         classes: classes("w-full"),
-        view: view,
+        view: view, # test concurrency
         style: @field.get_html(:style, view: view, element: :input)
       %>
     <% else %>

--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -98,7 +98,7 @@
         resource: @resource,
         disabled: disabled,
         classes: classes("w-full"),
-        view: view, # test concurrency
+        view: view,
         style: @field.get_html(:style, view: view, element: :input)
       %>
     <% else %>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Implements gh actions' [concurrency](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency) which will stop previous CI actions on each new commit, avoiding creating big workflow queues.