### PR TITLE
chore: change pagy default size to integer

### DIFF
--- a/lib/avo/concerns/pagination.rb
+++ b/lib/avo/concerns/pagination.rb
@@ -18,7 +18,7 @@ module Avo
         unless defined? PAGINATION_DEFAULTS
           PAGINATION_DEFAULTS = {
             type: :default,
-            size: [1, 2, 2, 1],
+            size: 9,
           }
         end
       end

--- a/lib/avo/concerns/pagination.rb
+++ b/lib/avo/concerns/pagination.rb
@@ -18,7 +18,7 @@ module Avo
         unless defined? PAGINATION_DEFAULTS
           PAGINATION_DEFAULTS = {
             type: :default,
-            size: 9,
+            size: ::Pagy::VERSION >= ::Gem::Version.new("9.0") ? 9 : [1, 2, 2, 1],
           }
         end
       end

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -56,7 +56,7 @@ Avo.configure do |config|
   # config.pagination = -> do
   #   {
   #     type: :default,
-  #     size: 9,
+  #     size: 9, # `[1, 2, 2, 1]` for pagy < 9.0
   #   }
   # end
 

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -56,7 +56,7 @@ Avo.configure do |config|
   # config.pagination = -> do
   #   {
   #     type: :default,
-  #     size: [1, 2, 2, 1],
+  #     size: 9,
   #   }
   # end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3049 

Dropping the [array legacy API](https://ddnexus.github.io/pagy/docs/extras/size/) in favor of integer.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
  - https://github.com/avo-hq/docs.avohq.io/pull/276
- [ ] I have added tests that prove my fix is effective or that my feature works
