### PR TITLE
fix: `late-registration` javascript tag

### DIFF
--- a/app/components/avo/asset_manager/javascript_component.html.erb
+++ b/app/components/avo/asset_manager/javascript_component.html.erb
@@ -8,4 +8,8 @@
 <% end %>
 
 <%# This is the last script to run so it can register custom StimulusJS controllers from plugins. %>
-<%= javascript_include_tag 'late-registration', "data-turbo-track": "reload", defer: true %>
+<% if Avo::PACKED %>
+  <%= javascript_include_tag '/avo-assets/late-registration', "data-turbo-track": "reload", defer: true %>
+<% else %>
+  <%= javascript_include_tag 'late-registration', "data-turbo-track": "reload", defer: true %>
+<% end %>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes `javascript_include_tag` for `late-registration` to use `/avo-assets/` prefix when Avo is packed.