### PR TITLE
refactor: alias `row` to `cluster`

### DIFF
--- a/lib/avo/concerns/has_items.rb
+++ b/lib/avo/concerns/has_items.rb
@@ -43,6 +43,7 @@ module Avo
       delegate :field, to: :items_holder
       delegate :panel, to: :items_holder
       delegate :row, to: :items_holder
+      delegate :cluster, to: :items_holder
       delegate :tabs, to: :items_holder
       delegate :tool, to: :items_holder
       delegate :heading, to: :items_holder

--- a/lib/avo/resources/items/holder.rb
+++ b/lib/avo/resources/items/holder.rb
@@ -65,9 +65,12 @@ class Avo::Resources::Items::Holder
     add_item Avo::Resources::Items::Tab::Builder.parse_block(name: name, parent: @parent, **args, &block)
   end
 
-  def row(**args, &block)
+  def cluster(**args, &block)
     add_item Avo::Resources::Items::Row::Builder.parse_block(parent: @parent, **args, &block)
   end
+
+  # def row
+  alias_method :row, :cluster
 
   def tool(klass, **args)
     add_item klass.new(**args, view: self.parent.view, parent: self.parent)

--- a/lib/avo/resources/items/item_group.rb
+++ b/lib/avo/resources/items/item_group.rb
@@ -29,6 +29,7 @@ class Avo::Resources::Items::ItemGroup
     delegate :heading, to: :items_holder
     delegate :field, to: :items_holder
     delegate :row, to: :items_holder
+    delegate :cluster, to: :items_holder
     delegate :items, to: :items_holder
     delegate :sidebar, to: :items_holder
 

--- a/spec/dummy/app/avo/resources/person.rb
+++ b/spec/dummy/app/avo/resources/person.rb
@@ -32,7 +32,7 @@ class Avo::Resources::Person < Avo::BaseResource
             "Software Engineer"
           end
 
-          row do
+          cluster do
             field :company, stacked: true do
               "TechCorp Inc."
             end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Alias `row` to `cluster`

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
  - https://github.com/avo-hq/docs.avohq.io/pull/349
- [ ] I have added tests that prove my fix is effective or that my feature works
