### PR TITLE
🚨 fix: coherence within associations fields authorization

### DIFF
--- a/app/components/avo/fields/has_one_field/show_component.html.erb
+++ b/app/components/avo/fields/has_one_field/show_component.html.erb
@@ -5,7 +5,7 @@
 <% else %>
   <%= render Avo::PanelComponent.new(name: @field.name) do |c| %>
     <% c.with_tools do %>
-      <% if !@field.is_readonly? && !@field.is_disabled? && can_attach? %>
+      <% if can_attach? %>
         <%= a_link attach_path,
           icon: 'heroicons/outline/link',
           color: :primary,
@@ -17,7 +17,7 @@
           <%= t('avo.attach_item', item: @field.name.humanize(capitalize: false)) %>
         <% end %>
       <% end %>
-      <% if !@field.is_readonly? && !@field.is_disabled? && can_see_the_create_button? %>
+      <% if can_see_the_create_button? %>
         <%= a_link create_path,
           icon: 'heroicons/outline/plus',
           'data-target': 'create',


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #2614 

`read_only` and `disabled` options were interfering with the rendering of attach/create buttons on `has_one` fields, while not affecting other association fields such as `has_many`.

We decided to remove these options from the attach/create functionality to maintain consistency with other fields, and now attach/create is controlled solely through authorization ([attach_{association}?](https://docs.avohq.io/3.0/authorization.html#attach_association) / [create_{association}?](https://docs.avohq.io/3.0/authorization.html#create_association)).

### 🚨 Breaking Changes

Heads up: `read_only` and `disabled` don't affect `has_one` fields anymore.

Please search for all `has_one` fields still using the `read_only` or `disabled` options and update them with the correct authorization methods: [attach_{association}?](https://docs.avohq.io/3.0/authorization.html#attach_association) and [create_{association}?](https://docs.avohq.io/3.0/authorization.html#create_association) 


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
  - https://github.com/avo-hq/docs.avohq.io/pull/352
- [ ] I have added tests that prove my fix is effective or that my feature works
