### PR TITLE
fix: has many record selection disables parent's actions

### DIFF
--- a/app/components/avo/actions_component.rb
+++ b/app/components/avo/actions_component.rb
@@ -102,7 +102,8 @@ class Avo::ActionsComponent < Avo::BaseComponent
       disabled: action.disabled?,
       turbo_prefetch: false,
       enabled_classes: "text-black",
-      disabled_classes: "text-gray-500"
+      disabled_classes: "text-gray-500",
+      resource_name: action.resource.model_key
     }
   end
 

--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -301,7 +301,8 @@ class Avo::ResourceComponent < Avo::BaseComponent
         turbo_prefetch: false,
         # When action has record present behave as standalone and keep always active.
         "actions-picker-target": (action.action.standalone || action.action.record.present?) ? "standaloneAction" : "resourceAction",
-        disabled: action.action.disabled?
+        disabled: action.action.disabled?,
+        resource_name: action.action.resource.model_key
       } do
       action.label
     end

--- a/app/javascript/js/controllers/item_selector_controller.js
+++ b/app/javascript/js/controllers/item_selector_controller.js
@@ -75,19 +75,27 @@ export default class extends Controller {
 
   enableResourceActions() {
     this.actionLinks.forEach((link) => {
-      link.classList.add(link.dataset.enabledClasses)
-      link.classList.remove(link.dataset.disabledClasses)
-      link.setAttribute('data-href', link.getAttribute('href'))
-      link.dataset.disabled = false
+      // Enable only if is on the same resource context
+      // Avoiding to enable unrelated actions when selecting items on a has many table
+      if (link.dataset.resourceName === this.resourceName) {
+        link.classList.add(link.dataset.enabledClasses)
+        link.classList.remove(link.dataset.disabledClasses)
+        link.setAttribute('data-href', link.getAttribute('href'))
+        link.dataset.disabled = false
+      }
     })
   }
 
   disableResourceActions() {
     this.actionLinks.forEach((link) => {
-      link.classList.remove(link.dataset.enabledClasses)
-      link.classList.add(link.dataset.disabledClasses)
-      link.setAttribute('href', link.getAttribute('data-href'))
-      link.dataset.disabled = true
+      // Disable only if is on the same resource context
+      // Avoiding to disable unrelated actions when selecting items on a has many table
+      if (link.dataset.resourceName === this.resourceName) {
+        link.classList.remove(link.dataset.enabledClasses)
+        link.classList.add(link.dataset.disabledClasses)
+        link.setAttribute('href', link.getAttribute('data-href'))
+        link.dataset.disabled = true
+      }
     })
   }
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3575 

Actions should only be enabled or disabled when a selected item belongs to the same context/resource. This way, in the "has many" context, only the relevant "has many" actions will be modified.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
