### PR TITLE
Remove unnecessary blank lines in resource template

### DIFF
--- a/lib/generators/avo/templates/resource/resource.tt
+++ b/lib/generators/avo/templates/resource/resource.tt
@@ -26,5 +26,3 @@ class Avo::Resources::<%= resource_class %> < <%= parent_resource %><% if option
     field :id, as: :id<%= generate_fields %>
   end<% end %>
 end
-
-


### PR DESCRIPTION
# Description
Auto generated resources have whitespaces. Rubocop doesn't allow them. It raises errors.

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording

![Screenshot 2025-02-25 at 17 16 55](https://github.com/user-attachments/assets/bd087e1c-445f-4842-988b-280ff80dc450)
![Screenshot 2025-02-25 at 17 17 07](https://github.com/user-attachments/assets/b073abfb-1812-440d-a6da-42486f264d38)


## Manual review steps

1. Use standart Rails rubocop rules.
2. Create a new model
3. run `bin/rubocop -f github`

