### PR TITLE
fix: action redirect loop

### DIFF
--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -117,11 +117,14 @@ module Avo
 
             turbo_stream.turbo_frame_set_src(Avo::MODAL_FRAME_ID, src)
           when :redirect
-            turbo_stream.redirect_to(
-              Avo::ExecutionContext.new(target: @response[:path]).handle,
-              turbo_frame: @response[:redirect_args][:turbo_frame],
-              **@response[:redirect_args].except(:turbo_frame)
-            )
+            [
+              turbo_stream.avo_close_modal,
+              turbo_stream.redirect_to(
+                Avo::ExecutionContext.new(target: @response[:path]).handle,
+                turbo_frame: @response[:redirect_args][:turbo_frame],
+                **@response[:redirect_args].except(:turbo_frame)
+              )
+            ]
           when :close_modal
             # Close the modal and flash the messages
             [
@@ -132,7 +135,10 @@ module Avo
             # Reload the page
             back_path = request.referer || params[:referrer].presence || resources_path(resource: @resource)
 
-            turbo_stream.redirect_to(back_path)
+            [
+              turbo_stream.avo_close_modal,
+              turbo_stream.redirect_to(back_path)
+            ]
           end
 
           responses = if @action.appended_turbo_streams.present?

--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -99,6 +99,10 @@ module Avo
       # Flash the messages collected from the action
       flash_messages
 
+      # Always execute turbo_stream.avo_close_modal on all responses, including redirects
+      # Exclude response types intended to keep the modal open
+      # This ensures the modal frame refreshes, preventing it from retaining the SRC of the previous action
+      # and avoids re-triggering that SRC during back navigation
       respond_to do |format|
         format.turbo_stream do
           turbo_response = case @response[:type]

--- a/spec/dummy/app/avo/actions/test/no_confirmation_posts_redirect.rb
+++ b/spec/dummy/app/avo/actions/test/no_confirmation_posts_redirect.rb
@@ -1,0 +1,9 @@
+class Avo::Actions::Test::NoConfirmationPostsRedirect < Avo::BaseAction
+  self.name = "Redirect to Posts"
+  self.no_confirmation = true
+  self.standalone = true
+
+  def handle(**args)
+    redirect_to avo.resources_posts_path
+  end
+end

--- a/spec/dummy/app/avo/resources/user.rb
+++ b/spec/dummy/app/avo/resources/user.rb
@@ -72,6 +72,7 @@ class Avo::Resources::User < Avo::BaseResource
     action Avo::Actions::Sub::DummyAction
     action Avo::Actions::DownloadFile, icon: "heroicons/outline/arrow-left"
     divider
+    action Avo::Actions::Test::NoConfirmationPostsRedirect
     action Avo::Actions::Test::NoConfirmationRedirect
     action Avo::Actions::Test::CloseModal
     action Avo::Actions::Test::DoNothing

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -206,6 +206,22 @@ RSpec.describe "Actions", type: :system do
 
       expect(page).to have_text "hey en"
     end
+
+    it "redirects to posts and don't redirect when navigating back" do
+      visit avo.resources_users_path
+
+      click_on "Actions"
+      click_on "Redirect to Posts"
+
+      wait_for_loaded
+
+      expect(current_path).to eq avo.resources_posts_path
+
+      page.go_back
+      wait_for_loaded
+
+      expect(current_path).to eq avo.resources_users_path
+    end
   end
 
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3409

Implement `turbo_stream.avo_close_modal` on all responses, excluding those intended to keep the modal open. This ensures the action modal is refreshed, preventing it from retaining the SRC of the last executed action. When navigating back, the modal is present in a fresh state, avoiding unintended re-execution of the previous action.

While enabling `turbo_temporary` on the frame could address this issue, it introduces another problem: the modal disappears when navigating back, and actions fail to execute.

This solution resolves both issues effectively and includes tests to validate the behavior.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works
