### PR TITLE
enhancement: `cache_associations_pagination` option

### DIFF
--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -297,14 +297,20 @@ module Avo
       # avo-resources-project.has_many.avo-resources-user.page
       page_key = "#{pagination_key}.page"
 
-      session[page_key] = params[:page] || session[page_key] || 1
-      @index_params[:page] = session[page_key]
+      @index_params[:page] = if Avo.configuration.cache_associations_pagination
+        session[page_key] = params[:page] || session[page_key] || 1
+      else
+        params[:page] || 1
+      end
 
       # avo-resources-project.has_many.avo-resources-user.per_page
       per_page_key = "#{pagination_key}.per_page"
 
-      session[per_page_key] = params[:per_page] || session[per_page_key] || Avo.configuration.via_per_page
-      @index_params[:per_page] = session[per_page_key]
+      @index_params[:per_page] = if Avo.configuration.cache_associations_pagination
+        session[per_page_key] = params[:per_page] || session[per_page_key] || Avo.configuration.via_per_page
+      else
+        params[:per_page] || Avo.configuration.via_per_page
+      end
     end
   end
 end

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -27,6 +27,7 @@ module Avo
     attr_accessor :full_width_index_view
     attr_accessor :cache_resources_on_index_view
     attr_accessor :cache_resource_filters
+    attr_accessor :cache_associations_pagination
     attr_accessor :context
     attr_accessor :display_breadcrumbs
     attr_accessor :hide_layout_when_printing
@@ -87,6 +88,7 @@ module Avo
       @full_width_index_view = false
       @cache_resources_on_index_view = Avo::PACKED
       @cache_resource_filters = false
+      @cache_associations_pagination = false
       @context = proc {}
       @initial_breadcrumbs = proc {
         add_breadcrumb I18n.t("avo.home").humanize, avo.root_path

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -78,6 +78,8 @@ Avo.configure do |config|
   #   ActiveSupport::Cache.lookup_store(:solid_cache_store)
   # }
   # config.cache_resources_on_index_view = true
+  # Flag that enables / disables persistence for page and per_page options on associations tables.
+  # config.cache_associations_pagination = false
   ## permanent enable or disable cache_resource_filters, default value is false
   # config.cache_resource_filters = false
   ## provide a lambda to enable or disable cache_resource_filters per user/resource.

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -45,6 +45,7 @@ Avo.configure do |config|
   config.search_debounce = 300
   # config.field_wrapper_layout = :stacked
   config.cache_resource_filters = false
+  config.cache_associations_pagination = false
   config.click_row_to_view_record = true
 
   config.turbo = {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adding the `cache_associations_pagination` configuration that enables persistence on associations pagination settings.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
e a comment with output from the test if that's the case.
