### PR TITLE
dx: disable select all feature when serialization raises error

### DIFF
--- a/app/components/avo/index/resource_table_component.rb
+++ b/app/components/avo/index/resource_table_component.rb
@@ -18,8 +18,6 @@ class Avo::Index::ResourceTableComponent < Avo::BaseComponent
   prop :actions, _Nilable(_Array(Avo::BaseAction))
 
   def encrypted_query
-    return :select_all_disabled if @query.nil?
-
     # TODO: move this to the resource where we can apply the adapter pattern
     if Module.const_defined?("Ransack::Search") && @query.instance_of?(Ransack::Search)
       @query = @query.result
@@ -27,8 +25,7 @@ class Avo::Index::ResourceTableComponent < Avo::BaseComponent
 
     Avo::Services::EncryptionService.encrypt(message: @query, purpose: :select_all, serializer: Marshal)
   rescue
-    disabled_select_all_warning
-    :select_all_disabled
+    disable_select_all
   end
 
   def selected_page_label
@@ -94,7 +91,7 @@ class Avo::Index::ResourceTableComponent < Avo::BaseComponent
 
   private
 
-  def disabled_select_all_warning
+  def disable_select_all
     if Rails.env.development?
       Avo.error_manager.add({
         url: "https://docs.avohq.io/3.0/select-all.html#serialization-known-issues",
@@ -104,5 +101,7 @@ class Avo::Index::ResourceTableComponent < Avo::BaseComponent
                   Click here for more details.\n\r"
       })
     end
+
+    :select_all_disabled
   end
 end

--- a/app/components/avo/index/resource_table_component.rb
+++ b/app/components/avo/index/resource_table_component.rb
@@ -96,9 +96,7 @@ class Avo::Index::ResourceTableComponent < Avo::BaseComponent
       Avo.error_manager.add({
         url: "https://docs.avohq.io/3.0/select-all.html#serialization-known-issues",
         target: "_blank",
-        message: "Something went wrong while serializing the query object.\n\r
-                  Select all feature is disabled since it relies on the serialized query.\n\r
-                  Click here for more details.\n\r"
+        message: "An error occurred while serializing the query object. The Select All feature has been disabled because it depends on successful query serialization. For more details and troubleshooting steps, click here."
       })
     end
 

--- a/app/components/avo/index/resource_table_component.rb
+++ b/app/components/avo/index/resource_table_component.rb
@@ -27,16 +27,7 @@ class Avo::Index::ResourceTableComponent < Avo::BaseComponent
 
     Avo::Services::EncryptionService.encrypt(message: @query, purpose: :select_all, serializer: Marshal)
   rescue
-    if Rails.env.development?
-      Avo.error_manager.add({
-        url: "https://docs.avohq.io/3.0/select-all.html#serialization-known-issues",
-        target: "_blank",
-        message: "Something went wrong while serializing the query object.\n\r
-                  Select all feature is disabled since it relies on the serialized query.\n\r
-                  Click here for more details.\n\r"
-      })
-    end
-
+    disabled_select_all_warning
     :select_all_disabled
   end
 
@@ -99,5 +90,19 @@ class Avo::Index::ResourceTableComponent < Avo::BaseComponent
     header_fields.uniq!(&:table_header_label)
 
     [header_fields, table_row_components]
+  end
+
+  private
+
+  def disabled_select_all_warning
+    if Rails.env.development?
+      Avo.error_manager.add({
+        url: "https://docs.avohq.io/3.0/select-all.html#serialization-known-issues",
+        target: "_blank",
+        message: "Something went wrong while serializing the query object.\n\r
+                  Select all feature is disabled since it relies on the serialized query.\n\r
+                  Click here for more details.\n\r"
+      })
+    end
   end
 end

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -24,9 +24,10 @@ class Post < ApplicationRecord
 
   # Trigger TypeError: no _dump_data is defined for class Proc when serializing query
   # Test it by applying a status filter
-  normalizes :status, with: ->(status) {
-    status
-  }
+  # Only for rails > 7.1
+  # normalizes :status, with: ->(status) {
+  #   status
+  # }
 
   has_one_attached :cover_photo
   has_one_attached :audio

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -22,6 +22,12 @@ class Post < ApplicationRecord
 
   validates :name, presence: true
 
+  # Trigger TypeError: no _dump_data is defined for class Proc when serializing query
+  # Test it by applying a status filter
+  normalizes :status, with: ->(status) {
+    status
+  }
+
   has_one_attached :cover_photo
   has_one_attached :audio
   has_many_attached :attachments


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3196 

Disable "Select All" when serializing the query raises any error.

In development  a warning message is displayed. The warning includes a link to documentation that explains how the "Select All" feature works and provides some guidance on known issues.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
  - https://github.com/avo-hq/docs.avohq.io/pull/286
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
![image](https://github.com/user-attachments/assets/0317bfbb-03ef-4560-9ce9-969b13cae3dd)

