### PR TITLE
Check #email_address for sidebar name

### DIFF
--- a/app/components/avo/sidebar_profile_component.rb
+++ b/app/components/avo/sidebar_profile_component.rb
@@ -16,6 +16,8 @@ class Avo::SidebarProfileComponent < Avo::BaseComponent
       @user.name
     elsif @user.respond_to?(:email) && @user.email.present?
       @user.email
+    elsif @user.respond_to?(:email_address) && @user.email_address.present?
+      @user.email_address
     else
       "Avo user"
     end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Rails 8's new baked in authentication implementation uses user#email_address by default, so I figured it would be nice to support that by default in Avo as well to make things feel seamless for the new release. This is a pretty lightweight PR but please let me know if you've like a section in the docs specific to supporting the new baked in authentication since the manual testing steps below are juuuuust fiddly enough to maybe merit their own section.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Create a new app with the Rails 8 beta
2. Add authentication with `bin/rails generate authentication`
3. Create a user
4. Install Avo
5. Modify the Avo initializer to use `Current.user` for the `current_user_method` and `session_path` for the `sign_out_path_name`.
6. Modify the Avo initializer to use Rails' default authentication concern with:
```
Rails.configuration.to_prepare do
  Avo::ApplicationController.include Authentication
end
```
7. Append `main_app.` to any redirects in the Authentication concern.

Manual reviewer: please leave a comment with output from the test if that's the case.
