### PR TITLE
fix: pagy 9 `data-turbo-frame`

### DIFF
--- a/app/components/avo/paginator_component.html.erb
+++ b/app/components/avo/paginator_component.html.erb
@@ -6,10 +6,10 @@
           <div class="flex items-center">
             <%= content_tag :label, name: t('avo.per_page').downcase do %>
               <%= select_tag 'per_page',
-                options_for_select(per_page_options, index_params[:per_page]),
+                options_for_select(per_page_options, @index_params[:per_page]),
                 class: 'appearance-none inline-flex bg-white-100 disabled:bg-white-400 disabled:cursor-not-allowed focus:bg-white text-slate-700 disabled:text-slate-600 rounded-md py-1 px-2 leading-tight border border-slate-300 outline-none focus:border-slate-400 outline w-16 mr-1 text-sm',
                 data: {
-                  'turbo-frame': turbo_frame,
+                  'turbo-frame': @turbo_frame,
                   'per-page-target': 'selector',
                   action: 'change->per-page#reload'
                 }
@@ -17,7 +17,7 @@
             <% end %>
           </div>
           <% per_page_options.each do |option| %>
-            <%= link_to "Change to #{option} items per page", change_items_per_page_url(option), class: 'hidden', 'data-per-page-option': option, 'data-turbo-frame': turbo_frame %>
+            <%= link_to "Change to #{option} items per page", change_items_per_page_url(option), class: 'hidden', 'data-per-page-option': option, 'data-turbo-frame': @turbo_frame %>
           <% end %>
         </div>
       </div>
@@ -31,7 +31,7 @@
 
       <% if @pagy.pages > 1 %>
         <%# @todo: add first & last page. make the first and last buttons rounded %>
-        <%== helpers.pagy_nav @pagy %>
+        <%== helpers.pagy_nav @pagy, anchor_string: "data-turbo-frame=\"#{@turbo_frame}\"" %>
       <% end %>
     </div>
   </div>

--- a/app/components/avo/paginator_component.rb
+++ b/app/components/avo/paginator_component.rb
@@ -1,16 +1,9 @@
 # frozen_string_literal: true
 
 class Avo::PaginatorComponent < Avo::BaseComponent
-  attr_reader :pagy
-  attr_reader :turbo_frame
-  attr_reader :index_params
-  attr_reader :resource
-  attr_reader :parent_record
-  attr_reader :discreet_pagination
-
   def initialize(resource: nil, parent_record: nil, pagy: nil, turbo_frame: nil, index_params: nil, discreet_pagination: nil)
     @pagy = pagy
-    @turbo_frame = turbo_frame
+    @turbo_frame = CGI.escapeHTML(turbo_frame) if turbo_frame
     @index_params = index_params
     @resource = resource
     @parent_record = parent_record
@@ -18,15 +11,15 @@ class Avo::PaginatorComponent < Avo::BaseComponent
   end
 
   def change_items_per_page_url(option)
-    if parent_record.present?
-      helpers.related_resources_path(parent_record, parent_record, per_page: option, keep_query_params: true, page: 1)
+    if @parent_record.present?
+      helpers.related_resources_path(@parent_record, @parent_record, per_page: option, keep_query_params: true, page: 1)
     else
-      helpers.resources_path(resource: resource, per_page: option, keep_query_params: true, page: 1)
+      helpers.resources_path(resource: @resource, per_page: option, keep_query_params: true, page: 1)
     end
   end
 
   def render?
-    return false if discreet_pagination && pagy.pages <= 1
+    return false if @discreet_pagination && @pagy.pages <= 1
 
     if ::Pagy::VERSION >= ::Gem::Version.new("9.0")
       @pagy.limit > 0
@@ -37,9 +30,9 @@ class Avo::PaginatorComponent < Avo::BaseComponent
 
   def per_page_options
     @per_page_options ||= begin
-      options = [*Avo.configuration.per_page_steps, Avo.configuration.per_page.to_i, index_params[:per_page].to_i]
+      options = [*Avo.configuration.per_page_steps, Avo.configuration.per_page.to_i, @index_params[:per_page].to_i]
 
-      if parent_record.present?
+      if @parent_record.present?
         options.prepend Avo.configuration.via_per_page
       end
 

--- a/spec/system/avo/filters/filters_spec.rb
+++ b/spec/system/avo/filters/filters_spec.rb
@@ -342,8 +342,8 @@ RSpec.describe "Filters", type: :system do
         wait_for_loaded
         check "Featured"
 
-        expect(page).to have_css "[aria-label='Next']"
-        expect(page).to have_css "[aria-label='Previous']"
+        expect(page).to have_css "[data-turbo-frame][aria-label='Next']"
+        expect(page).to have_css "[data-turbo-frame][aria-label='Previous']"
 
         expect(find(".current")).to have_text "1"
         expect(find(".current")).not_to have_text "2"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where pagy `data-turbo-frame` was missing. Pagy 9 brings this breaking change where the `anchor_string` need to be passed on the front end helpers instead of passing it to the `pagy` method in the controller.

I have also removed the `attr_reader`s from the `Avo::PaginatorComponent` in favor of the instance variables as a performance tweak.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
