### PR TITLE
feature: action dynamic backdrop option

### DIFF
--- a/app/components/avo/modal_component.html.erb
+++ b/app/components/avo/modal_component.html.erb
@@ -1,7 +1,7 @@
 <div class="modal-container fixed inset-0 w-full min-h-screen z-[100] flex justify-center items-center"
   data-controller="modal"
   data-modal-target="modal"
-  data-modal-dynamic-backdrop-value="<%= dynamic_backdrop %>"
+  data-modal-close-modal-on-backdrop-click-value="<%= close_modal_on_backdrop_click %>"
 >
   <div aria-expanded="true" class="modal-overlay absolute w-full h-full bg-opacity-25 bg-gray-800 flex justify-center items-center" data-modal-target="backdrop" data-action="click->modal#close" ></div>
   <div aria-expanded="true" role="dialog" aria-modal="true" class="modal-body rounded-lg inset-auto bg-white flex z-50 relative shadow-modal <%= overflow_classes %> <%= width_classes %> <%= height_classes %>">

--- a/app/components/avo/modal_component.html.erb
+++ b/app/components/avo/modal_component.html.erb
@@ -1,8 +1,10 @@
 <div class="modal-container fixed inset-0 w-full min-h-screen z-[100] flex justify-center items-center"
   data-controller="modal"
   data-modal-target="modal"
+  data-modal-target="modal"
+  data-modal-dynamic-backdrop-value="<%= dynamic_backdrop %>"
 >
-  <div aria-expanded="true" class="modal-overlay absolute w-full h-full bg-opacity-25 bg-gray-800 flex justify-center items-center" data-action="click->modal#close"></div>
+  <div aria-expanded="true" class="modal-overlay absolute w-full h-full bg-opacity-25 bg-gray-800 flex justify-center items-center" data-modal-target="backdrop" data-action="click->modal#close" ></div>
   <div aria-expanded="true" role="dialog" aria-modal="true" class="modal-body rounded-lg inset-auto bg-white flex z-50 relative shadow-modal <%= overflow_classes %> <%= width_classes %> <%= height_classes %>">
     <div class="flex-1 flex flex-col justify-between">
       <div>
@@ -25,4 +27,3 @@
     </div>
   </div>
 </div>
-

--- a/app/components/avo/modal_component.html.erb
+++ b/app/components/avo/modal_component.html.erb
@@ -1,7 +1,6 @@
 <div class="modal-container fixed inset-0 w-full min-h-screen z-[100] flex justify-center items-center"
   data-controller="modal"
   data-modal-target="modal"
-  data-modal-target="modal"
   data-modal-dynamic-backdrop-value="<%= dynamic_backdrop %>"
 >
   <div aria-expanded="true" class="modal-overlay absolute w-full h-full bg-opacity-25 bg-gray-800 flex justify-center items-center" data-modal-target="backdrop" data-action="click->modal#close" ></div>

--- a/app/components/avo/modal_component.rb
+++ b/app/components/avo/modal_component.rb
@@ -7,6 +7,7 @@ class Avo::ModalComponent < Avo::BaseComponent
   prop :width, default: :md
   prop :body_class
   prop :overflow, default: :auto
+  prop :dynamic_backdrop, default: true
 
   def width_classes
     case @width.to_sym
@@ -23,5 +24,9 @@ class Avo::ModalComponent < Avo::BaseComponent
 
   def overflow_classes
     @overflow == :auto ? "overflow-auto" : ""
+  end
+
+  def dynamic_backdrop
+    @dynamic_backdrop
   end
 end

--- a/app/components/avo/modal_component.rb
+++ b/app/components/avo/modal_component.rb
@@ -7,7 +7,7 @@ class Avo::ModalComponent < Avo::BaseComponent
   prop :width, default: :md
   prop :body_class
   prop :overflow, default: :auto
-  prop :dynamic_backdrop, default: true, reader: :public
+  prop :close_modal_on_backdrop_click, default: true, reader: :public
 
   def width_classes
     case @width.to_sym

--- a/app/components/avo/modal_component.rb
+++ b/app/components/avo/modal_component.rb
@@ -7,7 +7,7 @@ class Avo::ModalComponent < Avo::BaseComponent
   prop :width, default: :md
   prop :body_class
   prop :overflow, default: :auto
