### PR TITLE
[2.x] Remove last usage of _reflections in favor of reflect_on_association.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
       id: run_tests
       run: bundle exec rspec spec/features
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: always() && steps.run_tests.outcome == 'failure'
       with:
         name: rspec_failed_screenshots
@@ -197,7 +197,7 @@ jobs:
       id: run_tests
       run: bundle exec rspec spec/system
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: always() && steps.run_tests.outcome == 'failure'
       with:
         name: rspec_failed_screenshots

--- a/app/components/avo/fields/belongs_to_field/autocomplete_component.rb
+++ b/app/components/avo/fields/belongs_to_field/autocomplete_component.rb
@@ -41,7 +41,7 @@ class Avo::Fields::BelongsToField::AutocompleteComponent < ViewComponent::Base
   end
 
   def reflection_class
-    has_polymorphic_association? ? polymorphic_class : @resource.model_class._reflections[@field.id.to_s].klass
+    has_polymorphic_association? ? polymorphic_class : @resource.model_class.reflect_on_association(@field.id).klass
   end
 
   private

--- a/app/components/avo/fields/has_one_field/show_component.rb
+++ b/app/components/avo/fields/has_one_field/show_component.rb
@@ -36,7 +36,7 @@ class Avo::Fields::HasOneField::ShowComponent < Avo::Fields::ShowComponent
   end
 
   def create_path
