### PR TITLE
✨ Controls placement on resource level

### DIFF
--- a/app/components/avo/index/table_row_component.html.erb
+++ b/app/components/avo/index/table_row_component.html.erb
@@ -1,7 +1,4 @@
 <%# hover:z-[21] removed from tr class to solve flickering actions component on row controls and z-20 changed to z-21%>
-<%
-  resource_controls_placement = @resource.controls_placement || Avo.configuration.resource_controls_placement
-%>
 
 <%= content_tag :tr,
   class: class_names("bg-white hover:bg-gray-50 hover:shadow-row z-21 border-b", {"cursor-pointer": click_row_to_view_record}),
@@ -23,7 +20,7 @@
       </div>
     </td>
   <% end %>
-  <% if resource_controls_placement == :left %>
+  <% if @resource.resource_controls_render_on_the_left? %>
     <td class="text-right whitespace-nowrap w-px" data-control="resource-controls">
       <div class="flex items-center justify-end flex-grow-0 h-full">
         <%= render resource_controls_component %>
@@ -45,7 +42,7 @@
       <td class="text-center">—</td>
     <% end %>
   <% end %>
-  <% if resource_controls_placement == :right %>
+  <% if @resource.resource_controls_render_on_the_right? %>
     <td class="text-right whitespace-nowrap px-3" data-control="resource-controls">
       <div class="flex items-center justify-end flex-grow-0 h-full">
         <%= render resource_controls_component %>

--- a/app/components/avo/index/table_row_component.html.erb
+++ b/app/components/avo/index/table_row_component.html.erb
@@ -1,4 +1,8 @@
 <%# hover:z-[21] removed from tr class to solve flickering actions component on row controls and z-20 changed to z-21%>
