### PR TITLE
fix: radio field accessibility

### DIFF
--- a/app/components/avo/fields/radio_field/edit_component.html.erb
+++ b/app/components/avo/fields/radio_field/edit_component.html.erb
@@ -2,8 +2,8 @@
   <div class="flex flex-col gap-2">
     <% @field.options.each do |key, value| %>
       <div>
-        <%= form.radio_button @field.id, key %>
-        <%= form.label @field.id, value, value: value %>
+        <%= form.radio_button @field.id, key, checked: (@field.value.to_s == key.to_s) %>
+        <%= form.label @field.id, value, value: key %>
       </div>
     <% end %>
   </div>

--- a/spec/dummy/app/avo/actions/sub/dummy_action.rb
+++ b/spec/dummy/app/avo/actions/sub/dummy_action.rb
@@ -13,7 +13,7 @@ class Avo::Actions::Sub::DummyAction < Avo::BaseAction
   end
 
   def fields
-    field :size, as: :radio, options: {small: "Small Option", medium: "Medium Option", large: "Large Option"}
+    field :size, as: :radio, options: {small: "Small Option", medium: "Medium Option", large: "Large Option"}, default: :medium
     TestBuddy.hi("Dummy action fields")
     field :keep_modal_open, as: :boolean
     field :persistent_text, as: :text

--- a/spec/features/avo/radio_field_spec.rb
+++ b/spec/features/avo/radio_field_spec.rb
@@ -75,7 +75,12 @@ RSpec.describe "RadioField", type: :feature do
 
       expect(page).to have_text("Small Option")
       expect(page).to have_text("Medium Option")
+      expect(page).to have_checked_field("fields_size_medium")
       expect(page).to have_text("Large Option")
+
+      find("label[for='fields_size_large']").click
+      expect(page).not_to have_checked_field("fields_size_medium")
+      expect(page).to have_checked_field("fields_size_large")
     end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3659
Fixes #3649

Fix radio field accessibility by correctly associating the label with its corresponding checkbox. Also ensures that the radio field selects the default value if given on actions.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works
