### PR TITLE
fix: undefined local variable or method `resource` for an instance of Avo::Index::TableRowComponent

### DIFF
--- a/app/components/avo/index/table_row_component.rb
+++ b/app/components/avo/index/table_row_component.rb
@@ -6,7 +6,7 @@ class Avo::Index::TableRowComponent < Avo::BaseComponent
 
   attr_writer :header_fields
 
-  prop :resource, _Nilable(Avo::BaseResource)
+  prop :resource, _Nilable(Avo::BaseResource), reader: :public
   prop :reflection, _Nilable(ActiveRecord::Reflection::AbstractReflection)
   prop :parent_record, _Nilable(_Any)
   prop :parent_resource, _Nilable(Avo::BaseResource)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Add reader for `resource` on `Avo::Index::TableRowComponent`

```ruby
undefined local variable or method `resource` for an instance of Avo::Index::TableRowComponent
```