-  prop :dynamic_backdrop, default: true
+  prop :dynamic_backdrop, default: true, reader: :public
 
   def width_classes
     case @width.to_sym
@@ -24,9 +24,5 @@ class Avo::ModalComponent < Avo::BaseComponent
 
   def overflow_classes
     @overflow == :auto ? "overflow-auto" : ""
-  end
-
-  def dynamic_backdrop
-    @dynamic_backdrop
   end
 end

--- a/app/javascript/js/controllers/modal_controller.js
+++ b/app/javascript/js/controllers/modal_controller.js
@@ -1,9 +1,15 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ['modal']
+  static targets = ['modal', 'backdrop']
+
+  static values = {
+    dynamicBackdrop: true,
+  }
 
   close() {
+    if (event.target === this.backdropTarget && !this.dynamicBackdropValue) return
+
     this.modalTarget.remove()
 
     document.dispatchEvent(new Event('actions-modal:close'))

--- a/app/javascript/js/controllers/modal_controller.js
+++ b/app/javascript/js/controllers/modal_controller.js
@@ -4,11 +4,11 @@ export default class extends Controller {
   static targets = ['modal', 'backdrop']
 
   static values = {
-    dynamicBackdrop: true,
+    closeModalOnBackdropClick: true,
   }
 
   close() {
-    if (event.target === this.backdropTarget && !this.dynamicBackdropValue) return
+    if (event.target === this.backdropTarget && !this.closeModalOnBackdropClickValue) return
 
     this.modalTarget.remove()
 

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -21,7 +21,7 @@
         **@action.class.form_data_attributes,
       } do |form|
     %>
-    <%= render Avo::ModalComponent.new(dynamic_backdrop: @action.click_backdrop_to_close_modal) do |c| %>
+    <%= render Avo::ModalComponent.new(close_modal_on_backdrop_click: @action.close_modal_on_backdrop_click) do |c| %>
       <% c.with_heading do %>
         <%= @action.action_name %>
       <% end %>

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -21,7 +21,7 @@
         **@action.class.form_data_attributes,
       } do |form|
     %>
-    <%= render Avo::ModalComponent.new do |c| %>
+    <%= render Avo::ModalComponent.new(dynamic_backdrop: @action.dynamic_backdrop) do |c| %>
       <% c.with_heading do %>
         <%= @action.action_name %>
       <% end %>

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -21,7 +21,7 @@
         **@action.class.form_data_attributes,
       } do |form|
     %>
-    <%= render Avo::ModalComponent.new(dynamic_backdrop: @action.dynamic_backdrop) do |c| %>
+    <%= render Avo::ModalComponent.new(dynamic_backdrop: @action.click_backdrop_to_close_modal) do |c| %>
       <% c.with_heading do %>
         <%= @action.action_name %>
       <% end %>

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -14,6 +14,7 @@ module Avo
     class_attribute :may_download_file
     class_attribute :turbo
     class_attribute :authorize, default: true
+    class_attribute :dynamic_backdrop, default: true
 
     attr_accessor :view
     attr_accessor :response

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -14,7 +14,7 @@ module Avo
     class_attribute :may_download_file
     class_attribute :turbo
     class_attribute :authorize, default: true
-    class_attribute :click_backdrop_to_close_modal, default: true
+    class_attribute :close_modal_on_backdrop_click, default: true
 
     attr_accessor :view
     attr_accessor :response

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -14,7 +14,7 @@ module Avo
     class_attribute :may_download_file
     class_attribute :turbo
     class_attribute :authorize, default: true
-    class_attribute :dynamic_backdrop, default: true
+    class_attribute :click_backdrop_to_close_modal, default: true
 
     attr_accessor :view
     attr_accessor :response

--- a/spec/dummy/app/avo/actions/export_csv.rb
+++ b/spec/dummy/app/avo/actions/export_csv.rb
@@ -4,7 +4,7 @@ class Avo::Actions::ExportCsv < Avo::BaseAction
   self.name = "Export CSV"
   self.no_confirmation = false
   self.standalone = true
-  self.dynamic_backdrop = false
+  self.click_backdrop_to_close_modal = false
 
   def fields
     # Add more fields here for custom user-selected columns

