### PR TITLE
fix: maintain `per_page` param in associations

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -316,14 +316,14 @@ module Avo
 
       # Pagination
       @index_params[:page] = params[:page] || page_from_session || 1
-      @index_params[:per_page] = Avo.configuration.per_page
-
-      if cookies[:per_page].present?
-        @index_params[:per_page] = cookies[:per_page]
-      end
+      @index_params[:per_page] = cookies[:per_page] || Avo.configuration.per_page
 
       if @parent_record.present?
-        @index_params[:per_page] = Avo.configuration.via_per_page
+        per_page_key = "#{@record.to_global_id}.has_many.#{@resource.class.to_s.parameterize}.per_page"
+        session[per_page_key] = params[:per_page] || session[per_page_key]
+        per_page_from_session = session[per_page_key]
+
+        @index_params[:per_page] = per_page_from_session || Avo.configuration.via_per_page
       end
 
       if params[:per_page].present?

--- a/spec/system/avo/tabs_spec.rb
+++ b/spec/system/avo/tabs_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe "Tabs", type: :system do
     find('a[data-selected="false"][data-tabs-tab-name-param="Projects"]').click
     within("#has_and_belongs_to_many_field_show_projects") do
       expect(page).to have_text "Displaying items 1-8 of 9 in total"
-      find('select#per_page.appearance-none').select('24')
+      find("select#per_page.appearance-none").select("24")
     end
 
     expect(page).to have_text "Displaying 9 items"

--- a/spec/system/avo/tabs_spec.rb
+++ b/spec/system/avo/tabs_spec.rb
@@ -200,4 +200,26 @@ RSpec.describe "Tabs", type: :system do
     expect(page).to have_css('a.current[role="link"][aria-disabled="true"][aria-current="page"]', text: "2")
     expect(page).to have_text "Displaying items 9-9 of 9 in total"
   end
+
+  it "keeps the per_page on association when back is used" do
+    visit avo.resources_user_path user
+
+    find('a[data-selected="false"][data-tabs-tab-name-param="Projects"]').click
+    within("#has_and_belongs_to_many_field_show_projects") do
+      expect(page).to have_text "Displaying items 1-8 of 9 in total"
+      find('select#per_page.appearance-none').select('24')
+    end
+
+    expect(page).to have_text "Displaying 9 items"
+    expect(find('select#per_page.appearance-none').find('option[selected]').text).to eq('24')
+
+    find_all('a[aria-label="View project"]')[0].click
+    wait_for_loaded
+
+    page.go_back
+    wait_for_loaded
+
+    expect(page).to have_text "Displaying 9 items"
+    expect(find('select#per_page.appearance-none').find('option[selected]').text).to eq('24')
+  end
 end

--- a/spec/system/avo/tabs_spec.rb
+++ b/spec/system/avo/tabs_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe "Tabs", type: :system do
     end
 
     expect(page).to have_text "Displaying 9 items"
-    expect(find('select#per_page.appearance-none').find('option[selected]').text).to eq('24')
+    expect(find("select#per_page.appearance-none").find("option[selected]").text).to eq("24")
 
     find_all('a[aria-label="View project"]')[0].click
     wait_for_loaded
@@ -220,6 +220,6 @@ RSpec.describe "Tabs", type: :system do
     wait_for_loaded
 
     expect(page).to have_text "Displaying 9 items"
-    expect(find('select#per_page.appearance-none').find('option[selected]').text).to eq('24')
+    expect(find("select#per_page.appearance-none").find("option[selected]").text).to eq("24")
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3489 

Store `per_page` on associations making the navigation between associated records a bit smoother.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