+<%
+  resource_controls_placement = @resource.controls_placement || Avo.configuration.resource_controls_placement
+%>
+
 <%= content_tag :tr,
   class: class_names("bg-white hover:bg-gray-50 hover:shadow-row z-21 border-b", {"cursor-pointer": click_row_to_view_record}),
   data: {
@@ -19,7 +23,7 @@
       </div>
     </td>
   <% end %>
-  <% if Avo.configuration.resource_controls_on_the_left? %>
+  <% if resource_controls_placement == :left %>
     <td class="text-right whitespace-nowrap w-px" data-control="resource-controls">
       <div class="flex items-center justify-end flex-grow-0 h-full">
         <%= render resource_controls_component %>
@@ -41,7 +45,7 @@
       <td class="text-center">—</td>
     <% end %>
   <% end %>
-  <% if Avo.configuration.resource_controls_on_the_right? %>
+  <% if resource_controls_placement == :right %>
     <td class="text-right whitespace-nowrap px-3" data-control="resource-controls">
       <div class="flex items-center justify-end flex-grow-0 h-full">
         <%= render resource_controls_component %>

--- a/app/views/avo/partials/_table_header.html.erb
+++ b/app/views/avo/partials/_table_header.html.erb
@@ -2,6 +2,7 @@
   # Currently there isn't a way to summarize records on associations.
   # We'd love to support this feature so please send in a PR.
   should_summarize = @parent_record.blank?
+  resource_controls_placement = @resource.controls_placement || Avo.configuration.resource_controls_placement
 %>
 
 <thead
@@ -26,7 +27,7 @@
       <% end %>
     </th>
   <% end %>
-  <% if Avo.configuration.resource_controls_on_the_left? %>
+  <% if resource_controls_placement == :left %>
     <th class="max-w-24" data-control="resource-controls-th">
       <!-- Item controls cell -->
     </th>
@@ -100,7 +101,7 @@
       <% end %>
     <% end %>
   <% end %>
-  <% if Avo.configuration.resource_controls_on_the_right? %>
+  <% if resource_controls_placement == :right %>
     <th class="w-px max-w-24" data-control="resource-controls-th">
       <!-- Item controls cell -->
     </th>

--- a/app/views/avo/partials/_table_header.html.erb
+++ b/app/views/avo/partials/_table_header.html.erb
@@ -2,7 +2,6 @@
   # Currently there isn't a way to summarize records on associations.
   # We'd love to support this feature so please send in a PR.
   should_summarize = @parent_record.blank?
-  resource_controls_placement = @resource.controls_placement || Avo.configuration.resource_controls_placement
 %>
 
 <thead
@@ -27,7 +26,7 @@
       <% end %>
     </th>
   <% end %>
-  <% if resource_controls_placement == :left %>
+  <% if @resource.resource_controls_render_on_the_left? %>
     <th class="max-w-24" data-control="resource-controls-th">
       <!-- Item controls cell -->
     </th>
@@ -101,7 +100,7 @@
       <% end %>
     <% end %>
   <% end %>
-  <% if resource_controls_placement == :right %>
+  <% if @resource.resource_controls_render_on_the_right? %>
     <th class="w-px max-w-24" data-control="resource-controls-th">
       <!-- Item controls cell -->
     </th>

--- a/lib/avo/concerns/controls_placement.rb
+++ b/lib/avo/concerns/controls_placement.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Avo
+  module Concerns
+    module ControlsPlacement
+      extend ActiveSupport::Concern
+
+      def controls_placement_calculated
+        @controls_placement_calculated ||= controls_placement || Avo.configuration.resource_controls_placement
+      end
+
+      def resource_controls_render_on_the_right?
+        controls_placement_calculated == :right || resource_controls_render_on_both_sides?
+      end
+
+      def resource_controls_render_on_the_left?
+        controls_placement_calculated == :left || resource_controls_render_on_both_sides?
+      end
+
+      private
+
+      def resource_controls_render_on_both_sides?
+        controls_placement_calculated == :both
+      end
+    end
+  end
+end

--- a/lib/avo/configuration/resource_configuration.rb
+++ b/lib/avo/configuration/resource_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avo
   class Configuration
     module ResourceConfiguration
@@ -7,14 +9,6 @@ module Avo
 
       def resource_controls_placement
         @resource_controls_placement_instance || :right
-      end
-
-      def resource_controls_on_the_left?
-        resource_controls_placement == :left
-      end
-
-      def resource_controls_on_the_right?
-        resource_controls_placement == :right
       end
     end
   end

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -15,6 +15,7 @@ module Avo
       include Avo::Concerns::HasHelpers
       include Avo::Concerns::Hydration
       include Avo::Concerns::Pagination
+      include Avo::Concerns::ControlsPlacement
 
       # Avo::Current methods
       delegate :context, to: Avo::Current

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -78,6 +78,7 @@ module Avo
       class_attribute :components, default: {}
       class_attribute :default_sort_column, default: :created_at
       class_attribute :default_sort_direction, default: :desc
+      class_attribute :controls_placement, default: nil
 
       # EXTRACT:
       class_attribute :ordering

--- a/spec/features/avo/resource_controls_placement_spec.rb
+++ b/spec/features/avo/resource_controls_placement_spec.rb
@@ -10,25 +10,72 @@ RSpec.feature "ResourceControlsPlacement", type: :feature do
   end
 
   describe "with controls on the left" do
-    it "shows to the left" do
+    it "shows to the left when configured from Avo.configuration" do
       Avo.configuration.resource_controls_placement = :left
       visit "/admin/resources/comments"
 
       within find("table") do
         # XPath containing the index of the cell
-        expect(page).to have_xpath('tbody/tr[1]/td[1][@data-control="resource-controls"]')
+        expect(page).to have_xpath("tbody/tr[1]/td[1][@data-control='resource-controls']")
+      end
+    end
+
+    it "shows to the left when configured from resource configuration" do
+      with_temporary_class_option(Avo::Resources::Comment, :controls_placement, :left) do
+        visit "/admin/resources/comments"
+
+        within find("table") do
+          # XPath containing the index of the cell
+          expect(page).to have_xpath("tbody/tr[1]/td[1][@data-control='resource-controls']")
+        end
       end
     end
   end
 
   describe "with controls on the right" do
-    it "shows to the right" do
+    it "shows to the right when configured from Avo.configuration" do
       Avo.configuration.resource_controls_placement = :right
       visit "/admin/resources/comments"
 
       within find("table") do
         # XPath containing the index of the cell
-        expect(page).to have_xpath('tbody/tr[1]/td[6][@data-control="resource-controls"]')
+        expect(page).to have_xpath("tbody/tr[1]/td[6][@data-control='resource-controls']")
+      end
+    end
+
+    it "shows to the right when configured from resource configuration" do
+      with_temporary_class_option(Avo::Resources::Comment, :controls_placement, :right) do
+        visit "/admin/resources/comments"
+
+        within find("table") do
+          # XPath containing the index of the cell
+          expect(page).to have_xpath("tbody/tr[1]/td[6][@data-control='resource-controls']")
+        end
+      end
+    end
+  end
+
+  describe "with controls on both sides" do
+    it "shows on both sides when configured from Avo.configuration" do
+      Avo.configuration.resource_controls_placement = :both
+      visit "/admin/resources/comments"
+
+      within find("table") do
+        # XPath containing the index of the cell
+        expect(page).to have_xpath("tbody/tr[1]/td[1][@data-control='resource-controls']")
+        expect(page).to have_xpath("tbody/tr[1]/td[7][@data-control='resource-controls']")
+      end
+    end
+
+    it "shows on both sides when configured from resource configuration" do
+      with_temporary_class_option(Avo::Resources::Comment, :controls_placement, :both) do
+        visit "/admin/resources/comments"
+
+        within find("table") do
+          # XPath containing the index of the cell
+          expect(page).to have_xpath("tbody/tr[1]/td[1][@data-control='resource-controls']")
+          expect(page).to have_xpath("tbody/tr[1]/td[7][@data-control='resource-controls']")
+        end
       end
     end
   end


### PR DESCRIPTION
# Description
You can now have the placement of the actions set on the resource too. So you can have a resource with controls on the left and another one with controls on the right.

# Checklist:
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. On a resource level, add `self.controls_placement = :left`
2. View the controls being rendered on the `left` instead of the default `right` value
