### PR TITLE
Fix translation in de locale

### DIFF
--- a/lib/generators/avo/templates/locales/avo.de.yml
+++ b/lib/generators/avo/templates/locales/avo.de.yml
@@ -15,7 +15,7 @@ de:
     attachment_class_attached: "%{attachment_class} angehängt."
     attachment_class_detached: "%{attachment_class} abgehängt."
     attachment_destroyed: Anhang gelöscht
-    attachment_failed: Kon %{attachment_class} niet bijvoegen
+    attachment_failed: "%{attachment_class} konnte nicht angehängt werden"
     cancel: Abbrechen
     choose_a_country: Land auswählen
     choose_an_option: Option auswählen


### PR DESCRIPTION
# Description

It looks like this one translation is from the dutch locale, but it's definitely not German.

This fixes this one translation to be in German.

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
n/a

## Manual review steps
n/a
