### PR TITLE
feature: translate trix field controller js warnings

### DIFF
--- a/app/components/avo/fields/trix_field/edit_component.rb
+++ b/app/components/avo/fields/trix_field/edit_component.rb
@@ -29,9 +29,9 @@ class Avo::Fields::TrixField::EditComponent < Avo::Fields::EditComponent
       hide_attachment_filesize: @field.hide_attachment_filesize,
       hide_attachment_url: @field.hide_attachment_url,
       is_action_text: @field.is_action_text?,
-      upload_warning: t('avo.you_cant_upload_new_resource'),
-      attachment_disable_warning: t('avo.this_field_has_attachments_disabled'),
-      attachment_key_warning: t('avo.you_havent_set_attachment_key')
+      upload_warning: t("avo.you_cant_upload_new_resource"),
+      attachment_disable_warning: t("avo.this_field_has_attachments_disabled"),
+      attachment_key_warning: t("avo.you_havent_set_attachment_key")
     }.transform_keys { |key| "trix_field_#{key}_value" }
   end
 end

--- a/app/components/avo/fields/trix_field/edit_component.rb
+++ b/app/components/avo/fields/trix_field/edit_component.rb
@@ -29,6 +29,9 @@ class Avo::Fields::TrixField::EditComponent < Avo::Fields::EditComponent
       hide_attachment_filesize: @field.hide_attachment_filesize,
       hide_attachment_url: @field.hide_attachment_url,
       is_action_text: @field.is_action_text?,
+      upload_warning: t('avo.you_cant_upload_new_resource'),
+      attachment_disable_warning: t('avo.this_field_has_attachments_disabled'),
+      attachment_key_warning: t('avo.you_havent_set_attachment_key')
     }.transform_keys { |key| "trix_field_#{key}_value" }
   end
 end

