### PR TITLE
fix: pass wrapper data on heading field

### DIFF
--- a/app/components/avo/fields/common/heading_component.rb
+++ b/app/components/avo/fields/common/heading_component.rb
@@ -8,7 +8,7 @@ class Avo::Fields::Common::HeadingComponent < Avo::BaseComponent
   def after_initialize
     @view = @field.resource.view
     @classes = "flex items-start py-1 leading-tight bg-gray-100 text-gray-500 text-xs #{@field.get_html(:classes, view: @view, element: :wrapper)}"
-    @data = stimulus_data_attributes
+    @data = {**stimulus_data_attributes, **@field.get_html(:data, view: @view, element: :wrapper)}
     add_stimulus_attributes_for(@field.resource, @data)
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR ensures that wrapper data is correctly assigned to `heading` fields.

```ruby
field :title, as: :heading, html: -> {
  edit do
    wrapper do
      classes do
        "hidden"
      end
      # This was not assigned before this PR
      data do
        {
          "some-controller-target": "titleHeading"
        }
      end
    end
  end
}
```