### PR TITLE
performance: sym_link

### DIFF
--- a/lib/tasks/avo_tasks.rake
+++ b/lib/tasks/avo_tasks.rake
@@ -79,8 +79,10 @@ task "avo:sym_link" do
     `touch #{packages_path}/.keep`
   end
 
+  gem_paths = `bundle list --paths 2>/dev/null`
+
   ["avo-advanced", "avo-pro", "avo-dynamic_filters", "avo-dashboards", "avo-menu", "avo-kanban"].each do |gem|
-    path = `bundle show #{gem} 2> /dev/null`.chomp
+    path = `echo "$gem_paths" | grep "/$gem" | head -n 1`
 
     # If path is emty we check if package is defined outside of root (on release process it is)
     if path.empty?


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3107

_All tests were done on my local machine._

`rails avo:sym_link` was taking around 6 seconds to execute.

With this improvement, it went down to around  3 seconds, where 90% of the execution time is starting the task, not the actual task code.

The execution time of the code inside the task was decreased drastically.

If the code from the task were executed on a bash script it would cut all the time required for starting the task but we need it on the task to enhance on `assets:precompile`.

If from the task we call a script instead the execution time is almost the same, there are no significant improvements.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works