### PR TITLE
enhancement: extra params on global search

### DIFF
--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -24,6 +24,10 @@ export default class extends Controller {
     'clearButton',
   ]
 
+  static values = {
+    extraParams: Object,
+  }
+
   debouncedFetch = debouncePromise(fetch, this.searchDebounce)
 
   destroyMethod
@@ -256,6 +260,7 @@ export default class extends Controller {
       ...Object.fromEntries(new URLSearchParams(window.location.search)),
       q: query,
       global: false,
+      ...this.extraParamsValue,
     }
 
     if (this.isGlobalSearch) {

--- a/app/views/avo/partials/_navbar.html.erb
+++ b/app/views/avo/partials/_navbar.html.erb
@@ -7,7 +7,7 @@
     <%= render partial: "avo/partials/logo" %>
   </div>
   <div class="flex-1 flex items-center justify-between lg:justify-start space-x-2 sm:space-x-8 lg:px-2">
-    <%= render Avo::Pro::GlobalSearchComponent.new rescue nil %>
+    <%= render Avo::Pro::GlobalSearchComponent.new(resource:) if defined?(Avo::Pro::GlobalSearchComponent) %>
     <div class="m-0">
       <%= render partial: "avo/partials/header" %>
     </div>

--- a/app/views/layouts/avo/application.html.erb
+++ b/app/views/layouts/avo/application.html.erb
@@ -29,7 +29,7 @@
   <body class="bg-application os-mac">
     <div class="relative flex flex-1 w-full min-h-full" data-controller="sidebar" data-sidebar-open-value="<%= @sidebar_open %>">
       <div class="flex-1 flex flex-col max-w-full">
-        <%= render partial: "avo/partials/navbar" %>
+        <%= render partial: "avo/partials/navbar", locals: { resource: @resource } %>
         <div data-sidebar-target="mainArea" class="content-area flex-1 flex pt-16 relative <%= "sidebar-open" if @sidebar_open %>">
           <div class="hidden lg:flex">
             <%= render Avo::SidebarComponent.new sidebar_open: @sidebar_open %>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3324
Related PR https://github.com/avo-hq/avo-pro/pull/95

Now, `params[:resource_class]` and `params[:record_id]` are present on the search query, bringing information about the resource and the record.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
https://www.loom.com/share/84b66f8b21cc4908beba09abe1f79d19?sid=d7975477-b20a-40d2-be24-372553de5db4
