### PR TITLE
fix: tags filters closing on tag selection

### DIFF
--- a/app/javascript/js/controllers/toggle_controller.js
+++ b/app/javascript/js/controllers/toggle_controller.js
@@ -6,12 +6,12 @@ export default class extends Controller {
   static targets = ['panel']
 
   static values = {
-    // One may want to have an element that is exempt from triggerring the click outside event
-    exemptionContainer: String,
+    // One may want to have elements that are exempt from triggering the click outside event
+    exemptionContainers: Array,
   }
 
-  get exemptionContainerTarget() {
-    return document.querySelector(this.exemptionContainerValue)
+  get exemptionContainerTargets() {
+    return this.exemptionContainersValue.map((selector) => document.querySelector(selector)).filter(Boolean)
   }
 
   connect() {
@@ -20,13 +20,9 @@ export default class extends Controller {
 
   clickOutside(e) {
     if (this.hasPanelTarget) {
-      if (this.hasExemptionContainerValue && this.exemptionContainerTarget) {
-        const inExemptionContainer = this.exemptionContainerTarget.contains(e.target)
+      const isInExemptionContainer = this.hasExemptionContainersValue && this.exemptionContainerTargets.some((container) => container.contains(e.target))
 
-        if (!inExemptionContainer) {
-          leave(this.panelTarget)
-        }
-      } else {
+      if (!isInExemptionContainer) {
         leave(this.panelTarget)
       }
     }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3296 

Add tags options to the exemption containers and refactor the JS code to accept more than one exemption container.

#### Related PR
[avo-dynamic_filters #71](https://github.com/avo-hq/avo-dynamic_filters/pull/71)