### PR TITLE
fix: don't submit form on autocomplete

### DIFF
--- a/app/javascript/js/controllers/form_controller.js
+++ b/app/javascript/js/controllers/form_controller.js
@@ -2,7 +2,10 @@ import { Controller } from '@hotwired/stimulus'
 
 // Connects to data-controller="form"
 export default class extends Controller {
-  submit() {
+  submit(event) {
+    // return if event.key is undefined preventing the form submit on autocomplete event
+    if (!event.key) return
+
     this.element.requestSubmit()
   }
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3553

**Problem:**
Autocomplete interactions were inadvertently triggering the `submit` action on the `form` controller. This action is intended to be triggered only by the specified Stimulus [Keyboard events](https://stimulus.hotwired.dev/reference/actions#keyboardevent-filter): 
`keydown.ctrl+enter->form#submit` and `keydown.meta+enter->form#submit`.

**Solution:**
This PR introduces a guard clause to ensure that the `event.key` property is present before proceeding with the form submission. This effectively prevents unintended triggers caused by autocomplete behavior.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
