### PR TITLE
enhancement: persistence setting

### DIFF
--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -304,7 +304,7 @@ module Avo
       # avo-resources-project.has_many.avo-resources-user.page
       page_key = "#{pagination_key}.page"
 
-      @index_params[:page] = if Avo.configuration.cache_associations_pagination
+      @index_params[:page] = if Avo.configuration.session_persistence_enabled?
         session[page_key] = params[:page] || session[page_key] || 1
       else
         params[:page] || 1
@@ -315,7 +315,7 @@ module Avo
       # avo-resources-project.has_many.avo-resources-user.per_page
       per_page_key = "#{pagination_key}.per_page"
 
-      @index_params[:per_page] = if Avo.configuration.cache_associations_pagination
+      @index_params[:per_page] = if Avo.configuration.session_persistence_enabled?
         session[per_page_key] = params[:per_page] || session[per_page_key] || Avo.configuration.via_per_page
       else
         params[:per_page] || Avo.configuration.via_per_page

--- a/lib/avo/concerns/filters_session_handler.rb
+++ b/lib/avo/concerns/filters_session_handler.rb
@@ -2,13 +2,13 @@ module Avo
   module Concerns
     module FiltersSessionHandler
       def reset_filters
-        return unless cache_resource_filters?
+        return unless Avo.configuration.session_persistence_enabled?
 
         session.delete(filters_session_key)
       end
 
       def fetch_filters
-        return filters_from_params unless cache_resource_filters?
+        return filters_from_params unless Avo.configuration.session_persistence_enabled?
 
         (filters_from_params && save_filters_to_session) || filters_from_session
       end
@@ -30,14 +30,6 @@ module Avo
           turbo_frame controller resource_name related_name
           action id
         ].map { |key| params[key] }.compact.join("/")
-      end
-
-      def cache_resource_filters?
-        Avo::ExecutionContext.new(
-          target: Avo.configuration.cache_resource_filters,
-          current_user: _current_user,
-          resource: @resource
-        ).handle
       end
     end
   end

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -11,6 +11,7 @@ module Avo
     attr_writer :pagination
     attr_writer :explicit_authorization
     attr_writer :exclude_from_status
+    attr_writer :persistence
     attr_accessor :timezone
     attr_accessor :per_page
     attr_accessor :per_page_steps
@@ -26,8 +27,6 @@ module Avo
     attr_accessor :full_width_container
     attr_accessor :full_width_index_view
     attr_accessor :cache_resources_on_index_view
-    attr_accessor :cache_resource_filters
-    attr_accessor :cache_associations_pagination
     attr_accessor :context
     attr_accessor :display_breadcrumbs
     attr_accessor :hide_layout_when_printing
@@ -87,8 +86,9 @@ module Avo
       @full_width_container = false
       @full_width_index_view = false
       @cache_resources_on_index_view = Avo::PACKED
