### PR TITLE
Removed defer attribute from the avo.base.css stylesheet tag

### DIFF
--- a/app/views/layouts/avo/application.html.erb
+++ b/app/views/layouts/avo/application.html.erb
@@ -13,7 +13,7 @@
     <%= render partial: "avo/partials/branding" %>
     <%= render partial: "avo/partials/pre_head" %>
     <%= render Avo::AssetManager::StylesheetComponent.new asset_manager: Avo.asset_manager %>
-    <%= stylesheet_link_tag @stylesheet_assets_path, "data-turbo-track": "reload", defer: true, as: "style" %>
+    <%= stylesheet_link_tag @stylesheet_assets_path, "data-turbo-track": "reload", as: "style" %>
 
     <% path = Avo::PACKED ? "/avo-assets/avo.base" : "avo.base" %>
     <%= javascript_include_tag path, "data-turbo-track": "reload", defer: true %>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When you load a page in avo the html `<link>` tag to load `avo.base.css` it ha a `defer` attribute on it. `defer` isn't a valid attribute for a `<link>` tag - it is for `<script>` tags and having it here is invalid html. I think this is also causing loading issues in google chrome for me when I redirect from avo to my main app.

I've removed defer from the `<link>` tag. This should make the html valid and shouldn't have any bad effects (as it shouldn't be used on a `<link>` tag anyway).

Fixes # (issue)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Check that the css for avo still loads correctly.

Manual reviewer: please leave a comment with output from the test if that's the case.
