### PR TITLE
fix: update `associations_mapping` reference in resource generator

### DIFF
--- a/lib/generators/avo/resource_generator.rb
+++ b/lib/generators/avo/resource_generator.rb
@@ -228,7 +228,7 @@ module Generators
             # If the through_reflection is not a HasManyReflection, add it to the fields hash using the class of the through_reflection
             # ex (team.rb): has_one :admin, through: :admin_membership, source: :user
             # we use the class of the through_reflection (HasOneReflection -> has_one :admin) to generate the field
-            associations_mapping[association.through_reflection.class]
+            ::Avo::Mappings::ASSOCIATIONS_MAPPING[association.through_reflection.class]
           end
         end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3688

In one previous refactor [fields mapping refactor](https://github.com/avo-hq/avo/pull/3595), we overlooked one call to the obsolete `associations_mapping` method.

This PR swaps that call with `::Avo::Mappings::ASSOCIATIONS_MAPPING`

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