--- a/app/javascript/js/controllers/fields/trix_field_controller.js
+++ b/app/javascript/js/controllers/fields/trix_field_controller.js
@@ -17,6 +17,9 @@ export default class extends Controller {
     hideAttachmentFilesize: Boolean,
     hideAttachmentUrl: Boolean,
     isActionText: Boolean,
+    uploadWarning: String,
+    attachmentDisableWarning: String,
+    attachmentKeyWarning: String,
   }
 
   get uploadUrl() {
@@ -43,7 +46,7 @@ export default class extends Controller {
         // Prevent file uploads for fields that have attachments disabled.
         if (this.attachmentsDisabledValue) {
           event.preventDefault()
-          alert('This field has attachments disabled.')
+          alert(this.attachmentDisableWarningValue)
 
           return
         }
@@ -51,7 +54,7 @@ export default class extends Controller {
         // Prevent file uploads for resources that haven't been saved yet.
         if (!this.resourceIdValue) {
           event.preventDefault()
-          alert("You can't upload files into the Trix editor until you save the resource.")
+          alert(this.uploadWarningValue)
 
           return
         }
@@ -60,7 +63,7 @@ export default class extends Controller {
         // When is rich text, attachment key is not needed.
         if (!this.isActionTextValue && !this.attachmentKeyValue) {
           event.preventDefault()
-          alert("You haven't set an `attachment_key` to this Trix field.")
+          alert(this.attachmentKeyWarningValue)
         }
       }
     })

--- a/lib/generators/avo/templates/locales/avo.ar.yml
+++ b/lib/generators/avo/templates/locales/avo.ar.yml
@@ -110,6 +110,7 @@ ar:
     sign_out: تسجيل الخروج
     switch_to_view: التبديل إلى عرض %{view_type}
     table_view: عرض الجدول
+    this_field_has_attachments_disabled: هذا الحقل لديه المرفقات معطلة.
     tools: الأدوات
     type_to_search: اكتب للبحث.
     unauthorized: غير مصرح به
@@ -126,4 +127,6 @@ ar:
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> السجلات المحددة من كل الصفحات
     x_records_selected_from_page_html: <span class="font-bold text-gray-700">%{selected}</span> السجلات المختارة في هذه الصفحة
     yes_confirm: نعم، أنا متأكد
+    you_cant_upload_new_resource: لا يمكنك تحميل الملفات في محرر Trix حتى تحفظ السجل.
+    you_havent_set_attachment_key: لم تقم بتعيين `attachment_key` لهذا الحقل Trix.
     you_missed_something_check_form: ربما نسيت شيئًا، يرجى التحقق من البيانات.

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -100,6 +100,7 @@ en:
     sign_out: Sign out
     switch_to_view: Switch to %{view_type} view
     table_view: Table view
+    this_field_has_attachments_disabled: This field has attachments disabled.
     tools: Tools
     type_to_search: Type to search.
     unauthorized: Unauthorized
@@ -116,4 +117,6 @@ en:
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> records selected from all pages
     x_records_selected_from_page_html: <span class="font-bold text-gray-700">%{selected}</span> records selected on this page
     yes_confirm: Yes, I'm sure
+    you_cant_upload_new_resource: You can't upload files into the Trix editor until you save the resource.
+    you_havent_set_attachment_key: You haven't set an `attachment_key` to this Trix field.
     you_missed_something_check_form: You might have missed something. Please check the form.

--- a/lib/generators/avo/templates/locales/avo.es.yml
+++ b/lib/generators/avo/templates/locales/avo.es.yml
@@ -102,6 +102,7 @@ es:
     sign_out: Salir
     switch_to_view: Cambiar a la vista %{view_type}
     table_view: Vista en tabla
+    this_field_has_attachments_disabled: Este campo tiene los adjuntos deshabilitados.
     tools: Herramientas
     type_to_search: Escribe para buscar.
     unauthorized: No autorizado
@@ -118,4 +119,6 @@ es:
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> registros seleccionados en todas las páginas
     x_records_selected_from_page_html: <span class="font-bold text-gray-700">%{selected}</span> registros seleccionados en esta página
     yes_confirm: Sí, estoy seguro
+    you_cant_upload_new_resource: No puedes subir archivos al editor Trix hasta que guardes el recurso.
+    you_havent_set_attachment_key: No has establecido una `attachment_key` para este campo Trix.
     you_missed_something_check_form: Es posible que hayas pasado algo por alto. Comprueba el formulario.

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -102,6 +102,7 @@ fr:
     sign_out: Se déconnecter
     switch_to_view: Passez à la vue %{view_type}
     table_view: Vue table
+    this_field_has_attachments_disabled: Ce champ a les pièces jointes désactivées.
     tools: Outils
     type_to_search: Type à rechercher.
     unauthorized: Non autorisé
@@ -118,4 +119,6 @@ fr:
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> enregistrements sélectionnés dans toutes les pages
     x_records_selected_from_page_html: <span class="font-bold text-gray-700">%{selected}</span> éléments sélectionnés de cette page
     yes_confirm: Oui, je suis sûr
+    you_cant_upload_new_resource: Vous ne pouvez pas télécharger de fichiers dans l'éditeur Trix tant que vous n'avez pas enregistré la ressource.
+    you_havent_set_attachment_key: Vous devez définir une `attachment_key` pour ce champ Trix.
     you_missed_something_check_form: Vous avez peut-être oublié quelque chose. Veuillez vérifier le formulaire

--- a/lib/generators/avo/templates/locales/avo.ja.yml
+++ b/lib/generators/avo/templates/locales/avo.ja.yml
@@ -102,6 +102,7 @@ ja:
     sign_out: サインアウト
     switch_to_view: "%{view_type}ビューに切り替える"
     table_view: テーブルビュー
+    this_field_has_attachments_disabled: このフィールドには添付ファイルが無効になっています。
     tools: ツール
     type_to_search: 検索する内容を入力してください。
     unauthorized: 許可されていません
@@ -118,4 +119,6 @@ ja:
     x_records_selected_from_all_pages_html: すべてのページから<span class="font-bold text-gray-700">%{count}</span>個のレコードが選択されました
     x_records_selected_from_page_html: このページから<span class="font-bold text-gray-700">%{selected}</span>個のレコードが選択されました
     yes_confirm: はい、私は確信しています
+    you_cant_upload_new_resource: リソースを保存するまで、Trixエディタにファイルをアップロードすることはできません。
+    you_havent_set_attachment_key: このTrixフィールドに`attachment_key`が設定されていません。
     you_missed_something_check_form: 何か見落としているかもしれません。フォームを確認してください。

--- a/lib/generators/avo/templates/locales/avo.nb.yml
+++ b/lib/generators/avo/templates/locales/avo.nb.yml
@@ -102,6 +102,7 @@ nb:
     sign_out: Logg ut
     switch_to_view: Bytt til %{view_type} vis
     table_view: Tabell visning
+    this_field_has_attachments_disabled: Dette feltet har vedlegg deaktivert.
     tools: Redskapene
     type_to_search: Søk.
     unauthorized: Ikke autorisert
@@ -118,4 +119,6 @@ nb:
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> poster valgt fra alle sider
     x_records_selected_from_page_html: <span class="font-bold text-gray-700">%{selected}</span> poster valgt på denne siden
     yes_confirm: Ja, jeg er sikker
+    you_cant_upload_new_resource: Du kan ikke laste opp filer til Trix editoren før du lagrer ressursen.
+    you_havent_set_attachment_key: Du har ikke satt en `attachment_key` til dette Trix-feltet.
     you_missed_something_check_form: Her mangler du noe. Vennligst sjekk skjemaet.

--- a/lib/generators/avo/templates/locales/avo.nn.yml
+++ b/lib/generators/avo/templates/locales/avo.nn.yml
@@ -102,6 +102,7 @@ nn:
     sign_out: Logg ut
     switch_to_view: Bytt til %{view_type} vis
     table_view: Tabellvisning
+    this_field_has_attachments_disabled: Dette feltet har vedlegg deaktivert.
     tools: Reiskapane
     type_to_search: Søk.
     unauthorized: Ikkje autorisert
@@ -118,4 +119,6 @@ nn:
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> valde postar frå alle sider
     x_records_selected_from_page_html: <span class="font-bold text-gray-700">%{selected}</span> poster valgt på denne siden
     yes_confirm: Ja, eg er sikker
+    you_cant_upload_new_resource: Du kan ikkje laste opp filer til Trix-editoren før du lagrar ressursen.
+    you_havent_set_attachment_key: Du har ikkje sett ein `attachment_key` til dette Trix-feltet.
     you_missed_something_check_form: Her manglar du noko. Ver venleg og sjekk skjemaet.

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -102,6 +102,7 @@ pt-BR:
     sign_out: sair
     switch_to_view: Alterar para visão %{view_type}
     table_view: Visualização em tabela
+    this_field_has_attachments_disabled: Este campo tem anexos desativados.
     tools: Ferramentas
     type_to_search: Digite para buscar.
     unauthorized: Não autorizado
@@ -118,4 +119,6 @@ pt-BR:
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> registros selecionados de todas as páginas
     x_records_selected_from_page_html: <span class="font-bold text-gray-700">%{selected}</span> registros selecionados nesta página
     yes_confirm: Sim, tenho certeza
+    you_cant_upload_new_resource: Você não pode fazer upload de imagens no editor Trix até salvar o recurso.
+    you_havent_set_attachment_key: Você precisa definir uma `attachment_key` para este campo Trix.
     you_missed_something_check_form: Você pode ter esquecido algo. Por favor, cheque o formulário.

--- a/lib/generators/avo/templates/locales/avo.pt.yml
+++ b/lib/generators/avo/templates/locales/avo.pt.yml
@@ -102,6 +102,7 @@ pt:
     sign_out: Terminar sessão
     switch_to_view: Alterar para visão %{view_type}
     table_view: Visualização em tabela
+    this_field_has_attachments_disabled: Este campo tem anexos desativados.
     tools: Ferramentas
     type_to_search: Escreva para pesquisar.
     unauthorized: Não autorizado
@@ -118,4 +119,6 @@ pt:
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> itens selecionados de todas as páginas
     x_records_selected_from_page_html: <span class="font-bold text-gray-700">%{selected}</span> itens selecionados nesta página
     yes_confirm: Sim, tenho a certeza
+    you_cant_upload_new_resource: Não pode carregar ficheiros no editor Trix até guardar o recurso.
+    you_havent_set_attachment_key: Precisa definir uma `attachment_key` para este campo Trix.
     you_missed_something_check_form: Pode ter-se esquecido algo. Por favor, verifique o formulário.

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -104,6 +104,7 @@ ro:
     sign_out: Delogare
     switch_to_view: Comutați la vizualizarea %{view_type}
     table_view: Vezi sub formă de tabel
+    this_field_has_attachments_disabled: Acest câmp are atașamente dezactivate.
     tools: Instrumente
     type_to_search: Caută aici...
     unauthorized: Neautorizat
@@ -120,4 +121,6 @@ ro:
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> selectate din toate paginile
     x_records_selected_from_page_html: <span class="font-bold text-gray-700">%{selected}</span> selectate
     yes_confirm: Da, sunt sigur
+    you_cant_upload_new_resource: Nu poți încărca fișiere în editorul Trix până când nu salvezi resursa.
+    you_havent_set_attachment_key: Trebuie să setezi o `attachment_key` pentru acest câmp Trix.
     you_missed_something_check_form: S-ar putea să fi omis ceva. Vă rugăm să verificați formularul.

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -102,6 +102,7 @@ tr:
     sign_out: Çıkış yap
     switch_to_view: "%{view_type} görünümüne kay"
     table_view: Tablo görünümü
+    this_field_has_attachments_disabled: Bu alanın ekleri devre dışı bırakıldı.
     tools: Araçlar
     type_to_search: Aramak için yazın.
     unauthorized: Yetkisiz
@@ -118,4 +119,6 @@ tr:
     x_records_selected_from_all_pages_html: <span class="font-bold text-gray-700">%{count}</span> tüm sayfalardan seçilen kayıtlar
     x_records_selected_from_page_html: <span class="font-bold text-gray-700">%{selected}</span> bu sayfada seçilen kayıtlar
     yes_confirm: Evet, eminim
+    you_cant_upload_new_resource: Kaynağı kaydedene kadar Trix editörüne dosya yükleyemezsiniz.
+    you_havent_set_attachment_key: Bu Trix alanına bir `attachment_key` ayarlamadınız.
     you_missed_something_check_form: Bir şeyleri kaçırmış olabilirsiniz. Lütfen formu kontrol edin.

--- a/spec/system/avo/trix_field_spec.rb
+++ b/spec/system/avo/trix_field_spec.rb
@@ -39,8 +39,14 @@ RSpec.describe "TrixField", type: :system do
       it "contains js alert messages translated" do
         visit "/admin/resources/posts/#{post.id}/edit"
 
-        data = first("[data-upload-warning]")[:'data-upload-warning']
-        expect(data).to eq t("avo.you_cant_upload_new_resource")
+        upload_warning_message = find("[data-trix-field-upload-warning-value]")[:'data-trix-field-upload-warning-value']
+        expect(upload_warning_message).to eq I18n.t("avo.you_cant_upload_new_resource")
+
+        attachment_disable_message = find("[data-trix-field-attachment-disable-warning-value]")[:'data-trix-field-attachment-disable-warning-value']
+        expect(attachment_disable_message).to eq I18n.t("avo.this_field_has_attachments_disabled")
+
+        attachment_key_warning_message = find("[data-trix-field-attachment-key-warning-value]")[:'data-trix-field-attachment-key-warning-value']
+        expect(attachment_key_warning_message).to eq I18n.t("avo.you_havent_set_attachment_key")
       end
     end
   end

--- a/spec/system/avo/trix_field_spec.rb
+++ b/spec/system/avo/trix_field_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe "TrixField", type: :system do
 
         expect(find_field_value_element("body")).to have_text "Works for us!!!"
       end
+
+      it "contains js alert messages translated" do
+        visit "/admin/resources/posts/#{post.id}/edit"
+
+        data = first("[data-upload-warning]")[:'data-upload-warning']
+        expect(data).to eq t("avo.you_cant_upload_new_resource")
+      end
     end
   end
 

--- a/spec/system/avo/trix_field_spec.rb
+++ b/spec/system/avo/trix_field_spec.rb
@@ -39,13 +39,13 @@ RSpec.describe "TrixField", type: :system do
       it "contains js alert messages translated" do
         visit "/admin/resources/posts/#{post.id}/edit"
 
-        upload_warning_message = find("[data-trix-field-upload-warning-value]")[:'data-trix-field-upload-warning-value']
+        upload_warning_message = find("[data-trix-field-upload-warning-value]")[:"data-trix-field-upload-warning-value"]
         expect(upload_warning_message).to eq I18n.t("avo.you_cant_upload_new_resource")
 
-        attachment_disable_message = find("[data-trix-field-attachment-disable-warning-value]")[:'data-trix-field-attachment-disable-warning-value']
+        attachment_disable_message = find("[data-trix-field-attachment-disable-warning-value]")[:"data-trix-field-attachment-disable-warning-value"]
         expect(attachment_disable_message).to eq I18n.t("avo.this_field_has_attachments_disabled")
 
-        attachment_key_warning_message = find("[data-trix-field-attachment-key-warning-value]")[:'data-trix-field-attachment-key-warning-value']
+        attachment_key_warning_message = find("[data-trix-field-attachment-key-warning-value]")[:"data-trix-field-attachment-key-warning-value"]
         expect(attachment_key_warning_message).to eq I18n.t("avo.you_havent_set_attachment_key")
       end
     end


### PR DESCRIPTION
# Description
Translates trix_field_controller js warnings

Fixes #3329

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
![image](https://github.com/user-attachments/assets/74798a75-b70c-4540-a1aa-8b6f7f212204)

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Change the locale to one of locales supported
2. Try to upload a image in trix when creating a new resource

Manual reviewer: please leave a comment with output from the test if that's the case.

## Documentation

https://github.com/avo-hq/docs.avohq.io/pull/301
