### PR TITLE
Fix pagy nav typo

### DIFF
--- a/app/components/avo/media_library/list_component.html.erb
+++ b/app/components/avo/media_library/list_component.html.erb
@@ -51,7 +51,7 @@
       <div class="flex-2 w-full sm:flex sm:items-center sm:justify-between space-y-2 sm:space-y-0 text-center sm:text-left pagy-gem-version-<%= helpers.pagy_major_version %> ">
         <div class="text-sm text-slate-600 mr-4"><%== helpers.pagy_info @pagy %></div>
         <% if @pagy.pages > 1 %>
-          <%== helpers.pagy_nav(@pagy, xanchor_string: "data-turbo-frame=\"#{@turbo_frame}\"") %>
+          <%== helpers.pagy_nav(@pagy, anchor_string: "data-turbo-frame=\"#{@turbo_frame}\"") %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
# Description
Small typo fix that leads to an AttributeError (`unknown keyword: :xanchor_string`) in the Media Library