### PR TITLE
feature: process search results

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -9,14 +9,22 @@ module Avo
     before_action :set_resource, only: :show
 
     def show
-      render json: search_resources([resource])
+      render json: search_resources([resource], request:)
     rescue => error
       render_error _label: error.message
     end
 
+    def process_results(results, request:)
+      results
+    end
+
     private
 
-    def search_resources(resources)
+    def search_resources(resources, request: nil)
+      process_results search_results(resources, request:), request:
+    end
+
+    def search_results(resources, request: nil)
       resources
         .map do |resource|
           # Apply authorization

--- a/lib/avo/resources/resource_manager.rb
+++ b/lib/avo/resources/resource_manager.rb
@@ -101,6 +101,15 @@ module Avo
       end
 
       # Returns the Avo resource by singular snake_cased name
+      #
+      # get_resource_by_name('z posts') => instance of Avo::Resources::ZPost
+      def get_resource_by_plural_name(name)
+        resources.find do |resource|
+          resource.plural_name == name
+        end
+      end
+
+      # Returns the Avo resource by singular snake_cased name
       # From all the resources that use the same model_class, it will fetch the first one in alphabetical order
       #
       # get_resource_by_name('User') => instance of Avo::Resources::User


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo/issues/3301
Related PR: https://github.com/avo-hq/avo-pro/pull/92

You can now monkeypatch the `process_results` method with something like this:

```ruby
# avo.rb initializer
Rails.configuration.to_prepare do
  Avo::SearchController.prepend SearchControllerExtensions
end

# app/controllers/concerns/search_controller_extensions.rb
module SearchControllerExtensions
  def process_results(resources, request: nil)
    regex = /.*\/resources\/(.*).*/

      if request&.referrer.present?
        resource_path = request.referrer.match(regex).captures.first

        if resource_path.present?
          resource_class = Avo.resource_manager.get_resource_by_plural_name resource_path
        end
      end
    results = super
	#  {"posts": {...}, "users": {...}
    
    # process results somehow to make the resource you want stand out

    # return the results
	results
  end
end
```

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
