### PR TITLE
fix: `translation_key` class attribute

### DIFF
--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -54,7 +54,6 @@ module Avo
       class_attribute :single_includes, default: []
       class_attribute :single_attachments, default: []
       class_attribute :authorization_policy
-      class_attribute :translation_key
       class_attribute :default_view_type, default: :table
       class_attribute :devise_password_optional, default: false
       class_attribute :scopes_loader
@@ -175,10 +174,6 @@ module Avo
           route_key.singularize
         end
 
-        def translation_key
-          @translation_key || "avo.resource_translations.#{class_name.underscore}"
-        end
-
         def name
           name_from_translation_key(count: 1, default: class_name.underscore.humanize)
         end
@@ -245,6 +240,8 @@ module Avo
           Avo::ExecutionContext.new(target: search[key], resource: self, record: record).handle
         end
       end
+
+      class_attribute :translation_key, default: "avo.resource_translations.#{class_name.underscore}"
 
       delegate :context, to: ::Avo::Current
       delegate :name, to: :class

--- a/spec/dummy/app/avo/resources/course.rb
+++ b/spec/dummy/app/avo/resources/course.rb
@@ -5,6 +5,7 @@ class Avo::Resources::Course < Avo::BaseResource
   self.keep_filters_panel_open = true
   self.stimulus_controllers = "city-in-country toggle-fields"
   # self.default_sort_column = :country
+  self.translation_key = "test.translation_key.course"
 
   def show_fields
     fields_bag

--- a/spec/dummy/config/locales/avo.pt.yml
+++ b/spec/dummy/config/locales/avo.pt.yml
@@ -3,3 +3,9 @@ pt:
   avo:
     resource_translations:
       product: "Produto"
+  test:
+    translation_key:
+      course:
+        zero: cursos
+        one: curso
+        other: cursos

--- a/spec/features/avo/i18n_spec.rb
+++ b/spec/features/avo/i18n_spec.rb
@@ -21,4 +21,13 @@ RSpec.feature "i18n", type: :feature do
       expect(page).to have_button("Save the product!")
     end
   end
+
+  describe "resource translation_key" do
+    it "apply translation_key" do
+      visit avo.resources_courses_path(force_locale: :pt)
+
+      expect(page).to have_text("Cursos")
+      expect(page).to have_text("Criar novo curso")
+    end
+  end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3538

The `translation_key` method defined in the base resource relied on an instance attribute, `@translation_key`, which was always `nil`.

```ruby
    class << self
        def translation_key
          @translation_key || "avo.resource_translations.#{class_name.underscore}"
        end
    end
```

Previously, a bug in Rails (prior to [this Rails PR](https://github.com/rails/rails/pull/53640)) inadvertently redefined the class attribute reader for all sub-classes that defined the class attribute, causing `translation_key` to exhibit the expected behavior by chance. After the fix in Rails 8.0.1, the correct reader from the parent class is now used. However, since `@translation_key` is an instance attribute rather than a class-level attribute, it remains `nil`, and the method defaults to the fallback value. Check https://github.com/rails/rails/issues/53992 for more details.

To fix this, I removed the `translation_key` reader override and utilized the `default` option instead. Since the `default` option relies on the `class_name` method, I adjusted the definition of `translation_key` to occur after defining the class methods.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works
