### PR TITLE
refactor: plugins reporting and versions hiding

### DIFF
--- a/app/controllers/avo/application_controller.rb
+++ b/app/controllers/avo/application_controller.rb
@@ -328,5 +328,13 @@ module Avo
         "avo/application"
       end
     end
+
+    def authenticate_developer_or_admin!
+      raise_404 unless Avo::Current.user_is_developer? || Avo::Current.user_is_admin?
+    end
+
+    def raise_404
+      raise ActionController::RoutingError.new "No route matches"
+    end
   end
 end

--- a/app/controllers/avo/debug_controller.rb
+++ b/app/controllers/avo/debug_controller.rb
@@ -2,7 +2,13 @@ require_dependency "avo/application_controller"
 
 module Avo
   class DebugController < ApplicationController
+    before_action :authenticate_developer_or_admin!
+
     def status
+      respond_to do |format|
+        format.html { render :status }
+        format.text { render :status }
+      end
     end
 
     def send_to_hq

--- a/app/controllers/avo/private_controller.rb
+++ b/app/controllers/avo/private_controller.rb
@@ -2,6 +2,8 @@ require_dependency "avo/application_controller"
 
 module Avo
   class PrivateController < ApplicationController
+    before_action :authenticate_developer_or_admin!
+
     def design
       @page_title = "Design [Private]"
     end

--- a/app/views/avo/debug/status.html.erb
+++ b/app/views/avo/debug/status.html.erb
@@ -76,7 +76,7 @@
               <ul>
                 <li>Avo <%= Avo::VERSION %></li>
                 <% Avo.plugin_manager.plugins.each do |plugin| %>
-                  <li><%= plugin.klass.name %> - <%= plugin.klass.version %></li>
+                  <li><%= plugin.name %> - <%= plugin.version %></li>
                 <% end %>
               </ul>
             </div>

--- a/app/views/avo/debug/status.text.erb
+++ b/app/views/avo/debug/status.text.erb
@@ -1,0 +1,6 @@
+<!-- Avo version: <%= Avo::VERSION %> -->
+<!-- Rails version: <%= Rails::VERSION::STRING %> -->
+<!-- Environment: <%= Rails.env %> -->
+<!-- License ID: <%= Avo.license.id %> -->
+<!-- License valid?: <%= Avo.license.valid ? "valid" : "invalid" %>  -->
+<!-- Plugins: <%= Avo.plugin_manager.to_s %> -->

--- a/app/views/layouts/avo/application.html.erb
+++ b/app/views/layouts/avo/application.html.erb
@@ -53,12 +53,6 @@
     <%= render partial: "avo/partials/alerts" %>
     <%= render partial: "avo/partials/scripts" %>
     <%= render partial: "avo/partials/confirm_dialog" %>
-    <!-- Avo version: <%= Avo::VERSION %> -->
-    <!-- Rails version: <%= Rails::VERSION::STRING %> -->
-    <!-- Environment: <%= Rails.env %> -->
-    <!-- License ID: <%= Avo.license.id %> -->
-    <!-- License valid?: <%= Avo.license.valid ? "valid" : "invalid" %>  -->
-    <!-- Plugins: <%= Avo.plugin_manager.to_s %> -->
   </body>
 </html>
 <!-- ✨ Built with Avo • https://www.avohq.io/ -->

--- a/lib/avo/plugin.rb
+++ b/lib/avo/plugin.rb
@@ -3,9 +3,15 @@ module Avo
     attr_reader :name
     attr_reader :priority
 
+    delegate :version, :namespace, :engine, to: :class
+
     def initialize(*, name:, priority:, **, &block)
       @name = name
       @priority = priority
+    end
+
+    def to_s
+      "#{name}-#{version}"
     end
 
     class << self

--- a/lib/avo/plugin_manager.rb
+++ b/lib/avo/plugin_manager.rb
@@ -37,7 +37,7 @@ module Avo
     def as_json(*arg)
       plugins.map do |plugin|
         {
-          klass: plugin.klass.to_s,
+          klass: plugin.to_s,
           priority: plugin.priority,
         }
       end
@@ -45,7 +45,7 @@ module Avo
 
     def to_s
       plugins.map do |plugin|
-        plugin.klass.to_s
+        plugin.to_s
       end.join(",")
     rescue
       "Failed to fetch plugins."

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -101,6 +101,7 @@ Avo.configure do |config|
   # }
 
   ## == Customization ==
+  config.click_row_to_view_record = true
   # config.app_name = 'Avocadelicious'
   # config.timezone = 'UTC'
   # config.currency = 'USD'
@@ -114,7 +115,6 @@ Avo.configure do |config|
   # config.buttons_on_form_footers = true
   # config.field_wrapper_layout = true
   # config.resource_parent_controller = "Avo::ResourcesController"
-  # config.click_row_to_view_record = false
 
   ## == Branding ==
   # config.branding = {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes an issue with plugin reporting and hides the ruby/rails/avo aversions from the public.
- Adds the `/avo/avo_private/status.txt` path to quickly find out what you need
- hides all the private stuff behind the lightweight `user_is_admin?` or `user_is_developer?` flags

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
