### PR TITLE
fix: radio field on actions & improve accessibility

### DIFF
--- a/app/components/avo/fields/radio_field/edit_component.html.erb
+++ b/app/components/avo/fields/radio_field/edit_component.html.erb
@@ -3,7 +3,7 @@
     <% @field.options.each do |key, value| %>
       <div>
         <%= form.radio_button @field.id, key %>
-        <%= form.label @field.id, value: value %>
+        <%= form.label @field.id, value, value: value %>
       </div>
     <% end %>
   </div>

--- a/spec/dummy/app/avo/actions/sub/dummy_action.rb
+++ b/spec/dummy/app/avo/actions/sub/dummy_action.rb
@@ -13,6 +13,7 @@ class Avo::Actions::Sub::DummyAction < Avo::BaseAction
   end
 
   def fields
+    field :size, as: :radio, options: {small: "Small Option", medium: "Medium Option", large: "Large Option"}
     TestBuddy.hi("Dummy action fields")
     field :keep_modal_open, as: :boolean
     field :persistent_text, as: :text

--- a/spec/features/avo/radio_field_spec.rb
+++ b/spec/features/avo/radio_field_spec.rb
@@ -76,7 +76,6 @@ RSpec.describe "RadioField", type: :feature do
       expect(page).to have_text("Small Option")
       expect(page).to have_text("Medium Option")
       expect(page).to have_text("Large Option")
-
     end
   end
 end

--- a/spec/features/avo/radio_field_spec.rb
+++ b/spec/features/avo/radio_field_spec.rb
@@ -62,4 +62,21 @@ RSpec.describe "RadioField", type: :feature do
       end
     end
   end
+
+  describe "on actions" do
+    it "display options" do
+      visit avo.resources_users_path
+
+      expect(page).not_to have_text("Small Option")
+      expect(page).not_to have_text("Medium Option")
+      expect(page).not_to have_text("Large Option")
+
+      open_panel_action(action_name: "Dummy action")
+
+      expect(page).to have_text("Small Option")
+      expect(page).to have_text("Medium Option")
+      expect(page).to have_text("Large Option")
+
+    end
+  end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3539

Fixes radio field labels to ensure proper association with options. Clicking a label now correctly selects the corresponding radio button, improving usability and accessibility. 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works