### PR TITLE
fix: broken attach and attach another button for searchable associations

### DIFF
--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -68,8 +68,7 @@ module Avo
         .append_query(
           {
             view: @resource&.view&.to_s,
-            for_attribute: @field&.try(:for_attribute),
-            turbo_frame: params[:turbo_frame],
+            for_attribute: @field&.try(:for_attribute)
           }.compact
         )
         .to_s

--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -68,7 +68,8 @@ module Avo
         .append_query(
           {
             view: @resource&.view&.to_s,
-            for_attribute: @field&.try(:for_attribute)
+            for_attribute: @field&.try(:for_attribute),
+            turbo_frame: params[:turbo_frame],
           }.compact
         )
         .to_s

--- a/app/views/avo/associations/new.html.erb
+++ b/app/views/avo/associations/new.html.erb
@@ -41,8 +41,14 @@
                 stacked: true,
                 classes: 'w-full'
               %>
-              <%= hidden_field_tag :turbo_frame, params[:turbo_frame] %>
             <% end %>
+            <%#
+              It is important to render this hidden field to allow selective rendering of the turbo frame.
+              (e.g. in the case of "Attach and Attach Another")
+
+              Without this, the entire page will be reloaded when the form is submitted.
+            %>
+            <%= hidden_field_tag :turbo_frame, params[:turbo_frame] %>
             <% @attach_fields&.each_with_index do |field, index| %>
               <%= render(Avo::Items::SwitcherComponent.new(
                 resource: @related_resource,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I _think_ this is all that's necessary to fix the issue linked below. In the AssociationsController, we expect a `:turbo_frame` param to be passed to the route if we want to rerender the turbo frame instead of closing it. The only bit I'm unclear on is whether we need to have additional special handling for the `attach_another` button. I figured [this](https://github.com/avo-hq/avo/blob/f6d132891fdf87a754af0880a3a97b9b3e0d4f51/app/controllers/avo/associations_controller.rb#L256) was enough.

Fixes #3456 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
