### PR TITLE
fix: resource fails to show when title is numeric

### DIFF
--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -395,21 +395,22 @@ module Avo
       end
 
       def record_title
-        if @record.nil?
-          name
-        elsif title.nil?
-          # Get the title from the record if title is not set, try to get the name, title or label, or fallback to the to_param
-          @record.try(:name) || @record.try(:title) || @record.try(:label) || @record.to_param
+        fetch_record_title.to_s
+      end
 
-        else
-          # If the title is a symbol, get the value from the record else execute the block/string
-          case title
-          when Symbol
-            @record.send title
-          when Proc
-            Avo::ExecutionContext.new(target: title, resource: self, record: @record).handle
-          end
-        end.to_s
+      def fetch_record_title
+        return name if @record.nil?
+
+        # Get the title from the record if title is not set, try to get the name, title or label, or fallback to the to_param
+        return @record.try(:name) || @record.try(:title) || @record.try(:label) || @record.to_param if title.nil?
+
+        # If the title is a symbol, get the value from the record else execute the block/string
+        case title
+        when Symbol
+          @record.send title
+        when Proc
+          Avo::ExecutionContext.new(target: title, resource: self, record: @record).handle
+        end
       end
 
       def available_view_types

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -395,18 +395,21 @@ module Avo
       end
 
       def record_title
-        return name if @record.nil?
+        if @record.nil?
+          name
+        elsif title.nil?
+          # Get the title from the record if title is not set, try to get the name, title or label, or fallback to the to_param
+          @record.try(:name) || @record.try(:title) || @record.try(:label) || @record.to_param
 
-        # Get the title from the record if title is not set, try to get the name, title or label, or fallback to the to_param
-        return @record.try(:name) || @record.try(:title) || @record.try(:label) || @record.to_param if title.nil?
-
-        # If the title is a symbol, get the value from the record else execute the block/string
-        case title
-        when Symbol
-          @record.send title
-        when Proc
-          Avo::ExecutionContext.new(target: title, resource: self, record: @record).handle
-        end
+        else
+          # If the title is a symbol, get the value from the record else execute the block/string
+          case title
+          when Symbol
+            @record.send title
+          when Proc
+            Avo::ExecutionContext.new(target: title, resource: self, record: @record).handle
+          end
+        end.to_s
       end
 
       def available_view_types

--- a/spec/features/avo/resource_title_spec.rb
+++ b/spec/features/avo/resource_title_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.feature "Resource title option", type: :feature do
+  let!(:project) { create :project }
+
+  it "dont raise any error while visiting show viw with title as id" do
+    with_temporary_class_option(Avo::Resources::Project, :title, :id) do
+      expect { visit avo.resources_project_path(project) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3201 

Enforce `String` type on `record_title` method

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)~
- [x] I have added tests that prove my fix is effective or that my feature works
