### PR TITLE
fix: classes on field wrapper component

### DIFF
--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -20,12 +20,10 @@ class Avo::FieldWrapperComponent < Avo::BaseComponent
     value&.to_sym
   end
   prop :args, kind: :**, default: {}.freeze
-  prop :classes do |value|
-    @args&.dig(:class) || ""
-  end
 
   def after_initialize
     @action = @field.action
+    @classes = @args.dig(:class) || ""
   end
 
   def classes(extra_classes = "")

--- a/app/components/avo/index/field_wrapper_component.rb
+++ b/app/components/avo/index/field_wrapper_component.rb
@@ -7,12 +7,10 @@ class Avo::Index::FieldWrapperComponent < Avo::BaseComponent
   prop :center_content, default: false
   prop :flush, default: false
   prop :args, kind: :**, default: {}.freeze
-  prop :classes do |value|
-    @args&.dig(:class) || ""
-  end
 
   def after_initialize
     @view = Avo::ViewInquirer.new("index")
+    @classes = @args.dig(:class) || ""
   end
 
   def classes

--- a/app/components/avo/panel_component.rb
+++ b/app/components/avo/panel_component.rb
@@ -24,8 +24,9 @@ class Avo::PanelComponent < Avo::BaseComponent
   prop :profile_photo
   prop :cover_photo
   prop :args, kind: :**, default: {}.freeze
-  prop :name do |value|
-    value || @args&.dig(:title)
+
+  def after_initialize
+    @name = @args.dig(:name) || @args.dig(:title)
   end
 
   def classes


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes the field wrapper component classes. Previously, the way props were being handled did not account for custom classes, such as "bg-red-500."

For instance, in the following usage:
`<%= index_field_wrapper **field_wrapper_args, class: 'bg-red-500' do %>`

The custom class "bg-red-500" was not being applied correctly. This PR ensures that custom classes are properly merged and rendered.


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
