### PR TITLE
fix: grid view item selector

### DIFF
--- a/app/javascript/js/controllers/item_selector_controller.js
+++ b/app/javascript/js/controllers/item_selector_controller.js
@@ -44,15 +44,19 @@ export default class extends Controller {
 
     ids.push(this.resourceId)
 
-    // Mark the row as selected
-    this.element.closest('tr').classList.add('selected-row')
+    // Mark the row as selected if on table view
+    if (this.element.closest('tr')) {
+      this.element.closest('tr').classList.add('selected-row')
+    }
 
     this.currentIds = ids
   }
 
   removeFromSelected() {
-    // Un-mark the row as selected
-    this.element.closest('tr').classList.remove('selected-row')
+    // Un-mark the row as selected if on table view
+    if (this.element.closest('tr')) {
+      this.element.closest('tr').classList.remove('selected-row')
+    }
 
     this.currentIds = this.currentIds.filter(
       (item) => item.toString() !== this.resourceId,

--- a/spec/system/avo/actions_spec.rb
+++ b/spec/system/avo/actions_spec.rb
@@ -408,6 +408,30 @@ RSpec.describe "Actions", type: :system do
     end
   end
 
+  describe "select items on grid view" do
+    let!(:post) { create :post }
+
+    it "enables and disables the actions" do
+      visit avo.resources_posts_path
+
+      # Find disabled action
+      click_on "Actions"
+      expect(page.find("a", text: "Toggle post published")["data-disabled"]).to eq "true"
+
+      # Hover grid element, select post, and verify that action is not disabled anymore
+      find("[data-component-name=\"avo/index/grid_item_component\"][data-resource-name=\"posts\"][data-record-id=\"#{post.id}\"]").hover
+      find('input[type="checkbox"][data-action="input->item-selector#toggle input->item-select-all#selectRow"]', visible: false).click
+      click_on "Actions"
+      expect(page.find("a", text: "Toggle post published")["data-disabled"]).to eq "false"
+
+      # Hover grid element, "unselect" post, and verify that action is disabled again
+      find("[data-component-name=\"avo/index/grid_item_component\"][data-resource-name=\"posts\"][data-record-id=\"#{post.id}\"]").hover
+      find('input[type="checkbox"][data-action="input->item-selector#toggle input->item-select-all#selectRow"]', visible: false).click
+      click_on "Actions"
+      expect(page.find("a", text: "Toggle post published")["data-disabled"]).to eq "true"
+    end
+  end
+
   #   let!(:roles) { { admin: false, manager: false, writer: false } }
   #   let!(:user) { create :user, active: true, roles: roles }
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3591

Fixes an issue where non-standalone actions were not being enabled or disabled after selecting or deselecting records in grid view.

This issue originated from two lines of JavaScript that attempted to add and remove a class to the closest `<tr>` element without verifying its existence. However, in grid view, no `<tr>` elements are present.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works
