### PR TITLE
Adds a rake task to detect missing translations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,7 @@ load "rails/tasks/engine.rake"
 load "rails/tasks/statistics.rake"
 
 load "lib/tasks/avo_tasks.rake"
+load "lib/tasks/i18n.rake"
 
 require "bundler/gem_tasks"
 

--- a/lib/tasks/i18n.rake
+++ b/lib/tasks/i18n.rake
@@ -1,0 +1,50 @@
+desc "Compares the en avo translation keys with the other locales and reports missing keys"
+task "avo:i18n:missing_translations" => :environment do
+  # Nothing to compare if there's only one locale
+  return if I18n.available_locales.size <= 1
+
+  # This locale is considered the reference as to what keys should exist
+  locale_to_compare_to = :en
+
+  # Ensure translations are loaded
+  I18n.backend.send(:init_translations)
+
+  # Get all translations
+  translations = I18n.backend.send(:translations)
+
+  # Helper method to collect all translation keys in in a given scope
+  def collect_translation_keys(scope, translations)
+    translations.map do |key, translations|
+      new_scope = scope + [key]
+      if translations.is_a?(Hash)
+        collect_translation_keys(new_scope, translations)
+      else
+        new_scope.join(".")
+      end
+    end.flatten
+  end
+
+  # Collect all avo translation keys in the reference locale
+  reference_keys = collect_translation_keys([], translations[locale_to_compare_to][:avo]).freeze
+
+  locales_with_missing_keys = {}
+
+  I18n.available_locales.without(locale_to_compare_to).reject do |locale|
+    # Skip locales that don't contain avo translations
+    translations[locale][:avo].nil?
+  end.each do |locale|
+    locale_keys = collect_translation_keys([], translations[locale][:avo])
+
+    missing_keys = reference_keys - locale_keys
+
+    locales_with_missing_keys[locale] = missing_keys if missing_keys.any?
+  end
+
+  locales_with_missing_keys.each do |locale, missing_keys|
+    puts "Missing keys in #{locale}:"
+    puts missing_keys.map { |k| "  #{locale}.avo.#{k}" }.join("\n")
+  end
+
+  # Signal an error if any missing keys were found (for CI)
+  exit 1 if locales_with_missing_keys.any?
+end


### PR DESCRIPTION
# Description
This adds a Rake task that compares the English translation keys for Avo with the Avo translations in the other locales, and reports any missing translations. If any are found, it exits with error code 1. It ignores any locales that don't have translations in the `avo` scope.

Run it with `bundle exec rake avo:i18n:missing_translations`

This could e.g. be run as part of a pre-release workflow to ensure that all locales have the required translation keys. This would prevent issues like #3400.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
Part of the output of this task if run against the current main branch:
<img width="666" alt="Screenshot 2024-11-09 at 13 45 52" src="https://github.com/user-attachments/assets/b3766cf4-2f17-41e4-9762-e7f804802b66">

Note that this shows the key from #3400 as missing in the de locale, amongst others.

## Manual review steps

1. Run the rake task.
2. Add one of the missing translations.
3. Re-run the rake task, and see if the key is still reported as missing.