### PR TITLE
refactor: start using `Avo::ResourceNotFoundError` instead `ActionController::RoutingError`

### DIFF
--- a/app/controllers/avo/base_application_controller.rb
+++ b/app/controllers/avo/base_application_controller.rb
@@ -93,7 +93,7 @@ module Avo
     end
 
     def set_resource
-      raise ActionController::RoutingError.new "No route matches" if resource.nil?
+      raise Avo::ResourceNotFoundError.new(resource_name) if resource.nil?
 
       @resource = resource.new(view: params[:view].presence || action_name.to_s, user: _current_user, params: params)
 

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -57,8 +57,8 @@ module Avo
 
   class ResourceNotFoundError < StandardError
     def initialize(resource_name)
-      super "Resource for '#{resource_name}' not found.\n" \
-        "You can generate a resource for it by running 'rails generate avo:resource #{resource_name}'."
+      super("Resource for '#{resource_name}' not found.\n" \
+        "You can generate a resource for it by running 'rails generate avo:resource #{resource_name}'.")
     end
   end
 

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -57,8 +57,10 @@ module Avo
 
   class ResourceNotFoundError < StandardError
     def initialize(resource_name)
-      super("Resource for '#{resource_name}' not found.\n" \
-        "You can generate a resource for it by running 'rails generate avo:resource #{resource_name}'.")
+      super(
+        "Resource for '#{resource_name}' not found.\n" \
+        "You can generate a resource for it by running 'rails generate avo:resource #{resource_name}'."
+      )
     end
   end
 

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -55,6 +55,13 @@ module Avo
     end
   end
 
+  class ResourceNotFoundError < StandardError
+    def initialize(resource_name)
+      super "Resource for '#{resource_name}' not found.\n" \
+        "You can generate a resource for it by running 'rails generate avo:resource #{resource_name}'."
+    end
+  end
+
   class << self
     attr_reader :logger
     attr_reader :cache_store


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This update replaces the `ActionController::RoutingError` with a more descriptive and debuggable custom error, `Avo::ResourceNotFoundError`, when a requested resource is not found.  

## Motivation  
The default `ActionController::RoutingError` can obscure the root cause of missing resources, making debugging more challenging. By introducing `Avo::ResourceNotFoundError`, we ensure clearer error messaging and a more maintainable approach to handling resource lookup failures.  
