### PR TITLE
enhancement: add divider to custom list (custom controls)

### DIFF
--- a/app/components/avo/actions_component.rb
+++ b/app/components/avo/actions_component.rb
@@ -68,7 +68,7 @@ class Avo::ActionsComponent < Avo::BaseComponent
   def render_item(action)
     case action
     when Avo::Divider
-      render_divider(action)
+      render Avo::DividerComponent.new(action.label)
     when Avo::BaseAction
       render_action_link(action)
     when defined?(Avo::Advanced::Resources::Controls::Action) && Avo::Advanced::Resources::Controls::Action
@@ -83,11 +83,6 @@ class Avo::ActionsComponent < Avo::BaseComponent
   end
 
   private
-
-  def render_divider(action)
-    label = action.label.is_a?(Hash) ? action.label[:label] : nil
-    render Avo::DividerComponent.new(label)
-  end
 
   def render_action_link(action, icon: nil)
     link_to action.link_arguments(resource: @resource, arguments: action.arguments).first,

--- a/lib/avo/divider.rb
+++ b/lib/avo/divider.rb
@@ -1,8 +1,8 @@
 class Avo::Divider < Avo::BaseAction
-  attr_reader :label, :view
+  attr_reader :label
 
-  def initialize(label: nil, view: nil, **kwargs)
-    @label = label
-    @view = view
+  def initialize(**kwargs)
+    @label = kwargs[:label]
+    @view = kwargs[:view]
   end
 end

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -322,8 +322,8 @@ module Avo
         cards
       end
 
-      def divider(label = nil)
-        entity_loader(:action).use({class: Divider, label: label}.compact)
+      def divider(**kwargs)
+        entity_loader(:action).use({class: Divider, **kwargs}.compact)
       end
 
       # def fields / def cards

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -322,8 +322,8 @@ module Avo
         cards
       end
 
-      def divider(**)
-        entity_loader(:action).use({class: Divider, **}.compact)
+      def divider(**kwargs)
+        entity_loader(:action).use({class: Divider, **kwargs}.compact)
       end
 
       # def fields / def cards

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -322,8 +322,8 @@ module Avo
         cards
       end
 
-      def divider(**kwargs)
-        entity_loader(:action).use({class: Divider, **kwargs}.compact)
+      def divider(**)
+        entity_loader(:action).use({class: Divider, **}.compact)
       end
 
       # def fields / def cards


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3297

### Related PR
https://github.com/avo-hq/avo-advanced/pull/51

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
  - https://github.com/avo-hq/docs.avohq.io/pull/309
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording

```ruby
self.index_controls = -> do
  action Avo::Actions::ReleaseFish

  list label: "Custom Index List", icon: "heroicons/outline/cube-transparent", style: :primary, color: :slate, title: "A custom list" do
    link_to "Google", "https://google.com", icon: "heroicons/outline/academic-cap"
    divider label: "↓ Action ↓"
    action Avo::Actions::Sub::DummyAction, icon: "heroicons/outline/globe"
    divider
    link_to "Fish.com", "https://fish.com", icon: "heroicons/outline/fire", target: :_blank
    link_to "Avo", "https://avohq.io/", target: :_blank
  end
end
```

![image](https://github.com/user-attachments/assets/0a615db5-2a3d-4bab-8e23-b02248d9ece9)
