### PR TITLE
fix: remove type from query

### DIFF
--- a/app/components/avo/index/resource_table_component.rb
+++ b/app/components/avo/index/resource_table_component.rb
@@ -14,7 +14,7 @@ class Avo::Index::ResourceTableComponent < Avo::BaseComponent
   prop :parent_record, _Nilable(_Any)
   prop :parent_resource, _Nilable(Avo::BaseResource)
   prop :pagy, _Nilable(Pagy)
-  prop :query, _Nilable(ActiveRecord::Relation)
+  prop :query, _Nilable(_Any)
   prop :actions, _Nilable(_Array(Avo::BaseAction))
 
   def encrypted_query

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -17,7 +17,7 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
   prop :parent_record, _Nilable(_Any)
   prop :parent_resource, _Nilable(Avo::BaseResource)
   prop :applied_filters, Hash, default: {}.freeze
-  prop :query, _Nilable(ActiveRecord::Relation), reader: :public
+  prop :query, _Nilable(_Any), reader: :public
   # This should be
   # prop :scopes, _Nilable(_Array(Avo::Advanced::Scopes::BaseScope)), reader: :public
   # However, Avo::Advanced::Scopes::BaseScope raises an error because


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3294

Remove `ActiveRecord::Relation` type from `query` since using some gems (like [Scenic gem](https://github.com/scenic-views/scenic)) might return other types.