### PR TITLE
fix: field wrapper overflow

### DIFF
--- a/app/components/avo/field_wrapper_component.html.erb
+++ b/app/components/avo/field_wrapper_component.html.erb
@@ -17,14 +17,14 @@
     <% end %>
     <% if on_edit? && @field.is_required? %> <span class="text-red-600 ml-1">*</span> <% end %>
   <% end %>
-  <%= content_tag :div, class: class_names("flex-1 flex flex-row md:min-h-inherit px-6 overflow-x-auto",
+  <%= content_tag :div, class: class_names("flex-1 flex flex-row md:min-h-inherit px-6",
     @field.get_html(:classes, view: @view, element: :content),
       {
         "pb-4": stacked?,
         "py-2": !compact?,
         "py-1": compact?,
       }), data: {slot: "value"} do %>
-    <div class="self-center w-full break-words <% unless full_width? || compact? || stacked? %> md:w-8/12 has-sidebar:w-full <% end %>">
+    <div class="self-center w-full <% unless full_width? || compact? || stacked? %> md:w-8/12 has-sidebar:w-full <% end %>">
       <% if on_show? %>
         <div class="flex flex-row items-center group gap-x-1">
           <% if render_dash? %>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Revert https://github.com/avo-hq/avo/pull/3542, which will reopen https://github.com/avo-hq/avo/issues/3530.

The `overflow-x-auto` property was causing some malfunctions, and `break-words` does not work on long strings like `a78020e0e5066b883c6f820603b2604277941d62d4b4cbbcfc18743712aae70053911007e6de1f2cf68df1dcee2f1cd14a3b1028e1f908a256ab0761d372a66`.

Using `break-all` is not ideal, as it will break all words indiscriminately, ignoring grammar or natural word breaks.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
