### PR TITLE
fix: `break-words` on show content

### DIFF
--- a/app/components/avo/field_wrapper_component.html.erb
+++ b/app/components/avo/field_wrapper_component.html.erb
@@ -17,14 +17,14 @@
     <% end %>
     <% if on_edit? && @field.is_required? %> <span class="text-red-600 ml-1">*</span> <% end %>
   <% end %>
-  <%= content_tag :div, class: class_names("flex-1 flex flex-row md:min-h-inherit px-6",
+  <%= content_tag :div, class: class_names("flex-1 flex flex-row md:min-h-inherit px-6 overflow-x-auto",
     @field.get_html(:classes, view: @view, element: :content),
       {
         "pb-4": stacked?,
         "py-2": !compact?,
         "py-1": compact?,
       }), data: {slot: "value"} do %>
-    <div class="self-center w-full <% unless full_width? || compact? || stacked? %> md:w-8/12 has-sidebar:w-full <% end %>">
+    <div class="self-center w-full break-words <% unless full_width? || compact? || stacked? %> md:w-8/12 has-sidebar:w-full <% end %>">
       <% if on_show? %>
         <% if render_dash? %>
           —

--- a/spec/dummy/app/avo/resources/user.rb
+++ b/spec/dummy/app/avo/resources/user.rb
@@ -120,6 +120,8 @@ class Avo::Resources::User < Avo::BaseResource
       required: true,
       only_on: [:index]
 
+    field :some_token, only_on: :show
+
     field :is_writer, as: :text,
       sortable: -> {
         # Order by something else completely, just to make a test case that clearly and reliably does what we want.
@@ -154,6 +156,7 @@ class Avo::Resources::User < Avo::BaseResource
 
   def main_panel_sidebar
     sidebar do
+      field :some_token, only_on: :show
       test_field("Inside main_panel_sidebar")
       with_options only_on: :show do
         field :email, as: :gravatar, link_to_record: true, as_avatar: :circle

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -104,4 +104,6 @@ class User < ApplicationRecord
       delete: true,
     }
   end
+
+  def some_token = @some_token ||= SecureRandom.hex(64)
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3530 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

### Before

![image](https://github.com/user-attachments/assets/ac002df4-f467-40f1-ae9e-a67238fe6413)

### After

![image](https://github.com/user-attachments/assets/42d4682e-d15f-4633-b4ef-78b7ef8f9584)

