### PR TITLE
fix: fetch all display fields on preview

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -214,6 +214,8 @@ module Avo
     def preview
       @resource.hydrate(record: @record, view: Avo::ViewInquirer.new(:show), user: _current_user, params: params)
 
+      @preview_fields = @resource.get_preview_fields
+
       render layout: params[:turbo_frame].blank?
     end
 

--- a/app/views/avo/base/preview.html.erb
+++ b/app/views/avo/base/preview.html.erb
@@ -4,9 +4,9 @@
       <div class="text-md font-semibold uppercase text-gray-800">Previewing <%= @resource.record_title %></div>
     <% end %>
 
-    <% if @resource.get_preview_fields.present? %>
+    <% if @preview_fields.present? %>
       <div class="mt-0 divide-y border-t">
-        <% @resource.get_preview_fields.each_with_index do |field, index| %>
+        <% @preview_fields.each_with_index do |field, index| %>
           <%= render field
             .hydrate(
               resource: @resource,

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -298,9 +298,17 @@ module Avo
       end
 
       def fetch_fields
+        if view.preview?
+          [:fields, :index_fields, :show_fields, :display_fields].each do |fields_method|
+            send(fields_method) if respond_to?(fields_method)
+          end
+
+          return
+        end
+
         possible_methods_for_view = VIEW_METHODS_MAPPING[view.to_sym]
 
-        # Safe navigation operator is used because the view can be "destroy" or "preview"
+        # Safe navigation operator is used because the view can be "destroy"
         possible_methods_for_view&.each do |method_for_view|
           return send(method_for_view) if respond_to?(method_for_view)
         end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2487

Call all display fields methods when searching for preview fields.

As a performance improvement, I refactored the code to call `@resource.get_preview_fields` only once per preview request instead of twice.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
