### PR TITLE
Update Twitter link to X in the Demo App section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Avo is a very custom Admin Panel Framework, Content Management System, and Inter
 <br>
 🎸 **Demo App**: [Avodemo](https://main.avodemo.com/)
 <br>
-🐤 **Twitter**: [`avo_hq`](https://twitter.com/avo_hq)
+🐤 **X(formerly Twitter)**: [`avo_hq`](https://x.com/avo_hq)
 <br>
 🔧 **Issue Tracker**: [GitHub Issues](http://github.com/avo-hq/avo/issues)
 <br>


### PR DESCRIPTION
# Description

This PR updates the Twitter link to X in the Demo App section to reflect the rebranding from Twitter to X. This change ensures that users are directed to the correct platform link. 

Fixes # (issue)

---

By submitting this contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.

---

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

---

## Screenshots & recording

Since this is a minor update to a link, no screenshots or recordings are necessary.

---

## Manual review steps

1. Verify that the updated X link in the Demo App section is functioning correctly.
2. Ensure the link is accessible and points to the appropriate X page.

Manual reviewer: Please leave a comment with output from the test if that's the case.