### PR TITLE
Add `mapkick_options` to location field

### DIFF
--- a/app/components/avo/fields/location_field/show_component.html.erb
+++ b/app/components/avo/fields/location_field/show_component.html.erb
@@ -1,6 +1,6 @@
 <%= field_wrapper **field_wrapper_args do %>
   <% if field.value_present? %>
-    <%= js_map [{latitude: field.value[0], longitude: field.value[1]}], id: "location-map", zoom: field.zoom, controls: true %>
+    <%= js_map [{latitude: field.value[0], longitude: field.value[1]}], id: "location-map", zoom: field.zoom, controls: true, **field.mapkick_options %>
   <% else %>
     —
   <% end %>

--- a/lib/avo/fields/location_field.rb
+++ b/lib/avo/fields/location_field.rb
@@ -3,6 +3,7 @@
 module Avo
   module Fields
     class LocationField < BaseField
+      attr_reader :mapkick_options
       attr_reader :stored_as, :zoom
 
       def initialize(id, **args, &block)
@@ -10,6 +11,7 @@ module Avo
         super(id, **args, &block)
 
         @stored_as = args[:stored_as].present? ? args[:stored_as] : nil # You can pass it an array of db columns [:latitude, :longitude]
+        @mapkick_options = args[:mapkick_options].presence || {}
         @zoom = args[:zoom].present? ? args[:zoom].to_i : 15
       end
 

--- a/spec/dummy/app/avo/resources/city.rb
+++ b/spec/dummy/app/avo/resources/city.rb
@@ -37,13 +37,13 @@ class Avo::Resources::City < Avo::BaseResource
   def base_fields
     field :id, as: :id
     field :coordinates,
-          as: :location,
-          stored_as: [:latitude, :longitude],
-          mapkick_options: {
-            style: "mapbox://styles/mapbox/satellite-v9",
-            controls: true,
-            markers: {color: "#000"}
-          }
+      as: :location,
+      stored_as: [:latitude, :longitude],
+      mapkick_options: {
+        style: "mapbox://styles/mapbox/satellite-v9",
+        controls: true,
+        markers: {color: "#FFC0CB"}
+      }
     field :city_center_area,
       as: :area,
       geometry: :polygon,

--- a/spec/dummy/app/avo/resources/city.rb
+++ b/spec/dummy/app/avo/resources/city.rb
@@ -36,7 +36,14 @@ class Avo::Resources::City < Avo::BaseResource
 
   def base_fields
     field :id, as: :id
-    field :coordinates, as: :location, stored_as: [:latitude, :longitude]
+    field :coordinates,
+          as: :location,
+          stored_as: [:latitude, :longitude],
+          mapkick_options: {
+            style: "mapbox://styles/mapbox/satellite-v9",
+            controls: true,
+            markers: {color: "#000"}
+          }
     field :city_center_area,
       as: :area,
       geometry: :polygon,

--- a/spec/system/avo/location_field_spec.rb
+++ b/spec/system/avo/location_field_spec.rb
@@ -58,11 +58,17 @@ RSpec.describe "LocationField", type: :system do
     let!(:city) { create :city, latitude: 48.8584, longitude: 2.2945 }
 
     context "show" do
-      it "renders a map" do
+      before do
         Avo::Fields::LocationField::ShowComponent.any_instance.stub(:js_map).and_return("map_content_here")
         visit "/admin/resources/cities/#{city.id}"
+      end
 
+      it "renders a map" do
         expect(page).to have_text("map_content_here")
+      end
+
+      it "applies mapkick options correctly" do
+        expect(page).to have_css("div#location-map [data-marker-color='#000']")
       end
     end
 

--- a/spec/system/avo/location_field_spec.rb
+++ b/spec/system/avo/location_field_spec.rb
@@ -58,17 +58,11 @@ RSpec.describe "LocationField", type: :system do
     let!(:city) { create :city, latitude: 48.8584, longitude: 2.2945 }
 
     context "show" do
-      before do
+      it "renders a map" do
         Avo::Fields::LocationField::ShowComponent.any_instance.stub(:js_map).and_return("map_content_here")
         visit "/admin/resources/cities/#{city.id}"
-      end
 
-      it "renders a map" do
         expect(page).to have_text("map_content_here")
-      end
-
-      it "applies mapkick options correctly" do
-        expect(page).to have_css("div#location-map [data-marker-color='#000']")
       end
     end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3147

Allows to configure `mapkick_options` on location field 
<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->
```ruby
field :coordinates,
  as: :location,
  stored_as: [:latitude, :longitude],
  mapkick_options: {
    style: 'mapbox://styles/mapbox/satellite-v9',
    controls: true
  }
```

![image](https://github.com/user-attachments/assets/36e34f11-16df-49b2-b7d5-fbf5abd4a91e)


# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
  - https://github.com/avo-hq/docs.avohq.io/pull/334
- [ ] I have added tests that prove my fix is effective or that my feature works
