### PR TITLE
refactor: remove types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -194,4 +194,4 @@ gem "pagy", "> 8"
 
 gem "csv"
 
-gem "avo-initializer", github: "avo-hq/avo-initializer"
+gem "prop_initializer", github: "avo-hq/prop_initializer", branch: "main"

--- a/Gemfile
+++ b/Gemfile
@@ -194,4 +194,4 @@ gem "pagy", "> 8"
 
 gem "csv"
 
-gem "literal", github: "avo-hq/literal"
+gem "avo-initializer", github: "avo-hq/avo-initializer"

--- a/Gemfile
+++ b/Gemfile
@@ -193,5 +193,3 @@ gem "avo-record_link_field"
 gem "pagy", "> 8"
 
 gem "csv"
-
-gem "prop_initializer", github: "avo-hq/prop_initializer", branch: "main"

--- a/Gemfile
+++ b/Gemfile
@@ -193,3 +193,5 @@ gem "avo-record_link_field"
 gem "pagy", "> 8"
 
 gem "csv"
+
+gem "literal", github: "avo-hq/literal"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,10 +6,10 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/literal.git
-  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  remote: https://github.com/avo-hq/avo-initializer.git
+  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
   specs:
-    literal (0.2.1)
+    avo-initializer (0.1.0)
 
 GIT
   remote: https://github.com/rails/rails.git
@@ -121,7 +121,6 @@ PATH
       addressable
       docile
       inline_svg
-      literal (~> 0.2)
       meta-tags
       pagy (>= 7.0.0)
       turbo-rails (>= 2.0.0)
@@ -691,6 +690,7 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
+  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -726,7 +726,6 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
-  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,14 +6,6 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/prop_initializer.git
-  revision: ec6808bc18b00ee53123497e885305d4d63da9de
-  branch: main
-  specs:
-    prop_initializer (0.1.0)
-      zeitwerk (>= 2.6.18)
-
-GIT
   remote: https://github.com/rails/rails.git
   revision: b88d9af34fbc1c84ce2769ba02584eab2c28ac6e
   branch: main
@@ -125,6 +117,7 @@ PATH
       inline_svg
       meta-tags
       pagy (>= 7.0.0)
+      prop_initializer
       turbo-rails (>= 2.0.0)
       turbo_power (>= 0.6.0)
       view_component (>= 3.7.0)
@@ -456,6 +449,8 @@ GEM
       hashids (>= 1.0.0, < 2.0.0)
       rails (>= 6.0.0)
     prettier_print (1.2.1)
+    prop_initializer (0.1.0)
+      zeitwerk (>= 2.6.18)
     psych (5.1.2)
       stringio
     public_suffix (6.0.1)
@@ -735,7 +730,6 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pluggy!
   prefixed_ids
-  prop_initializer!
   puma (~> 6.4)
   rails!
   rails-controller-testing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,12 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
+  remote: https://github.com/avo-hq/literal.git
+  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  specs:
+    literal (0.2.1)
+
+GIT
   remote: https://github.com/rails/rails.git
   revision: b88d9af34fbc1c84ce2769ba02584eab2c28ac6e
   branch: main
@@ -391,7 +397,6 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    literal (0.2.1)
     logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -721,6 +726,7 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
+  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,10 +6,12 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/avo-initializer.git
-  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
+  remote: https://github.com/avo-hq/prop_initializer.git
+  revision: ec6808bc18b00ee53123497e885305d4d63da9de
+  branch: main
   specs:
-    avo-initializer (0.1.0)
+    prop_initializer (0.1.0)
+      zeitwerk (>= 2.6.18)
 
 GIT
   remote: https://github.com/rails/rails.git
@@ -690,7 +692,6 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
-  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -734,6 +735,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pluggy!
   prefixed_ids
+  prop_initializer!
   puma (~> 6.4)
   rails!
   rails-controller-testing

--- a/app/components/avo/actions_component.rb
+++ b/app/components/avo/actions_component.rb
@@ -3,8 +3,6 @@
 class Avo::ActionsComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
 
-  ACTION_FILTER = _Set(_Class(Avo::BaseAction))
-
   prop :as_row_control, default: false
   prop :icon
   prop :size, default: :md

--- a/app/components/avo/actions_component.rb
+++ b/app/components/avo/actions_component.rb
@@ -5,32 +5,32 @@ class Avo::ActionsComponent < Avo::BaseComponent
 
   ACTION_FILTER = _Set(_Class(Avo::BaseAction))
 
-  prop :as_row_control, _Boolean, default: false
-  prop :icon, _Nilable(String)
-  prop :size, Avo::ButtonComponent::SIZE, default: :md
-  prop :title, _Nilable(String)
-  prop :color, _Nilable(Symbol) do |value|
+  prop :as_row_control, default: false
+  prop :icon
+  prop :size, default: :md
+  prop :title
+  prop :color do |value|
     value || :primary
   end
-  prop :include, _Nilable(ACTION_FILTER), default: [].freeze do |include|
+  prop :include, default: [].freeze do |include|
     Array(include).to_set
   end
-  prop :custom_list, _Boolean, default: false
-  prop :label, _Nilable(String) do |label|
+  prop :custom_list, default: false
+  prop :label do |label|
     if @custom_list
       label
     else
       label || I18n.t("avo.actions")
     end
   end
-  prop :style, Avo::ButtonComponent::STYLE, default: :outline
-  prop :actions, _Array(_Any), default: [].freeze
-  prop :exclude, _Nilable(ACTION_FILTER), default: [].freeze do |exclude|
+  prop :style, default: :outline
+  prop :actions, default: [].freeze
+  prop :exclude, default: [].freeze do |exclude|
     Array(exclude).to_set
   end
-  prop :resource, _Nilable(Avo::BaseResource)
-  prop :view, _Nilable(Avo::ViewInquirer)
-  prop :host_component, _Nilable(_Any)
+  prop :resource
+  prop :view
+  prop :host_component
 
   delegate_missing_to :@host_component
 

--- a/app/components/avo/alert_component.rb
+++ b/app/components/avo/alert_component.rb
@@ -3,8 +3,8 @@
 class Avo::AlertComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
 
-  prop :type, nil, :positional
-  prop :message, nil, :positional
+  prop :type, kind: :positional
+  prop :message, kind: :positional
 
   def icon
     return "heroicons/solid/exclamation-circle" if is_error?

--- a/app/components/avo/alert_component.rb
+++ b/app/components/avo/alert_component.rb
@@ -3,8 +3,8 @@
 class Avo::AlertComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
 
-  prop :type, Symbol, :positional
-  prop :message, String, :positional
+  prop :type, nil, :positional
+  prop :message, nil, :positional
 
   def icon
     return "heroicons/solid/exclamation-circle" if is_error?

--- a/app/components/avo/asset_manager/javascript_component.rb
+++ b/app/components/avo/asset_manager/javascript_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::AssetManager::JavascriptComponent < Avo::BaseComponent
-  prop :asset_manager, Avo::AssetManager
+  prop :asset_manager
 
   delegate :javascripts, to: :@asset_manager
 end

--- a/app/components/avo/asset_manager/stylesheet_component.rb
+++ b/app/components/avo/asset_manager/stylesheet_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::AssetManager::StylesheetComponent < Avo::BaseComponent
-  prop :asset_manager, Avo::AssetManager
+  prop :asset_manager
 
   delegate :stylesheets, to: :@asset_manager
 end

--- a/app/components/avo/backtrace_alert_component.rb
+++ b/app/components/avo/backtrace_alert_component.rb
@@ -3,7 +3,7 @@
 class Avo::BacktraceAlertComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
 
-  prop :backtrace, _Nilable(Array)
+  prop :backtrace
 
   def render?
     @backtrace.present?

--- a/app/components/avo/base_component.rb
+++ b/app/components/avo/base_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::BaseComponent < ViewComponent::Base
-  extend Avo::Initializer::Properties
+  extend PropInitializer::Properties
   include Turbo::FramesHelper
   include Avo::Concerns::FindAssociationField
 

--- a/app/components/avo/base_component.rb
+++ b/app/components/avo/base_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::BaseComponent < ViewComponent::Base
-  extend Literal::Properties
+  extend Avo::Initializer::Properties
   include Turbo::FramesHelper
   include Avo::Concerns::FindAssociationField
 

--- a/app/components/avo/button_component.rb
+++ b/app/components/avo/button_component.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::ButtonComponent < Avo::BaseComponent
-  SIZE = _Union(:xs, :sm, :md, :lg, :xl)
-  STYLE = _Union(:primary, :outline, :text, :icon)
-
-  prop :path, nil, :positional
+  prop :path, kind: :positional
   prop :size, default: :md
   prop :style, default: :outline
   prop :color, default: :gray
@@ -16,7 +13,7 @@ class Avo::ButtonComponent < Avo::BaseComponent
   prop :rounded, default: true
   prop :compact, default: false
   prop :aria, default: {}.freeze
