### PR TITLE
Add image uploads to the EasyMDE editor

### DIFF
--- a/app/components/avo/fields/easy_mde_field/edit_component.html.erb
+++ b/app/components/avo/fields/easy_mde_field/edit_component.html.erb
@@ -7,6 +7,7 @@
         view: view,
         'easy-mde-target': 'element',
         'component-options': @field.options.to_json,
+        upload_url: @field.options[:upload_url]
       },
       disabled: disabled?,
       placeholder: @field.placeholder,

--- a/lib/avo/fields/easy_mde_field.rb
+++ b/lib/avo/fields/easy_mde_field.rb
@@ -10,12 +10,22 @@ module Avo
 
         @always_show = args[:always_show].present? ? args[:always_show] : false
         @height = args[:height].present? ? args[:height].to_s : "auto"
+        @upload_url = args[:upload_url].present? ? args[:upload_url] : direct_uploads_url
+        @image_upload = args[:image_upload].present? ? args[:image_upload] : false
         @spell_checker = args[:spell_checker].present? ? args[:spell_checker] : false
         @options = {
           spell_checker: @spell_checker,
           always_show: @always_show,
-          height: @height
+          height: @height,
+          image_upload: @image_upload,
+          upload_url: direct_uploads_url
         }
+      end
+
+      private
+
+      def direct_uploads_url
+        "/rails/active_storage/direct_uploads"
       end
     end
   end

--- a/spec/dummy/app/avo/resources/project.rb
+++ b/spec/dummy/app/avo/resources/project.rb
@@ -60,7 +60,7 @@ class Avo::Resources::Project < Avo::BaseResource
       relative: true,
       timezone: "EET",
       format: "MMMM dd, y HH:mm:ss z"
-    field :description, as: :easy_mde, height: "350px"
+    field :description, as: :easy_mde, height: "350px", image_upload: true
     field :files,
       as: :files,
       translation_key: "avo.field_translations.files",


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds the ability to upload images from the Easy MDE markdown editor.

If the `image_upload` boolean attribute is present when configuring the field, it will add an icon that can trigger image uploads and the ability to drag and drop files into the editor.

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
The feature flow looks like this:

https://github.com/user-attachments/assets/e699b2f2-4d2d-4d36-a8b1-3f711ccd16d1

## Manual review steps
1. Run the Avo test application.
2. Navigate to the projects page.
3. Click on the edit icon for the last project or any project whatsoever.
4. On the project page, focus on the Easy MDE editor and go to an empty line or make an empty line.
5. Click on the second image icon, which will render a system file upload flow.
6. Choose an image file (JPG, PNG, WEBP, etc.).
7. The file should upload and be inserted into the markdown text.
