### PR TITLE
fix: consider browser dynamic toolbar state for sidebar height

### DIFF
--- a/app/components/avo/sidebar_component.html.erb
+++ b/app/components/avo/sidebar_component.html.erb
@@ -1,5 +1,5 @@
 <div
-  class="avo-sidebar fixed z-[60] t-0 application-sidebar w-64 flex-1 border-r lg:border-none bg-none h-[calc(100vh-4rem)] bg-application lg:bg-transparent <%= 'print:hidden' if Avo.configuration.hide_layout_when_printing %> <%= 'hidden' unless @sidebar_open %>"
+  class="avo-sidebar fixed z-[60] t-0 application-sidebar w-64 flex-1 border-r lg:border-none bg-none h-[calc(100dvh-4rem)] bg-application lg:bg-transparent <%= 'print:hidden' if Avo.configuration.hide_layout_when_printing %> <%= 'hidden' unless @sidebar_open %>"
   data-sidebar-target="<%= stimulus_target %>"
 >
   <div class="flex flex-col w-full h-full">


### PR DESCRIPTION
# Description

Fixes https://github.com/avo-hq/avo/issues/2009 .

Username and logout links are hidden on mobile device when browser's address bar is opened. The workaround is to use `dvh` instead of `vh` to calculate sidebar height properly. 

`dvh` is [supported](https://caniuse.com/?search=dvh) by all main browsers in 2024.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

1. How it works with `vh`:

https://github.com/user-attachments/assets/9fa43cf2-df93-42da-be24-29efbaa46f74

2. How it works with `dvh`:


https://github.com/user-attachments/assets/32070b28-fa21-4de5-84e0-6424457f18e7
