### PR TITLE
perf: svg loading improvements

### DIFF
--- a/app/helpers/avo/application_helper.rb
+++ b/app/helpers/avo/application_helper.rb
@@ -65,7 +65,7 @@ module Avo
 
       file_name = "#{file_name}.svg" unless file_name.end_with? ".svg"
 
-      with_asset_finder(::Avo::SvgFinder) do
+      Avo::CACHED_SVGS[file_name] ||= with_asset_finder(::Avo::SvgFinder) do
         inline_svg file_name, **args
       end
     end

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -19,6 +19,7 @@ module Avo
   COOKIES_KEY = "avo"
   MODAL_FRAME_ID = :modal_frame
   ACTIONS_BACKGROUND_FRAME = :actions_background
+  CACHED_SVGS = {}
 
   class LicenseVerificationTemperedError < StandardError; end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

On the same lines with https://github.com/avo-hq/avo/pull/3177 but this time, it works. Thanks Paul for the help.

We are caching, in memory, all the svg paths.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
