### PR TITLE
chore: add invalid license log notification.

### DIFF
--- a/app/controllers/concerns/avo/initializes_avo.rb
+++ b/app/controllers/concerns/avo/initializes_avo.rb
@@ -7,6 +7,12 @@ module Avo
       Avo::Current.view_context = view_context
       Avo.init
       Avo::Current.license = Licensing::LicenseManager.new(Licensing::HQ.new(request).response).license
+
+      # Output a warning in the logs if the license is invalid
+      if Avo::Current.license.invalid?
+        Avo.logger.debug "Your Avo license looks invalid. Please troubleshoot it using the directions here: https://docs.avohq.io/3.0/license-troubleshooting.html"
+      end
+
       Avo::Current.locale = locale
     end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds a notification in your Rails logs if the license is invalid.

![CleanShot 2025-01-27 at 12 52 08@2x](https://github.com/user-attachments/assets/8d6a2794-bda2-4e4a-814d-ff92dad76fb9)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
