### PR TITLE
fix: modify array resource constant registration to use Avo namespace

### DIFF
--- a/lib/avo/resources/array_resource.rb
+++ b/lib/avo/resources/array_resource.rb
@@ -13,7 +13,7 @@ module Avo
 
       class << self
         def model_class
-          @@model_class ||= Object.const_set(
+          @@model_class ||= Avo.const_set(
             class_name,
             Class.new do
               include ActiveModel::Model
@@ -68,7 +68,7 @@ module Avo
           # Dynamically create a class with accessors for all unique keys from the records
           keys = array_of_records.flat_map(&:keys).uniq
 
-          Object.const_set(
+          Avo.const_set(
             class_name,
             Class.new do
               include ActiveModel::Model
@@ -82,7 +82,7 @@ module Avo
             end
           )
 
-          custom_class = class_name.constantize
+          custom_class = "Avo::#{class_name}".constantize
 
           # Map the records to instances of the dynamically created class
           array_of_records.map do |item|


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3682 

Modify array resource constant registration to use Avo namespace

This update ensures that defining a resource like:

```ruby
class Avo::Resources::Movie < Avo::Resources::ArrayResource
```

will generate a corresponding `Avo::Movie` backbone model instead of `Movie`.

By namespacing the generated model within `Avo`, we prevent potential conflicts with an existing `Movie` class in the parent application.


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works