### PR TITLE
fix: allow `Symbol` on `Avo::ProfileItemComponent` `method`

### DIFF
--- a/app/components/avo/profile_item_component.rb
+++ b/app/components/avo/profile_item_component.rb
@@ -11,7 +11,7 @@ class Avo::ProfileItemComponent < Avo::BaseComponent
     value&.to_sym
   end
   prop :title, _Nilable(String), reader: :public
-  prop :method, _Nilable(String), reader: :public
+  prop :method, _Nilable(_Union(_String,  _Symbol)), reader: :public
   prop :params, _Nilable(Hash), default: {}.freeze, reader: :public
   prop :classes, String, default: "", reader: :public
 

--- a/app/components/avo/profile_item_component.rb
+++ b/app/components/avo/profile_item_component.rb
@@ -11,7 +11,7 @@ class Avo::ProfileItemComponent < Avo::BaseComponent
     value&.to_sym
   end
   prop :title, _Nilable(String), reader: :public
-  prop :method, _Nilable(_Union(_String,  _Symbol)), reader: :public
+  prop :method, _Nilable(_Union(_String, _Symbol)), reader: :public
   prop :params, _Nilable(Hash), default: {}.freeze, reader: :public
   prop :classes, String, default: "", reader: :public
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Allow `Symbol` on  `Avo::ProfileItemComponent` `method` prop.

```ruby
  config.profile_menu = -> do
    link_to "Sign out", path: main_app.destroy_user_session_path, icon: "user-circle", method: :post
  end
```

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
