### PR TITLE
Add a newline before appending the avo tailwind command to Procfile.dev

### DIFF
--- a/lib/generators/avo/tailwindcss/install_generator.rb
+++ b/lib/generators/avo/tailwindcss/install_generator.rb
@@ -35,7 +35,7 @@ module Generators
           script_name = "avo:tailwindcss"
           if Rails.root.join("Procfile.dev").exist?
             say "Add #{cmd = "avo_css: yarn #{script_name} --watch"} to Procfile.dev"
-            append_to_file "Procfile.dev", "#{cmd}\n"
+            append_to_file "Procfile.dev", "\n#{cmd}\n"
           else
             say "Add default Procfile.dev"
             copy_file template_path("Procfile.dev"), "Procfile.dev"


### PR DESCRIPTION
# Description
When running the tailwind generator, it appends the avo command to the end of the file. If the file doesn't end in a newline, it adds it to the previous line.

Fixes # 3187

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
