### PR TITLE
chore: revert media library anchor_string

### DIFF
--- a/app/components/avo/media_library/list_component.html.erb
+++ b/app/components/avo/media_library/list_component.html.erb
@@ -51,7 +51,10 @@
       <div class="flex-2 w-full sm:flex sm:items-center sm:justify-between space-y-2 sm:space-y-0 text-center sm:text-left pagy-gem-version-<%= helpers.pagy_major_version %> ">
         <div class="text-sm text-slate-600 mr-4"><%== helpers.pagy_info @pagy %></div>
         <% if @pagy.pages > 1 %>
-          <%== helpers.pagy_nav(@pagy, anchor_string: "data-turbo-frame=\"#{@turbo_frame}\"") %>
+          <%# xanchor_string is not valid key word argument and it breaks when require "pagy/extras/calendar" %>
+          <%# https://github.com/ddnexus/pagy/blob/d70e443872a5b18da4e482454b3c8b4a1c86cb6b/gem/lib/pagy/extras/calendar.rb#L47 %>
+          <%#== helpers.pagy_nav(@pagy, xanchor_string: "data-turbo-frame=\"#{@turbo_frame}\"") %>
+          <%== helpers.pagy_nav(@pagy) %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Removing `anchor_string` since it was not intentionally while developing media library pagination. `xanchor_string` was used to prevent `anchor_string` application but that approach breaks [here](https://github.com/ddnexus/pagy/blob/d70e443872a5b18da4e482454b3c8b4a1c86cb6b/gem/lib/pagy/extras/calendar.rb#L47)  when requiring the extra calendar

This PR removes the `anchor_string` introduced [here](https://github.com/avo-hq/avo/pull/3639) and keeps the original `xanchor_string` commented.