### PR TITLE
refactor: add `resource` and `parent_resource` on associations `scope` block

### DIFF
--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -29,7 +29,13 @@ module Avo
       @association_field = find_association_field(resource: @parent_resource, association: params[:related_name])
 
       if @association_field.present? && @association_field.scope.present?
-        @query = Avo::ExecutionContext.new(target: @association_field.scope, query: @query, parent: @parent_record).handle
+        @query = Avo::ExecutionContext.new(
+          target: @association_field.scope,
+          query: @query,
+          parent: @parent_record,
+          resource: @resource,
+          parent_resource: @parent_resource
+        ).handle
       end
 
       super

--- a/spec/dummy/app/avo/resources/user.rb
+++ b/spec/dummy/app/avo/resources/user.rb
@@ -253,7 +253,11 @@ class Avo::Resources::User < Avo::BaseResource
       field :comments,
         as: :has_many,
         # show_on: :edit,
-        scope: -> { query.starts_with parent.first_name[0].downcase },
+        scope: -> {
+          TestBuddy.hi("parent_resource:#{parent_resource.present?},resource:#{resource.present?}")
+
+          query.starts_with parent.first_name[0].downcase
+        },
         description: "The comments listed in the attach modal all start with the name of the parent user."
       field :comment, as: :has_one, name: "Main comment"
     end

--- a/spec/features/avo/has_many_field_spec.rb
+++ b/spec/features/avo/has_many_field_spec.rb
@@ -112,6 +112,7 @@ RSpec.feature "HasManyField", type: :feature do
     let!(:a_comment) { create :comment, user: user, body: "A comment that starts with the letter A" }
 
     subject do
+      expect(TestBuddy).to receive(:hi).with("parent_resource:true,resource:true").at_least :once
       visit "/admin/resources/users/#{user.id}/comments?turbo_frame=has_many_field_show_comments"
       page
     end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Add `resource` and `parent_resource` on associations `scope` block

Docs: https://docs.avohq.io/3.0/associations/has_many.html#scope

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works