### PR TITLE
fix: warning: already initialized constant Avo::Concerns::HasFieldDiscovery::COLUMN_NAMES_TO_IGNORE

### DIFF
--- a/lib/avo/concerns/has_field_discovery.rb
+++ b/lib/avo/concerns/has_field_discovery.rb
@@ -13,9 +13,11 @@ module Avo
     module HasFieldDiscovery
       extend ActiveSupport::Concern
 
-      COLUMN_NAMES_TO_IGNORE = %i[
-        encrypted_password reset_password_token reset_password_sent_at remember_created_at password_digest
-      ].freeze
+      if !defined?(COLUMN_NAMES_TO_IGNORE)
+        COLUMN_NAMES_TO_IGNORE = %i[
+          encrypted_password reset_password_token reset_password_sent_at remember_created_at password_digest
+        ].freeze
+      end
 
       class_methods do
         def column_names_mapping


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes:

```
.../avo/lib/avo/concerns/has_field_discovery.rb:16: warning: already initialized constant Avo::Concerns::HasFieldDiscovery::COLUMN_NAMES_TO_IGNORE
.../avo/lib/avo/concerns/has_field_discovery.rb:16: warning: previous definition of COLUMN_NAMES_TO_IGNORE was here
```
