### PR TITLE
fix: implicit_authorization on default authorization service

### DIFF
--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -154,7 +154,7 @@ module Avo
 
       if @authorization.has_method?(method.to_sym)
         @authorization.authorize_action method.to_sym
-      elsif Avo.configuration.authorization_client.present? && Avo.configuration.implicit_authorization
+      elsif !@authorization.is_a?(Avo::Services::AuthorizationService) && Avo.configuration.implicit_authorization
         raise Avo::NotAuthorizedError.new
       end
     end

--- a/lib/avo/concerns/checks_assoc_authorization.rb
+++ b/lib/avo/concerns/checks_assoc_authorization.rb
@@ -34,8 +34,10 @@ module Avo
 
         if service.has_method?(method_name, raise_exception: false)
           service.authorize_action(method_name, record:, raise_exception: false)
-        else
+        else !service.is_a?(Avo::Services::AuthorizationService)
           !Avo.configuration.implicit_authorization
+        else
+          true
         end
       end
     end

--- a/lib/avo/concerns/checks_assoc_authorization.rb
+++ b/lib/avo/concerns/checks_assoc_authorization.rb
@@ -34,7 +34,7 @@ module Avo
 
         if service.has_method?(method_name, raise_exception: false)
           service.authorize_action(method_name, record:, raise_exception: false)
-        else !service.is_a?(Avo::Services::AuthorizationService)
+        elsif !service.is_a?(Avo::Services::AuthorizationService)
           !Avo.configuration.implicit_authorization
         else
           true

--- a/lib/avo/fields/has_base_field.rb
+++ b/lib/avo/fields/has_base_field.rb
@@ -99,8 +99,10 @@ module Avo
 
         if service.has_method? method
           service.authorize_action(method, raise_exception: false)
-        else
+        elsif !service.is_a?(Avo::Services::AuthorizationService)
           !Avo.configuration.implicit_authorization
+        else
+          true
         end
       end
 

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -32,6 +32,7 @@ Avo.configure do |config|
   config.locale = :en
   # config.raise_error_on_missing_policy = true
   # config.authorization_client = "Avo::Services::AuthorizationClients::ExtraPunditClient"
+  # Shouldn't impact on community only if custom authorization service was configured.
   config.implicit_authorization = true
 
   ## == Customization ==

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -32,6 +32,7 @@ Avo.configure do |config|
   config.locale = :en
   # config.raise_error_on_missing_policy = true
   # config.authorization_client = "Avo::Services::AuthorizationClients::ExtraPunditClient"
+  config.implicit_authorization = true
 
   ## == Customization ==
   config.id_links_to_resource = true


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3327

Apply `implicit_authorization` only when using a custom authorization service or the `Avo::Pro::Authorization::AuthorizationService`.

If the default `Avo::Services::AuthorizationService` is being used, bypass the `implicit_authorization` logic entirely.

In summary, `implicit_authorization` should only take effect if a custom authorization service is implemented or when using Avo Pro.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works