--- a/spec/dummy/app/avo/actions/export_csv.rb
+++ b/spec/dummy/app/avo/actions/export_csv.rb
@@ -4,7 +4,7 @@ class Avo::Actions::ExportCsv < Avo::BaseAction
   self.name = "Export CSV"
   self.no_confirmation = false
   self.standalone = true
-  self.click_backdrop_to_close_modal = false
+  self.close_modal_on_backdrop_click = false
 
   def fields
     # Add more fields here for custom user-selected columns

--- a/spec/dummy/app/avo/actions/export_csv.rb
+++ b/spec/dummy/app/avo/actions/export_csv.rb
@@ -4,6 +4,7 @@ class Avo::Actions::ExportCsv < Avo::BaseAction
   self.name = "Export CSV"
   self.no_confirmation = false
   self.standalone = true
+  self.dynamic_backdrop = false
 
   def fields
     # Add more fields here for custom user-selected columns

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -168,6 +168,35 @@ RSpec.describe "Actions", type: :system do
     end
   end
 
+  describe "action modal dynamic backdrop" do
+    it "closes the modal on backdrop click" do
+      Avo::Actions::ExportCsv.click_backdrop_to_close_modal = true
+
+      visit "/admin/resources/projects"
+
+      click_on "Actions"
+      click_on "Export CSV"
+      find('[data-modal-target="backdrop"]').trigger("click")
+
+      expect(page).not_to have_selector '[data-controller="modal"]'
+    end
+
+    it "does not close the modal on backdrop click" do
+      Avo::Actions::ExportCsv.click_backdrop_to_close_modal = false
+
+      visit "/admin/resources/projects"
+
+      click_on "Actions"
+      click_on "Export CSV"
+      find('[data-modal-target="backdrop"]').trigger("click")
+
+      expect(page).to have_selector '[data-controller="modal"]'
+
+      click_on "Cancel"
+      expect(page).not_to have_selector '[data-controller="modal"]'
+    end
+  end
+
   describe "redirects when no confirmation" do
     it "redirects to hey page" do
       visit "/admin/resources/users"

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -168,9 +168,9 @@ RSpec.describe "Actions", type: :system do
     end
   end
 
-  describe "action modal dynamic backdrop" do
+  describe "action close_modal_on_backdrop_click" do
     it "closes the modal on backdrop click" do
-      Avo::Actions::ExportCsv.click_backdrop_to_close_modal = true
+      Avo::Actions::ExportCsv.close_modal_on_backdrop_click = true
 
       visit "/admin/resources/projects"
 
@@ -182,7 +182,7 @@ RSpec.describe "Actions", type: :system do
     end
 
     it "does not close the modal on backdrop click" do
-      Avo::Actions::ExportCsv.click_backdrop_to_close_modal = false
+      Avo::Actions::ExportCsv.close_modal_on_backdrop_click = false
 
       visit "/admin/resources/projects"
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3326 
Related PR: https://github.com/avo-hq/docs.avohq.io/pull/303

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording

https://www.loom.com/share/970418f8279244f7b4feb97e2617bff5?sid=f44ba85f-55c0-4809-a464-cc1328f628a2

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

By default, action modals use a dynamic backdrop. Added a `self.dynamic_backdrop = false` action option in case you want to prevent the user from closing the modal when clicking on the backdrop.

```ruby
class Avo::Actions::DummyAction < Avo::BaseAction
  self.name = "Dummy action"
  self.dynamic_backdrop = false

  def handle(query:, fields:, current_user:, resource:, **args)
    # Do something here
    succeed 'Yup'
  end
end
```

## Questions

I saw that other action options like `no_confirmation` and `standalone`  doesn't have tests.
1) Should I add tests for a simple feature like this one?

PS: It's not laziness, I'm assuming it's not worth it in this context.

------------------

I left a usage example on the `Avo::Actions::ExportCsv`  action:

```ruby
class Avo::Actions::ExportCsv < Avo::BaseAction
  ...
  self.dynamic_backdrop = false
  ...
end
```

2) Should I remove it?

------------------

I decided to use the name `dynamic_backdrop`  instead of `⁠close_on_backdrop_click`. Usually dynamic/static is used to indicate the backdrop behavior.
3) Do you prefer to keep it `⁠close_on_backdrop_click` ?

------------------

4) Should I add `dynamic_backdrop` option on the action generator?
