### PR TITLE
fix: multiple tippy renders

### DIFF
--- a/app/javascript/avo.base.js
+++ b/app/javascript/avo.base.js
@@ -56,6 +56,12 @@ function initTippy() {
         title = reference.getAttribute('tippy_title')
       }
 
+      // Remove data-tippy to avoid multiples tippy renders for the same element
+      // Tag element with has-data-tippy
+      // Revert data-tippy attribute on turbo:before-cache to render the tippy on page navigation (ex when back button is pressed)
+      reference.removeAttribute('data-tippy')
+      reference.setAttribute('has-data-tippy', true)
+
       return title
     },
     onShow(tooltipInstance) {
@@ -118,6 +124,10 @@ document.addEventListener('turbo:submit-start', () => document.body.classList.ad
 document.addEventListener('turbo:submit-end', () => document.body.classList.remove('turbo-loading'))
 document.addEventListener('turbo:before-cache', () => {
   document.querySelectorAll('[data-turbo-remove-before-cache]').forEach((element) => element.remove())
+  document.querySelectorAll('[has-data-tippy="true"]').forEach((element) => {
+    element.removeAttribute('has-data-tippy')
+    element.setAttribute('data-tippy', 'tooltip')
+  })
 })
 
 window.Avo = window.Avo || { configuration: {} }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes a bug introduced here https://github.com/avo-hq/avo/pull/3284

- Removing the `data-tippy` attribute to prevent multiple tooltip renders on the same element.
- Tagging the element with a `has-data-tippy` attribute to track the tooltip status.
- Reverting the `data-tippy` attribute on `turbo:before-cache` event to ensure tooltips are properly reinitialized on page navigation (e.g., when the back button is pressed).

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
