### PR TITLE
refactor: callable `disabled_features`

### DIFF
--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -36,7 +36,7 @@ module Avo
     attr_accessor :display_license_request_timeout_error
     attr_accessor :current_user_resource_name
     attr_accessor :raise_error_on_missing_policy
-    attr_accessor :disabled_features
+    attr_writer :disabled_features
     attr_accessor :buttons_on_form_footers
     attr_accessor :main_menu
     attr_accessor :profile_menu
@@ -155,8 +155,12 @@ module Avo
       @root_path
     end
 
+    def disabled_features
+      Avo::ExecutionContext.new(target: @disabled_features).handle
+    end
+
     def feature_enabled?(feature)
-      !@disabled_features.map(&:to_sym).include?(feature.to_sym)
+      !disabled_features.map(&:to_sym).include?(feature.to_sym)
     end
 
     def branding


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Callable `disabled_features`

```ruby
Avo.configure do |config|
  config.disabled_features = -> { current_user.is_admin? ? [] : [:global_search] }
end
```

Tests: https://github.com/avo-hq/avo-pro/pull/93
Docs: https://github.com/avo-hq/docs.avohq.io/commit/1432973377a6769669e55fef6b673190a185a293