### PR TITLE
fix: add options_for_filter method to `BadgeField`

### DIFF
--- a/lib/avo/fields/badge_field.rb
+++ b/lib/avo/fields/badge_field.rb
@@ -11,6 +11,10 @@ module Avo
         default_options = {info: :info, success: :success, danger: :danger, warning: :warning, neutral: :neutral}
         @options = args[:options].present? ? default_options.merge(args[:options]) : default_options
       end
+
+      def options_for_filter
+        @options.values.flatten.uniq
+      end
     end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/avo-hq/avo-dynamic_filters/issues/82

Dynamic filters will now pick the correct options from badge fields. 

```ruby
    field :stage, as: :badge, options: {info: ["Discovery", "Idea"], success: "Done", warning: "On hold", danger: "Cancelled"}, filterable: true
```

![image](https://github.com/user-attachments/assets/405b3dd5-3a8d-49c9-b785-d6b72dead7d6)


Notice that `neutral` is an option since it is one of the [default options](https://github.com/avo-hq/avo/blob/main/lib/avo/fields/badge_field.rb#L11). 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
