### PR TITLE
fix: missing locale keys for `created_at_timestamp` and `updated_at_timestamp`

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -224,3 +224,32 @@ To keep track of the schema structure for the models, run `annotate --models --e
 ## Using VSCode?
 
 We compiled [an extension pack](https://marketplace.visualstudio.com/items?itemName=adrianthedev.vsruby) with a few extensions that should help you with Ruby development. We use them with Avo.
+
+## Adding I18n Keys
+
+When incorporating I18n keys, such as `avo.preview`, it's important to ensure that all locale files include the key with appropriate translations.
+
+### Step 1: Add and Normalize
+First, add the key to the `avo.en.yml` file. Then, run the following command to normalize the locale files alphabetically:
+```bash
+i18n-tasks normalize
+```
+
+### Step 2: Adding Missing Keys with or without Translation
+
+When adding missing keys, you have two options: proceed without translation or automatically translate them using OpenAI.
+
+#### Option 1: Add Missing Keys Without Translation
+Run the following command to add the missing keys to all locale files:
+```bash
+i18n-tasks add-missing
+```
+This will populate the missing keys but retain the original label without translations applied.
+
+#### Option 2: Add and Automatically Translate Missing Keys
+If you prefer to automatically translate the missing keys, skip the previous step and execute this command with your OpenAI API token:
+```bash
+OPENAI_API_KEY=TOKEN bundle exec i18n-tasks translate-missing --backend=openai
+```
+
+Replace `TOKEN` with your actual OpenAI API key. This step will both add the missing keys and translate them automatically.

--- a/lib/generators/avo/templates/locales/avo.ar.yml
+++ b/lib/generators/avo/templates/locales/avo.ar.yml
@@ -33,6 +33,7 @@ ar:
     confirm: تأكيد
     copy: نسخ
     create_new_item: إنشاء %{item} جديد
+    created_at_timestamp: تم الإنشاء في %{created_at}
     dashboard: لوحة القيادة
     dashboards: لوحات القيادة
     default_scope: الجميع
@@ -126,6 +127,7 @@ ar:
     type_to_search: اكتب للبحث.
     unauthorized: غير مصرح به
     undo: تراجع
+    updated_at_timestamp: تم التحديث في %{updated_at}
     view: عرض
     view_item: عرض %{item}
     visit_record_on_external_path: زيارة السجل على الرابط الخارجي

--- a/lib/generators/avo/templates/locales/avo.de.yml
+++ b/lib/generators/avo/templates/locales/avo.de.yml
@@ -27,6 +27,7 @@ de:
     confirm: Bestätigen
     copy: Kopieren
     create_new_item: Neues %{item} erstellen
+    created_at_timestamp: Erstellt am %{createdAt}
     dashboard: Dashboard
     dashboards: Dashboards
     default_scope: Alle
@@ -116,6 +117,7 @@ de:
     type_to_search: Tippen, um zu suchen.
     unauthorized: Nicht autorisiert
     undo: Rückgängig machen
+    updated_at_timestamp: Aktualisiert am %{updatedAt}
     view: Anzeigen
     view_item: "%{item} anzeigen"
     visit_record_on_external_path: Datensatz über externen Link besuchen

--- a/lib/generators/avo/templates/locales/avo.de.yml
+++ b/lib/generators/avo/templates/locales/avo.de.yml
@@ -27,7 +27,7 @@ de:
     confirm: Bestätigen
     copy: Kopieren
     create_new_item: Neues %{item} erstellen
-    created_at_timestamp: Erstellt am %{createdAt}
+    created_at_timestamp: Erstellt am %{created_at}
     dashboard: Dashboard
     dashboards: Dashboards
     default_scope: Alle

--- a/lib/generators/avo/templates/locales/avo.de.yml
+++ b/lib/generators/avo/templates/locales/avo.de.yml
@@ -117,7 +117,7 @@ de:
     type_to_search: Tippen, um zu suchen.
     unauthorized: Nicht autorisiert
     undo: Rückgängig machen
-    updated_at_timestamp: Aktualisiert am %{updatedAt}
+    updated_at_timestamp: Aktualisiert am %{updated_at}
     view: Anzeigen
     view_item: "%{item} anzeigen"
     visit_record_on_external_path: Datensatz über externen Link besuchen

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -27,6 +27,7 @@ en:
     confirm: Confirm
     copy: Copy
     create_new_item: Create new %{item}
+    created_at_timestamp: Created at %{created_at}
     dashboard: Dashboard
     dashboards: Dashboards
     default_scope: All
@@ -116,6 +117,7 @@ en:
     type_to_search: Type to search.
     unauthorized: Unauthorized
     undo: undo
+    updated_at_timestamp: Updated at %{updated_at}
     view: View
     view_item: view %{item}
     visit_record_on_external_path: Visit record on external path

--- a/lib/generators/avo/templates/locales/avo.es.yml
+++ b/lib/generators/avo/templates/locales/avo.es.yml
@@ -29,6 +29,7 @@ es:
     confirm: Confirmar
     copy: Copiar
     create_new_item: Crear nuevo/a %{item}
+    created_at_timestamp: Creado en %{created_at}
     dashboard: Panel
     dashboards: Paneles
     default_scope: Todos
@@ -118,6 +119,7 @@ es:
     type_to_search: Escribe para buscar.
     unauthorized: No autorizado
     undo: deshacer
+    updated_at_timestamp: Actualizado en %{updated_at}
     view: Vista
     view_item: ver %{item}
     visit_record_on_external_path: Visitar registro en enlace externo

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -29,6 +29,7 @@ fr:
     confirm: Confirmer
     copy: Copier
     create_new_item: Créer un nouveau %{item}
+    created_at_timestamp: Créé le %{createdAt}
     dashboard: Tableau de bord
     dashboards: Tableaux de bord
     default_scope: Tout
@@ -118,6 +119,7 @@ fr:
     type_to_search: Type à rechercher.
     unauthorized: Non autorisé
     undo: annuler
+    updated_at_timestamp: Mis à jour le %{updatedAt}
     view: Vue
     view_item: voir %{item}
     visit_record_on_external_path: Consulter l'enregistrement via un lien externe

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -29,7 +29,7 @@ fr:
     confirm: Confirmer
     copy: Copier
     create_new_item: Créer un nouveau %{item}
-    created_at_timestamp: Créé le %{createdAt}
+    created_at_timestamp: Créé le %{created_at}
     dashboard: Tableau de bord
     dashboards: Tableaux de bord
     default_scope: Tout

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -119,7 +119,7 @@ fr:
     type_to_search: Type à rechercher.
     unauthorized: Non autorisé
     undo: annuler
-    updated_at_timestamp: Mis à jour le %{updatedAt}
+    updated_at_timestamp: Mis à jour le %{updated_at}
     view: Vue
     view_item: voir %{item}
     visit_record_on_external_path: Consulter l'enregistrement via un lien externe

--- a/lib/generators/avo/templates/locales/avo.it.yml
+++ b/lib/generators/avo/templates/locales/avo.it.yml
@@ -27,6 +27,7 @@ it:
     confirm: Conferma
     copy: Copia
     create_new_item: Crea nuovo %{item}
+    created_at_timestamp: Creato il %{created_at}
     dashboard: Cruscotto
     dashboards: Cruscotti
     default_scope: Tutti
@@ -116,6 +117,7 @@ it:
     type_to_search: Digita per cercare.
     unauthorized: Non autorizzato
     undo: Annulla
+    updated_at_timestamp: Aggiornato il %{updated_at}
     view: Visualizza
     view_item: Visualizza %{item}
     visit_record_on_external_path: Visita il record tramite link esterno

--- a/lib/generators/avo/templates/locales/avo.ja.yml
+++ b/lib/generators/avo/templates/locales/avo.ja.yml
@@ -29,6 +29,7 @@ ja:
     confirm: 確認
     copy: コピー
     create_new_item: 新しい%{item}を作成
+    created_at_timestamp: "%{created_at}で作成"
     dashboard: ダッシュボード
     dashboards: ダッシュボード
     default_scope: 全て
@@ -118,6 +119,7 @@ ja:
     type_to_search: 検索する内容を入力してください。
     unauthorized: 許可されていません
     undo: 元に戻す
+    updated_at_timestamp: "%{updated_at}で更新"
     view: ビュー
     view_item: "%{item}を表示"
     visit_record_on_external_path: 外部リンクで記録を確認する

--- a/lib/generators/avo/templates/locales/avo.nb.yml
+++ b/lib/generators/avo/templates/locales/avo.nb.yml
@@ -29,6 +29,7 @@ nb:
     confirm: Bekreft
     copy: Kopier
     create_new_item: Lag ny %{item}
+    created_at_timestamp: Opprettet den %{created_at}
     dashboard: Dashboard
     dashboards: Dashboards
     default_scope: Alle
@@ -118,6 +119,7 @@ nb:
     type_to_search: Søk.
     unauthorized: Ikke autorisert
     undo: angre
+    updated_at_timestamp: Oppdatert den %{updated_at}
     view: Vis
     view_item: vis %{item}
     visit_record_on_external_path: Besøk posten via en ekstern lenke

--- a/lib/generators/avo/templates/locales/avo.nl.yml
+++ b/lib/generators/avo/templates/locales/avo.nl.yml
@@ -27,6 +27,7 @@ nl:
     confirm: Bevestigen
     copy: Kopie
     create_new_item: Nieuw %{item} aanmaken
+    created_at_timestamp: Aangemaakt op %{created_at}
     dashboard: Dashboard
     dashboards: Dashboards
     default_scope: Alle
@@ -116,6 +117,7 @@ nl:
     type_to_search: Typ om te zoeken.
     unauthorized: Niet geautoriseerd
     undo: Ongedaan maken
+    updated_at_timestamp: Bijgewerkt op %{updated_at}
     view: Bekijken
     view_item: "%{item} bekijken"
     visit_record_on_external_path: Bezoek record via een externe link

--- a/lib/generators/avo/templates/locales/avo.nn.yml
+++ b/lib/generators/avo/templates/locales/avo.nn.yml
@@ -29,6 +29,7 @@ nn:
     confirm: Stadfest
     copy: Kopier
     create_new_item: Lag ny %{item}
+    created_at_timestamp: Oppretta den %{created_at}
     dashboard: Dashboard
     dashboards: Dashboards
     default_scope: Alle
@@ -118,6 +119,7 @@ nn:
     type_to_search: Søk.
     unauthorized: Ikkje autorisert
     undo: angre
+    updated_at_timestamp: Oppdatert den %{updated_at}
     view: Vis
     view_item: vis %{item}
     visit_record_on_external_path: Besøk posten via ein ekstern lenke

--- a/lib/generators/avo/templates/locales/avo.pl.yml
+++ b/lib/generators/avo/templates/locales/avo.pl.yml
@@ -27,6 +27,7 @@ pl:
     confirm: Potwierdź
     copy: Kopiuj
     create_new_item: Utwórz nowy %{item}
+    created_at_timestamp: Utworzono o %{created_at}
     dashboard: Pulpit nawigacyjny
     dashboards: Pulpity nawigacyjne
     default_scope: Wszystkie
@@ -118,6 +119,7 @@ pl:
     type_to_search: Wpisz, aby wyszukać.
     unauthorized: Brak autoryzacji
     undo: Cofnij
+    updated_at_timestamp: Zaktualizowano o %{updated_at}
     view: Widok
     view_item: Wyświetl %{item}
     visit_record_on_external_path: Odwiedź rekord za pomocą zewnętrznego linku

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -29,6 +29,7 @@ pt-BR:
     confirm: Confirmar
     copy: Copiar
     create_new_item: Criar novo %{item}
+    created_at_timestamp: Criado em %{createdAt}
     dashboard: Painel
     dashboards: Painéis
     default_scope: Todos
@@ -118,6 +119,7 @@ pt-BR:
     type_to_search: Digite para buscar.
     unauthorized: Não autorizado
     undo: desfazer
+    updated_at_timestamp: Atualizado em %{updatedAt}
     view: Visualizar
     view_item: visualizar %{item}
     visit_record_on_external_path: Visitar registro através de link externo

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -29,7 +29,7 @@ pt-BR:
     confirm: Confirmar
     copy: Copiar
     create_new_item: Criar novo %{item}
-    created_at_timestamp: Criado em %{createdAt}
+    created_at_timestamp: Criado em %{created_at}
     dashboard: Painel
     dashboards: Painéis
     default_scope: Todos

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -119,7 +119,7 @@ pt-BR:
     type_to_search: Digite para buscar.
     unauthorized: Não autorizado
     undo: desfazer
-    updated_at_timestamp: Atualizado em %{updatedAt}
+    updated_at_timestamp: Atualizado em %{updated_at}
     view: Visualizar
     view_item: visualizar %{item}
     visit_record_on_external_path: Visitar registro através de link externo

--- a/lib/generators/avo/templates/locales/avo.pt.yml
+++ b/lib/generators/avo/templates/locales/avo.pt.yml
@@ -29,7 +29,7 @@ pt:
     confirm: Confirmar
     copy: Copiar
     create_new_item: Criar novo %{item}
-    created_at_timestamp: Criado em %{%{created_at}}
+    created_at_timestamp: Criado em %{created_at}
     dashboard: Painel
     dashboards: Painéis
     default_scope: Todos
@@ -119,7 +119,7 @@ pt:
     type_to_search: Escreva para pesquisar.
     unauthorized: Não autorizado
     undo: desfazer
-    updated_at_timestamp: Atualizado em %{%{updated_at}}
+    updated_at_timestamp: Atualizado em %{updated_at}
     view: Ver
     view_item: ver %{item}
     visit_record_on_external_path: Visitar registro através de link externo

--- a/lib/generators/avo/templates/locales/avo.pt.yml
+++ b/lib/generators/avo/templates/locales/avo.pt.yml
@@ -29,6 +29,7 @@ pt:
     confirm: Confirmar
     copy: Copiar
     create_new_item: Criar novo %{item}
+    created_at_timestamp: Criado em %{%{created_at}}
     dashboard: Painel
     dashboards: Painéis
     default_scope: Todos
@@ -118,6 +119,7 @@ pt:
     type_to_search: Escreva para pesquisar.
     unauthorized: Não autorizado
     undo: desfazer
+    updated_at_timestamp: Atualizado em %{%{updated_at}}
     view: Ver
     view_item: ver %{item}
     visit_record_on_external_path: Visitar registro através de link externo

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -30,6 +30,7 @@ ro:
     confirm: Confirm
     copy: Copiază
     create_new_item: Creează %{item}
+    created_at_timestamp: Creat la %{created_at}
     dashboard: Panou de control
     dashboards: Panouri de control
     default_scope: Tot
@@ -120,6 +121,7 @@ ro:
     type_to_search: Caută aici...
     unauthorized: Neautorizat
     undo: Anulează
+    updated_at_timestamp: Actualizat la %{updated_at}
     view: vezi
     view_item: vezi %{item}
     visit_record_on_external_path: Vizitați înregistrarea printr-un link extern

--- a/lib/generators/avo/templates/locales/avo.ru.yml
+++ b/lib/generators/avo/templates/locales/avo.ru.yml
@@ -27,6 +27,7 @@ ru:
     confirm: Подтвердить
     copy: Копировать
     create_new_item: Создать новый %{item}
+    created_at_timestamp: Создано в %{created_at}
     dashboard: Панель управления
     dashboards: Панели управления
     default_scope: Все
@@ -118,6 +119,7 @@ ru:
     type_to_search: Поиск...
     unauthorized: Не авторизован
     undo: Отменить
+    updated_at_timestamp: Обновлено в %{updated_at}
     view: Просмотр
     view_item: Просмотр %{item}
     visit_record_on_external_path: Перейти к записи через внешнюю ссылку

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -29,6 +29,7 @@ tr:
     confirm: Onayla
     copy: Kopya
     create_new_item: Yeni bir %{item} oluşturun
+    created_at_timestamp: "%{created_at} tarihinde oluşturuldu"
     dashboard: Yönetim Paneli
     dashboards: Yönetim Panelleri
     default_scope: Herşey
@@ -118,6 +119,7 @@ tr:
     type_to_search: Aramak için yazın.
     unauthorized: Yetkisiz
     undo: geri al
+    updated_at_timestamp: "%{updated_at} tarihinde güncellendi"
     view: Görünüm
     view_item: "%{item} öğresini görüntüle"
     visit_record_on_external_path: Harici bağlantı yoluyla kaydı ziyaret et

--- a/lib/generators/avo/templates/locales/avo.uk.yml
+++ b/lib/generators/avo/templates/locales/avo.uk.yml
@@ -27,6 +27,7 @@ uk:
     confirm: Підтвердити
     copy: Копіювати
     create_new_item: Створити новий %{item}
+    created_at_timestamp: Sukurta %{created_at}
     dashboard: Панель керування
     dashboards: Панелі керування
     default_scope: Всі
@@ -118,6 +119,7 @@ uk:
     type_to_search: Введіть для пошуку.
     unauthorized: Не авторизовано
     undo: Скасувати
+    updated_at_timestamp: Atnaujinta %{updated_at}
     view: Перегляд
     view_item: Перегляд %{item}
     visit_record_on_external_path: Перейти до запису через зовнішнє посилання

--- a/lib/generators/avo/templates/locales/avo.zh.yml
+++ b/lib/generators/avo/templates/locales/avo.zh.yml
@@ -27,6 +27,7 @@ zh:
     confirm: 确认
     copy: 复制
     create_new_item: 创建新的 %{item}
+    created_at_timestamp: 创建于%{created_at}
     dashboard: 仪表盘
     dashboards: 仪表盘
     default_scope: 所有
@@ -116,6 +117,7 @@ zh:
     type_to_search: 输入以搜索。
     unauthorized: 未经授权
     undo: 撤销
+    updated_at_timestamp: 更新于%{updated_at}
     view: 查看
     view_item: 查看 %{item}
     visit_record_on_external_path: 通过外部链接访问记录


### PR DESCRIPTION


# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes the missing locale keys for `created_at_timestamp` and `updated_at_timestamp`

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
