### PR TITLE
fix: profile menu position

### DIFF
--- a/app/components/avo/sidebar_profile_component.html.erb
+++ b/app/components/avo/sidebar_profile_component.html.erb
@@ -21,7 +21,7 @@
       <%= helpers.svg "avo/three-dots", class: 'h-4' %>
     </a>
     <div
-      class="hidden absolute flex flex-col inset-auto right-0 -mt-28 bg-white rounded min-w-[200px] shadow-context z-40"
+      class="hidden absolute flex flex-col inset-auto right-0 bottom-0 mb-8 bg-white rounded min-w-[200px] shadow-context z-40"
       data-toggle-target="panel"
       data-transition-enter="transition ease-in-out duration-100"
       data-transition-enter-start="transform opacity-0 translate-y-3"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3482 

Fixes a bug where the profile menu wasn't positioned correctly.

![CleanShot 2024-12-03 at 14 48 53](https://github.com/user-attachments/assets/f2717df9-920d-49ef-a9f7-ced9bb26f003)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works