### PR TITLE
Add disabled prop to ProfileItemComponent

### DIFF
--- a/app/components/avo/profile_item_component.html.erb
+++ b/app/components/avo/profile_item_component.html.erb
@@ -5,6 +5,7 @@
     target: target,
     title: title,
     method: method,
+    disabled: disabled,
     params: params do %>
     <%= helpers.svg(icon, class: 'h-4 mr-1') if icon.present? %> <%= label %>
   <% end %>

--- a/app/components/avo/profile_item_component.rb
+++ b/app/components/avo/profile_item_component.rb
@@ -12,6 +12,7 @@ class Avo::ProfileItemComponent < Avo::BaseComponent
   end
   prop :title, reader: :public
   prop :method, reader: :public
+  prop :disabled, reader: :public
   prop :params, default: {}.freeze, reader: :public
   prop :classes, default: "", reader: :public
 


### PR DESCRIPTION
# Description
Add the ability to set a profile item's button to disabled, for example when adding an account switcher

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works