### PR TITLE
fix: improve tippy tooltip to support browser back button

### DIFF
--- a/app/javascript/avo.base.js
+++ b/app/javascript/avo.base.js
@@ -43,9 +43,18 @@ function initTippy() {
   tippy('[data-tippy="tooltip"]', {
     theme: 'light',
     content(reference) {
-      const title = reference.getAttribute('title')
-      reference.removeAttribute('title')
-      reference.removeAttribute('data-tippy')
+      // On fist load get the title
+      // Remove the title attribute from the element to avoid the default HTML title attribute behavior
+      // Add the title value to tippy_title attribute
+      // When browser back is clicked get the title from tippy_title
+      let title = reference.getAttribute('title')
+
+      if (title) {
+        reference.setAttribute('tippy_title', title)
+        reference.removeAttribute('title')
+      } else {
+        title = reference.getAttribute('tippy_title')
+      }
 
       return title
     },


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3265 

- On the first load, get the `title` attribute value from the element and remove the attribute to prevent the default HTML title behavior.
- The retrieved title is stored in a new `tippy_title` attribute to ensure it can be used for future reference.
- When navigating back via the browser's back button, the `tippy_title` attribute is used to repopulate the tooltip content instead of relying on the now-removed title attribute.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

https://github.com/user-attachments/assets/0703c503-a00b-438e-97a6-030a8cdaee47

