### PR TITLE
enhancement: `exclude_from_status` configuration

### DIFF
--- a/app/views/avo/debug/status.html.erb
+++ b/app/views/avo/debug/status.html.erb
@@ -9,7 +9,8 @@
     'port',
     'ip',
     'app_name',
-  ]
+  ].excluding(Avo.configuration.exclude_from_status)
+
   hq_payload = Avo::Licensing::HQ.new(request).payload
 %>
 <div class="flex flex-col">

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -10,6 +10,7 @@ module Avo
     attr_writer :turbo
     attr_writer :pagination
     attr_writer :explicit_authorization
+    attr_writer :exclude_from_status
     attr_accessor :timezone
     attr_accessor :per_page
     attr_accessor :per_page_steps
@@ -121,6 +122,7 @@ module Avo
       @search_results_count = 8
       @first_sorting_option = :desc # :desc or :asc
       @associations_lookup_list_limit = 1000
+      @exclude_from_status = []
     end
 
     # Authorization is enabled when:
@@ -249,6 +251,10 @@ module Avo
 
     def turbo
       Avo::ExecutionContext.new(target: @turbo).handle
+    end
+
+    def exclude_from_status
+      Avo::ExecutionContext.new(target: @exclude_from_status).handle
     end
 
     def default_turbo

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -120,6 +120,7 @@ Avo.configure do |config|
   # config.field_wrapper_layout = true
   # config.resource_parent_controller = "Avo::ResourcesController"
   # config.first_sorting_option = :desc # :desc or :asc
+  # config.exclude_from_status = []
 
   ## == Branding ==
   # config.branding = {

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -14,6 +14,7 @@ Avo.configure do |config|
 
   ## == Licensing ==
   config.license_key = ENV["AVO_LICENSE_KEY"]
+  config.exclude_from_status = ["license_key"]
 
   ## == App context ==
   config.current_user_method = :current_user


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Add `exclude_from_status` configuration where can be defined what status item to exclude on the status page.

Usage example: 

```ruby
Avo.configure do |config|
  config.exclude_from_status = ["license_key"]
  # OR
  config.exclude_from_status = -> do 
    ["license_key"]
  end
end
```