### PR TITLE
fix: tailwind integration dependencies

### DIFF
--- a/lib/tasks/avo_tasks.rake
+++ b/lib/tasks/avo_tasks.rake
@@ -134,5 +134,5 @@ desc "Installs yarn dependencies for Avo"
 task "avo:yarn_install" do
   # tailwind.preset.js needs this dependencies in order to be required
   puts "[Avo->] Adding yarn dependencies"
-  `yarn add tailwindcss @tailwindcss/forms @tailwindcss/typography @tailwindcss/container-queries --cwd #{Avo::Engine.root}`
+  `yarn add tailwindcss@^3.4.17 @tailwindcss/forms@^0.5.10 @tailwindcss/typography@^0.5.16 @tailwindcss/container-queries@^0.1.1 --cwd #{Avo::Engine.root}`
 end

--- a/lib/tasks/avo_tasks.rake
+++ b/lib/tasks/avo_tasks.rake
@@ -133,6 +133,7 @@ end
 desc "Installs yarn dependencies for Avo"
 task "avo:yarn_install" do
   # tailwind.preset.js needs this dependencies in order to be required
+  # Ensure that versions remain updated and synchronized with those specified in package.json.
   puts "[Avo->] Adding yarn dependencies"
   `yarn add tailwindcss@^3.4.17 @tailwindcss/forms@^0.5.10 @tailwindcss/typography@^0.5.16 @tailwindcss/container-queries@^0.1.1 --cwd #{Avo::Engine.root}`
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue where the Tailwind version used in the Tailwind integration was not specified, resulting in a "random" version being used instead of the one used to render Avo styles. This fix ensures that the preset uses the same Tailwind version as Avo during the build process to prevent style overrides and conflicts.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
