### PR TITLE
Fixed argument prefix warnings

### DIFF
--- a/app/components/avo/fields/area_field/edit_component.html.erb
+++ b/app/components/avo/fields/area_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= @form.text_field field.id,
     value: field.value.to_s,
     class: classes("w-full"),

--- a/app/components/avo/fields/area_field/show_component.html.erb
+++ b/app/components/avo/fields/area_field/show_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <% if field.value.present? %>
     <%= area_map field.map_data, **field.mapkick_options %>
   <% else %>

--- a/app/components/avo/fields/badge_field/index_component.html.erb
+++ b/app/components/avo/fields/badge_field/index_component.html.erb
@@ -1,3 +1,3 @@
-<%= index_field_wrapper **field_wrapper_args, flush: true do %>
+<%= index_field_wrapper(**field_wrapper_args, flush: true) do %>
   <%= render Avo::Fields::Common::BadgeViewerComponent.new value: @field.value, options: @field.options %>
 <% end %>

--- a/app/components/avo/fields/badge_field/show_component.html.erb
+++ b/app/components/avo/fields/badge_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= render Avo::Fields::Common::BadgeViewerComponent.new value: @field.value, options: @field.options %>
 <% end %>

--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -5,7 +5,7 @@
       data-association="<%= @field.id %>"
       data-association-class="<%= @field&.target_resource&.model_class || nil %>"
     >
