### PR TITLE
fix: `change_items_per_page_url` on paginator component

### DIFF
--- a/app/components/avo/paginator_component.rb
+++ b/app/components/avo/paginator_component.rb
@@ -3,6 +3,7 @@
 class Avo::PaginatorComponent < Avo::BaseComponent
   prop :resource
   prop :parent_record
+  prop :parent_resource
   prop :pagy
   prop :turbo_frame do |frame|
     frame.present? ? CGI.escapeHTML(frame) : :_top
@@ -12,7 +13,14 @@ class Avo::PaginatorComponent < Avo::BaseComponent
 
   def change_items_per_page_url(option)
     if @parent_record.present?
-      helpers.related_resources_path(@parent_record, @parent_record, per_page: option, keep_query_params: true, page: 1)
+      helpers.related_resources_path(
+        @parent_record,
+        @parent_record,
+        parent_resource: @parent_resource,
+        per_page: option,
+        keep_query_params: true,
+        page: 1
+      )
     else
       helpers.resources_path(resource: @resource, per_page: option, keep_query_params: true, page: 1)
     end

--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -79,7 +79,7 @@
       <% if view_type.to_sym == :table || view_type.to_sym == :map %>
         <% if @records.present? %>
           <div class="mt-4 w-full">
-            <%= render Avo::PaginatorComponent.new pagy: @pagy, turbo_frame: @turbo_frame, index_params: @index_params, resource: @resource, parent_record: @parent_record, discreet_pagination: field&.discreet_pagination %>
+            <%= render Avo::PaginatorComponent.new pagy: @pagy, turbo_frame: @turbo_frame, index_params: @index_params, resource: @resource, parent_record: @parent_record, parent_resource: @parent_resource, discreet_pagination: field&.discreet_pagination %>
           </div>
         <% end %>
       <% end %>
@@ -88,7 +88,7 @@
           <%= render Avo::Index::ResourceGridComponent.new(resources: @resources, resource: @resource, reflection: @reflection, parent_record: @parent_record, parent_resource: @parent_resource, actions: @actions) %>
         </div>
         <div class="mt-6">
-          <%= render Avo::PaginatorComponent.new pagy: @pagy, turbo_frame: @turbo_frame, index_params: @index_params, resource: @resource, parent_record: @parent_record, discreet_pagination: field&.discreet_pagination %>
+          <%= render Avo::PaginatorComponent.new pagy: @pagy, turbo_frame: @turbo_frame, index_params: @index_params, resource: @resource, parent_record: @parent_record, parent_resource: @parent_resource, discreet_pagination: field&.discreet_pagination %>
         </div>
       <% end %>
     <% end %>

--- a/app/helpers/avo/url_helpers.rb
+++ b/app/helpers/avo/url_helpers.rb
@@ -61,6 +61,7 @@ module Avo
       parent_record,
       record,
       keep_query_params: false,
+      parent_resource: nil,
       **args
     )
       return if record.nil?
@@ -75,7 +76,9 @@ module Avo
       rescue
       end
 
-      avo.resources_associations_index_path(parent_record.model_name.route_key, record.to_param, **existing_params, **args)
+      route_key = parent_resource&.route_key || parent_record.model_name.route_key
+
+      avo.resources_associations_index_path(route_key, record.to_param, **existing_params, **args)
     end
 
     def resource_view_path(**args)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3667

Fixing `change_items_per_page_url` by using the parent resource's route key instead of the parent model's route key.

This is useful when the parent resource uses `self.model_class` and its route key differs from that of the parent model.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
