### PR TITLE
Enhancement: improve message when missing array resource for array fields

### DIFF
--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -93,9 +93,13 @@ module Avo
         user: _current_user,
         # force the action view to in order to render new-related fields (hidden field)
         view: Avo::ViewInquirer.new(:new),
+<<<<<<< HEAD
         arguments: BaseAction.decode_arguments(params[:arguments] || params.dig(:fields, :arguments)) || {},
         query: @query,
         index_query: decrypted_index_query
+=======
+        arguments: BaseAction.decode_arguments(action_arguments) || {}
+>>>>>>> e21688a2 (First draft for brakeman dashboard fix)
       )
 
       # Fetch action's fields
@@ -197,6 +201,22 @@ module Avo
 
     def verify_authorization
       raise Avo::NotAuthorizedError.new unless @action.authorized?
+    end
+
+    def resource_id
+      params.permit(:id)[:id]
+    end
+
+    def resource_ids
+      params.permit(:resource_ids)[:resource_ids]
+    end
+
+    def arguments_id
+      params.permit(:arguments)[:arguments]
+    end
+
+    def action_arguments
+      params[:arguments] || params.dig(:fields, :arguments)
     end
   end
 end

--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -93,13 +93,7 @@ module Avo
         user: _current_user,
         # force the action view to in order to render new-related fields (hidden field)
         view: Avo::ViewInquirer.new(:new),
-<<<<<<< HEAD
-        arguments: BaseAction.decode_arguments(params[:arguments] || params.dig(:fields, :arguments)) || {},
-        query: @query,
-        index_query: decrypted_index_query
-=======
         arguments: BaseAction.decode_arguments(action_arguments) || {}
->>>>>>> e21688a2 (First draft for brakeman dashboard fix)
       )
 
       # Fetch action's fields

--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -291,6 +291,7 @@ module Avo
             render turbo_stream: reload_frame_turbo_streams
           end
         else
+           #the method below should be refactored to remove the params.permit! and specify which exact keys should be passed to it
           format.html { redirect_to params[:referrer] || resource_view_response_path }
         end
       end

--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -291,7 +291,7 @@ module Avo
             render turbo_stream: reload_frame_turbo_streams
           end
         else
-           #the method below should be refactored to remove the params.permit! and specify which exact keys should be passed to it
+          # the method below should be refactored to remove the params.permit! and specify which exact keys should be passed to it
           format.html { redirect_to params[:referrer] || resource_view_response_path }
         end
       end

--- a/app/controllers/avo/base_application_controller.rb
+++ b/app/controllers/avo/base_application_controller.rb
@@ -106,11 +106,12 @@ module Avo
 
     def set_related_resource
       # Find the field from the parent resource
+      @field = find_association_field(resource: @resource, association: params[:related_name])
       related_resource = find_association_field(resource: @resource, association: params[:related_name])
         .hydrate(record: @record)
         .resource_class(params)
 
-      raise Avo::MissingResourceError.new(related_resource_name) if related_resource.nil?
+      raise Avo::MissingResourceError.new(related_resource_name, @field.id, @field) if related_resource.nil?
 
       action_view = action_name.to_sym
 

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -653,16 +653,10 @@ module Avo
 
       @index_params[:per_page] = cookies[:per_page] || Avo.configuration.per_page
     end
-<<<<<<< HEAD
 
     # If we don't get a query object predefined from a child controller like associations, just spin one up
     def set_query
       @query ||= @resource.class.query_scope
-=======
-    
-    def turboframe_id
-      params.permit(:turbo_frame)[:turbo_frame]
->>>>>>> e21688a2 (First draft for brakeman dashboard fix)
     end
   end
 end

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -653,10 +653,16 @@ module Avo
 
       @index_params[:per_page] = cookies[:per_page] || Avo.configuration.per_page
     end
+<<<<<<< HEAD
 
     # If we don't get a query object predefined from a child controller like associations, just spin one up
     def set_query
       @query ||= @resource.class.query_scope
+=======
+    
+    def turboframe_id
+      params.permit(:turbo_frame)[:turbo_frame]
+>>>>>>> e21688a2 (First draft for brakeman dashboard fix)
     end
   end
 end

--- a/app/controllers/avo/charts_controller.rb
+++ b/app/controllers/avo/charts_controller.rb
@@ -3,9 +3,9 @@ require_dependency "avo/base_controller"
 module Avo
   class ChartsController < BaseController
     def distribution_chart
-      @values_summary = summary_query.group(params[:field_id].to_sym).reorder("count_all desc").count
+      @values_summary = summary_query.group(field_id.to_sym).reorder("count_all desc").count
 
-      @field_id = params[:field_id]
+      @field_id = field_id
 
       render "avo/partials/distribution_chart", layout: "avo/blank"
     end
