### PR TITLE
fix: array resource adapter

### DIFF
--- a/lib/avo/resources/array_resource.rb
+++ b/lib/avo/resources/array_resource.rb
@@ -14,14 +14,14 @@ module Avo
       class << self
         def model_class
           @@model_class ||= Object.const_set(
-            name,
+            class_name,
             Class.new do
               include ActiveModel::Model
 
               class << self
                 def primary_key = nil
 
-                def all = "Avo::Resources::#{name}".constantize.new.fetch_records
+                def all = "Avo::Resources::#{class_name}".constantize.new.fetch_records
               end
             end
           )
@@ -40,7 +40,7 @@ module Avo
 
       def fetch_records(array_of_records = nil)
         array_of_records ||= records
-        raise "Unable to fetch any #{name}" if array_of_records.nil?
+        raise "Unable to fetch any #{class_name}" if array_of_records.nil?
 
         # When the array of records is declared in a field's block, we need to get that block from the parent resource
         # If there is no block try to pick those from the parent_record
@@ -69,7 +69,7 @@ module Avo
           keys = array_of_records.flat_map(&:keys).uniq
 
           Object.const_set(
-            name,
+            class_name,
             Class.new do
               include ActiveModel::Model
 
@@ -82,7 +82,7 @@ module Avo
             end
           )
 
-          custom_class = name.constantize
+          custom_class = class_name.constantize
 
           # Map the records to instances of the dynamically created class
           array_of_records.map do |item|


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes part of #3680 

The `ArrayResource` was incorrectly using `name` instead of `class_name` to define the backbone class. This caused errors when working with multi-word resources such as `Avo::Resources::DisplayName`.  

This fix ensures that `class_name` is used correctly.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