-  prop :args, nil, :**, default: {}.freeze
+  prop :args, kind: :**, default: {}.freeze
   prop :class
 
   def args

--- a/app/components/avo/button_component.rb
+++ b/app/components/avo/button_component.rb
@@ -4,20 +4,20 @@ class Avo::ButtonComponent < Avo::BaseComponent
   SIZE = _Union(:xs, :sm, :md, :lg, :xl)
   STYLE = _Union(:primary, :outline, :text, :icon)
 
-  prop :path, _Nilable(String), :positional
-  prop :size, Symbol, default: :md
-  prop :style, Symbol, default: :outline
-  prop :color, Symbol, default: :gray
-  prop :icon, _Nilable(Symbol) do |value|
+  prop :path, nil, :positional
+  prop :size, default: :md
+  prop :style, default: :outline
+  prop :color, default: :gray
+  prop :icon do |value|
     value&.to_sym
   end
-  prop :icon_class, String, default: ""
-  prop :is_link, _Boolean, default: false
-  prop :rounded, _Boolean, default: true
-  prop :compact, _Boolean, default: false
-  prop :aria, Hash, default: {}.freeze
-  prop :args, Hash, :**, default: {}.freeze
-  prop :class, _Nilable(String)
+  prop :icon_class, default: ""
+  prop :is_link, default: false
+  prop :rounded, default: true
+  prop :compact, default: false
+  prop :aria, default: {}.freeze
+  prop :args, nil, :**, default: {}.freeze
+  prop :class
 
   def args
     if @args[:loading]

--- a/app/components/avo/cover_photo_component.rb
+++ b/app/components/avo/cover_photo_component.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Avo::CoverPhotoComponent < Avo::BaseComponent
-  prop :cover_photo, _Nilable(Avo::CoverPhoto)
-  prop :size, _Nilable(Symbol) do |value|
+  prop :cover_photo
+  prop :size do |value|
     @cover_photo&.size
   end
 

--- a/app/components/avo/divider_component.rb
+++ b/app/components/avo/divider_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Avo::DividerComponent < Avo::BaseComponent
-  prop :label, nil, :positional
-  prop :args, nil, :**
+  prop :label, kind: :positional
+  prop :args, kind: :**
 end

--- a/app/components/avo/divider_component.rb
+++ b/app/components/avo/divider_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Avo::DividerComponent < Avo::BaseComponent
-  prop :label, _Nilable(String), :positional
-  prop :args, Hash, :**
+  prop :label, nil, :positional
+  prop :args, nil, :**
 end

--- a/app/components/avo/empty_state_component.rb
+++ b/app/components/avo/empty_state_component.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class Avo::EmptyStateComponent < Avo::BaseComponent
-  prop :message, _Nilable(String)
-  prop :view_type, Symbol, default: :table do |value|
+  prop :message
+  prop :view_type, default: :table do |value|
     value&.to_sym
   end
-  prop :add_background, _Boolean, default: false
-  prop :by_association, _Boolean, default: false
+  prop :add_background, default: false
+  prop :by_association, default: false
 
   def text
     @message || locale_message

--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -19,7 +19,7 @@ class Avo::FieldWrapperComponent < Avo::BaseComponent
   prop :label_for do |value|
     value&.to_sym
   end
-  prop :args, nil, :**, default: {}.freeze
+  prop :args, kind: :**, default: {}.freeze
   prop :classes do |value|
     @args&.dig(:class) || ""
   end

--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -3,24 +3,24 @@
 class Avo::FieldWrapperComponent < Avo::BaseComponent
   include Avo::Concerns::HasResourceStimulusControllers
 
-  prop :dash_if_blank, _Boolean, default: true
-  prop :data, Hash, default: {}.freeze
-  prop :compact, _Boolean, default: false
-  prop :help, _Nilable(String)
-  prop :field, _Nilable(Avo::Fields::BaseField)
-  prop :form, _Nilable(ActionView::Helpers::FormBuilder)
-  prop :full_width, _Boolean, default: false
-  prop :label, _Nilable(String)
-  prop :resource, _Nilable(Avo::BaseResource)
-  prop :short, _Boolean, default: false
-  prop :stacked, _Nilable(_Boolean)
-  prop :style, String, default: ""
-  prop :view, Avo::ViewInquirer, default: Avo::ViewInquirer.new(:show).freeze
-  prop :label_for, _Nilable(Symbol) do |value|
+  prop :dash_if_blank, default: true
+  prop :data, default: {}.freeze
+  prop :compact, default: false
+  prop :help
+  prop :field
+  prop :form
+  prop :full_width, default: false
+  prop :label
+  prop :resource
+  prop :short, default: false
+  prop :stacked
+  prop :style, default: ""
+  prop :view, default: Avo::ViewInquirer.new(:show).freeze
+  prop :label_for do |value|
     value&.to_sym
   end
-  prop :args, Hash, :**, default: {}.freeze
-  prop :classes, _Nilable(String) do |value|
+  prop :args, nil, :**, default: {}.freeze
+  prop :classes do |value|
     @args&.dig(:class) || ""
   end
 

