### PR TITLE
Have Avo tailwind watcher cover ejected components.

### DIFF
--- a/lib/generators/avo/templates/tailwindcss/tailwind.config.js
+++ b/lib/generators/avo/templates/tailwindcss/tailwind.config.js
@@ -7,5 +7,6 @@ module.exports = {
     './app/views/**/*.html.erb',
     './app/helpers/**/*.rb',
     './app/javascript/**/*.js',
+    './app/components/avo/**/*.html.erb',
   ],
 }


### PR DESCRIPTION
# Description
I ran the generator to install tailwind for avo. I had an ejected component that wasn't in the config for tailwind to watch. I added the folder where it ejected the component to.

Fixes # (issue)
I haven't submitted an issue.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Eject a component. I had Avo::Views::ResourceShowComponent ejected and modified.
1. Add a div with tailwind classes in it. I did a button.
2. You'll see that some of the classes don't apply.
3. Apply this fix.
4. You'll see it start working.

Manual reviewer: please leave a comment with output from the test if that's the case.
