### PR TITLE
fix: verify `exemptionContainerTarget` presence

### DIFF
--- a/app/javascript/js/controllers/toggle_controller.js
+++ b/app/javascript/js/controllers/toggle_controller.js
@@ -20,7 +20,7 @@ export default class extends Controller {
 
   clickOutside(e) {
     if (this.hasPanelTarget) {
-      if (this.hasExemptionContainerValue) {
+      if (this.hasExemptionContainerValue && this.exemptionContainerTarget) {
         const inExemptionContainer = this.exemptionContainerTarget.contains(e.target)
 
         if (!inExemptionContainer) {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3282 

Verify `exemptionContainerTarget` presence before executing exemption on `clickOutside`.


https://github.com/user-attachments/assets/d51df323-2971-4f6e-8188-38bf5750b644


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
