### PR TITLE
fix: global search warning

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -54,7 +54,9 @@ module Avo
         return nil unless render_error?
 
         search_query_undefined = error_payload(
-          _label: "Please configure the search for #{resource}",
+          header: "⚠️ Warning ⚠️",
+          help: "",
+          _label: "Search is disabled for #{resource}.\n To enable it please use this guide...",
           _url: "https://docs.avohq.io/3.0/search.html#enable-search-for-a-resource"
         )
 
@@ -207,10 +209,15 @@ module Avo
       }, status: 500
     end
 
-    def error_payload(_label:, _url: "")
+    def error_payload(
+      _label:,
+      _url: "",
+      header: "🚨 An error occurred during search 🚨",
+      help: "Please review and resolve the issue before deployment 🚨"
+    )
       {
-        header: "🚨 An error occurred during search 🚨",
-        help: "Please review and resolve the issue before deployment 🚨",
+        header:,
+        help:,
         results: {
           _label:,
           _url:,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes the global search warning when a resource has search disabled. Previously, it appeared as an error.

### Before

![image](https://github.com/user-attachments/assets/b06017bb-7953-40f7-86fa-416130a61a66)

### After

![image](https://github.com/user-attachments/assets/c49ad393-9147-44b9-8864-20795654b4e4)

