### PR TITLE
feature: apply `show` policy on `click_row_to_view_record`

### DIFF
--- a/app/components/avo/index/resource_controls_component.rb
+++ b/app/components/avo/index/resource_controls_component.rb
@@ -2,6 +2,7 @@
 
 class Avo::Index::ResourceControlsComponent < Avo::ResourceComponent
   include Avo::ApplicationHelper
+  include Avo::Concerns::ChecksShowAuthorization
 
   prop :resource, _Nilable(Avo::BaseResource)
   prop :reflection, _Nilable(ActiveRecord::Reflection::AbstractReflection)
@@ -18,15 +19,6 @@ class Avo::Index::ResourceControlsComponent < Avo::ResourceComponent
     return authorize_association_for(:edit) if @reflection.present?
 
     @resource.authorization.authorize_action(:edit, raise_exception: false)
-  end
-
-  def can_view?
-    return false if Avo.configuration.resource_default_view.edit?
-
-    return authorize_association_for(:show) if @reflection.present?
-
-    # Even if there's a @reflection object present, for show we're going to fallback to the original policy.
-    @resource.authorization.authorize_action(:show, raise_exception: false)
   end
 
   def show_path

--- a/app/components/avo/index/table_row_component.rb
+++ b/app/components/avo/index/table_row_component.rb
@@ -2,6 +2,7 @@
 
 class Avo::Index::TableRowComponent < Avo::BaseComponent
   include Avo::ResourcesHelper
+  include Avo::Concerns::ChecksShowAuthorization
 
   attr_writer :header_fields
 
@@ -24,5 +25,9 @@ class Avo::Index::TableRowComponent < Avo::BaseComponent
     )
   end
 
-  def click_row_to_view_record = Avo.configuration.click_row_to_view_record
+  def click_row_to_view_record
+    return false unless Avo.configuration.click_row_to_view_record
+
+    can_view?
+  end
 end

--- a/app/components/avo/index/table_row_component.rb
+++ b/app/components/avo/index/table_row_component.rb
@@ -26,8 +26,6 @@ class Avo::Index::TableRowComponent < Avo::BaseComponent
   end
 
   def click_row_to_view_record
-    return false unless Avo.configuration.click_row_to_view_record
-
-    can_view?
+    Avo.configuration.click_row_to_view_record && can_view?
   end
 end

--- a/lib/avo/concerns/checks_show_authorization.rb
+++ b/lib/avo/concerns/checks_show_authorization.rb
@@ -1,0 +1,18 @@
+module Avo
+  module Concerns
+    module ChecksShowAuthorization
+      include Avo::Concerns::ChecksAssocAuthorization
+
+      extend ActiveSupport::Concern
+
+      def can_view?
+        return false if Avo.configuration.resource_default_view.edit?
+
+        return authorize_association_for(:show) if @reflection.present?
+
+        # Even if there's a @reflection object present, for show we're going to fallback to the original policy.
+        @resource.authorization.authorize_action(:show, raise_exception: false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3200

Apply `show?` policy on `click_row_to_view_record` feature. If `show?` returns `false` then the row should not be clickable.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