@@ -50,6 +50,10 @@ module Avo
       end
 
       association_query
+    end
+
+    def field_id
+      params[:field_id]
     end
   end
 end

--- a/app/helpers/avo/application_helper.rb
+++ b/app/helpers/avo/application_helper.rb
@@ -106,7 +106,7 @@ module Avo
       Avo.configuration.root_path
     end
 
-    #the method below should be refactored to remove the params.permit! and specify which exact keys should be passed to it
+    # the method below should be refactored to remove the params.permit! and specify which exact keys should be passed to it
     def mount_path
       Avo::Engine.routes.find_script_name(params.permit!.to_h.symbolize_keys)
     end

--- a/app/helpers/avo/application_helper.rb
+++ b/app/helpers/avo/application_helper.rb
@@ -106,6 +106,7 @@ module Avo
       Avo.configuration.root_path
     end
 
+    #the method below should be refactored to remove the params.permit! and specify which exact keys should be passed to it
     def mount_path
       Avo::Engine.routes.find_script_name(params.permit!.to_h.symbolize_keys)
     end

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -29,16 +29,9 @@
       <div class="flex-1 flex">
         <%= @action.get_message %>
       </div>
-<<<<<<< HEAD
-      <%= form.hidden_field :avo_resource_ids, value: params[:id] || params[:resource_ids], 'data-action-target': 'resourceIds' %>
-      <%= form.hidden_field :avo_selected_all, 'data-action-target': 'selectedAll' %>
-      <%= form.hidden_field :avo_index_query, 'data-action-target': 'indexQuery' %>
-      <%= form.hidden_field :arguments, value: params[:arguments] %>
-=======
       <%= form.hidden_field :avo_resource_ids, value: @resource_id || @resource_ids, 'data-action-target': 'resourceIds' %>
       <%= form.hidden_field :avo_selected_query, 'data-action-target': 'selectedAllQuery' %>
       <%= form.hidden_field :arguments, value: @arguments_id %>
->>>>>>> e21688a2 (First draft for brakeman dashboard fix)
       <% if @fields.present? %>
         <div class="mt-4 -mx-6">
           <% @fields.each_with_index do |field, index| %>

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -29,10 +29,16 @@
       <div class="flex-1 flex">
         <%= @action.get_message %>
       </div>
+<<<<<<< HEAD
       <%= form.hidden_field :avo_resource_ids, value: params[:id] || params[:resource_ids], 'data-action-target': 'resourceIds' %>
       <%= form.hidden_field :avo_selected_all, 'data-action-target': 'selectedAll' %>
       <%= form.hidden_field :avo_index_query, 'data-action-target': 'indexQuery' %>
       <%= form.hidden_field :arguments, value: params[:arguments] %>
+=======
+      <%= form.hidden_field :avo_resource_ids, value: @resource_id || @resource_ids, 'data-action-target': 'resourceIds' %>
+      <%= form.hidden_field :avo_selected_query, 'data-action-target': 'selectedAllQuery' %>
+      <%= form.hidden_field :arguments, value: @arguments_id %>
+>>>>>>> e21688a2 (First draft for brakeman dashboard fix)
       <% if @fields.present? %>
         <div class="mt-4 -mx-6">
           <% @fields.each_with_index do |field, index| %>

--- a/app/views/avo/base/index.html.erb
+++ b/app/views/avo/base/index.html.erb
@@ -1,4 +1,4 @@
-<%= render Avo::TurboFrameWrapperComponent.new(params[:turbo_frame]) do %>
+<%= render Avo::TurboFrameWrapperComponent.new(@turboframe_id) do %>
   <%= render @component.new(
       resource: @resource,
       resources: @resources,
@@ -8,7 +8,7 @@
       filters: @filters,
       actions: @actions,
       reflection: @reflection,
-      turbo_frame: params[:turbo_frame],
+      turbo_frame: @turboframe_id,
       parent_record: @parent_record,
       parent_resource: @parent_resource,
       applied_filters: @applied_filters,

--- a/app/views/avo/partials/_table_header.html.erb
+++ b/app/views/avo/partials/_table_header.html.erb
@@ -66,13 +66,8 @@
       } do %>
       <%= content_tag :div,
         class: "relative flex items-center justify-between w-full" do %>
-<<<<<<< HEAD
         <% if field.sortable && @resource.sorting_supported? %>
           <%= link_to params.permit!.merge(sort_by: sort_by, sort_direction: sort_direction),
-=======
-        <% if field.sortable %>
-          <%= link_to params.permit(:view, :view_type, :turbo_frame, :resource_name, :id, :related_name, :sort_by, :sort_direction).merge(sort_by: sort_by, sort_direction: sort_direction),
->>>>>>> e21688a2 (First draft for brakeman dashboard fix)
             class: class_names("flex-1 flex justify-between", text_classes),
             'data-turbo-frame': params[:turbo_frame] do %>
             <%= field.table_header_label %>