-      @cache_resource_filters = false
-      @cache_associations_pagination = false
+      @persistence = {
+        driver: nil
+      }
       @context = proc {}
       @initial_breadcrumbs = proc {
         add_breadcrumb I18n.t("avo.home").humanize, avo.root_path
@@ -277,6 +277,14 @@ module Avo
 
     def explicit_authorization
       Avo::ExecutionContext.new(target: @explicit_authorization).handle
+    end
+
+    def persistence
+      Avo::ExecutionContext.new(target: @persistence).handle
+    end
+
+    def session_persistence_enabled?
+      persistence[:driver] == :session
     end
   end
 

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -78,12 +78,6 @@ Avo.configure do |config|
   #   ActiveSupport::Cache.lookup_store(:solid_cache_store)
   # }
   # config.cache_resources_on_index_view = true
-  ## permanent enable or disable cache_resource_filters, default value is false
-  # config.cache_resource_filters = false
-  ## provide a lambda to enable or disable cache_resource_filters per user/resource.
-  # config.cache_resource_filters = -> { current_user.cache_resource_filters? }
-  ## Control persistence for the page and per-page options in association tables.
-  # config.cache_associations_pagination = false
 
   ## == Turbo options ==
   # config.turbo = -> do

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -44,8 +44,6 @@ Avo.configure do |config|
   config.resource_default_view = :show
   config.search_debounce = 300
   # config.field_wrapper_layout = :stacked
-  config.cache_resource_filters = false
-  config.cache_associations_pagination = false
   config.click_row_to_view_record = true
 
   config.turbo = {

--- a/spec/system/avo/filters/persist_filters_spec.rb
+++ b/spec/system/avo/filters/persist_filters_spec.rb
@@ -18,12 +18,9 @@ RSpec.describe "Persist Filters", type: :system do
 
     context "cache resource filter enabled" do
       around(:each) do |it|
-        saved_value = Avo.configuration.cache_resource_filters
-        Avo.configuration.cache_resource_filters = lambda {
-          true
-        }
+        Avo.configuration.persistence = {driver: :session}
         it.run
-        Avo.configuration.cache_resource_filters = saved_value
+        Avo.configuration.persistence = {driver: nil}
       end
 
       it "persist filters by name" do
@@ -54,10 +51,9 @@ RSpec.describe "Persist Filters", type: :system do
 
     context "cache resource filter disabled" do
       around(:each) do |it|
-        saved_value = Avo.configuration.cache_resource_filters
-        Avo.configuration.cache_resource_filters = false
+        Avo.configuration.persistence = {driver: :session}
         it.run
-        Avo.configuration.cache_resource_filters = saved_value
+        Avo.configuration.persistence = {driver: nil}
       end
 
       it "doesn't persist filters by name" do

--- a/spec/system/avo/filters/persist_filters_spec.rb
+++ b/spec/system/avo/filters/persist_filters_spec.rb
@@ -50,12 +50,6 @@ RSpec.describe "Persist Filters", type: :system do
     end
 
     context "cache resource filter disabled" do
-      around(:each) do |it|
-        Avo.configuration.persistence = {driver: :session}
-        it.run
-        Avo.configuration.persistence = {driver: nil}
-      end
-
       it "doesn't persist filters by name" do
         visit url
         expect(page).to have_text("Displaying 2 item")

--- a/spec/system/avo/tabs_spec.rb
+++ b/spec/system/avo/tabs_spec.rb
@@ -181,8 +181,7 @@ RSpec.describe "Tabs", type: :system do
   end
 
   it "keeps the pagination on tab when back is used" do
-    default_cache_associations_pagination_value = Avo.configuration.cache_associations_pagination
-    Avo.configuration.cache_associations_pagination = true
+    Avo.configuration.persistence = {driver: :session}
 
     visit avo.resources_user_path user
 
@@ -203,12 +202,12 @@ RSpec.describe "Tabs", type: :system do
     expect(page).to have_css('a.current[role="link"][aria-disabled="true"][aria-current="page"]', text: "2")
     expect(page).to have_text "Displaying items 9-9 of 9 in total"
 
-    Avo.configuration.cache_associations_pagination = default_cache_associations_pagination_value
+    Avo.configuration.persistence = {driver: nil}
   end
 
   it "keeps the per_page on association when back is used" do
-    default_cache_associations_pagination_value = Avo.configuration.cache_associations_pagination
-    Avo.configuration.cache_associations_pagination = true
+    Avo.configuration.persistence = {driver: :session}
+
     visit avo.resources_user_path user
 
     find('a[data-selected="false"][data-tabs-tab-name-param="Projects"]').click
@@ -229,6 +228,6 @@ RSpec.describe "Tabs", type: :system do
     expect(page).to have_text "Displaying 9 items"
     expect(find("select#per_page.appearance-none").find("option[selected]").text).to eq("24")
 
-    Avo.configuration.cache_associations_pagination = default_cache_associations_pagination_value
+    Avo.configuration.persistence = {driver: nil}
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The `persistence` configuration enables retention of specific UI settings, such as pagination and static filters, across user interactions.

#### Configuration

To set the `:driver` for persistence, configure it as follows:

```ruby
config.persistence = { driver: :session }

# Or

config.persistence = -> do
  { driver: :session }
end
```

#### Behavior

- **Associations Pagination:** Keeps the pagination state for associated records.
- **Static Filters:** Retains static filter configurations applied by the user.

By setting `:driver` to `:session`, these configurations will persist within the user's session, maintaining their state across requests while the session remains active.

> [!WARNING]
> **`config.cache_resource_filters` is obsolete**  
> The `config.cache_resource_filters` option has been replaced by `config.persistence`.  
>
> If you previously used:  
> ```ruby
> config.cache_resource_filters = true
> ```  
> Replace it with:  
> ```ruby
> config.persistence = { driver: :session }
> ```  
> This ensures the same functionality, preserving resource filters (and pagination state) within the session.


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
  - https://docs.avohq.io/3.0/customization.html#persistence
- [x] I have added tests that prove my fix is effective or that my feature works
