### PR TITLE
enhancement: eject components from plugins

### DIFF
--- a/lib/generators/avo/eject_generator.rb
+++ b/lib/generators/avo/eject_generator.rb
@@ -117,8 +117,16 @@ module Generators
           # Example: Avo::Views::ResourceIndexComponent => avo/views/resource_index_component
           component = component_to_eject.underscore
 
+
           # Get the component path for both, the rb and erb files
-          rb, erb = ["app/components/#{component}.rb", "app/components/#{component}.html.erb"]
+          rb, erb = if component_constant = component_to_eject.safe_constantize
+            # If component is a constant, find the source location
+            source_location = component_constant.source_location
+
+            [source_location, source_location.gsub(".rb", ".html.erb")]
+          else
+            ["app/components/#{component}.rb", "app/components/#{component}.html.erb"]
+          end
 
           # Return if one of the components doesn't exist
           if !path_exists?(rb) || !path_exists?(erb)

--- a/lib/generators/avo/eject_generator.rb
+++ b/lib/generators/avo/eject_generator.rb
@@ -117,7 +117,6 @@ module Generators
           # Example: Avo::Views::ResourceIndexComponent => avo/views/resource_index_component
           component = component_to_eject.underscore
 
-
           # Get the component path for both, the rb and erb files
           rb, erb = if component_constant = component_to_eject.safe_constantize
             # If component is a constant, find the source location

--- a/lib/generators/avo/eject_generator.rb
+++ b/lib/generators/avo/eject_generator.rb
@@ -118,7 +118,7 @@ module Generators
           component = component_to_eject.underscore
 
           # Get the component path for both, the rb and erb files
-          rb, erb = if component_constant = component_to_eject.safe_constantize
+          rb, erb = if (component_constant = component_to_eject.safe_constantize)
             # If component is a constant, find the source location
             source_location = component_constant.source_location
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Allow to eject components from plugins, for example, to eject kanban item: `rails g avo:eject --component Avo::Kanban::Items::ItemComponent`

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
