### PR TITLE
fix: verify type when fetching associations fields

### DIFF
--- a/app/components/avo/base_component.rb
+++ b/app/components/avo/base_component.rb
@@ -3,6 +3,7 @@
 class Avo::BaseComponent < ViewComponent::Base
   extend Literal::Properties
   include Turbo::FramesHelper
+  include Avo::Concerns::FindAssociationField
 
   def has_with_trial(ability)
     Avo.license.has_with_trial(ability)
@@ -12,8 +13,7 @@ class Avo::BaseComponent < ViewComponent::Base
 
   # Use the @parent_resource to fetch the field using the @reflection name.
   def field
-    reflection_name = params[:related_name]&.to_sym || @reflection.name
-    @parent_resource.get_field(reflection_name)
+    find_association_field(resource: @parent_resource, association: params[:related_name] || @reflection.name)
   rescue
     nil
   end

--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -11,6 +11,7 @@ module Avo
     include Avo::ApplicationHelper
     include Avo::UrlHelpers
     include Avo::Concerns::Breadcrumbs
+    include Avo::Concerns::FindAssociationField
 
     protect_from_forgery with: :exception
     around_action :set_avo_locale
@@ -85,7 +86,7 @@ module Avo
 
     def related_resource
       # Find the field from the parent resource
-      field = @resource.get_field params[:related_name]
+      field = find_association_field(resource: @resource, association: params[:related_name])
 
       return field.use_resource if field&.use_resource.present?
 

--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -26,7 +26,7 @@ module Avo
       @parent_resource.hydrate(record: @parent_record)
       association_name = BaseResource.valid_association_name(@parent_record, association_from_params)
       @query = @related_authorization.apply_policy @parent_record.send(association_name)
-      @association_field = @parent_resource.get_field params[:related_name]
+      @association_field = find_association_field(resource: @parent_resource, association: params[:related_name])
 
       if @association_field.present? && @association_field.scope.present?
         @query = Avo::ExecutionContext.new(target: @association_field.scope, query: @query, parent: @parent_record).handle
@@ -126,7 +126,7 @@ module Avo
     end
 
     def set_reflection_field
-      @field = @resource.get_field(@related_resource_name.to_sym)
+      @field = find_association_field(resource: @resource, association: @related_resource_name)
       @field.hydrate(resource: @resource, record: @record, view: Avo::ViewInquirer.new(:new))
     rescue
     end

--- a/lib/avo/concerns/find_association_field.rb
+++ b/lib/avo/concerns/find_association_field.rb
@@ -1,0 +1,21 @@
+module Avo
+  module Concerns
+    module FindAssociationField
+      # The supported association types are defined in the ASSOCIATIONS constant.
+      unless defined?(ASSOCIATIONS)
+        ASSOCIATIONS = ["belongs_to", "has_one", "has_many", "has_and_belongs_to_many"]
+      end
+
+      # This method is used to find an association field for a given resource.
+      # Ideally, the exact type of the association should be known in advance.
+      # However, there are cases where the type is unknown
+      # and the method will return the first matching association field
+      # based on the provided association name.
+      def find_association_field(resource:, association:)
+        resource.get_field_definitions.find do |field|
+          (field.id == association.to_sym) && field.type.in?(ASSOCIATIONS)
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/app/avo/resources/store.rb
+++ b/spec/dummy/app/avo/resources/store.rb
@@ -12,8 +12,8 @@ class Avo::Resources::Store < Avo::BaseResource
       field :location, as: :has_one
     end
 
-    # Use the same id as the :has_many field intentinally to test if correct association field is fetched when rendering
-    # the association
+    # Intentionally use the same ID as the :has_many field to test whether the correct association field
+    # is retrieved during rendering of the association.
     field :patrons, as: :tags do
       record.patrons.map(&:name)
     end

--- a/spec/dummy/app/avo/resources/store.rb
+++ b/spec/dummy/app/avo/resources/store.rb
@@ -12,6 +12,12 @@ class Avo::Resources::Store < Avo::BaseResource
       field :location, as: :has_one
     end
 
+    # Use the same id as the :has_many field intentinally to test if correct association field is fetched when rendering
+    # the association
+    field :patrons, as: :tags do
+      record.patrons.map(&:name)
+    end
+
     field :patrons,
       as: :has_many,
       through: :patronships,

--- a/spec/system/avo/has_many_spec.rb
+++ b/spec/system/avo/has_many_spec.rb
@@ -105,4 +105,22 @@ RSpec.feature "HasManyField", type: :system do
       end
     end
   end
+
+  describe "duplicated field id" do
+    let!(:store) { create(:store) }
+
+    it "render tags and has many field" do
+      StorePatron.create!(user:, store:, review: "some review")
+      visit avo.resources_store_path(store)
+
+      # Find user name on tags field
+      expect(page).to have_css('div[data-field-id="patrons"] div[data-target="tag-component"]', text: user.name)
+
+      # Find user name on has many field
+      within("tr[data-record-id='#{user.id}']") do
+        expect(page).to have_text(user.first_name)
+        expect(page).to have_text(user.last_name)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3166
Fixes #3158

In the previous attempt [#3230](https://github.com/avo-hq/avo/pull/3230), I aimed to target the exact field type when fetching association fields. However, that approach was abandoned as it led down a rabbit hole and was difficult to stabilize. In some cases, identifying the exact field type would require passing it through params, which is not ideal for maintainability and simplicity.

This PR simplifies things by following the 80/20 rule. Instead of trying to pinpoint the exact field type, Avo now just checks if the field is one of the supported associations when fetching fields. This fixes the reported issue and similar ones without overcomplicating things.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works