### PR TITLE
enhancement: add `saveButton` stimulus target to save button

### DIFF
--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -1,6 +1,7 @@
 class Avo::ResourceComponent < Avo::BaseComponent
   include Avo::Concerns::ChecksAssocAuthorization
   include Avo::Concerns::RequestMethods
+  include Avo::Concerns::HasResourceStimulusControllers
 
   attr_reader :fields_by_panel
   attr_reader :has_one_panels
@@ -190,14 +191,18 @@ class Avo::ResourceComponent < Avo::BaseComponent
   def render_save_button(control)
     return unless can_see_the_save_button?
 
+    data_attributes = {
+      turbo_confirm: @resource.confirm_on_save ? t("avo.are_you_sure") : nil
+    }
+
+    add_stimulus_attributes_for(@resource, data_attributes, "saveButton")
+
     a_button color: :primary,
       style: :primary,
       loading: true,
       type: :submit,
       icon: "avo/save",
-      data: {
-        turbo_confirm: @resource.confirm_on_save ? t("avo.are_you_sure") : nil
-      } do
+      data: data_attributes do
       control.label
     end
   end

--- a/lib/avo/concerns/has_resource_stimulus_controllers.rb
+++ b/lib/avo/concerns/has_resource_stimulus_controllers.rb
@@ -38,9 +38,9 @@ module Avo
         attributes
       end
 
-      def add_stimulus_attributes_for(entity, attributes)
+      def add_stimulus_attributes_for(entity, attributes, target_name = nil)
         entity.get_stimulus_controllers.split(" ").each do |controller|
-          attributes["#{controller}-target"] = "#{@field.id.to_s.underscore}_#{@field.type.to_s.underscore}_wrapper".camelize(:lower)
+          attributes["#{controller}-target"] = target_name || "#{@field.id.to_s.underscore}_#{@field.type.to_s.underscore}_wrapper".camelize(:lower)
         end
       end
     end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3607

Adding the `saveButton` target to all the stimulus controllers registered on a resource.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
