### PR TITLE
fix: unknown keyword rel on menu link

### DIFF
--- a/app/components/avo/sidebar/link_component.html.erb
+++ b/app/components/avo/sidebar/link_component.html.erb
@@ -1,5 +1,5 @@
 <% if @path.present? %>
-  <%= send link_method, @path, class: classes, active: @active, target: @target, data: @data do %>
+  <%= send link_method, @path, class: classes, active: @active, target: @target, data: @data, **@args do %>
     <%= helpers.svg @icon, class: "h-4 text-gray-700" if @icon.present? %>
     <%= @label %>
     <% if @target == :_blank %>

--- a/app/components/avo/sidebar/link_component.rb
+++ b/app/components/avo/sidebar/link_component.rb
@@ -11,6 +11,7 @@ class Avo::Sidebar::LinkComponent < Avo::BaseComponent
   end
   prop :data, Hash, default: {}.freeze
   prop :icon, _Nilable(String)
+  prop :args, Hash, :**, default: {}.freeze
 
   def is_external?
     # If the path contains the scheme, check if it includes the root path or not


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3199 

Now all extra arguments are passed to the menu link.

### Related PR
https://github.com/avo-hq/avo-menu/pull/33

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

