### PR TITLE
Fix Turbo.config.forms.confirm deprecation message

### DIFF
--- a/app/javascript/js/custom-confirm.js
+++ b/app/javascript/js/custom-confirm.js
@@ -1,6 +1,6 @@
 import { Turbo } from '@hotwired/turbo-rails'
 
-Turbo.setConfirmMethod((message) => {
+Turbo.config.forms.confirm = (message) => {
   const dialog = document.getElementById('turbo-confirm')
   dialog.querySelector('p').textContent = message
   dialog.showModal()
@@ -16,4 +16,4 @@ Turbo.setConfirmMethod((message) => {
       resolve(dialog.returnValue === 'confirm')
     }, { once: true })
   })
-})
+}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Turbo 8 deprecated `Turbo.setConfirmMethod()` and instead moved it to `Turbo.config.forms.confirm` instead (see https://github.com/hotwired/turbo/pull/1216). Because of that, avo is throwing deprecation messages in the javascript console:

    Please replace `Turbo.setConfirmMethod(confirmMethod)` with `Turbo.config.forms.confirm = confirmMethod`. The top-level function is deprecated and will be removed in a future version of Turbo.

I've updated the code to use the new config object instead, which should resolve the deprecation warning.

Fixes # (issue)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Confirm that turbo confirmation popups still work.

Manual reviewer: please leave a comment with output from the test if that's the case.
