### PR TITLE
fix: session key for pagination

### DIFF
--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -290,5 +290,21 @@ module Avo
         options << t("avo.more_records_available") if options.size == Avo.configuration.associations_lookup_list_limit
       end
     end
+
+    def set_pagination_params
+      pagination_key = "#{@parent_resource.class.to_s.parameterize}.has_many.#{@related_resource.class.to_s.parameterize}"
+
+      # avo-resources-project.has_many.avo-resources-user.page
+      page_key = "#{pagination_key}.page"
+
+      session[page_key] = params[:page] || session[page_key] || 1
+      @index_params[:page] = session[page_key]
+
+      # avo-resources-project.has_many.avo-resources-user.per_page
+      per_page_key = "#{pagination_key}.per_page"
+
+      session[per_page_key] = params[:per_page] || session[per_page_key] || Avo.configuration.via_per_page
+      @index_params[:per_page] = session[per_page_key]
+    end
   end
 end

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -644,9 +644,11 @@ module Avo
 
     def set_pagination_params
       @index_params[:page] = params[:page] || 1
-      @index_params[:per_page] = params[:per_page] || cookies[:per_page] || Avo.configuration.per_page
 
+      # If the request includes the 'per_page' parameter, save its value to the cookies
       cookies[:per_page] = params[:per_page] if params[:per_page].present?
+
+      @index_params[:per_page] = cookies[:per_page] || Avo.configuration.per_page
     end
   end
 end

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -314,7 +314,7 @@ module Avo
         # avo-resources-project.has_many.avo-resources-user.page
         page_key = "#{pagination_key}.page"
 
-        session[page_key] = params[:page] || session[key]
+        session[page_key] = params[:page] || session[page_key]
         page_from_session = session[page_key]
 
         # avo-resources-project.has_many.avo-resources-user.per_page

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -307,7 +307,8 @@ module Avo
     def set_index_params
       @index_params = {}
 
-      if @parent_resource.present? && @related_resource.present?
+      # When association table
+      if [@parent_resource, @related_resource].all?(&:present?)
         pagination_key = "#{@parent_resource.class.to_s.parameterize}.has_many.#{@related_resource.class.to_s.parameterize}"
 
         # avo-resources-project.has_many.avo-resources-user.page
@@ -323,7 +324,7 @@ module Avo
         per_page_from_session = session[per_page_key]
 
         @index_params[:per_page] = per_page_from_session || Avo.configuration.via_per_page
-      else
+      else # When index table
         @index_params[:per_page] = params[:per_page] || cookies[:per_page] || Avo.configuration.per_page
 
         cookies[:per_page] = params[:per_page] if params[:per_page].present?

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -643,9 +643,9 @@ module Avo
     end
 
     def set_pagination_params
-      # Pagination
-      # When association table
-      if [@parent_resource, @related_resource].all?(&:present?)
+      rendering_association = @parent_resource.present? && @related_resource.present?
+
+      if rendering_association
         pagination_key = "#{@parent_resource.class.to_s.parameterize}.has_many.#{@related_resource.class.to_s.parameterize}"
 
         # avo-resources-project.has_many.avo-resources-user.page
@@ -660,7 +660,7 @@ module Avo
         session[per_page_key] = params[:per_page] || session[per_page_key] || Avo.configuration.via_per_page
         @index_params[:per_page] = session[per_page_key]
       else # When index table
-        @index_params[:page] = params[:page] || page_from_session || 1
+        @index_params[:page] = params[:page] || 1
         @index_params[:per_page] = params[:per_page] || cookies[:per_page] || Avo.configuration.per_page
 
         cookies[:per_page] = params[:per_page] if params[:per_page].present?

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -643,28 +643,10 @@ module Avo
     end
 
     def set_pagination_params
-      rendering_association = @parent_resource.present? && @related_resource.present?
+      @index_params[:page] = params[:page] || 1
+      @index_params[:per_page] = params[:per_page] || cookies[:per_page] || Avo.configuration.per_page
 
-      if rendering_association
-        pagination_key = "#{@parent_resource.class.to_s.parameterize}.has_many.#{@related_resource.class.to_s.parameterize}"
-
-        # avo-resources-project.has_many.avo-resources-user.page
-        page_key = "#{pagination_key}.page"
-
-        session[page_key] = params[:page] || session[page_key] || 1
-        @index_params[:page] = session[page_key]
-
-        # avo-resources-project.has_many.avo-resources-user.per_page
-        per_page_key = "#{pagination_key}.per_page"
-
-        session[per_page_key] = params[:per_page] || session[per_page_key] || Avo.configuration.via_per_page
-        @index_params[:per_page] = session[per_page_key]
-      else # When index table
-        @index_params[:page] = params[:page] || 1
-        @index_params[:per_page] = params[:per_page] || cookies[:per_page] || Avo.configuration.per_page
-
-        cookies[:per_page] = params[:per_page] if params[:per_page].present?
-      end
+      cookies[:per_page] = params[:per_page] if params[:per_page].present?
     end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Use `@parent_resource` to generate the pagination key on session instead of using the `@record`

When `@record` is used there will be one entry for each record - association pair:

- `gid://avo3-dummy/Project/36.has_many.avo-resources-user`
- `gid://avo3-dummy/Project/37.has_many.avo-resources-user`
- etc...

But we want one single entry between each parent_resource - association pair:

- `avo-resources-project.has_many.avo-resources-user`

