### PR TITLE
fix: hide empty menu groups and sections

### DIFF
--- a/app/components/avo/sidebar/base_item_component.rb
+++ b/app/components/avo/sidebar/base_item_component.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class Avo::Sidebar::BaseItemComponent < Avo::BaseComponent
-  attr_reader :item
-  delegate :items, :collapsable, :collapsed, to: :@item
+  attr_reader :item, :items
+  delegate :collapsable, :collapsed, to: :@item
 
   def initialize(item: nil)
     @item = item
+    @items = @item.items.select(&:visible?)
   end
 
   def render?


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://discord.com/channels/740892036978442260/1138182212655788054/1270409584024096952

Check for `visible?` on all items before rendering the menu group/section

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works