--- a/app/components/avo/fields/common/badge_viewer_component.rb
+++ b/app/components/avo/fields/common/badge_viewer_component.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Avo::Fields::Common::BadgeViewerComponent < Avo::BaseComponent
-  prop :value, _Union(_String, _Symbol)
-  prop :options, Hash
+  prop :value
+  prop :options
 
   def after_initialize
     @backgrounds = {

--- a/app/components/avo/fields/common/boolean_check_component.rb
+++ b/app/components/avo/fields/common/boolean_check_component.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class Avo::Fields::Common::BooleanCheckComponent < Avo::BaseComponent
-  prop :checked, _Boolean, default: false
-  prop :icon, _Nilable(String) do |value|
+  prop :checked, default: false
+  prop :icon do |value|
     @checked ? "heroicons/outline/check-circle" : "heroicons/outline/x-circle"
   end
-  prop :classes, _Nilable(String) do |value|
+  prop :classes do |value|
     "h-6 #{@checked ? "text-green-600" : "text-red-500"}"
   end
 end

--- a/app/components/avo/fields/common/boolean_group_component.rb
+++ b/app/components/avo/fields/common/boolean_group_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Avo::Fields::Common::BooleanGroupComponent < Avo::BaseComponent
-  prop :options, Hash, default: {}.freeze
-  prop :value, _Nilable(Hash)
+  prop :options, default: {}.freeze
+  prop :value
 end

--- a/app/components/avo/fields/common/files/controls_component.rb
+++ b/app/components/avo/fields/common/files/controls_component.rb
@@ -6,9 +6,9 @@ class Avo::Fields::Common::Files::ControlsComponent < Avo::BaseComponent
 
   delegate :id, to: :@field
 
-  prop :field, Avo::Fields::BaseField
-  prop :file, _Any
-  prop :resource, Avo::BaseResource
+  prop :field
+  prop :file
+  prop :resource
 
   def destroy_path
     Avo::Services::URIService.parse(@resource.record_path).append_paths("active_storage_attachments", id, @file.id).to_s

--- a/app/components/avo/fields/common/files/list_viewer_component.rb
+++ b/app/components/avo/fields/common/files/list_viewer_component.rb
@@ -3,8 +3,8 @@
 class Avo::Fields::Common::Files::ListViewerComponent < Avo::BaseComponent
   include Turbo::FramesHelper
 
-  prop :field, Avo::Fields::BaseField
-  prop :resource, Avo::BaseResource
+  prop :field
+  prop :resource
 
   def classes
     base_classes = "py-4 rounded-2xl max-w-full"

--- a/app/components/avo/fields/common/files/view_type/grid_item_component.rb
+++ b/app/components/avo/fields/common/files/view_type/grid_item_component.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Avo::Fields::Common::Files::ViewType::GridItemComponent < Avo::BaseComponent
-  prop :field, Avo::Fields::BaseField
-  prop :resource, Avo::BaseResource
-  prop :file, _Nilable(_Any)
-  prop :extra_classes, _Nilable(String)
+  prop :field
+  prop :resource
+  prop :file
+  prop :extra_classes
 
   def id
     @field.id

--- a/app/components/avo/fields/common/gravatar_viewer_component.rb
+++ b/app/components/avo/fields/common/gravatar_viewer_component.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class Avo::Fields::Common::GravatarViewerComponent < Avo::BaseComponent
-  prop :md5, _Nilable(String)
-  prop :link, _Nilable(String)
-  prop :default, _Nilable(String)
-  prop :size, _Nilable(Integer)
-  prop :rounded, _Boolean, default: false
-  prop :link_to_record, _Boolean, default: false
-  prop :title, _Nilable(String)
+  prop :md5
+  prop :link
+  prop :default
+  prop :size
+  prop :rounded, default: false
+  prop :link_to_record, default: false
+  prop :title
 end

--- a/app/components/avo/fields/common/heading_component.rb
+++ b/app/components/avo/fields/common/heading_component.rb
@@ -3,7 +3,7 @@
 class Avo::Fields::Common::HeadingComponent < Avo::BaseComponent
   include Avo::Concerns::HasResourceStimulusControllers
 
-  prop :field, Avo::Fields::BaseField
+  prop :field
 
   def after_initialize
     @view = @field.resource.view

--- a/app/components/avo/fields/common/key_value_component.rb
+++ b/app/components/avo/fields/common/key_value_component.rb
@@ -3,7 +3,7 @@
 class Avo::Fields::Common::KeyValueComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
 
-  prop :field, Avo::Fields::BaseField
-  prop :form, _Nilable(ActionView::Helpers::FormBuilder)
-  prop :view, Avo::ViewInquirer, default: Avo::ViewInquirer.new(:show).freeze
+  prop :field
+  prop :form
+  prop :view, default: Avo::ViewInquirer.new(:show).freeze
 end

--- a/app/components/avo/fields/common/progress_bar_component.rb
+++ b/app/components/avo/fields/common/progress_bar_component.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class Avo::Fields::Common::ProgressBarComponent < Avo::BaseComponent
-  prop :value, Integer
-  prop :display_value, _Boolean, default: false
-  prop :value_suffix, _Nilable(String)
-  prop :max, Integer, default: 100
-  prop :view, Avo::ViewInquirer, reader: :public, default: Avo::ViewInquirer.new(:index).freeze
+  prop :value
+  prop :display_value, default: false
+  prop :value_suffix
+  prop :max, default: 100
+  prop :view, reader: :public, default: Avo::ViewInquirer.new(:index).freeze
 
   delegate :show?, :index?, to: :view
 end

--- a/app/components/avo/fields/common/status_viewer_component.rb
+++ b/app/components/avo/fields/common/status_viewer_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Avo::Fields::Common::StatusViewerComponent < Avo::BaseComponent
-  prop :status, String
-  prop :label, String
+  prop :status
+  prop :label
 end

--- a/app/components/avo/fields/tags_field/tag_component.rb
+++ b/app/components/avo/fields/tags_field/tag_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Avo::Fields::TagsField::TagComponent < Avo::BaseComponent
-  prop :label, _Nilable(String)
-  prop :title, _Nilable(String)
+  prop :label
+  prop :title
 end

--- a/app/components/avo/filters_component.rb
+++ b/app/components/avo/filters_component.rb
@@ -3,10 +3,10 @@
 class Avo::FiltersComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
 
-  prop :filters, _Array(Avo::Filters::BaseFilter), default: [].freeze
-  prop :resource, _Nilable(Avo::BaseResource)
-  prop :applied_filters, Hash, default: {}.freeze
-  prop :parent_record, _Nilable(_Any)
+  prop :filters, default: [].freeze
+  prop :resource
+  prop :applied_filters, default: {}.freeze
+  prop :parent_record
 
   def render?
     @filters.present?

--- a/app/components/avo/flash_alerts_component.rb
+++ b/app/components/avo/flash_alerts_component.rb
@@ -3,5 +3,5 @@
 class Avo::FlashAlertsComponent < Avo::BaseComponent
   include Avo::ApplicationHelper
 
-  prop :flashes, ActionDispatch::Flash::FlashHash, default: [].freeze
+  prop :flashes, default: [].freeze
 end

--- a/app/components/avo/index/field_wrapper_component.rb
+++ b/app/components/avo/index/field_wrapper_component.rb
@@ -6,7 +6,7 @@ class Avo::Index::FieldWrapperComponent < Avo::BaseComponent
   prop :dash_if_blank, default: true
   prop :center_content, default: false
   prop :flush, default: false
-  prop :args, nil, :**, default: {}.freeze
+  prop :args, kind: :**, default: {}.freeze
   prop :classes do |value|
     @args&.dig(:class) || ""
   end

--- a/app/components/avo/index/field_wrapper_component.rb
+++ b/app/components/avo/index/field_wrapper_component.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class Avo::Index::FieldWrapperComponent < Avo::BaseComponent
-  prop :field, _Nilable(Avo::Fields::BaseField)
-  prop :resource, _Nilable(Avo::BaseResource)
-  prop :dash_if_blank, _Boolean, default: true
-  prop :center_content, _Boolean, default: false
-  prop :flush, _Boolean, default: false
-  prop :args, Hash, :**, default: {}.freeze
-  prop :classes, _Nilable(String) do |value|
+  prop :field
+  prop :resource
+  prop :dash_if_blank, default: true
+  prop :center_content, default: false
+  prop :flush, default: false
+  prop :args, nil, :**, default: {}.freeze
+  prop :classes do |value|
     @args&.dig(:class) || ""
   end
 

--- a/app/components/avo/index/grid_item_component.rb
+++ b/app/components/avo/index/grid_item_component.rb
@@ -4,11 +4,11 @@ class Avo::Index::GridItemComponent < Avo::BaseComponent
   include Avo::ResourcesHelper
   include Avo::Fields::Concerns::HasHTMLAttributes
 
-  prop :resource, _Nilable(Avo::BaseResource)
-  prop :reflection, _Nilable(ActiveRecord::Reflection::AbstractReflection)
-  prop :parent_record, _Nilable(_Any)
-  prop :parent_resource, _Nilable(Avo::BaseResource)
-  prop :actions, _Nilable(_Array(Avo::BaseAction))
+  prop :resource
+  prop :reflection
+  prop :parent_record
+  prop :parent_resource
+  prop :actions
 
   def after_initialize
     @card = Avo::ExecutionContext.new(target: @resource.grid_view[:card], resource: @resource, record: @resource.record).handle

--- a/app/components/avo/index/resource_controls_component.rb
+++ b/app/components/avo/index/resource_controls_component.rb
@@ -4,12 +4,12 @@ class Avo::Index::ResourceControlsComponent < Avo::ResourceComponent
   include Avo::ApplicationHelper
   include Avo::Concerns::ChecksShowAuthorization
 
-  prop :resource, _Nilable(Avo::BaseResource)
-  prop :reflection, _Nilable(ActiveRecord::Reflection::AbstractReflection)
-  prop :parent_record, _Nilable(_Any)
-  prop :parent_resource, _Nilable(Avo::BaseResource)
-  prop :view_type, Symbol, default: :table
-  prop :actions, _Nilable(_Array(Avo::BaseAction))
+  prop :resource
+  prop :reflection
+  prop :parent_record
+  prop :parent_resource
+  prop :view_type, default: :table
+  prop :actions
 
   def can_detach?
     is_has_many_association? ? super : false

--- a/app/components/avo/index/resource_grid_component.rb
+++ b/app/components/avo/index/resource_grid_component.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Avo::Index::ResourceGridComponent < Avo::BaseComponent
-  prop :resources, _Array(_Nilable(Avo::BaseResource))
-  prop :resource, _Nilable(Avo::BaseResource)
-  prop :reflection, _Nilable(ActiveRecord::Reflection::AbstractReflection)
-  prop :parent_record, _Nilable(_Any)
-  prop :parent_resource, _Nilable(Avo::BaseResource)
-  prop :actions, _Nilable(_Array(Avo::BaseAction)), reader: :public
+  prop :resources
+  prop :resource
+  prop :reflection
+  prop :parent_record
+  prop :parent_resource
+  prop :actions, reader: :public
 end

--- a/app/components/avo/index/resource_table_component.rb
+++ b/app/components/avo/index/resource_table_component.rb
@@ -8,14 +8,14 @@ class Avo::Index::ResourceTableComponent < Avo::BaseComponent
     @header_fields, @table_row_components = cache_table_rows
   end
 
-  prop :resources, _Nilable(_Array(Avo::BaseResource))
-  prop :resource, _Nilable(Avo::BaseResource)
-  prop :reflection, _Nilable(ActiveRecord::Reflection::AbstractReflection)
-  prop :parent_record, _Nilable(_Any)
-  prop :parent_resource, _Nilable(Avo::BaseResource)
-  prop :pagy, _Nilable(Pagy)
-  prop :query, _Nilable(_Any)
-  prop :actions, _Nilable(_Array(Avo::BaseAction))
+  prop :resources
+  prop :resource
+  prop :reflection
+  prop :parent_record
+  prop :parent_resource
+  prop :pagy
+  prop :query
+  prop :actions
 
   def encrypted_query
     # TODO: move this to the resource where we can apply the adapter pattern

--- a/app/components/avo/index/table_row_component.rb
+++ b/app/components/avo/index/table_row_component.rb
@@ -6,13 +6,13 @@ class Avo::Index::TableRowComponent < Avo::BaseComponent
 
   attr_writer :header_fields
 
-  prop :resource, _Nilable(Avo::BaseResource), reader: :public
-  prop :reflection, _Nilable(ActiveRecord::Reflection::AbstractReflection)
-  prop :parent_record, _Nilable(_Any)
-  prop :parent_resource, _Nilable(Avo::BaseResource)
-  prop :actions, _Nilable(_Array(Avo::BaseAction))
-  prop :fields, _Nilable(_Array(Avo::Fields::BaseField))
-  prop :header_fields, _Nilable(_Array(String))
+  prop :resource, reader: :public
+  prop :reflection
+  prop :parent_record
+  prop :parent_resource
+  prop :actions
+  prop :fields
+  prop :header_fields
 
   def resource_controls_component
     Avo::Index::ResourceControlsComponent.new(

--- a/app/components/avo/items/panel_component.rb
+++ b/app/components/avo/items/panel_component.rb
@@ -3,17 +3,17 @@
 class Avo::Items::PanelComponent < Avo::ResourceComponent
   include Avo::ApplicationHelper
 
-  prop :form, _Nilable(ActionView::Helpers::FormBuilder)
-  prop :item, _Nilable(Avo::Resources::Items::Panel)
-  prop :is_main_panel, _Nilable(_Boolean)
-  prop :resource, Avo::BaseResource
-  prop :view, Avo::ViewInquirer
-  prop :actions, _Nilable(_Array(Avo::BaseAction)), reader: :public
-  prop :index, _Nilable(Integer), reader: :public
-  prop :parent_component, _Nilable(ViewComponent::Base)
-  prop :parent_record, _Nilable(_Any)
-  prop :parent_resource, _Nilable(Avo::BaseResource)
-  prop :reflection, _Nilable(ActiveRecord::Reflection::AbstractReflection)
+  prop :form
+  prop :item
+  prop :is_main_panel
+  prop :resource
+  prop :view
+  prop :actions, reader: :public
+  prop :index, reader: :public
+  prop :parent_component
+  prop :parent_record
+  prop :parent_resource
+  prop :reflection
 
   delegate :controls,
     :title,

--- a/app/components/avo/items/visible_items_component.rb
+++ b/app/components/avo/items/visible_items_component.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class Avo::Items::VisibleItemsComponent < Avo::BaseComponent
-  prop :resource, _Nilable(Avo::BaseResource)
-  prop :item, _Nilable(Avo::Concerns::IsResourceItem)
-  prop :view, _Nilable(Avo::ViewInquirer)
-  prop :form, _Nilable(ActionView::Helpers::FormBuilder)
-  prop :field_component_extra_args, _Nilable(Hash), default: {}.freeze
+  prop :resource
+  prop :item
+  prop :view
+  prop :form
+  prop :field_component_extra_args, default: {}.freeze
 end

--- a/app/components/avo/loading_component.rb
+++ b/app/components/avo/loading_component.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Avo::LoadingComponent < Avo::BaseComponent
-  prop :title, _Nilable(String)
+  prop :title
 end

--- a/app/components/avo/modal_component.rb
+++ b/app/components/avo/modal_component.rb
@@ -4,9 +4,9 @@ class Avo::ModalComponent < Avo::BaseComponent
   renders_one :heading
   renders_one :controls
 
-  prop :width, Symbol, default: :md
-  prop :body_class, _Nilable(String)
-  prop :overflow, _Nilable(Symbol), default: :auto
+  prop :width, default: :md
+  prop :body_class
+  prop :overflow, default: :auto
 
   def width_classes
     case @width.to_sym

--- a/app/components/avo/paginator_component.rb
+++ b/app/components/avo/paginator_component.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class Avo::PaginatorComponent < Avo::BaseComponent
-  prop :resource, _Nilable(Avo::BaseResource)
-  prop :parent_record, _Nilable(_Any)
-  prop :pagy, _Nilable(Pagy)
-  prop :turbo_frame, _Nilable(_Union(String, Symbol)) do |frame|
+  prop :resource
+  prop :parent_record
+  prop :pagy
+  prop :turbo_frame do |frame|
     frame.present? ? CGI.escapeHTML(frame) : :_top
   end
-  prop :index_params, _Nilable(Hash)
-  prop :discreet_pagination, _Nilable(_Boolean)
+  prop :index_params
+  prop :discreet_pagination
 
   def change_items_per_page_url(option)
     if @parent_record.present?

--- a/app/components/avo/panel_component.rb
+++ b/app/components/avo/panel_component.rb
@@ -23,7 +23,7 @@ class Avo::PanelComponent < Avo::BaseComponent
   prop :classes
   prop :profile_photo
   prop :cover_photo
-  prop :args, nil, :**, default: {}.freeze
+  prop :args, kind: :**, default: {}.freeze
   prop :name do |value|
     value || @args&.dig(:title)
   end

--- a/app/components/avo/panel_component.rb
+++ b/app/components/avo/panel_component.rb
@@ -15,16 +15,16 @@ class Avo::PanelComponent < Avo::BaseComponent
   renders_one :footer_tools
   renders_one :footer
 
-  prop :description, _Nilable(String)
-  prop :body_classes, _Nilable(String)
-  prop :data, Hash, default: {}.freeze
-  prop :display_breadcrumbs, _Boolean, default: false
-  prop :index, _Nilable(Integer)
-  prop :classes, _Nilable(String)
-  prop :profile_photo, _Nilable(Avo::ProfilePhoto)
-  prop :cover_photo, _Nilable(Avo::CoverPhoto)
-  prop :args, Hash, :**, default: {}.freeze
-  prop :name, _Nilable(_Union(_String, _Integer)) do |value|
+  prop :description
+  prop :body_classes
+  prop :data, default: {}.freeze
+  prop :display_breadcrumbs, default: false
+  prop :index
+  prop :classes
+  prop :profile_photo
+  prop :cover_photo
+  prop :args, nil, :**, default: {}.freeze
+  prop :name do |value|
     value || @args&.dig(:title)
   end
 

--- a/app/components/avo/panel_name_component.rb
+++ b/app/components/avo/panel_name_component.rb
@@ -3,10 +3,10 @@
 class Avo::PanelNameComponent < Avo::BaseComponent
   renders_one :body
 
-  prop :name, _Nilable(_Union(_String, _Integer))
-  prop :url, _Nilable(String)
-  prop :target, Symbol, default: :self do |value|
+  prop :name
+  prop :url
+  prop :target, default: :self do |value|
     value&.to_sym
   end
-  prop :classes, String, default: ""
+  prop :classes, default: ""
 end

--- a/app/components/avo/profile_item_component.rb
+++ b/app/components/avo/profile_item_component.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
 class Avo::ProfileItemComponent < Avo::BaseComponent
-  prop :label, _Nilable(String), reader: :public
-  prop :icon, _Nilable(String), reader: :public
-  prop :path, _Nilable(String), reader: :public
-  prop :active, Symbol, default: :inclusive, reader: :public do |value|
+  prop :label, reader: :public
+  prop :icon, reader: :public
+  prop :path, reader: :public
+  prop :active, default: :inclusive, reader: :public do |value|
     value&.to_sym
   end
-  prop :target, _Nilable(Symbol), reader: :public do |value|
+  prop :target, reader: :public do |value|
     value&.to_sym
   end
-  prop :title, _Nilable(String), reader: :public
-  prop :method, _Nilable(_Union(_String, _Symbol)), reader: :public
-  prop :params, _Nilable(Hash), default: {}.freeze, reader: :public
-  prop :classes, String, default: "", reader: :public
+  prop :title, reader: :public
+  prop :method, reader: :public
+  prop :params, default: {}.freeze, reader: :public
+  prop :classes, default: "", reader: :public
 
   def title
     @title || @label

--- a/app/components/avo/profile_photo_component.rb
+++ b/app/components/avo/profile_photo_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::ProfilePhotoComponent < Avo::BaseComponent
-  prop :profile_photo, _Nilable(Avo::ProfilePhoto)
+  prop :profile_photo
 
   def render?
     @profile_photo.present? && @profile_photo.visible_in_current_view?

--- a/app/components/avo/referrer_params_component.rb
+++ b/app/components/avo/referrer_params_component.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Avo::ReferrerParamsComponent < Avo::BaseComponent
-  prop :back_path, _Nilable(String)
+  prop :back_path
 end

--- a/app/components/avo/resource_sidebar_component.rb
+++ b/app/components/avo/resource_sidebar_component.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class Avo::ResourceSidebarComponent < Avo::BaseComponent
-  prop :resource, _Nilable(Avo::BaseResource)
-  prop :sidebar, _Nilable(Avo::Resources::Items::Sidebar)
-  prop :index, _Nilable(Integer)
-  prop :params, _Nilable(ActionController::Parameters)
-  prop :form, _Nilable(ActionView::Helpers::FormBuilder)
-  prop :view, _Nilable(Avo::ViewInquirer), reader: :public
+  prop :resource
+  prop :sidebar
+  prop :index
+  prop :params
+  prop :form
+  prop :view, reader: :public
 
   def render?
     Avo.license.has_with_trial(:resource_sidebar)

--- a/app/components/avo/row_component.rb
+++ b/app/components/avo/row_component.rb
@@ -3,6 +3,6 @@
 class Avo::RowComponent < Avo::BaseComponent
   renders_one :body
 
-  prop :classes, _Nilable(String)
-  prop :data, Hash, default: {}.freeze
+  prop :classes
+  prop :data, default: {}.freeze
 end

--- a/app/components/avo/row_selector_component.rb
+++ b/app/components/avo/row_selector_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Avo::RowSelectorComponent < Avo::BaseComponent
-  prop :floating, _Boolean, default: false
-  prop :size, Symbol, default: :md
+  prop :floating, default: false
+  prop :size, default: :md
 end

--- a/app/components/avo/sidebar/base_item_component.rb
+++ b/app/components/avo/sidebar/base_item_component.rb
@@ -3,9 +3,8 @@
 class Avo::Sidebar::BaseItemComponent < Avo::BaseComponent
   delegate :collapsable, :collapsed, to: :@item
 
-  # Object = Avo::Menu::BaseItem || ViewComponent::Base
-  prop :item, _Nilable(Object), reader: :public
-  prop :locals, _Nilable(Hash), default: {}.freeze
+  prop :item, reader: :public
+  prop :locals, default: {}.freeze
 
   def after_initialize
     @items = @item.items.select(&:visible?)

--- a/app/components/avo/sidebar/heading_component.rb
+++ b/app/components/avo/sidebar/heading_component.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class Avo::Sidebar::HeadingComponent < Avo::BaseComponent
-  prop :label, _Nilable(String)
-  prop :icon, _Nilable(String)
-  prop :collapsable, _Boolean, default: false
-  prop :collapsed, _Boolean, default: false
-  prop :key, _Nilable(String)
+  prop :label
+  prop :icon
+  prop :collapsable, default: false
+  prop :collapsed, default: false
+  prop :key
 end

--- a/app/components/avo/sidebar/link_component.rb
+++ b/app/components/avo/sidebar/link_component.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 class Avo::Sidebar::LinkComponent < Avo::BaseComponent
-  prop :label, _Nilable(String)
-  prop :path, _Nilable(String)
-  prop :active, Symbol, default: :inclusive do |value|
+  prop :label
+  prop :path
+  prop :active, default: :inclusive do |value|
     value&.to_sym
   end
-  prop :target, _Nilable(Symbol) do |value|
+  prop :target do |value|
     value&.to_sym
   end
-  prop :data, Hash, default: {}.freeze
-  prop :icon, _Nilable(String)
-  prop :args, Hash, :**, default: {}.freeze
+  prop :data, default: {}.freeze
+  prop :icon
+  prop :args, :**, default: {}.freeze
 
   def is_external?
     # If the path contains the scheme, check if it includes the root path or not

--- a/app/components/avo/sidebar/link_component.rb
+++ b/app/components/avo/sidebar/link_component.rb
@@ -11,7 +11,7 @@ class Avo::Sidebar::LinkComponent < Avo::BaseComponent
   end
   prop :data, default: {}.freeze
   prop :icon
-  prop :args, :**, default: {}.freeze
+  prop :args, kind: :**, default: {}.freeze
 
   def is_external?
     # If the path contains the scheme, check if it includes the root path or not

--- a/app/components/avo/sidebar_component.rb
+++ b/app/components/avo/sidebar_component.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Avo::SidebarComponent < Avo::BaseComponent
-  prop :sidebar_open, _Boolean, default: false
-  prop :for_mobile, _Boolean, default: false
+  prop :sidebar_open, default: false
+  prop :for_mobile, default: false
 
   def dashboards
     return [] unless Avo.plugin_manager.installed?(:avo_dashboards)

--- a/app/components/avo/sidebar_profile_component.rb
+++ b/app/components/avo/sidebar_profile_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::SidebarProfileComponent < Avo::BaseComponent
-  prop :user, _Nilable(_Any)
+  prop :user
 
   def avatar
     if @user.respond_to?(:avatar) && @user.avatar.present?

--- a/app/components/avo/tab_group_component.rb
+++ b/app/components/avo/tab_group_component.rb
@@ -3,12 +3,12 @@
 class Avo::TabGroupComponent < Avo::BaseComponent
   delegate :group_param, to: :@group
 
-  prop :resource, Avo::BaseResource, reader: :public
-  prop :group, Avo::Resources::Items::TabGroup, reader: :public
-  prop :index, Integer, reader: :public
-  prop :form, _Nilable(ActionView::Helpers::FormBuilder), reader: :public
-  prop :params, ActionController::Parameters, reader: :public
-  prop :view, Avo::ViewInquirer, reader: :public
+  prop :resource, reader: :public
+  prop :group, reader: :public
+  prop :index, reader: :public
+  prop :form, reader: :public
+  prop :params, reader: :public
+  prop :view, reader: :public
 
   def after_initialize
     group.index = index

--- a/app/components/avo/tab_switcher_component.rb
+++ b/app/components/avo/tab_switcher_component.rb
@@ -7,11 +7,11 @@ class Avo::TabSwitcherComponent < Avo::BaseComponent
   delegate :white_panel_classes, to: :helpers
   delegate :group_param, to: :@group
 
-  prop :resource, Avo::BaseResource
-  prop :group, Avo::Resources::Items::TabGroup
-  prop :current_tab, Avo::Resources::Items::Tab
-  prop :active_tab_name, String, reader: :public
-  prop :view, Avo::ViewInquirer
+  prop :resource
+  prop :group
+  prop :current_tab
+  prop :active_tab_name, reader: :public
+  prop :view
 
   #TOD: helper to record:
   def tab_path(tab)

--- a/app/components/avo/turbo_frame_wrapper_component.rb
+++ b/app/components/avo/turbo_frame_wrapper_component.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Avo::TurboFrameWrapperComponent < Avo::BaseComponent
-  prop :name, nil, :positional
+  prop :name, kind: :positional
 end

--- a/app/components/avo/turbo_frame_wrapper_component.rb
+++ b/app/components/avo/turbo_frame_wrapper_component.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Avo::TurboFrameWrapperComponent < Avo::BaseComponent
-  prop :name, _Nilable(String), :positional
+  prop :name, nil, :positional
 end

--- a/app/components/avo/views/resource_edit_component.rb
+++ b/app/components/avo/views/resource_edit_component.rb
@@ -3,11 +3,11 @@
 class Avo::Views::ResourceEditComponent < Avo::ResourceComponent
   include Avo::ApplicationHelper
 
-  prop :resource, _Nilable(Avo::BaseResource)
-  prop :record, _Nilable(_Any)
-  prop :actions, _Array(Avo::BaseAction), default: [].freeze
-  prop :view, Avo::ViewInquirer, default: Avo::ViewInquirer.new(:edit).freeze
-  prop :display_breadcrumbs, _Boolean, default: true, reader: :public
+  prop :resource
+  prop :record
+  prop :actions, default: [].freeze
+  prop :view, default: Avo::ViewInquirer.new(:edit).freeze
+  prop :display_breadcrumbs, default: true, reader: :public
 
   def after_initialize
     @display_breadcrumbs = @reflection.blank? && display_breadcrumbs

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -4,25 +4,20 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
   include Avo::ResourcesHelper
   include Avo::ApplicationHelper
 
-  prop :resource, _Nilable(Avo::BaseResource)
-  prop :resources, _Nilable(_Array(Avo::BaseResource))
-  # This is sometimes an array of records or an ActiveRecord::Relation
-  prop :records, Enumerable, default: [].freeze
-  prop :pagy, _Nilable(Pagy)
-  prop :index_params, Hash, default: {}.freeze
-  prop :filters, _Array(Avo::Filters::BaseFilter), default: [].freeze
-  prop :actions, _Array(Avo::BaseAction), default: [].freeze
-  prop :reflection, _Nilable(ActiveRecord::Reflection::AbstractReflection)
-  prop :turbo_frame, _Nilable(String), default: ""
-  prop :parent_record, _Nilable(_Any)
-  prop :parent_resource, _Nilable(Avo::BaseResource)
-  prop :applied_filters, Hash, default: {}.freeze
-  prop :query, _Nilable(_Any), reader: :public
-  # This should be
-  # prop :scopes, _Nilable(_Array(Avo::Advanced::Scopes::BaseScope)), reader: :public
-  # However, Avo::Advanced::Scopes::BaseScope raises an error because
-  # that constant is only available in the advanced repo
-  prop :scopes, _Nilable(Object), reader: :public
+  prop :resource
+  prop :resources
+  prop :records, default: [].freeze
+  prop :pagy
+  prop :index_params, default: {}.freeze
+  prop :filters, default: [].freeze
+  prop :actions, default: [].freeze
+  prop :reflection
+  prop :turbo_frame, default: ""
+  prop :parent_record
+  prop :parent_resource
+  prop :applied_filters, default: {}.freeze
+  prop :query, reader: :public
+  prop :scopes, reader: :public
 
   def title
     if @reflection.present?

--- a/app/components/avo/views/resource_show_component.rb
+++ b/app/components/avo/views/resource_show_component.rb
@@ -5,12 +5,12 @@ class Avo::Views::ResourceShowComponent < Avo::ResourceComponent
 
   attr_reader :display_breadcrumbs
 
-  prop :resource, _Nilable(Avo::BaseResource)
-  prop :reflection, _Nilable(ActiveRecord::Reflection::AbstractReflection)
-  prop :parent_resource, _Nilable(Avo::BaseResource)
-  prop :parent_record, _Nilable(_Any)
-  prop :resource_panel, _Nilable(_Array(Avo::BaseAction)), reader: :public
-  prop :actions, _Array(Avo::BaseAction), default: [].freeze, reader: :public
+  prop :resource
+  prop :reflection
+  prop :parent_resource
+  prop :parent_record
+  prop :resource_panel, reader: :public
+  prop :actions, default: [].freeze, reader: :public
 
   def after_initialize
     @view = Avo::ViewInquirer.new("show")

--- a/avo.gemspec
+++ b/avo.gemspec
@@ -47,4 +47,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "meta-tags"
   spec.add_dependency "docile"
   spec.add_dependency "inline_svg"
+  spec.add_dependency "prop_initializer"
 end

--- a/avo.gemspec
+++ b/avo.gemspec
@@ -45,7 +45,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "turbo_power", ">= 0.6.0"
   spec.add_dependency "addressable"
   spec.add_dependency "meta-tags"
-  spec.add_dependency "literal", "~> 0.2"
   spec.add_dependency "docile"
   spec.add_dependency "inline_svg"
 end

--- a/gemfiles/rails_6.1_ruby_3.1.4.gemfile
+++ b/gemfiles/rails_6.1_ruby_3.1.4.gemfile
@@ -45,6 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
+gem "literal", git: "https://github.com/avo-hq/literal.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_6.1_ruby_3.1.4.gemfile
+++ b/gemfiles/rails_6.1_ruby_3.1.4.gemfile
@@ -45,7 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
-gem "avo-initializer", git: "https://github.com/avo-hq/avo-initializer.git"
+gem "prop_initializer", branch: "main", git: "https://github.com/avo-hq/prop_initializer.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_6.1_ruby_3.1.4.gemfile
+++ b/gemfiles/rails_6.1_ruby_3.1.4.gemfile
@@ -45,7 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
-gem "literal", git: "https://github.com/avo-hq/literal.git"
+gem "avo-initializer", git: "https://github.com/avo-hq/avo-initializer.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_6.1_ruby_3.1.4.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_3.1.4.gemfile.lock
@@ -5,6 +5,12 @@ GIT
     acts-as-taggable-on (10.0.0)
       activerecord (>= 6.1, < 8)
 
+GIT
+  remote: https://github.com/avo-hq/literal.git
+  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  specs:
+    literal (0.2.1)
+
 PATH
   remote: ../pluggy
   specs:
@@ -349,7 +355,6 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    literal (0.2.1)
     logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -687,6 +692,7 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
+  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/gemfiles/rails_6.1_ruby_3.1.4.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_3.1.4.gemfile.lock
@@ -6,10 +6,12 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/avo-initializer.git
-  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
+  remote: https://github.com/avo-hq/prop_initializer.git
+  revision: ec6808bc18b00ee53123497e885305d4d63da9de
+  branch: main
   specs:
-    avo-initializer (0.1.0)
+    prop_initializer (0.1.0)
+      zeitwerk (>= 2.6.18)
 
 PATH
   remote: ../pluggy
@@ -656,7 +658,6 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
-  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -700,6 +701,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pluggy!
   prefixed_ids
+  prop_initializer!
   psych (< 4)
   puma (~> 6.4)
   rails (~> 6.1)

--- a/gemfiles/rails_6.1_ruby_3.1.4.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_3.1.4.gemfile.lock
@@ -6,10 +6,10 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/literal.git
-  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  remote: https://github.com/avo-hq/avo-initializer.git
+  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
   specs:
-    literal (0.2.1)
+    avo-initializer (0.1.0)
 
 PATH
   remote: ../pluggy
@@ -27,7 +27,6 @@ PATH
       addressable
       docile
       inline_svg
-      literal (~> 0.2)
       meta-tags
       pagy (>= 7.0.0)
       turbo-rails (>= 2.0.0)
@@ -657,6 +656,7 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
+  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -692,7 +692,6 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
-  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/gemfiles/rails_6.1_ruby_3.3.0.gemfile
+++ b/gemfiles/rails_6.1_ruby_3.3.0.gemfile
@@ -45,6 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
+gem "literal", git: "https://github.com/avo-hq/literal.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_6.1_ruby_3.3.0.gemfile
+++ b/gemfiles/rails_6.1_ruby_3.3.0.gemfile
@@ -45,7 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
-gem "avo-initializer", git: "https://github.com/avo-hq/avo-initializer.git"
+gem "prop_initializer", branch: "main", git: "https://github.com/avo-hq/prop_initializer.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_6.1_ruby_3.3.0.gemfile
+++ b/gemfiles/rails_6.1_ruby_3.3.0.gemfile
@@ -45,7 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
-gem "literal", git: "https://github.com/avo-hq/literal.git"
+gem "avo-initializer", git: "https://github.com/avo-hq/avo-initializer.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_6.1_ruby_3.3.0.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_3.3.0.gemfile.lock
@@ -6,10 +6,12 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/avo-initializer.git
-  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
+  remote: https://github.com/avo-hq/prop_initializer.git
+  revision: ec6808bc18b00ee53123497e885305d4d63da9de
+  branch: main
   specs:
-    avo-initializer (0.1.0)
+    prop_initializer (0.1.0)
+      zeitwerk (>= 2.6.18)
 
 PATH
   remote: ../pluggy
@@ -629,7 +631,6 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
-  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -673,6 +674,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pluggy!
   prefixed_ids
+  prop_initializer!
   psych (< 4)
   puma (~> 6.4)
   rails (~> 6.1)

--- a/gemfiles/rails_6.1_ruby_3.3.0.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_3.3.0.gemfile.lock
@@ -5,6 +5,12 @@ GIT
     acts-as-taggable-on (10.0.0)
       activerecord (>= 6.1, < 8)
 
+GIT
+  remote: https://github.com/avo-hq/literal.git
+  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  specs:
+    literal (0.2.1)
+
 PATH
   remote: ../pluggy
   specs:
@@ -323,7 +329,6 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    literal (0.2.1)
     logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -660,6 +665,7 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
+  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/gemfiles/rails_6.1_ruby_3.3.0.gemfile.lock
+++ b/gemfiles/rails_6.1_ruby_3.3.0.gemfile.lock
@@ -6,10 +6,10 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/literal.git
-  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  remote: https://github.com/avo-hq/avo-initializer.git
+  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
   specs:
-    literal (0.2.1)
+    avo-initializer (0.1.0)
 
 PATH
   remote: ../pluggy
@@ -27,7 +27,6 @@ PATH
       addressable
       docile
       inline_svg
-      literal (~> 0.2)
       meta-tags
       pagy (>= 7.0.0)
       turbo-rails (>= 2.0.0)
@@ -630,6 +629,7 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
+  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -665,7 +665,6 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
-  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/gemfiles/rails_7.1_ruby_3.1.4.gemfile
+++ b/gemfiles/rails_7.1_ruby_3.1.4.gemfile
@@ -45,6 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
+gem "literal", git: "https://github.com/avo-hq/literal.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_7.1_ruby_3.1.4.gemfile
+++ b/gemfiles/rails_7.1_ruby_3.1.4.gemfile
@@ -45,7 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
-gem "avo-initializer", git: "https://github.com/avo-hq/avo-initializer.git"
+gem "prop_initializer", branch: "main", git: "https://github.com/avo-hq/prop_initializer.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_7.1_ruby_3.1.4.gemfile
+++ b/gemfiles/rails_7.1_ruby_3.1.4.gemfile
@@ -45,7 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
-gem "literal", git: "https://github.com/avo-hq/literal.git"
+gem "avo-initializer", git: "https://github.com/avo-hq/avo-initializer.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_7.1_ruby_3.1.4.gemfile.lock
+++ b/gemfiles/rails_7.1_ruby_3.1.4.gemfile.lock
@@ -6,10 +6,12 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/avo-initializer.git
-  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
+  remote: https://github.com/avo-hq/prop_initializer.git
+  revision: ec6808bc18b00ee53123497e885305d4d63da9de
+  branch: main
   specs:
-    avo-initializer (0.1.0)
+    prop_initializer (0.1.0)
+      zeitwerk (>= 2.6.18)
 
 PATH
   remote: ../pluggy
@@ -677,7 +679,6 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
-  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -721,6 +722,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pluggy!
   prefixed_ids
+  prop_initializer!
   psych (< 4)
   puma (~> 6.4)
   rails (~> 7.1)

--- a/gemfiles/rails_7.1_ruby_3.1.4.gemfile.lock
+++ b/gemfiles/rails_7.1_ruby_3.1.4.gemfile.lock
@@ -5,6 +5,12 @@ GIT
     acts-as-taggable-on (10.0.0)
       activerecord (>= 6.1, < 8)
 
+GIT
+  remote: https://github.com/avo-hq/literal.git
+  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  specs:
+    literal (0.2.1)
+
 PATH
   remote: ../pluggy
   specs:
@@ -362,7 +368,6 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    literal (0.2.1)
     logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -708,6 +713,7 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
+  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/gemfiles/rails_7.1_ruby_3.1.4.gemfile.lock
+++ b/gemfiles/rails_7.1_ruby_3.1.4.gemfile.lock
@@ -6,10 +6,10 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/literal.git
-  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  remote: https://github.com/avo-hq/avo-initializer.git
+  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
   specs:
-    literal (0.2.1)
+    avo-initializer (0.1.0)
 
 PATH
   remote: ../pluggy
@@ -27,7 +27,6 @@ PATH
       addressable
       docile
       inline_svg
-      literal (~> 0.2)
       meta-tags
       pagy (>= 7.0.0)
       turbo-rails (>= 2.0.0)
@@ -678,6 +677,7 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
+  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -713,7 +713,6 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
-  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/gemfiles/rails_7.1_ruby_3.3.0.gemfile
+++ b/gemfiles/rails_7.1_ruby_3.3.0.gemfile
@@ -45,6 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
+gem "literal", git: "https://github.com/avo-hq/literal.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_7.1_ruby_3.3.0.gemfile
+++ b/gemfiles/rails_7.1_ruby_3.3.0.gemfile
@@ -45,7 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
-gem "avo-initializer", git: "https://github.com/avo-hq/avo-initializer.git"
+gem "prop_initializer", branch: "main", git: "https://github.com/avo-hq/prop_initializer.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_7.1_ruby_3.3.0.gemfile
+++ b/gemfiles/rails_7.1_ruby_3.3.0.gemfile
@@ -45,7 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
-gem "literal", git: "https://github.com/avo-hq/literal.git"
+gem "avo-initializer", git: "https://github.com/avo-hq/avo-initializer.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_7.1_ruby_3.3.0.gemfile.lock
+++ b/gemfiles/rails_7.1_ruby_3.3.0.gemfile.lock
@@ -5,6 +5,12 @@ GIT
     acts-as-taggable-on (10.0.0)
       activerecord (>= 6.1, < 8)
 
+GIT
+  remote: https://github.com/avo-hq/literal.git
+  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  specs:
+    literal (0.2.1)
+
 PATH
   remote: ../pluggy
   specs:
@@ -336,7 +342,6 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    literal (0.2.1)
     logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -681,6 +686,7 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
+  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/gemfiles/rails_7.1_ruby_3.3.0.gemfile.lock
+++ b/gemfiles/rails_7.1_ruby_3.3.0.gemfile.lock
@@ -6,10 +6,12 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/avo-initializer.git
-  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
+  remote: https://github.com/avo-hq/prop_initializer.git
+  revision: ec6808bc18b00ee53123497e885305d4d63da9de
+  branch: main
   specs:
-    avo-initializer (0.1.0)
+    prop_initializer (0.1.0)
+      zeitwerk (>= 2.6.18)
 
 PATH
   remote: ../pluggy
@@ -650,7 +652,6 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
-  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -694,6 +695,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pluggy!
   prefixed_ids
+  prop_initializer!
   psych (< 4)
   puma (~> 6.4)
   rails (~> 7.1)

--- a/gemfiles/rails_7.1_ruby_3.3.0.gemfile.lock
+++ b/gemfiles/rails_7.1_ruby_3.3.0.gemfile.lock
@@ -6,10 +6,10 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/literal.git
-  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  remote: https://github.com/avo-hq/avo-initializer.git
+  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
   specs:
-    literal (0.2.1)
+    avo-initializer (0.1.0)
 
 PATH
   remote: ../pluggy
@@ -27,7 +27,6 @@ PATH
       addressable
       docile
       inline_svg
-      literal (~> 0.2)
       meta-tags
       pagy (>= 7.0.0)
       turbo-rails (>= 2.0.0)
@@ -651,6 +650,7 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
+  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -686,7 +686,6 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
-  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/gemfiles/rails_7.2.0.beta2_ruby_3.1.4.gemfile
+++ b/gemfiles/rails_7.2.0.beta2_ruby_3.1.4.gemfile
@@ -45,6 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
+gem "literal", git: "https://github.com/avo-hq/literal.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_7.2.0.beta2_ruby_3.1.4.gemfile
+++ b/gemfiles/rails_7.2.0.beta2_ruby_3.1.4.gemfile
@@ -45,7 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
-gem "avo-initializer", git: "https://github.com/avo-hq/avo-initializer.git"
+gem "prop_initializer", branch: "main", git: "https://github.com/avo-hq/prop_initializer.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_7.2.0.beta2_ruby_3.1.4.gemfile
+++ b/gemfiles/rails_7.2.0.beta2_ruby_3.1.4.gemfile
@@ -45,7 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
-gem "literal", git: "https://github.com/avo-hq/literal.git"
+gem "avo-initializer", git: "https://github.com/avo-hq/avo-initializer.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_7.2.0.beta2_ruby_3.1.4.gemfile.lock
+++ b/gemfiles/rails_7.2.0.beta2_ruby_3.1.4.gemfile.lock
@@ -6,10 +6,12 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/avo-initializer.git
-  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
+  remote: https://github.com/avo-hq/prop_initializer.git
+  revision: ec6808bc18b00ee53123497e885305d4d63da9de
+  branch: main
   specs:
-    avo-initializer (0.1.0)
+    prop_initializer (0.1.0)
+      zeitwerk (>= 2.6.18)
 
 PATH
   remote: ../pluggy
@@ -650,7 +652,6 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
-  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -694,6 +695,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pluggy!
   prefixed_ids
+  prop_initializer!
   psych (< 4)
   puma (~> 6.4)
   rails (~> 7.2.0.beta2)

--- a/gemfiles/rails_7.2.0.beta2_ruby_3.1.4.gemfile.lock
+++ b/gemfiles/rails_7.2.0.beta2_ruby_3.1.4.gemfile.lock
@@ -5,6 +5,12 @@ GIT
     acts-as-taggable-on (10.0.0)
       activerecord (>= 6.1, < 8)
 
+GIT
+  remote: https://github.com/avo-hq/literal.git
+  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  specs:
+    literal (0.2.1)
+
 PATH
   remote: ../pluggy
   specs:
@@ -336,7 +342,6 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    literal (0.2.1)
     logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -681,6 +686,7 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
+  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/gemfiles/rails_7.2.0.beta2_ruby_3.1.4.gemfile.lock
+++ b/gemfiles/rails_7.2.0.beta2_ruby_3.1.4.gemfile.lock
@@ -6,10 +6,10 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/literal.git
-  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  remote: https://github.com/avo-hq/avo-initializer.git
+  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
   specs:
-    literal (0.2.1)
+    avo-initializer (0.1.0)
 
 PATH
   remote: ../pluggy
@@ -27,7 +27,6 @@ PATH
       addressable
       docile
       inline_svg
-      literal (~> 0.2)
       meta-tags
       pagy (>= 7.0.0)
       turbo-rails (>= 2.0.0)
@@ -651,6 +650,7 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
+  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -686,7 +686,6 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
-  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/gemfiles/rails_7.2.0.beta2_ruby_3.3.0.gemfile
+++ b/gemfiles/rails_7.2.0.beta2_ruby_3.3.0.gemfile
@@ -45,6 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
+gem "literal", git: "https://github.com/avo-hq/literal.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_7.2.0.beta2_ruby_3.3.0.gemfile
+++ b/gemfiles/rails_7.2.0.beta2_ruby_3.3.0.gemfile
@@ -45,7 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
-gem "avo-initializer", git: "https://github.com/avo-hq/avo-initializer.git"
+gem "prop_initializer", branch: "main", git: "https://github.com/avo-hq/prop_initializer.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_7.2.0.beta2_ruby_3.3.0.gemfile
+++ b/gemfiles/rails_7.2.0.beta2_ruby_3.3.0.gemfile
@@ -45,7 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
-gem "literal", git: "https://github.com/avo-hq/literal.git"
+gem "avo-initializer", git: "https://github.com/avo-hq/avo-initializer.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_7.2.0.beta2_ruby_3.3.0.gemfile.lock
+++ b/gemfiles/rails_7.2.0.beta2_ruby_3.3.0.gemfile.lock
@@ -6,10 +6,12 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/avo-initializer.git
-  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
+  remote: https://github.com/avo-hq/prop_initializer.git
+  revision: ec6808bc18b00ee53123497e885305d4d63da9de
+  branch: main
   specs:
-    avo-initializer (0.1.0)
+    prop_initializer (0.1.0)
+      zeitwerk (>= 2.6.18)
 
 PATH
   remote: ../pluggy
@@ -650,7 +652,6 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
-  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -694,6 +695,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pluggy!
   prefixed_ids
+  prop_initializer!
   psych (< 4)
   puma (~> 6.4)
   rails (~> 7.2.0.beta2)

--- a/gemfiles/rails_7.2.0.beta2_ruby_3.3.0.gemfile.lock
+++ b/gemfiles/rails_7.2.0.beta2_ruby_3.3.0.gemfile.lock
@@ -5,6 +5,12 @@ GIT
     acts-as-taggable-on (10.0.0)
       activerecord (>= 6.1, < 8)
 
+GIT
+  remote: https://github.com/avo-hq/literal.git
+  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  specs:
+    literal (0.2.1)
+
 PATH
   remote: ../pluggy
   specs:
@@ -336,7 +342,6 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    literal (0.2.1)
     logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -681,6 +686,7 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
+  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/gemfiles/rails_7.2.0.beta2_ruby_3.3.0.gemfile.lock
+++ b/gemfiles/rails_7.2.0.beta2_ruby_3.3.0.gemfile.lock
@@ -6,10 +6,10 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/literal.git
-  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  remote: https://github.com/avo-hq/avo-initializer.git
+  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
   specs:
-    literal (0.2.1)
+    avo-initializer (0.1.0)
 
 PATH
   remote: ../pluggy
@@ -27,7 +27,6 @@ PATH
       addressable
       docile
       inline_svg
-      literal (~> 0.2)
       meta-tags
       pagy (>= 7.0.0)
       turbo-rails (>= 2.0.0)
@@ -651,6 +650,7 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
+  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -686,7 +686,6 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
-  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/gemfiles/rails_8.0_ruby_3.1.4.gemfile
+++ b/gemfiles/rails_8.0_ruby_3.1.4.gemfile
@@ -45,6 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
+gem "literal", git: "https://github.com/avo-hq/literal.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_8.0_ruby_3.1.4.gemfile
+++ b/gemfiles/rails_8.0_ruby_3.1.4.gemfile
@@ -45,7 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
-gem "avo-initializer", git: "https://github.com/avo-hq/avo-initializer.git"
+gem "prop_initializer", branch: "main", git: "https://github.com/avo-hq/prop_initializer.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_8.0_ruby_3.1.4.gemfile
+++ b/gemfiles/rails_8.0_ruby_3.1.4.gemfile
@@ -45,7 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
-gem "literal", git: "https://github.com/avo-hq/literal.git"
+gem "avo-initializer", git: "https://github.com/avo-hq/avo-initializer.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_8.0_ruby_3.1.4.gemfile.lock
+++ b/gemfiles/rails_8.0_ruby_3.1.4.gemfile.lock
@@ -6,10 +6,10 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/literal.git
-  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  remote: https://github.com/avo-hq/avo-initializer.git
+  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
   specs:
-    literal (0.2.1)
+    avo-initializer (0.1.0)
 
 GIT
   remote: https://github.com/rails/rails.git
@@ -126,7 +126,6 @@ PATH
       addressable
       docile
       inline_svg
-      literal (~> 0.2)
       meta-tags
       pagy (>= 7.0.0)
       turbo-rails (>= 2.0.0)
@@ -659,6 +658,7 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
+  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -694,7 +694,6 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
-  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/gemfiles/rails_8.0_ruby_3.1.4.gemfile.lock
+++ b/gemfiles/rails_8.0_ruby_3.1.4.gemfile.lock
@@ -6,10 +6,12 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/avo-initializer.git
-  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
+  remote: https://github.com/avo-hq/prop_initializer.git
+  revision: ec6808bc18b00ee53123497e885305d4d63da9de
+  branch: main
   specs:
-    avo-initializer (0.1.0)
+    prop_initializer (0.1.0)
+      zeitwerk (>= 2.6.18)
 
 GIT
   remote: https://github.com/rails/rails.git
@@ -658,7 +660,6 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
-  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -702,6 +703,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pluggy!
   prefixed_ids
+  prop_initializer!
   psych (< 4)
   puma (~> 6.4)
   rails!

--- a/gemfiles/rails_8.0_ruby_3.1.4.gemfile.lock
+++ b/gemfiles/rails_8.0_ruby_3.1.4.gemfile.lock
@@ -6,6 +6,12 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
+  remote: https://github.com/avo-hq/literal.git
+  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  specs:
+    literal (0.2.1)
+
+GIT
   remote: https://github.com/rails/rails.git
   revision: b88d9af34fbc1c84ce2769ba02584eab2c28ac6e
   branch: main
@@ -365,7 +371,6 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    literal (0.2.1)
     logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -689,6 +694,7 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
+  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/gemfiles/rails_8.0_ruby_3.3.0.gemfile
+++ b/gemfiles/rails_8.0_ruby_3.3.0.gemfile
@@ -45,6 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
+gem "literal", git: "https://github.com/avo-hq/literal.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_8.0_ruby_3.3.0.gemfile
+++ b/gemfiles/rails_8.0_ruby_3.3.0.gemfile
@@ -45,7 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
-gem "avo-initializer", git: "https://github.com/avo-hq/avo-initializer.git"
+gem "prop_initializer", branch: "main", git: "https://github.com/avo-hq/prop_initializer.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_8.0_ruby_3.3.0.gemfile
+++ b/gemfiles/rails_8.0_ruby_3.3.0.gemfile
@@ -45,7 +45,7 @@ gem "avo-money_field"
 gem "avo-record_link_field"
 gem "pagy", "> 8"
 gem "csv"
-gem "literal", git: "https://github.com/avo-hq/literal.git"
+gem "avo-initializer", git: "https://github.com/avo-hq/avo-initializer.git"
 gem "psych", "< 4"
 
 group :development do

--- a/gemfiles/rails_8.0_ruby_3.3.0.gemfile.lock
+++ b/gemfiles/rails_8.0_ruby_3.3.0.gemfile.lock
@@ -6,10 +6,10 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/literal.git
-  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  remote: https://github.com/avo-hq/avo-initializer.git
+  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
   specs:
-    literal (0.2.1)
+    avo-initializer (0.1.0)
 
 GIT
   remote: https://github.com/rails/rails.git
@@ -126,7 +126,6 @@ PATH
       addressable
       docile
       inline_svg
-      literal (~> 0.2)
       meta-tags
       pagy (>= 7.0.0)
       turbo-rails (>= 2.0.0)
@@ -659,6 +658,7 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
+  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -694,7 +694,6 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
-  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)

--- a/gemfiles/rails_8.0_ruby_3.3.0.gemfile.lock
+++ b/gemfiles/rails_8.0_ruby_3.3.0.gemfile.lock
@@ -6,10 +6,12 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
-  remote: https://github.com/avo-hq/avo-initializer.git
-  revision: da1dd681c06b34a09e4f8aee28e609cff4bdff1b
+  remote: https://github.com/avo-hq/prop_initializer.git
+  revision: ec6808bc18b00ee53123497e885305d4d63da9de
+  branch: main
   specs:
-    avo-initializer (0.1.0)
+    prop_initializer (0.1.0)
+      zeitwerk (>= 2.6.18)
 
 GIT
   remote: https://github.com/rails/rails.git
@@ -658,7 +660,6 @@ DEPENDENCIES
   annotate
   appraisal
   avo!
-  avo-initializer!
   avo-money_field
   avo-record_link_field
   aws-sdk-s3
@@ -702,6 +703,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pluggy!
   prefixed_ids
+  prop_initializer!
   psych (< 4)
   puma (~> 6.4)
   rails!

--- a/gemfiles/rails_8.0_ruby_3.3.0.gemfile.lock
+++ b/gemfiles/rails_8.0_ruby_3.3.0.gemfile.lock
@@ -6,6 +6,12 @@ GIT
       activerecord (>= 6.1, < 8)
 
 GIT
+  remote: https://github.com/avo-hq/literal.git
+  revision: e4765622b03ae597a13f4601f0302148a7c663dc
+  specs:
+    literal (0.2.1)
+
+GIT
   remote: https://github.com/rails/rails.git
   revision: b88d9af34fbc1c84ce2769ba02584eab2c28ac6e
   branch: main
@@ -365,7 +371,6 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    literal (0.2.1)
     logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -689,6 +694,7 @@ DEPENDENCIES
   jsbundling-rails
   launchy
   listen (>= 3.5.1)
+  literal!
   mapkick-rb (~> 0.1.4)
   meta-tags
   money-rails (~> 1.12)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Remove `spec.add_dependency "literal", "~> 0.2"` in favor of `spec.add_dependency "prop_initializer"`
- Use [prop_initilizer](https://github.com/avo-hq/prop_initializer) in favor of [literal](https://github.com/joeldrapper/literal/)
- Remove types from components `prop`s