### PR TITLE
refactor: extract breadcrumbs partial

### DIFF
--- a/app/components/avo/panel_component.html.erb
+++ b/app/components/avo/panel_component.html.erb
@@ -6,11 +6,7 @@
       <div class="flex justify-center sm:justify-start flex-col sm:flex-row w-full flex-1 has-cover-photo:mt-0">
         <%= render Avo::ProfilePhotoComponent.new profile_photo: @profile_photo %>
         <div class="flex flex-col flex-1 w-full">
-          <% if display_breadcrumbs? %>
-            <div class="breadcrumbs text-center sm:text-left mb-2">
-              <%= helpers.render_avo_breadcrumbs(separator: helpers.svg("chevron-right", class: "inline-block h-3 stroke-current relative top-[-1px] ml-1")) if Avo.configuration.display_breadcrumbs %>
-            </div>
-          <% end %>
+          <%= render partial: "avo/partials/panel_breadcrumbs" if display_breadcrumbs? %>
           <div class="flex-1 flex flex-col xl:flex-row justify-between gap-1 grow-0">
             <div class="overflow-hidden flex flex-col">
               <% if name_slot? %>

--- a/app/views/avo/partials/_panel_breadcrumbs.html.erb
+++ b/app/views/avo/partials/_panel_breadcrumbs.html.erb
@@ -1,0 +1,3 @@
+<div class="breadcrumbs text-center sm:text-left mb-2">
+  <%= render_avo_breadcrumbs(separator: svg("chevron-right", class: "inline-block h-3 stroke-current relative top-[-1px] mx-1")) %>
+</div>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

We've seen users who need custom breadcrumbs and we'd like to help them override our implementation without extracting the whole panel component.

Also fixes a small visual bug with icon spacing.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