-    association_id = @field.resource.model_class._reflections[@field.id.to_s].inverse_of.name
+    association_id = @field.resource.model_class.reflect_on_association(@field.id).inverse_of.name
 
     args = {
       via_relation: association_id,

--- a/app/components/avo/index/resource_controls_component.rb
+++ b/app/components/avo/index/resource_controls_component.rb
@@ -77,7 +77,11 @@ class Avo::Index::ResourceControlsComponent < Avo::ResourceComponent
   end
 
   def is_has_many_association?
-    @reflection.is_a?(::ActiveRecord::Reflection::HasManyReflection) || @reflection.is_a?(::ActiveRecord::Reflection::ThroughReflection)
+    @reflection.class.in? [
+      ActiveRecord::Reflection::HasManyReflection,
+      ActiveRecord::Reflection::HasAndBelongsToManyReflection,
+      ActiveRecord::Reflection::ThroughReflection
+    ]
   end
 
   def referrer_path

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -62,10 +62,20 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
   end
 
   def can_attach?
-    klass = @reflection
-    klass = @reflection.through_reflection if klass.is_a? ::ActiveRecord::Reflection::ThroughReflection
+    return false if has_reflection_and_is_read_only
 
-    @reflection.present? && klass.is_a?(::ActiveRecord::Reflection::HasManyReflection) && !has_reflection_and_is_read_only && authorize_association_for(:attach)
+    reflection_class = if @reflection.is_a?(::ActiveRecord::Reflection::ThroughReflection)
+      @reflection.through_reflection.class
+    else
+      @reflection.class
+    end
+
+    return false unless reflection_class.in? [
+      ActiveRecord::Reflection::HasManyReflection,
+      ActiveRecord::Reflection::HasAndBelongsToManyReflection
+    ]
+
+    authorize_association_for(:attach)
   end
 
   def create_path

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -226,7 +226,7 @@ module Avo
 
       return field.use_resource if field&.use_resource.present?
 
-      reflection = @model._reflections[params[:related_name]]
+      reflection = @model.class.reflect_on_association(params[:related_name])
 
       reflected_model = reflection.klass
 

--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -101,7 +101,7 @@ module Avo
     private
 
     def set_reflection
-      @reflection = @model._reflections[params[:related_name].to_s]
+      @reflection = @model.class.reflect_on_association(params[:related_name])
     end
 
     def set_attachment_class
@@ -127,7 +127,7 @@ module Avo
     end
 
     def reflection_class
-      reflection = @model._reflections[params[:related_name]]
+      reflection = @model.class.reflect_on_association(params[:related_name])
 
       klass = reflection.class.name.demodulize.to_s
       klass = reflection.through_reflection.class.name.demodulize.to_s if klass == "ThroughReflection"

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -148,7 +148,7 @@ module Avo
         end
 
         # For when working with has_one, has_one_through, has_many_through, has_and_belongs_to_many, polymorphic
-        if @reflection.is_a? ActiveRecord::Reflection::ThroughReflection
+        if @reflection.is_a?(ActiveRecord::Reflection::ThroughReflection) || @reflection.is_a?(ActiveRecord::Reflection::HasAndBelongsToManyReflection)
           # find the record
           via_resource = ::Avo::App.get_resource_by_model_name(params[:via_relation_class]).dup
           @related_record = via_resource.find_record params[:via_resource_id], params: params

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -134,7 +134,7 @@ module Avo
 
       # This means that the record has been created through another parent record and we need to attach it somehow.
       if params[:via_resource_id].present? && params[:via_belongs_to_resource_class].nil?
-        @reflection = @model._reflections[params[:via_relation]]
+        @reflection = @model.class.reflect_on_association(params[:via_relation])
         # Figure out what kind of association does the record have with the parent record
 
         # Fills in the required infor for belongs_to and has_many

--- a/gemfiles/rails_6.0_ruby_3.0.3.gemfile.lock
+++ b/gemfiles/rails_6.0_ruby_3.0.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    avo (2.46.0)
+    avo (2.52.0)
       actionview (>= 6.0)
       active_link_to
       activerecord (>= 6.0)
@@ -214,7 +214,7 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    inline_svg (1.9.0)
+    inline_svg (1.10.0)
       activesupport (>= 3.0)
       nokogiri (>= 1.6)
     iso (0.4.0)
@@ -266,7 +266,7 @@ GEM
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    pagy (6.0.4)
+    pagy (6.5.0)
     parallel (1.22.1)
     parser (3.2.2.0)
       ast (~> 2.4.1)
@@ -420,7 +420,7 @@ GEM
       thread_safe (~> 0.1)
     unaccent (0.4.0)
     unicode-display_width (2.4.2)
-    view_component (3.5.0)
+    view_component (3.14.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)

--- a/gemfiles/rails_6.0_ruby_3.2.2.gemfile.lock
+++ b/gemfiles/rails_6.0_ruby_3.2.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    avo (2.46.0)
+    avo (2.52.0)
       actionview (>= 6.0)
       active_link_to
       activerecord (>= 6.0)
@@ -214,7 +214,7 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    inline_svg (1.9.0)
+    inline_svg (1.10.0)
       activesupport (>= 3.0)
       nokogiri (>= 1.6)
     iso (0.4.0)
@@ -266,7 +266,7 @@ GEM
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    pagy (6.0.4)
+    pagy (6.5.0)
     parallel (1.22.1)
     parser (3.2.2.0)
       ast (~> 2.4.1)
@@ -420,7 +420,7 @@ GEM
       thread_safe (~> 0.1)
     unaccent (0.4.0)
     unicode-display_width (2.4.2)
-    view_component (3.5.0)
+    view_component (3.14.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)

--- a/gemfiles/rails_6.1_ruby_3.0.3.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_3.0.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    avo (2.46.0)
+    avo (2.52.0)
       actionview (>= 6.0)
       active_link_to
       activerecord (>= 6.0)
@@ -218,7 +218,7 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    inline_svg (1.9.0)
+    inline_svg (1.10.0)
       activesupport (>= 3.0)
       nokogiri (>= 1.6)
     iso (0.4.0)
@@ -270,7 +270,7 @@ GEM
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    pagy (6.0.4)
+    pagy (6.5.0)
     parallel (1.22.1)
     parser (3.2.2.0)
       ast (~> 2.4.1)
@@ -423,7 +423,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unaccent (0.4.0)
     unicode-display_width (2.4.2)
-    view_component (3.5.0)
+    view_component (3.14.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)

--- a/gemfiles/rails_6.1_ruby_3.2.2.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_3.2.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    avo (2.46.0)
+    avo (2.52.0)
       actionview (>= 6.0)
       active_link_to
       activerecord (>= 6.0)
@@ -218,7 +218,7 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    inline_svg (1.9.0)
+    inline_svg (1.10.0)
       activesupport (>= 3.0)
       nokogiri (>= 1.6)
     iso (0.4.0)
@@ -270,7 +270,7 @@ GEM
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    pagy (6.0.4)
+    pagy (6.5.0)
     parallel (1.22.1)
     parser (3.2.2.0)
       ast (~> 2.4.1)
@@ -423,7 +423,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unaccent (0.4.0)
     unicode-display_width (2.4.2)
-    view_component (3.5.0)
+    view_component (3.14.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)

--- a/gemfiles/rails_7.0_ruby_3.0.3.gemfile.lock
+++ b/gemfiles/rails_7.0_ruby_3.0.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    avo (2.46.0)
+    avo (2.52.0)
       actionview (>= 6.0)
       active_link_to
       activerecord (>= 6.0)
@@ -224,7 +224,7 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    inline_svg (1.9.0)
+    inline_svg (1.10.0)
       activesupport (>= 3.0)
       nokogiri (>= 1.6)
     iso (0.4.0)
@@ -276,7 +276,7 @@ GEM
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    pagy (6.0.4)
+    pagy (6.5.0)
     parallel (1.22.1)
     parser (3.2.2.0)
       ast (~> 2.4.1)
@@ -429,7 +429,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unaccent (0.4.0)
     unicode-display_width (2.4.2)
-    view_component (3.5.0)
+    view_component (3.14.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)

--- a/gemfiles/rails_7.0_ruby_3.2.2.gemfile.lock
+++ b/gemfiles/rails_7.0_ruby_3.2.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    avo (2.46.0)
+    avo (2.52.0)
       actionview (>= 6.0)
       active_link_to
       activerecord (>= 6.0)
@@ -224,7 +224,7 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    inline_svg (1.9.0)
+    inline_svg (1.10.0)
       activesupport (>= 3.0)
       nokogiri (>= 1.6)
     iso (0.4.0)
@@ -276,7 +276,7 @@ GEM
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    pagy (6.0.4)
+    pagy (6.5.0)
     parallel (1.22.1)
     parser (3.2.2.0)
       ast (~> 2.4.1)
@@ -429,7 +429,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unaccent (0.4.0)
     unicode-display_width (2.4.2)
-    view_component (3.5.0)
+    view_component (3.14.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -37,7 +37,7 @@ class User < ApplicationRecord
   has_many :comments
   has_many :team_memberships
   has_and_belongs_to_many :projects, inverse_of: :users
-  has_and_belongs_to_many :teams, join_table: :team_memberships, inverse_of: :admin
+  has_many :teams, through: :team_memberships, inverse_of: :admin
 
   has_one_attached :cv
 

--- a/spec/features/avo/breadcrumbs_spec.rb
+++ b/spec/features/avo/breadcrumbs_spec.rb
@@ -22,8 +22,7 @@ RSpec.feature "Breadcrumbs", type: :feature do
       expect(breadcrumbs).to have_text('Edit')
 
       # Ensure the breadcrumbs are in the correct order
-      breadcrumb_order = breadcrumbs.text
-      expect(breadcrumb_order).to match(/Dashboard.*Projects.*#{project.name}.*Edit/)
+      expect(breadcrumbs.text).to match(/Dashboard.*Projects.*#{project.name}.*Edit/)
     }
   end
 

--- a/spec/features/avo/breadcrumbs_spec.rb
+++ b/spec/features/avo/breadcrumbs_spec.rb
@@ -11,8 +11,20 @@ RSpec.feature "Breadcrumbs", type: :feature do
   subject { page.body }
 
   describe "with breadcrumbs" do
-    it { is_expected.to have_css ".breadcrumbs" }
-    it { is_expected.to have_text "Dashboard\n  \n\nProjects\n  \n\n#{project.name}\n  \n\nEdit\n" }
+    it {
+      # Find the breadcrumbs container
+      breadcrumbs = find('.breadcrumbs')
+
+      # Verify that the text includes all breadcrumbs
+      expect(breadcrumbs).to have_text('Dashboard')
+      expect(breadcrumbs).to have_text('Projects')
+      expect(breadcrumbs).to have_text(project.name)
+      expect(breadcrumbs).to have_text('Edit')
+
+      # Ensure the breadcrumbs are in the correct order
+      breadcrumb_order = breadcrumbs.text
+      expect(breadcrumb_order).to match(/Dashboard.*Projects.*#{project.name}.*Edit/)
+    }
   end
 
   describe "on a custom tool" do

--- a/spec/system/avo/dashboards_spec.rb
+++ b/spec/system/avo/dashboards_spec.rb
@@ -177,15 +177,12 @@ RSpec.describe "Dashboards", type: :system do
   end
 
   describe "card options" do
-    let(:url) { "/admin/dashboards/dashy" }
+    it do
+      visit "/admin/dashboards/dashy"
 
-    subject {
-      visit url
-      page
-    }
-
-    it { is_expected.to have_text "Users count" }
-    it { is_expected.to have_text "Active users metric" }
+      expect(page).to have_text "Users count"
+      expect(page).to have_text "Active users metric"
+    end
   end
 end
 

--- a/spec/system/avo/dashboards_spec.rb
+++ b/spec/system/avo/dashboards_spec.rb
@@ -177,12 +177,15 @@ RSpec.describe "Dashboards", type: :system do
   end
 
   describe "card options" do
-    it do
-      visit "/admin/dashboards/dashy"
+    let(:url) { "/admin/dashboards/dashy" }
 
-      expect(page).to have_text "Users count"
-      expect(page).to have_text "Active users metric"
-    end
+    subject {
+      visit url
+      page
+    }
+
+    it { is_expected.to have_text "Users count" }
+    it { is_expected.to have_text "Active users metric" }
   end
 end
 

--- a/spec/system/avo/dashboards_spec.rb
+++ b/spec/system/avo/dashboards_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe "Dashboards", type: :system do
     it "shows the empty screen" do
       visit "/admin/dashboards/sales"
 
-      content = page.find(".content")
+      # Ensure the content is loaded before making assertions
+      content = page.find(".content", wait: 5)
       expect(content).to have_text "Sales"
       expect(content).to have_text "Tiny dashboard description"
       expect(content).to have_text "No cards present"
@@ -19,21 +20,19 @@ RSpec.describe "Dashboards", type: :system do
   end
 
   describe "dashboard with cards" do
-    let(:card) { page.find("turbo-frame[id='#{full_card_id}']") }
+    let(:card) { page.find("turbo-frame[id='#{full_card_id}']", wait: 5) }
     let(:wait_for_card) { wait_for_turbo_frame_id full_card_id }
 
     subject do
       visit "/admin/dashboards/dashy"
-
       wait_for_card
-
       card
     end
 
     it "shows the dashboard info" do
       visit "/admin/dashboards/dashy"
 
-      content = page.find(".content")
+      content = page.find(".content", wait: 5)
       expect(content).to have_text "Dashy"
       expect(content).to have_text "The first dashbaord"
       expect(content).not_to have_text "No cards present"
@@ -49,7 +48,7 @@ RSpec.describe "Dashboards", type: :system do
       let(:index) { 0 }
       let(:card_id) { "users_metric" }
 
-      let(:card) { page.find("turbo-frame[id='#{full_card_id}'][data-card-index='#{index}']") }
+      let(:card) { page.find("turbo-frame[id='#{full_card_id}'][data-card-index='#{index}']", wait: 5) }
 
       it do
         is_expected.to have_text "Users count"
@@ -73,7 +72,7 @@ RSpec.describe "Dashboards", type: :system do
       let(:index) { 3 }
       let(:card_id) { "users_metric" }
 
-      let(:card) { page.find("turbo-frame[id='#{full_card_id}'][data-card-index='#{index}']") }
+      let(:card) { page.find("turbo-frame[id='#{full_card_id}'][data-card-index='#{index}']", wait: 5) }
 
       it do
         is_expected.to have_text "Active users metric"
@@ -179,10 +178,10 @@ RSpec.describe "Dashboards", type: :system do
   describe "card options" do
     let(:url) { "/admin/dashboards/dashy" }
 
-    subject {
+    subject do
       visit url
       page
-    }
+    end
 
     it { is_expected.to have_text "Users count" }
     it { is_expected.to have_text "Active users metric" }
@@ -191,10 +190,10 @@ end
 
 RSpec.describe "Dashboards", type: :feature do
   describe "dashboards visibility" do
-    subject {
+    subject do
       visit url
       page
-    }
+    end
 
     describe "visible dashboard" do
       let(:url) { "/admin/dashboards/dashy" }
@@ -219,5 +218,5 @@ def description_tooltip_has_text(text = "")
 
   card.find("[data-target='card-description']").hover
 
-  expect(page.find(".tippy-content[data-state='visible']")).to have_text text
+  expect(page.find(".tippy-content[data-state='visible']", wait: 5)).to have_text text
 end

--- a/spec/system/avo/tabs_spec.rb
+++ b/spec/system/avo/tabs_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Tabs", type: :system do
 
         expect(find("turbo-frame#has_and_belongs_to_many_field_show_teams")).to have_text "Teams"
         expect(find("turbo-frame#has_and_belongs_to_many_field_show_teams")).to have_link "Attach team"
-        expect(find("turbo-frame#has_and_belongs_to_many_field_show_teams")).to have_link "Create new team", href: "/admin/resources/teams/new?via_relation=users&via_relation_class=User&via_resource_id=#{user.slug}"
+        expect(find("turbo-frame#has_and_belongs_to_many_field_show_teams")).to have_link "Create new team", href: "/admin/resources/teams/new?via_relation=admin&via_relation_class=User&via_resource_id=#{user.slug}"
       end
 
       it "hides the birthday tab" do


### PR DESCRIPTION
- better compatible with newer Rails, since it casts to needed type on its own

successor to https://github.com/avo-hq/avo/pull/2927

I'm trying to setup Rails 7.2 for Avo 2.x CI at https://github.com/avo-hq/avo/pull/3204 as well, but it will probably need more time.