### PR TITLE
fix: search_controller null error

### DIFF
--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -220,8 +220,6 @@ export default class extends Controller {
       this.updateFieldAttribute(this.hiddenIdTarget, 'value', item._id)
       this.updateFieldAttribute(this.buttonTarget, 'value', this.removeHTMLTags(item._label))
 
-      document.querySelector('.aa-DetachedOverlay').remove()
-
       if (this.hasClearButtonTarget) {
         this.clearButtonTarget.classList.remove('hidden')
       }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes the JS search controller.

`.aa-DetachedOverlay` is already getting removed when a value is selected from the search list, there is no need to remove it with code.

Fixes:

```ruby
search_controller.js:223 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'remove')
    at n.handleOnSelect (search_controller.js:223:51)
```

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
