### PR TITLE
fix: svg cache

### DIFF
--- a/lib/avo/svg_finder.rb
+++ b/lib/avo/svg_finder.rb
@@ -13,10 +13,12 @@ class Avo::SvgFinder
       found_asset = default_strategy
 
       # Use the found asset
-      return found_asset if found_asset.present?
-
-      paths.find do |path|
-        File.exist? path
+      if found_asset.present?
+        found_asset
+      else
+        paths.find do |path|
+          File.exist? path
+        end
       end
     end
   end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

From the SVG caching saga, this PR fixes an early return that was bypassing the caching mechanism.

Related to https://github.com/avo-hq/avo/pull/3470 & https://github.com/avo-hq/avo/pull/3471