### PR TITLE
fix: disable non standalone actions on custom controls

### DIFF
--- a/app/components/avo/actions_component.rb
+++ b/app/components/avo/actions_component.rb
@@ -34,6 +34,13 @@ class Avo::ActionsComponent < Avo::BaseComponent
 
   def after_initialize
     filter_actions unless @custom_list
+
+    # Hydrate each action action with the record when rendering a list on row controls
+    if @as_row_control
+      @actions.each do |action|
+        action.hydrate(resource: @resource, record: @resource.record) if action.respond_to?(:hydrate)
+      end
+    end
   end
 
   def render?

--- a/app/components/avo/actions_component.rb
+++ b/app/components/avo/actions_component.rb
@@ -52,22 +52,7 @@ class Avo::ActionsComponent < Avo::BaseComponent
     end
   end
 
-  # How should the action be displayed by default
-  def is_disabled?(action)
-    return false if action.standalone || @as_row_control
-
-    on_index_page?
-  end
-
   private
-
-  def on_record_page?
-    @view.in?(["show", "edit", "new"])
-  end
-
-  def on_index_page?
-    !on_record_page?
-  end
 
   def icon(icon)
     svg icon, class: "h-5 shrink-0 mr-1 inline pointer-events-none"
@@ -112,15 +97,17 @@ class Avo::ActionsComponent < Avo::BaseComponent
       "turbo-frame": Avo::MODAL_FRAME_ID,
       action: "click->actions-picker#visitAction",
       "actions-picker-target": action.standalone ? "standaloneAction" : "resourceAction",
-      disabled: is_disabled?(action),
+      disabled: action.disabled?,
       turbo_prefetch: false,
+      enabled_classes: "text-black",
+      disabled_classes: "text-gray-500"
     }
   end
 
   def action_css_class(action)
     helpers.class_names("flex items-center px-4 py-3 w-full font-semibold text-sm hover:bg-primary-100", {
-      "text-gray-500": is_disabled?(action),
-      "text-black": !is_disabled?(action),
+      "text-gray-500": action.disabled?,
+      "text-black": action.enabled?,
     })
   end
 end

--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -282,10 +282,14 @@ class Avo::ResourceComponent < Avo::BaseComponent
       title: action.title,
       size: action.size,
       data: {
+        controller: "actions-picker",
         turbo_frame: Avo::MODAL_FRAME_ID,
         action_name: action.action.action_name,
         tippy: action.title ? :tooltip : nil,
         action: "click->actions-picker#visitAction",
+        turbo_prefetch: false,
+        "actions-picker-target": action.action.standalone ? "standaloneAction" : "resourceAction",
+        disabled: action.disabled?
       } do
       action.label
     end

--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -289,7 +289,7 @@ class Avo::ResourceComponent < Avo::BaseComponent
         action: "click->actions-picker#visitAction",
         turbo_prefetch: false,
         "actions-picker-target": action.action.standalone ? "standaloneAction" : "resourceAction",
-        disabled: action.disabled?
+        disabled: action.action.disabled?
       } do
       action.label
     end

--- a/app/javascript/js/controllers/item_selector_controller.js
+++ b/app/javascript/js/controllers/item_selector_controller.js
@@ -5,10 +5,6 @@ export default class extends Controller {
 
   checkbox = {}
 
-  get actionsPanelPresent() {
-    return this.actionsButtonElement !== null
-  }
-
   get actionLinks() {
     return document.querySelectorAll(
       'a[data-actions-picker-target="resourceAction"]',
@@ -26,7 +22,7 @@ export default class extends Controller {
   set currentIds(value) {
     this.stateHolderElement.dataset.selectedResources = JSON.stringify(value)
 
-    if (this.actionsPanelPresent) {
+    if (this.actionLinks.length > 0) {
       if (value.length > 0) {
         this.enableResourceActions()
       } else {
@@ -38,9 +34,6 @@ export default class extends Controller {
   connect() {
     this.resourceName = this.element.dataset.resourceName
     this.resourceId = this.element.dataset.resourceId
-    this.actionsButtonElement = document.querySelector(
-      `[data-actions-dropdown-button="${this.resourceName}"]`,
-    )
     this.stateHolderElement = document.querySelector(
       `[data-selected-resources-name="${this.resourceName}"]`,
     )

--- a/app/javascript/js/controllers/item_selector_controller.js
+++ b/app/javascript/js/controllers/item_selector_controller.js
@@ -1,16 +1,18 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ['panel'];
+  static targets = ['panel']
 
-  checkbox = {};
-
-  enabledClasses = ['text-black']
-
-  disabledClasses = ['text-gray-500']
+  checkbox = {}
 
   get actionsPanelPresent() {
     return this.actionsButtonElement !== null
+  }
+
+  get actionLinks() {
+    return document.querySelectorAll(
+      'a[data-actions-picker-target="resourceAction"]',
+    )
   }
 
   get currentIds() {
@@ -19,12 +21,6 @@ export default class extends Controller {
     } catch (error) {
       return []
     }
-  }
-
-  get actionLinks() {
-    return document.querySelectorAll(
-      '.js-actions-dropdown a[data-actions-picker-target="resourceAction"]',
-    )
   }
 
   set currentIds(value) {
@@ -76,8 +72,8 @@ export default class extends Controller {
 
   enableResourceActions() {
     this.actionLinks.forEach((link) => {
-      link.classList.add(...this.enabledClasses)
-      link.classList.remove(...this.disabledClasses)
+      link.classList.add(link.dataset.enabledClasses)
+      link.classList.remove(link.dataset.disabledClasses)
       link.setAttribute('data-href', link.getAttribute('href'))
       link.dataset.disabled = false
     })
@@ -85,8 +81,8 @@ export default class extends Controller {
 
   disableResourceActions() {
     this.actionLinks.forEach((link) => {
-      link.classList.remove(...this.enabledClasses)
-      link.classList.add(...this.disabledClasses)
+      link.classList.remove(link.dataset.enabledClasses)
+      link.classList.add(link.dataset.disabledClasses)
       link.setAttribute('href', link.getAttribute('data-href'))
       link.dataset.disabled = true
     })

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -2,6 +2,7 @@ module Avo
   class BaseAction
     include Avo::Concerns::HasItems
     include Avo::Concerns::HasActionStimulusControllers
+    include Avo::Concerns::Hydration
 
     class_attribute :name, default: nil
     class_attribute :message

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -292,6 +292,14 @@ module Avo
       @appended_turbo_streams = turbo_stream
     end
 
+    def enabled?
+      self.class.standalone || @record&.persisted?
+    end
+
+    def disabled?
+      !enabled?
+    end
+
     private
 
     def add_message(body, type = :info)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2735

Enable **non** standalone actions defined on `self.index_controls` only when a record is selected.

### Related PR 
https://github.com/avo-hq/avo-advanced/pull/50

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works