--- a/app/views/avo/partials/_table_header.html.erb
+++ b/app/views/avo/partials/_table_header.html.erb
@@ -66,8 +66,13 @@
       } do %>
       <%= content_tag :div,
         class: "relative flex items-center justify-between w-full" do %>
+<<<<<<< HEAD
         <% if field.sortable && @resource.sorting_supported? %>
           <%= link_to params.permit!.merge(sort_by: sort_by, sort_direction: sort_direction),
+=======
+        <% if field.sortable %>
+          <%= link_to params.permit(:view, :view_type, :turbo_frame, :resource_name, :id, :related_name, :sort_by, :sort_direction).merge(sort_by: sort_by, sort_direction: sort_direction),
+>>>>>>> e21688a2 (First draft for brakeman dashboard fix)
             class: class_names("flex-1 flex justify-between", text_classes),
             'data-turbo-frame': params[:turbo_frame] do %>
             <%= field.table_header_label %>

--- a/app/views/avo/partials/_view_toggle_button.html.erb
+++ b/app/views/avo/partials/_view_toggle_button.html.erb
@@ -27,7 +27,7 @@
       <% available_view_types.each do |type| %>
         <% is_active_view = view_type.to_s == type.to_s %>
 
-        <%= a_link url_for(params.permit!.merge(view_type: type)).to_s,
+        <%= a_link url_for(params.permit(:view_type, :turbo_frame, :view, :resource_name, :id, :related_name, :sort_by, :sort_direction).merge(view_type: type)).to_s,
           icon: info[type][:new_icon],
           color: is_active_view ? :primary : :gray,
           rounded: false,

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -37,21 +37,29 @@ module Avo
   class DeprecatedAPIError < StandardError; end
 
   class MissingResourceError < StandardError
-    def initialize(model_class, field_name = nil)
-      super(missing_resource_message(model_class, field_name))
+    def initialize(model_class, field_name = nil, field = nil)
+      super(missing_resource_message(model_class, field_name, field))
     end
 
     private
 
-    def missing_resource_message(model_class, field_name)
+    def missing_resource_message(model_class, field_name, field)
       model_name = model_class.to_s.underscore
       field_name ||= model_name
 
-      "Failed to find a resource while rendering the :#{field_name} field.\n" \
-      "You may generate a resource for it by running 'rails generate avo:resource #{model_name.singularize}'.\n" \
-      "\n" \
-      "Alternatively add the 'use_resource' option to the :#{field_name} field to specify a custom resource to be used.\n" \
-      "More info on https://docs.avohq.io/#{Avo::VERSION[0]}.0/resources.html."
+      if field.type == "array"
+        "Failed to find a resource while rendering the :#{field_name} field.\n" \
+        "You may generate a resource for it by running 'rails generate avo:resource #{model_name.singularize} --array'.\n" \
+        "\n" \
+        "Alternatively add the 'use_resource' option to the :#{field_name} field to specify a custom resource to be used.\n" \
+        "More info on https://docs.avohq.io/#{Avo::VERSION[0]}.0/array-resources.html."
+      else
+        "Failed to find a resource while rendering the :#{field_name} field.\n" \
+        "You may generate a resource for it by running 'rails generate avo:resource #{model_name.singularize}'.\n" \
+        "\n" \
+        "Alternatively add the 'use_resource' option to the :#{field_name} field to specify a custom resource to be used.\n" \
+        "More info on https://docs.avohq.io/#{Avo::VERSION[0]}.0/resources.html."
+      end
     end
   end
 

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -315,7 +315,7 @@ module Avo
       def get_resource_by_model_class(model_class)
         resource = Avo.resource_manager.get_resource_by_model_class(model_class)
 
-        resource || (raise Avo::MissingResourceError.new(model_class, id))
+        resource || (raise Avo::MissingResourceError.new(model_class, id, field))
       end
     end
   end

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -315,7 +315,7 @@ module Avo
       def get_resource_by_model_class(model_class)
         resource = Avo.resource_manager.get_resource_by_model_class(model_class)
 
-        resource || (raise Avo::MissingResourceError.new(model_class, id, field))
+        resource || (raise Avo::MissingResourceError.new(model_class, id, self))
       end
     end
   end

--- a/spec/dummy/app/controllers/avo/reviews_controller.rb_temp
+++ b/spec/dummy/app/controllers/avo/reviews_controller.rb_temp
@@ -1,0 +1,2 @@
+class Avo::ReviewsController < Avo::ResourcesController
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Enhances the thrown missing resource error such that when the field is of the type array, the error is thrown with an array flag  "--flag"

Fixes # (#3713)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

