### PR TITLE
enhancement: add `@index_query` access in actions

### DIFF
--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -61,9 +61,13 @@ module Avo
     private
 
     def set_query
-      resource_ids = action_params[:fields]&.dig(:avo_resource_ids)&.split(",") || []
+      @query = if selected_all?
+        decrypted_index_query
+      else
+        resource_ids = action_params[:fields]&.dig(:avo_resource_ids)&.split(",") || []
 
-      @query = selected_all? ? decrypted_index_query : (resource_ids.any? ? @resource.find_record(resource_ids, params: params) : [])
+        resource_ids.any? ? @resource.find_record(resource_ids, params: params) : []
+      end
     end
 
     def set_fields

--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -61,6 +61,8 @@ module Avo
     private
 
     def set_query
+      # If the user selected all records, use the decrypted index query
+      # Otherwise, find the records from the resource ids
       @query = if action_params[:fields]&.dig(:avo_selected_all) == "true"
         decrypted_index_query
       else

--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -79,7 +79,7 @@ module Avo
     end
 
     def set_fields
-      @fields = action_params[:fields].except(:avo_resource_ids, :avo_selected_query)
+      @fields = action_params[:fields].except(:avo_resource_ids, :avo_index_query)
     end
 
     def action_params

--- a/app/javascript/js/controllers/action_controller.js
+++ b/app/javascript/js/controllers/action_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ['resourceIds', 'form', 'selectedAllQuery']
+  static targets = ['resourceIds', 'form', 'selectedAll', 'indexQuery']
 
   static values = {
     noConfirmation: Boolean,
@@ -13,10 +13,11 @@ export default class extends Controller {
       this.resourceIdsTarget.value = this.resourceIds
     }
 
-    // This value is picked up from the DOM so we check true/false as strings
-    if (this.selectionOptions.itemSelectAllSelectedAllValue === 'true') {
-      this.selectedAllQueryTarget.value = this.selectionOptions.itemSelectAllSelectedAllQueryValue
-    }
+    // Select all checkbox
+    this.selectedAllTarget.value = this.selectionOptions.itemSelectAllSelectedAllValue
+
+    // Encrypted and encoded index query
+    this.indexQueryTarget.value = this.selectionOptions.itemSelectAllSelectedAllQueryValue
 
     if (this.noConfirmationValue) {
       this.formTarget.requestSubmit()

--- a/app/javascript/js/controllers/action_controller.js
+++ b/app/javascript/js/controllers/action_controller.js
@@ -16,8 +16,10 @@ export default class extends Controller {
     // Select all checkbox
     this.selectedAllTarget.value = this.selectionOptions.itemSelectAllSelectedAllValue
 
-    // Encrypted and encoded index query
-    this.indexQueryTarget.value = this.selectionOptions.itemSelectAllSelectedAllQueryValue
+    // Encrypted and encoded index query when it is present (index view)
+    if (this.selectionOptions.itemSelectAllSelectedAllQueryValue) {
+      this.indexQueryTarget.value = this.selectionOptions.itemSelectAllSelectedAllQueryValue
+    }
 
     if (this.noConfirmationValue) {
       this.formTarget.requestSubmit()

--- a/app/javascript/js/controllers/item_select_all_controller.js
+++ b/app/javascript/js/controllers/item_select_all_controller.js
@@ -107,8 +107,10 @@ export default class extends Controller {
 
         if (param === 'resourceIds') {
           url.searchParams.set('fields[avo_resource_ids]', resourceIds)
+          url.searchParams.set('fields[avo_selected_all]', 'false')
         } else if (param === 'selectedQuery') {
-          url.searchParams.set('fields[avo_selected_query]', selectedQuery)
+          url.searchParams.set('fields[avo_index_query]', selectedQuery)
+          url.searchParams.set('fields[avo_selected_all]', 'true')
         }
 
         link.href = url.toString()

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -30,7 +30,8 @@
         <%= @action.get_message %>
       </div>
       <%= form.hidden_field :avo_resource_ids, value: params[:id] || params[:resource_ids], 'data-action-target': 'resourceIds' %>
-      <%= form.hidden_field :avo_selected_query, 'data-action-target': 'selectedAllQuery' %>
+      <%= form.hidden_field :avo_selected_all, 'data-action-target': 'selectedAll' %>
+      <%= form.hidden_field :avo_index_query, 'data-action-target': 'indexQuery' %>
       <%= form.hidden_field :arguments, value: params[:arguments] %>
       <% if @fields.present? %>
         <div class="mt-4 -mx-6">

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -111,7 +111,7 @@ module Avo
       self.class.to_s.demodulize.underscore.humanize(keep_id_suffix: true)
     end
 
-    def initialize(record: nil, resource: nil, user: nil, view: nil, arguments: {}, icon: :play, query: nil)
+    def initialize(record: nil, resource: nil, user: nil, view: nil, arguments: {}, icon: :play, query: nil, index_query: nil)
       @record = record
       @resource = resource
       @user = user
@@ -123,7 +123,7 @@ module Avo
         record: record
       ).handle.with_indifferent_access
       @query = query
-
+      @index_query = index_query
       self.class.message ||= I18n.t("avo.are_you_sure_you_want_to_run_this_option")
       self.class.confirm_button_label ||= I18n.t("avo.run")
       self.class.cancel_button_label ||= I18n.t("avo.cancel")

--- a/spec/dummy/app/avo/actions/export_csv.rb
+++ b/spec/dummy/app/avo/actions/export_csv.rb
@@ -18,7 +18,10 @@ class Avo::Actions::ExportCsv < Avo::BaseAction
     # uncomment if you want to download all the records if none was selected
     # records = resource.model_class.all if records.blank?
 
-    return error "No record selected" if records.blank?
+    if records.blank?
+      inform "@index_query.count: #{@index_query.count}"
+      return error "No record selected"
+    end
 
     # uncomment to get all the models' attributes.
     # attributes = get_attributes_from_record records.first


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR introduces access to the `@index_query` variable within the `handle` method. This variable represents the index query of the resource, making it easier to work with the full dataset under various conditions:

- When "select all" is enabled, `@index_query == @query`.  
- When "select all" is **not** enabled, `@query` reflects only the selected records, whereas `@index_query` always returns the full index query with all filters and scopes applied.

This is particularly useful for standalone actions that need to operate on the entire dataset as defined by the current index query. For example, if a user applies filters and scopes, then selects **"Export All"**, the action can directly access the fully filtered query via `@index_query` without relying on manual selection handling.


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
