### PR TITLE
fix: text selection on table row triggers visit

### DIFF
--- a/app/javascript/js/controllers/table_row_controller.js
+++ b/app/javascript/js/controllers/table_row_controller.js
@@ -1,8 +1,17 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
+  connect() {
+    this.isSelecting = false
+    this.#bindSelectionEvents()
+  }
+
   visitRecord(event) {
     if (event.type !== 'click') {
+      return
+    }
+
+    if (this.#isTextSelected()) {
       return
     }
 
@@ -31,6 +40,31 @@ export default class extends Controller {
     } else {
       this.#visitInSameTab(url)
     }
+  }
+
+  #bindSelectionEvents() {
+    this.element.addEventListener('mousedown', this.#handleMouseDown.bind(this))
+    this.element.addEventListener('mousemove', this.#handleMouseMove.bind(this))
+  }
+
+  #handleMouseDown() {
+    this.isSelecting = false
+  }
+
+  #handleMouseMove(event) {
+    if (event.buttons === 1) { // Left mouse button is being held
+      this.isSelecting = true
+    }
+  }
+
+  #isTextSelected() {
+    if (this.isSelecting || window.getSelection().toString().length > 0) {
+      this.isSelecting = false
+
+      return true
+    }
+
+    return false
   }
 
   #visitInSameTab(url) {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue when a user was trying to select a piece of text on a table row (with click to visit record option on) and that would trigger the visit to that record instead of ignoring it.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. go to a table with `click_row_to_view_record` option on
1. select some text on a row
2. observe that thebrowser does not visit that record.

Manual reviewer: please leave a comment with output from the test if that's the case.
