### PR TITLE
fix: i18n on resource class

### DIFF
--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -179,7 +179,7 @@ module Avo
         end
 
         def name
-          @name ||= name_from_translation_key(count: 1, default: class_name.underscore.humanize)
+          name_from_translation_key(count: 1, default: class_name.underscore.humanize)
         end
         alias_method :singular_name, :name
 
@@ -203,8 +203,6 @@ module Avo
         end
 
         def underscore_name
-          return @name if @name.present?
-
           name.demodulize.underscore
         end
 
@@ -256,39 +254,6 @@ module Avo
       delegate :find_record, to: :class
       delegate :model_key, to: :class
       delegate :tab, to: :items_holder
-
-      # Test if instance methods fixes the issue
-      # Uncomment to test theory
-      # def translation_key
-      #   @translation_key || "avo.resource_translations.#{class_name.underscore}"
-      # end
-
-      # def name
-      #   @name ||= name_from_translation_key(count: 1, default: class_name.underscore.humanize)
-      # end
-      # alias_method :singular_name, :name
-
-      # def plural_name
-      #   name_from_translation_key(count: 2, default: name.pluralize)
-      # end
-
-      # def name_from_translation_key(count:, default:)
-      #   t(translation_key, count:, default:).humanize
-      # rescue I18n::InvalidPluralizationData
-      #   default
-      # end
-
-      # def underscore_name
-      #   return @name if @name.present?
-
-      #   name.demodulize.underscore
-      # end
-
-      # def navigation_label
-      #   plural_name.humanize
-      # end
-
-
 
       def initialize(record: nil, view: nil, user: nil, params: nil)
         @view = Avo::ViewInquirer.new(view) if view.present?

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -257,6 +257,39 @@ module Avo
       delegate :model_key, to: :class
       delegate :tab, to: :items_holder
 
+      # Test if instance methods fixes the issue
+      # Uncomment to test theory
+      # def translation_key
+      #   @translation_key || "avo.resource_translations.#{class_name.underscore}"
+      # end
+
+      # def name
+      #   @name ||= name_from_translation_key(count: 1, default: class_name.underscore.humanize)
+      # end
+      # alias_method :singular_name, :name
+
+      # def plural_name
+      #   name_from_translation_key(count: 2, default: name.pluralize)
+      # end
+
+      # def name_from_translation_key(count:, default:)
+      #   t(translation_key, count:, default:).humanize
+      # rescue I18n::InvalidPluralizationData
+      #   default
+      # end
+
+      # def underscore_name
+      #   return @name if @name.present?
+
+      #   name.demodulize.underscore
+      # end
+
+      # def navigation_label
+      #   plural_name.humanize
+      # end
+
+
+
       def initialize(record: nil, view: nil, user: nil, params: nil)
         @view = Avo::ViewInquirer.new(view) if view.present?
         @user = user if user.present?

--- a/spec/dummy/config/locales/avo.pt.yml
+++ b/spec/dummy/config/locales/avo.pt.yml
@@ -1,0 +1,5 @@
+---
+pt:
+  avo:
+    resource_translations:
+      product: "Produto"

--- a/spec/features/avo/generators/locales_generator_spec.rb
+++ b/spec/features/avo/generators/locales_generator_spec.rb
@@ -3,11 +3,19 @@ require "rails/generators"
 
 RSpec.feature "locales generator", type: :feature do
   it "generates the files" do
-    # Backup the en locale
-    en_locale_backup = Rails.root.join("config", "locales", "avo.en.yml.bak")
-    FileUtils.cp(Rails.root.join("config", "locales", "avo.en.yml"), en_locale_backup)
+    # Define locales to backup
+    backup_locales = %w[en pt]
 
-    locales = %w[en fr nn nb pt-BR pt ro tr ar ja es]
+    # Backup locales
+    backup_files = {}
+    backup_locales.each do |locale|
+      original_file = Rails.root.join("config", "locales", "avo.#{locale}.yml")
+      backup_file = Rails.root.join("config", "locales", "avo.#{locale}.yml.bak")
+      FileUtils.cp(original_file, backup_file) if File.exist?(original_file)
+      backup_files[locale] = { original: original_file, backup: backup_file }
+    end
+
+    locales = %w[ar de en es fr it ja nb nl nn pl pt-BR pt ro ru tr uk zh]
 
     files = locales.map do |locale|
       Rails.root.join("config", "locales", "avo.#{locale}.yml").to_s
@@ -17,11 +25,13 @@ RSpec.feature "locales generator", type: :feature do
       files << Rails.root.join("config", "locales", "pagy", "#{locale}.yml").to_s
     end
 
-    Rails::Generators.invoke("avo:locales", ["-q"], {destination_root: Rails.root})
+    Rails::Generators.invoke("avo:locales", ["-q"], { destination_root: Rails.root })
 
     check_files_and_clean_up files
 
-    # Restore the en locale
-    FileUtils.mv(en_locale_backup, Rails.root.join("config", "locales", "avo.en.yml"))
+    # Restore locales from backup
+    backup_files.each do |locale, paths|
+      FileUtils.mv(paths[:backup], paths[:original]) if File.exist?(paths[:backup])
+    end
   end
 end

--- a/spec/features/avo/generators/locales_generator_spec.rb
+++ b/spec/features/avo/generators/locales_generator_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "locales generator", type: :feature do
       original_file = Rails.root.join("config", "locales", "avo.#{locale}.yml")
       backup_file = Rails.root.join("config", "locales", "avo.#{locale}.yml.bak")
       FileUtils.cp(original_file, backup_file) if File.exist?(original_file)
-      backup_files[locale] = { original: original_file, backup: backup_file }
+      backup_files[locale] = {original: original_file, backup: backup_file}
     end
 
     locales = %w[ar de en es fr it ja nb nl nn pl pt-BR pt ro ru tr uk zh]
@@ -25,7 +25,7 @@ RSpec.feature "locales generator", type: :feature do
       files << Rails.root.join("config", "locales", "pagy", "#{locale}.yml").to_s
     end
 
-    Rails::Generators.invoke("avo:locales", ["-q"], { destination_root: Rails.root })
+    Rails::Generators.invoke("avo:locales", ["-q"], {destination_root: Rails.root})
 
     check_files_and_clean_up files
 

--- a/spec/features/avo/localization_spec.rb
+++ b/spec/features/avo/localization_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.feature "Localization spec", type: :feature do
+  describe "force_locale" do
+    it "translates the resource name on the create button" do
+      visit avo.resources_products_path(force_locale: :pt)
+
+      expect(page).to have_text "Criar novo produto"
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3449

Remove memoization from resource name to force re-evaluation on locale change.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

