### PR TITLE
Made the send_keys helper work in selenium as well as cuprite

### DIFF
--- a/lib/avo/test_helpers.rb
+++ b/lib/avo/test_helpers.rb
@@ -315,7 +315,11 @@ module Avo
     end
 
     def type(...)
-      page.driver.browser.keyboard.type(...)
+      if page.driver.browser.respond_to?(:keyboard)
+        page.driver.browser.keyboard.type(...)
+      else
+        page.send_keys(...)
+      end
     end
 
     def accept_custom_alert(&block)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

A few of the test helpers use the `type` helper method but in selenium it raises this error:

     NoMethodError:
       undefined method `keyboard' for #<Selenium::WebDriver::Chrome::Driver:0x000000013ebbb950>

I've changed this to do the same thing (type in the focused element) but in a way that should work in every capybara driver.

Fixes # (issue)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Tests using `add_tag` and other helpers that use the keyboard should still pass.

Manual reviewer: please leave a comment with output from the test if that's the case.
