### PR TITLE
fix: file field find persisted record

### DIFF
--- a/lib/avo/fields/file_field.rb
+++ b/lib/avo/fields/file_field.rb
@@ -30,7 +30,7 @@ module Avo
 
         # On edit view always show the persisted image. Related: issue#3008
         if final_value.instance_of?(ActiveStorage::Attached::One) && @view.edit?
-          persisted_record = @resource.find_record(@record.id)
+          persisted_record = @resource.find_record(@record.to_param)
           final_value = persisted_record.send(@for_attribute || @id)
         end
 

--- a/lib/avo/fields/file_field.rb
+++ b/lib/avo/fields/file_field.rb
@@ -27,11 +27,13 @@ module Avo
 
       def value
         final_value = super
+
         # On edit view always show the persisted image. Related: issue#3008
-        if final_value.instance_of?(ActiveStorage::Attached::One) && view == "edit"
-          persisted_record = record.class.find_by(id: record.id)
-          final_value = persisted_record.send(@for_attribute || id)
+        if final_value.instance_of?(ActiveStorage::Attached::One) && @view.edit?
+          persisted_record = @resource.find_record(@record.id)
+          final_value = persisted_record.send(@for_attribute || @id)
         end
+
         final_value
       end
     end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3473

Use the `find_record` resource method instead of directly querying the class to locate the `persisted_record` when handling file fields in an edit view.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
