### PR TITLE
fix: tailwind integration

### DIFF
--- a/lib/tasks/avo_tasks.rake
+++ b/lib/tasks/avo_tasks.rake
@@ -134,5 +134,5 @@ desc "Installs yarn dependencies for Avo"
 task "avo:yarn_install" do
   # tailwind.preset.js needs this dependencies in order to be required
   puts "[Avo->] Adding yarn dependencies"
-  `yarn add tailwindcss @tailwindcss/forms @tailwindcss/typography --cwd #{Avo::Engine.root}`
+  `yarn add tailwindcss @tailwindcss/forms @tailwindcss/typography @tailwindcss/container-queries --cwd #{Avo::Engine.root}`
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3623 by including the `@tailwindcss/container-queries` dependency on `avo:yarn_install` task.

This dependency is necessary when using [tailwind integration](https://docs.avohq.io/3.0/tailwindcss-integration.html).