### PR TITLE
fix: Rename Turbo Stream helpers to avoid clashes in user apps (#3462)

### DIFF
--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -104,13 +104,13 @@ module Avo
           turbo_response = case @response[:type]
           when :keep_modal_open
             # Only render the flash messages if the action keeps the modal open
-            turbo_stream.flash_alerts
+            turbo_stream.avo_flash_alerts
           when :download
             # Trigger download, removes modal and flash the messages
             [
-              turbo_stream.download(content: Base64.encode64(@response[:path]), filename: @response[:filename]),
-              turbo_stream.close_modal,
-              turbo_stream.flash_alerts
+              turbo_stream.avo_download(content: Base64.encode64(@response[:path]), filename: @response[:filename]),
+              turbo_stream.avo_close_modal,
+              turbo_stream.avo_flash_alerts
             ]
           when :navigate_to_action
             src, _ = @response[:action].link_arguments(resource: @action.resource, **@response[:navigate_to_action_args])
@@ -125,8 +125,8 @@ module Avo
           when :close_modal
             # Close the modal and flash the messages
             [
-              turbo_stream.close_modal,
-              turbo_stream.flash_alerts
+              turbo_stream.avo_close_modal,
+              turbo_stream.avo_flash_alerts
             ]
           else
             # Reload the page

--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -254,7 +254,7 @@ module Avo
       turbo_streams = super
 
       # We want to close the modal if the user wants to add just one record
-      turbo_streams << turbo_stream.close_modal if params[:button] != "attach_another"
+      turbo_streams << turbo_stream.avo_close_modal if params[:button] != "attach_another"
 
       turbo_streams
     end

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -556,7 +556,7 @@ module Avo
       flash[:error] = destroy_fail_message
 
       respond_to do |format|
-        format.turbo_stream { render turbo_stream: turbo_stream.flash_alerts }
+        format.turbo_stream { render turbo_stream: turbo_stream.avo_flash_alerts }
       end
     end
 
@@ -660,7 +660,7 @@ module Avo
     def reload_frame_turbo_streams
       [
         turbo_stream.turbo_frame_reload(params[:turbo_frame]),
-        turbo_stream.flash_alerts
+        turbo_stream.avo_flash_alerts
       ]
     end
   end

--- a/app/helpers/avo/turbo_stream_actions_helper.rb
+++ b/app/helpers/avo/turbo_stream_actions_helper.rb
@@ -1,16 +1,16 @@
 module Avo
   module TurboStreamActionsHelper
-    def download(content:, filename:)
+    def avo_download(content:, filename:)
       turbo_stream_action_tag :download, content: content, filename: filename
     end
 
-    def flash_alerts
+    def avo_flash_alerts
       turbo_stream_action_tag :append,
         target: "alerts",
         template: @view_context.render(Avo::FlashAlertsComponent.new(flashes: @view_context.flash.discard))
     end
 
-    def close_modal
+    def avo_close_modal
       turbo_stream_action_tag :replace,
         target: Avo::MODAL_FRAME_ID,
         template: @view_context.turbo_frame_tag(Avo::MODAL_FRAME_ID, data: {turbo_temporary: 1})

--- a/spec/helpers/avo/turbo_stream_actions_helper_spec.rb
+++ b/spec/helpers/avo/turbo_stream_actions_helper_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe Avo::TurboStreamActionsHelper, type: :helper do
+  let(:turbo_stream) do
+    Turbo::Streams::TagBuilder.new(self)
+  end
+
+  before do
+    @view_context = helper
+  end
+
+  describe "#avo_download" do
+    subject do
+      helper.avo_download(content:, filename:)
+    end
+
+    let(:content) { "file content" }
+    let(:filename) { "file.txt" }
+
+    it { is_expected.to have_css("turbo-stream[action=\"download\"]") }
+    it { is_expected.to have_css("turbo-stream[content=\"file content\"]") }
+    it { is_expected.to have_css("turbo-stream[filename=\"file.txt\"]") }
+  end
+
+  describe "#avo_flash_alerts" do
+    subject do
+      helper.avo_flash_alerts
+    end
+
+    before do
+      allow(helper).to receive(:render).and_return("flash alerts")
+      allow(helper).to receive(:flash).and_return(double(discard: {}))
+    end
+
+    it { is_expected.to have_css("turbo-stream[action=\"append\"]") }
+    it { is_expected.to have_css("turbo-stream[target=\"alerts\"]") }
+    it { is_expected.to include("<template>flash alerts</template>") }
+  end
+
+  describe "#avo_close_modal" do
+    subject do
+      helper.avo_close_modal
+    end
+
+    it { is_expected.to have_css("turbo-stream[action=\"replace\"]") }
+    it { is_expected.to have_css("turbo-stream[target=\"#{Avo::MODAL_FRAME_ID}\"]") }
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3462

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas - simple renaming, shouldn't require new comments
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs) - doesn't seem to be any documentation referencing these methods
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
