### PR TITLE
fix: auto generate resource fields when generating the model

### DIFF
--- a/lib/generators/avo/resource_generator.rb
+++ b/lib/generators/avo/resource_generator.rb
@@ -338,8 +338,8 @@ module Generators
           }
         end
         def generate_fields
-          return unless can_connect_to_the_database?
           return generate_fields_from_args if invoked_by_model_generator?
+          return unless can_connect_to_the_database?
 
           if model.blank?
             puts "Can't generate fields from model. '#{model_class}.rb' not found!"
@@ -359,7 +359,7 @@ module Generators
         def generated_fields_template
           return if fields.blank?
 
-          fields_string = "lo"
+          fields_string = ""
 
           fields.each do |field_name, field_options|
             # if field_options are not available (likely a missing resource for an association), skip the field


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes resource generator to autogenerate fields when generating a model.
This PR also removes an extra `lo` from the fields template.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
