### PR TITLE
fix: eject generator failing due to undefined source_location method

### DIFF
--- a/lib/generators/avo/eject_generator.rb
+++ b/lib/generators/avo/eject_generator.rb
@@ -118,9 +118,9 @@ module Generators
           component = component_to_eject.underscore
 
           # Get the component path for both, the rb and erb files
-          rb, erb = if (component_constant = component_to_eject.safe_constantize)
+          rb, erb = if component_constant == component_to_eject.safe_constantize
             # If component is a constant, find the source location
-            source_location = component_constant.new.method(component_constant.instance_methods.first).source_location.first
+            source_location = Module.const_source_location(component_constant.to_s).first
 
             [source_location, source_location.gsub(".rb", ".html.erb")]
           else

--- a/lib/generators/avo/eject_generator.rb
+++ b/lib/generators/avo/eject_generator.rb
@@ -120,7 +120,7 @@ module Generators
           # Get the component path for both, the rb and erb files
           rb, erb = if (component_constant = component_to_eject.safe_constantize)
             # If component is a constant, find the source location
-            source_location = Module.const_source_location(component_constant.to_s).first
+            source_location = component_constant.identifier
 
             [source_location, source_location.gsub(".rb", ".html.erb")]
           else

--- a/lib/generators/avo/eject_generator.rb
+++ b/lib/generators/avo/eject_generator.rb
@@ -120,7 +120,7 @@ module Generators
           # Get the component path for both, the rb and erb files
           rb, erb = if (component_constant = component_to_eject.safe_constantize)
             # If component is a constant, find the source location
-            source_location = component_constant.source_location
+            source_location = component_constant.new.method(component_constant.instance_methods.first).source_location.first
 
             [source_location, source_location.gsub(".rb", ".html.erb")]
           else

--- a/lib/generators/avo/eject_generator.rb
+++ b/lib/generators/avo/eject_generator.rb
@@ -118,7 +118,7 @@ module Generators
           component = component_to_eject.underscore
 
           # Get the component path for both, the rb and erb files
-          rb, erb = if component_constant == component_to_eject.safe_constantize
+          rb, erb = if (component_constant = component_to_eject.safe_constantize)
             # If component is a constant, find the source location
             source_location = Module.const_source_location(component_constant.to_s).first
 


### PR DESCRIPTION
# Description
Ejecting components now fails with source_location undefined error, this is because it's used on the class directly while it's supposed to be used on methods
https://ruby-doc.org/3.3.6/Method.html#method-i-source_location

Fixes # (issue)
Will use `const_source_location` instead to find the class

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