-    <%= field_wrapper **field_wrapper_args, label_for: @field.polymorphic_form_field_label, help: @field.polymorphic_help || '' do %>
+    <%= field_wrapper(**field_wrapper_args, label_for: @field.polymorphic_form_field_label, help: @field.polymorphic_help || '') do %>
       <%= @form.select @field.type_input_foreign_key, @field.types.map { |type| [Avo.resource_manager.get_resource_by_model_class(type.to_s).name, type.to_s] },
       {
         value: @field.value,
@@ -32,7 +32,7 @@
     <% @field.types.each do |type| %>
       <template data-belongs-to-field-target="type" data-type="<%= type %>">
         <div data-polymorphic-type="<%= type %>">
-          <%= field_wrapper **field_wrapper_args.merge!(data: reload_data), label: Avo.resource_manager.get_resource_by_model_class(type.to_s).name do %>
+          <%= field_wrapper(**field_wrapper_args.merge!(data: reload_data), label: Avo.resource_manager.get_resource_by_model_class(type.to_s).name) do %>
             <% if @field.is_searchable? %>
               <%= render Avo::Pro::SearchableAssociations::AutocompleteComponent.new form: @form,
                 disabled: disabled,
@@ -88,7 +88,7 @@
     <% end %>
   </div>
 <% else %>
-  <%= field_wrapper **field_wrapper_args.merge!(data: reload_data) do %>
+  <%= field_wrapper(**field_wrapper_args.merge!(data: reload_data)) do %>
     <% if @field.is_searchable? %>
       <%= render Avo::Pro::SearchableAssociations::AutocompleteComponent.new form: @form,
         field: @field,

--- a/app/components/avo/fields/belongs_to_field/index_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/index_component.html.erb
@@ -1,4 +1,4 @@
-<%= index_field_wrapper **field_wrapper_args do %>
+<%= index_field_wrapper(**field_wrapper_args) do %>
   <%= link_to @field.label, helpers.resource_view_path(
     record: @field.index_link_to_record,
     resource: @field.index_link_to_resource

--- a/app/components/avo/fields/belongs_to_field/show_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= link_to @field.label, resource_view_path, data: {turbo_frame: @field.target} %>
 <% end %>

--- a/app/components/avo/fields/boolean_field/edit_component.html.erb
+++ b/app/components/avo/fields/boolean_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <div class="h-8 flex items-center">
     <%= @form.check_box @field.id,
       value: @field.value,

--- a/app/components/avo/fields/boolean_field/index_component.html.erb
+++ b/app/components/avo/fields/boolean_field/index_component.html.erb
@@ -1,3 +1,3 @@
-<%= index_field_wrapper **field_wrapper_args, flush: true do %>
+<%= index_field_wrapper(**field_wrapper_args, flush: true) do %>
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>

--- a/app/components/avo/fields/boolean_field/show_component.html.erb
+++ b/app/components/avo/fields/boolean_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>

--- a/app/components/avo/fields/boolean_group_field/edit_component.html.erb
+++ b/app/components/avo/fields/boolean_group_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <div class="flex items-center">
     <div class="space-y-2">
       <% @field.options.each do |id, label| %>

--- a/app/components/avo/fields/boolean_group_field/index_component.html.erb
+++ b/app/components/avo/fields/boolean_group_field/index_component.html.erb
@@ -1,3 +1,3 @@
-<%= index_field_wrapper **field_wrapper_args, dash_if_blank: false do %>
+<%= index_field_wrapper(**field_wrapper_args, dash_if_blank: false) do %>
   <%= render Avo::Fields::Common::BooleanGroupComponent.new options: @field.options, value: @field.value %>
 <% end %>

--- a/app/components/avo/fields/boolean_group_field/show_component.html.erb
+++ b/app/components/avo/fields/boolean_group_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args, dash_if_blank: false do %>
+<%= field_wrapper(**field_wrapper_args, dash_if_blank: false) do %>
   <%= render Avo::Fields::Common::BooleanGroupComponent.new options: @field.options, value: @field.value %>
 <% end %>

--- a/app/components/avo/fields/code_field/edit_component.html.erb
+++ b/app/components/avo/fields/code_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args, full_width: true do %>
+<%= field_wrapper(**field_wrapper_args, full_width: true) do %>
   <div data-controller="code-field">
     <%= @form.text_area @field.id,
       value: @field.value,

--- a/app/components/avo/fields/code_field/show_component.html.erb
+++ b/app/components/avo/fields/code_field/show_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args, full_width: true do %>
+<%= field_wrapper(**field_wrapper_args, full_width: true) do %>
   <div data-controller="code-field" style="--height: <%= @field.height %>">
     <%= text_area_tag @field.id, @field.value,
       class: helpers.input_classes('w-full'),

--- a/app/components/avo/fields/country_field/edit_component.html.erb
+++ b/app/components/avo/fields/country_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= @form.select @field.id, @field.select_options, {
       value: @field.value,
       selected: @field.value,

--- a/app/components/avo/fields/country_field/index_component.html.erb
+++ b/app/components/avo/fields/country_field/index_component.html.erb
@@ -1,4 +1,4 @@
-<%= index_field_wrapper **field_wrapper_args do %>
+<%= index_field_wrapper(**field_wrapper_args) do %>
   <% if @field.display_code %>
     <%= @field.value %>
   <% else %>

--- a/app/components/avo/fields/country_field/show_component.html.erb
+++ b/app/components/avo/fields/country_field/show_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <% if @field.display_code %>
     <%= @field.value %>
   <% else %>

--- a/app/components/avo/fields/date_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= content_tag :div, data: {
       controller: "date-field",
       date_field_view_value: @view,

--- a/app/components/avo/fields/date_field/index_component.html.erb
+++ b/app/components/avo/fields/date_field/index_component.html.erb
@@ -1,4 +1,4 @@
-<%= index_field_wrapper **field_wrapper_args do %>
+<%= index_field_wrapper(**field_wrapper_args) do %>
    <%= content_tag :div, data: {
     controller: "date-field",
     date_field_view_value: @view,

--- a/app/components/avo/fields/date_field/show_component.html.erb
+++ b/app/components/avo/fields/date_field/show_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= content_tag :div, data: {
     controller: "date-field",
     date_field_view_value: @view,

--- a/app/components/avo/fields/date_time_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_time_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= content_tag :div, class: "flex relative", data: {
       controller: "date-field",
       date_field_view_value: @view,

--- a/app/components/avo/fields/date_time_field/index_component.html.erb
+++ b/app/components/avo/fields/date_time_field/index_component.html.erb
@@ -1,4 +1,4 @@
-<%= index_field_wrapper **field_wrapper_args do %>
+<%= index_field_wrapper(**field_wrapper_args) do %>
    <%= content_tag :div, data: {
     controller: "date-field",
     date_field_view_value: @view,

--- a/app/components/avo/fields/date_time_field/show_component.html.erb
+++ b/app/components/avo/fields/date_time_field/show_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= content_tag :div, data: {
     controller: "date-field",
     date_field_view_value: @view,

--- a/app/components/avo/fields/external_image_field/edit_component.html.erb
+++ b/app/components/avo/fields/external_image_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= @form.text_field @field.id,
     class: classes("w-full"),
     data: @field.get_html(:data, view: view, element: :input),

--- a/app/components/avo/fields/external_image_field/index_component.html.erb
+++ b/app/components/avo/fields/external_image_field/index_component.html.erb
@@ -1,4 +1,4 @@
-<%= index_field_wrapper **field_wrapper_args, flush: true do %>
+<%= index_field_wrapper(**field_wrapper_args, flush: true) do %>
   <% if @field.value.present? %>
     <%= link_to_if @field.link_to_record.present?,
                    image_tag(@field.value,

--- a/app/components/avo/fields/external_image_field/show_component.html.erb
+++ b/app/components/avo/fields/external_image_field/show_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <% if @field.value.present? %>
     <%= image_tag @field.value, style: 'max-width: 340px;' %>
   <% end %>

--- a/app/components/avo/fields/file_field/edit_component.html.erb
+++ b/app/components/avo/fields/file_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <% if @field.value.present? %>
     <div class="mb-2">
       <%= render Avo::Fields::Common::Files::ViewType::GridItemComponent.new resource: @resource, field: @field %>

--- a/app/components/avo/fields/file_field/index_component.html.erb
+++ b/app/components/avo/fields/file_field/index_component.html.erb
@@ -1,4 +1,4 @@
-<%= index_field_wrapper **field_wrapper_args, flush: flush? do %>
+<%= index_field_wrapper(**field_wrapper_args, flush: flush?) do %>
   <% if @field.value.present? %>
     <% if @field.value.attached? && @field.value.representable? && @field.is_image %>
       <%= link_to_if @field.link_to_record, image_tag(helpers.main_app.url_for(@field.value), class: 'h-10'), resource_view_path, class: 'block' %>

--- a/app/components/avo/fields/file_field/show_component.html.erb
+++ b/app/components/avo/fields/file_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= render Avo::Fields::Common::Files::ViewType::GridItemComponent.new resource: @resource, field: @field %>
 <% end %>

--- a/app/components/avo/fields/files_field/edit_component.html.erb
+++ b/app/components/avo/fields/files_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args, full_width: true do %>
+<%= field_wrapper(**field_wrapper_args, full_width: true) do %>
   <%= render Avo::Fields::Common::Files::ListViewerComponent.new(field: @field, resource: @resource) if @field.value.present? %>
 
   <% if can_upload_file? %>

--- a/app/components/avo/fields/files_field/index_component.html.erb
+++ b/app/components/avo/fields/files_field/index_component.html.erb
@@ -1,3 +1,3 @@
-<%= index_field_wrapper **field_wrapper_args do %>
+<%= index_field_wrapper(**field_wrapper_args) do %>
   <%= "#{length} #{t('avo.file', count: length)}" %>
 <% end %>

--- a/app/components/avo/fields/files_field/show_component.html.erb
+++ b/app/components/avo/fields/files_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args, full_width: true do %>
+<%= field_wrapper(**field_wrapper_args, full_width: true) do %>
   <%= render Avo::Fields::Common::Files::ListViewerComponent.new(field: @field, resource: @resource) if @field.value.present? %>
 <% end %>

--- a/app/components/avo/fields/gravatar_field/index_component.html.erb
+++ b/app/components/avo/fields/gravatar_field/index_component.html.erb
@@ -1,4 +1,4 @@
-<%= index_field_wrapper **field_wrapper_args, flush: true do %>
+<%= index_field_wrapper(**field_wrapper_args, flush: true) do %>
   <%= render Avo::Fields::Common::GravatarViewerComponent.new(
     md5: @field.md5,
     default: @field.default,

--- a/app/components/avo/fields/gravatar_field/show_component.html.erb
+++ b/app/components/avo/fields/gravatar_field/show_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= render Avo::Fields::Common::GravatarViewerComponent.new(
     md5: @field.md5,
     default: @field.default,

--- a/app/components/avo/fields/has_one_field/index_component.html.erb
+++ b/app/components/avo/fields/has_one_field/index_component.html.erb
@@ -1,3 +1,3 @@
-<%= index_field_wrapper **field_wrapper_args do %>
+<%= index_field_wrapper(**field_wrapper_args) do %>
   <%= link_to @field.label, helpers.resource_path(record: @field.value, resource: @field.target_resource) %>
 <% end %>

--- a/app/components/avo/fields/id_field/edit_component.html.erb
+++ b/app/components/avo/fields/id_field/edit_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= @field.value %>
 <% end %>

--- a/app/components/avo/fields/id_field/index_component.html.erb
+++ b/app/components/avo/fields/id_field/index_component.html.erb
@@ -1,3 +1,3 @@
-<%= index_field_wrapper **field_wrapper_args, class: 'whitespace-no-wrap w-[1%]' do %>
+<%= index_field_wrapper(**field_wrapper_args, class: 'whitespace-no-wrap w-[1%]') do %>
   <% link_to_if (@field.link_to_record or Avo.configuration.id_links_to_resource), @field.value, resource_view_path, title: t('avo.view_item', item: @resource.name).humanize %>
 <% end %>

--- a/app/components/avo/fields/id_field/show_component.html.erb
+++ b/app/components/avo/fields/id_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= @field.value %>
 <% end %>

--- a/app/components/avo/fields/key_value_field/edit_component.html.erb
+++ b/app/components/avo/fields/key_value_field/edit_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args, full_width: true do %>
+<%= field_wrapper(**field_wrapper_args, full_width: true) do %>
   <%= render Avo::Fields::Common::KeyValueComponent.new field: @field, form: @form, view: view %>
 <% end %>

--- a/app/components/avo/fields/key_value_field/show_component.html.erb
+++ b/app/components/avo/fields/key_value_field/show_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args, full_width: true do %>
+<%= field_wrapper(**field_wrapper_args, full_width: true) do %>
   <%= render Avo::Fields::Common::KeyValueComponent.new(
       field: @field,
       view: Avo::ViewInquirer.new(:show)

--- a/app/components/avo/fields/location_field/edit_component.html.erb
+++ b/app/components/avo/fields/location_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <% if field.value_as_array? %>
     <div class="flex gap-4">
       <%= @form.fields_for @field.id do |coordinates_form| %>

--- a/app/components/avo/fields/location_field/show_component.html.erb
+++ b/app/components/avo/fields/location_field/show_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <% if field.value_present? %>
     <%= js_map [{latitude: field.value[0], longitude: field.value[1]}], id: "location-map", zoom: field.zoom, controls: true, **field.mapkick_options %>
   <% else %>

--- a/app/components/avo/fields/markdown_field/edit_component.html.erb
+++ b/app/components/avo/fields/markdown_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args, full_width: true do %>
+<%= field_wrapper(**field_wrapper_args, full_width: true) do %>
   <div data-controller="easy-mde">
     <%= @form.text_area @field.id,
       value: @field.value,

--- a/app/components/avo/fields/markdown_field/show_component.html.erb
+++ b/app/components/avo/fields/markdown_field/show_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args, full_width: true do %>
+<%= field_wrapper(**field_wrapper_args, full_width: true) do %>
   <div data-controller="easy-mde">
     <%= text_area_tag @field.id, @field.value,
       class: helpers.input_classes('w-full js-has-easy-mde-editor'),

--- a/app/components/avo/fields/number_field/edit_component.html.erb
+++ b/app/components/avo/fields/number_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= @form.number_field @field.id,
     value: @field.value,
     class: classes("w-full"),

--- a/app/components/avo/fields/number_field/index_component.html.erb
+++ b/app/components/avo/fields/number_field/index_component.html.erb
@@ -1,3 +1,3 @@
-<%= index_field_wrapper **field_wrapper_args do %>
+<%= index_field_wrapper(**field_wrapper_args) do %>
   <%= @field.value %>
 <% end %>

--- a/app/components/avo/fields/number_field/show_component.html.erb
+++ b/app/components/avo/fields/number_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= @field.value %>
 <% end %>

--- a/app/components/avo/fields/password_field/edit_component.html.erb
+++ b/app/components/avo/fields/password_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <div class="relative" data-controller="<%= @field.revealable ? 'password-visibility' : nil %>">
     <%= @form.password_field @field.id,
       value: @field.value,

--- a/app/components/avo/fields/preview_field/index_component.html.erb
+++ b/app/components/avo/fields/preview_field/index_component.html.erb
@@ -1,4 +1,4 @@
-<%= index_field_wrapper **field_wrapper_args, dash_if_blank: false, class: 'whitespace-no-wrap w-[1%]', flush: true, center_content: true do %>
+<%= index_field_wrapper(**field_wrapper_args, dash_if_blank: false, class: 'whitespace-no-wrap w-[1%]', flush: true, center_content: true) do %>
   <%= link_to resource_view_path,
     title: t('avo.view_item', item: @resource.name).humanize,
     data: {

--- a/app/components/avo/fields/progress_bar_field/edit_component.html.erb
+++ b/app/components/avo/fields/progress_bar_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= content_tag :div, data: {controller: "progress-bar-field"} do %>
     <% if @field.display_value %>
       <div class="text-center text-sm font-semibold w-full leading-none mb-1">

--- a/app/components/avo/fields/progress_bar_field/index_component.html.erb
+++ b/app/components/avo/fields/progress_bar_field/index_component.html.erb
@@ -1,3 +1,3 @@
-<%= index_field_wrapper **field_wrapper_args, flush: true do %>
+<%= index_field_wrapper(**field_wrapper_args, flush: true) do %>
   <%= render Avo::Fields::Common::ProgressBarComponent.new value: @field.value, display_value: @field.display_value, value_suffix: @field.value_suffix, max: @field.max, view: view %>
 <% end %>

--- a/app/components/avo/fields/progress_bar_field/show_component.html.erb
+++ b/app/components/avo/fields/progress_bar_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= render Avo::Fields::Common::ProgressBarComponent.new value: @field.value, display_value: @field.display_value, value_suffix: @field.value_suffix, max: @field.max, view: view %>
 <% end %>

--- a/app/components/avo/fields/radio_field/edit_component.html.erb
+++ b/app/components/avo/fields/radio_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <div class="flex flex-col gap-2">
     <% @field.options.each do |key, value| %>
       <div>

--- a/app/components/avo/fields/radio_field/index_component.html.erb
+++ b/app/components/avo/fields/radio_field/index_component.html.erb
@@ -1,3 +1,3 @@
-<%= index_field_wrapper **field_wrapper_args do %>
+<%= index_field_wrapper(**field_wrapper_args) do %>
   <%== @field.value %>
 <% end %>

--- a/app/components/avo/fields/radio_field/show_component.html.erb
+++ b/app/components/avo/fields/radio_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%== @field.value %>
 <% end %>

--- a/app/components/avo/fields/select_field/edit_component.html.erb
+++ b/app/components/avo/fields/select_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= @form.select @field.id, options_for_select(@field.options_for_select, selected: @field.value), {
       include_blank: @field.include_blank
     },

--- a/app/components/avo/fields/select_field/index_component.html.erb
+++ b/app/components/avo/fields/select_field/index_component.html.erb
@@ -1,3 +1,3 @@
-<%= index_field_wrapper **field_wrapper_args do %>
+<%= index_field_wrapper(**field_wrapper_args) do %>
   <%= @field.label %>
 <% end %>

--- a/app/components/avo/fields/select_field/show_component.html.erb
+++ b/app/components/avo/fields/select_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args.merge(dash_if_blank: false) do %>
+<%= field_wrapper(**field_wrapper_args.merge(dash_if_blank: false)) do %>
   <%= @field.value.nil? ? "—" : @field.label %>
 <% end %>

--- a/app/components/avo/fields/status_field/edit_component.html.erb
+++ b/app/components/avo/fields/status_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= @form.text_field @field.id,
     class: classes("w-full"),
     data: @field.get_html(:data, view: view, element: :input),

--- a/app/components/avo/fields/status_field/index_component.html.erb
+++ b/app/components/avo/fields/status_field/index_component.html.erb
@@ -1,3 +1,3 @@
-<%= index_field_wrapper **field_wrapper_args do %>
+<%= index_field_wrapper(**field_wrapper_args) do %>
   <%= render Avo::Fields::Common::StatusViewerComponent.new label: @field.value, status: @field.status %>
 <% end %>

--- a/app/components/avo/fields/status_field/show_component.html.erb
+++ b/app/components/avo/fields/status_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= render Avo::Fields::Common::StatusViewerComponent.new label: @field.value, status: @field.status %>
 <% end %>

--- a/app/components/avo/fields/tags_field/edit_component.html.erb
+++ b/app/components/avo/fields/tags_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args, data: {
+<%= field_wrapper(**field_wrapper_args, data: {
       controller: "tags-field",
       tags_field_mode_value: @field.mode,
       tags_field_whitelist_items_value: @field.whitelist_items,
@@ -8,7 +8,7 @@
       tags_field_close_on_select_value: @field.close_on_select,
       tags_field_delimiters_value: @field.delimiters,
       tags_field_fetch_values_from_value: @field.fetch_values_from,
-    } do %>
+    }) do %>
     <%# We use a dummy field so the back action from Turbo does not brake the field %>
     <%# dummy field %>
     <%= text_field_tag "#{@field.id}-dummy", '',

--- a/app/components/avo/fields/tags_field/index_component.html.erb
+++ b/app/components/avo/fields/tags_field/index_component.html.erb
@@ -1,4 +1,4 @@
-<%= index_field_wrapper **field_wrapper_args, flush: true do %>
+<%= index_field_wrapper(**field_wrapper_args, flush: true) do %>
   <div class="flex gap-1 items-center flex-nowrap">
     <% value.take(3).each do |item| %>
       <%= render Avo::Fields::TagsField::TagComponent.new(label: label_from_item(item)) %>

--- a/app/components/avo/fields/tags_field/show_component.html.erb
+++ b/app/components/avo/fields/tags_field/show_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <div class="flex gap-1 items-center flex-wrap">
     <% @field.field_value.each do |item| %>
       <%= render Avo::Fields::TagsField::TagComponent.new(label: label_from_item(item)) %>

--- a/app/components/avo/fields/text_field/edit_component.html.erb
+++ b/app/components/avo/fields/text_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= form.text_field @field.id,
     value: @field.value,
     class: classes("w-full"),

--- a/app/components/avo/fields/text_field/index_component.html.erb
+++ b/app/components/avo/fields/text_field/index_component.html.erb
@@ -1,4 +1,4 @@
-<%= index_field_wrapper **field_wrapper_args do %>
+<%= index_field_wrapper(**field_wrapper_args) do %>
   <% if @field.as_html %>
     <%== @field.value %>
   <% elsif @field.protocol.present? %>

--- a/app/components/avo/fields/text_field/show_component.html.erb
+++ b/app/components/avo/fields/text_field/show_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <% if @field.as_html %>
     <%== @field.value %>
   <% elsif @field.protocol.present? %>

--- a/app/components/avo/fields/textarea_field/edit_component.html.erb
+++ b/app/components/avo/fields/textarea_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= @form.text_area @field.id,
     value: @field.value,
     class: classes("w-full"),

--- a/app/components/avo/fields/textarea_field/show_component.html.erb
+++ b/app/components/avo/fields/textarea_field/show_component.html.erb
@@ -1,3 +1,3 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <div class="whitespace-pre-line"><%= @field.value %></div>
 <% end %>

--- a/app/components/avo/fields/time_field/edit_component.html.erb
+++ b/app/components/avo/fields/time_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= content_tag :div, class: "flex relative", data: {
       controller: "date-field",
       date_field_view_value: @view,

--- a/app/components/avo/fields/time_field/index_component.html.erb
+++ b/app/components/avo/fields/time_field/index_component.html.erb
@@ -1,4 +1,4 @@
-<%= index_field_wrapper **field_wrapper_args do %>
+<%= index_field_wrapper(**field_wrapper_args) do %>
    <%= content_tag :div, data: {
     controller: "date-field",
     date_field_view_value: @view,

--- a/app/components/avo/fields/time_field/show_component.html.erb
+++ b/app/components/avo/fields/time_field/show_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= content_tag :div, data: {
     controller: "date-field",
     date_field_view_value: @view,

--- a/app/components/avo/fields/tiptap_field/edit_component.html.erb
+++ b/app/components/avo/fields/tiptap_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= content_tag :div,
     class: "tiptap__field",
     data: {

--- a/app/components/avo/fields/tiptap_field/show_component.html.erb
+++ b/app/components/avo/fields/tiptap_field/show_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%
     content_classes = 'tiptap__content py-2 max-w-4xl'
     content_classes << ' hidden' unless @field.always_show

--- a/app/components/avo/fields/trix_field/edit_component.html.erb
+++ b/app/components/avo/fields/trix_field/edit_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%= content_tag :div,
     class: "relative block overflow-x-auto max-w-4xl",
     data: {

--- a/app/components/avo/fields/trix_field/show_component.html.erb
+++ b/app/components/avo/fields/trix_field/show_component.html.erb
@@ -1,4 +1,4 @@
-<%= field_wrapper **field_wrapper_args do %>
+<%= field_wrapper(**field_wrapper_args) do %>
   <%
     content_classes = 'trix-content py-2 max-w-4xl'
     content_classes << ' hidden' unless @field.always_show


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

If I run an app using avo with warnings enabled I get a LOT of warnings like this:

    avo-3.16.1/app/components/avo/fields/files_field/edit_component.html.erb:1: warning: `**' interpreted as argument prefix

This is happening because a function is being called with `**` as the first argument but there are no brackets around the arguments. Adding brackets fixes the warning but it does not change the meaning, so I've done that for all field components.

Fixes # (issue)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Everything should work as before (this shouldn't change any behavior)

Manual reviewer: please leave a comment with output from the test if that's the case.
