### PR TITLE
dx: raise informative error when `inverse_of` is missing on STI

### DIFF
--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -117,6 +117,13 @@ module Avo
 
     def set_reflection
       @reflection = @record.class.reflect_on_association(association_from_params)
+
+      # Ensure inverse_of is present on STI
+      if !@record.class.descends_from_active_record? && @reflection.inverse_of.blank? && Rails.env.development?
+        raise "Avo relies on the 'inverse_of' option to establish the inverse association and perform some specific logic.\n"\
+          "Please configure the 'inverse_of' option for the '#{@reflection.macro} :#{@reflection.name}' association "\
+          "in the '#{@reflection.active_record.name}' model."
+      end
     end
 
     def set_attachment_class

--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -120,8 +120,8 @@ module Avo
 
       # Ensure inverse_of is present on STI
       if !@record.class.descends_from_active_record? && @reflection.inverse_of.blank? && Rails.env.development?
-        raise "Avo relies on the 'inverse_of' option to establish the inverse association and perform some specific logic.\n"\
-          "Please configure the 'inverse_of' option for the '#{@reflection.macro} :#{@reflection.name}' association "\
+        raise "Avo relies on the 'inverse_of' option to establish the inverse association and perform some specific logic.\n" \
+          "Please configure the 'inverse_of' option for the '#{@reflection.macro} :#{@reflection.name}' association " \
           "in the '#{@reflection.active_record.name}' model."
       end
     end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3406

In STI models, the `inverse_of` option is essential on associations for correctly configuring `via_*` parameters on links.

When Avo encounters an STI model without `inverse_of` set in the reflection, it will raise an informative error **in development environment only**.


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording

```ruby
class Users::Student < User
  has_many :marks, foreign_key: :student_id
end
```

![image](https://github.com/user-attachments/assets/07d227d9-dc11-4fae-b5d5-ecb456a581ee)
