### PR TITLE
chore: update derailed_benchmarks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ group :development do
 
   gem "actual_db_schema"
 
-  gem "derailed_benchmarks", "~> 2.1"
+  gem "derailed_benchmarks", "~> 2.1", ">= 2.1.2"
 
   # gem "ruby-statistics", "< 4"
 end
@@ -191,3 +191,5 @@ gem "avo-record_link_field"
 gem "pagy", "> 8"
 
 gem "csv"
+
+gem "statistics", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -620,6 +620,7 @@ GEM
     standard-performance (1.4.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.21.0)
+    statistics (1.0.0)
     stringio (3.1.1)
     syntax_tree (6.2.0)
       prettier_print (>= 1.2.0)
@@ -700,7 +701,7 @@ DEPENDENCIES
   cuprite
   database_cleaner-active_record
   debug
-  derailed_benchmarks (~> 2.1)
+  derailed_benchmarks (~> 2.1, >= 2.1.2)
   devise
   dotenv-rails
   erb-formatter
@@ -749,6 +750,7 @@ DEPENDENCIES
   spring-commands-rspec
   sprockets-rails
   standard
+  statistics (~> 1.0)
   test-prof
   tzinfo-data
   web-console (>= 3.3.0)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Updates `derailed_benchamrks` to work with `ruby-statistics` version `4.0.1` updated [here](https://github.com/avo-hq/avo/pull/3271)