### PR TITLE
chore: drop `universalid` dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,6 @@ PATH
       prop_initializer (>= 0.2.0)
       turbo-rails (>= 2.0.0)
       turbo_power (>= 0.6.0)
-      universalid
       view_component (>= 3.7.0)
       zeitwerk (>= 2.6.12)
 
@@ -162,7 +161,6 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brotli (0.6.0)
     builder (3.3.0)
     bump (0.10.0)
     bundler-integrity (1.0.9)
@@ -181,9 +179,6 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.5)
-    config (5.5.2)
-      deep_merge (~> 1.2, >= 1.2.1)
-      ostruct
     connection_pool (2.5.0)
     countries (7.1.0)
       unaccent (~> 0.3)
@@ -206,7 +201,6 @@ GEM
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    deep_merge (1.2.2)
     derailed_benchmarks (2.1.2)
       benchmark-ips (~> 2)
       dead_end
@@ -666,12 +660,6 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    universalid (0.1.7)
-      activesupport (>= 6.1)
-      brotli (>= 0.4)
-      config (>= 5.0)
-      msgpack (>= 1.7)
-      zeitwerk (>= 2.6)
     uri (1.0.2)
     useragent (0.16.11)
     view_component (3.21.0)

--- a/app/helpers/avo/application_helper.rb
+++ b/app/helpers/avo/application_helper.rb
@@ -170,14 +170,14 @@ module Avo
       container_is_full_width? ? "" : "2xl:container 2xl:mx-auto"
     end
 
-    # encode params
+    # encode & encrypt params
     def e(value)
-      Marshal.dump(value)
+      Avo::Services::EncryptionService.encrypt(message: value, purpose: :return_to, serializer: Marshal)
     end
 
-    # decode params
+    # decrypt & decode params
     def d(value)
-      Marshal.load(value)
+      Avo::Services::EncryptionService.decrypt(message: value, purpose: :return_to, serializer: Marshal)
     rescue
       value
     end

--- a/app/helpers/avo/application_helper.rb
+++ b/app/helpers/avo/application_helper.rb
@@ -172,12 +172,12 @@ module Avo
 
     # encode params
     def e(value)
-      URI::UID.build(value).payload
+      Marshal.dump(value)
     end
 
     # decode params
     def d(value)
-      URI::UID.from_payload(value).decode
+      Marshal.load(value)
     rescue
       value
     end

--- a/avo.gemspec
+++ b/avo.gemspec
@@ -48,5 +48,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "docile"
   spec.add_dependency "inline_svg"
   spec.add_dependency "prop_initializer", ">= 0.2.0"
-  spec.add_dependency "universalid"
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3650

This PR drops the `universalid` gem as it relies on `config` gem, which has been causing multiple issues.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
