### PR TITLE
refactor: use ivar for related_record

### DIFF
--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -140,9 +140,9 @@ module Avo
         # Get the foreign key and set it to the id we received in the params
         if @reflection.is_a?(ActiveRecord::Reflection::BelongsToReflection) || @reflection.is_a?(ActiveRecord::Reflection::HasManyReflection)
           related_resource = Avo.resource_manager.get_resource_by_model_class params[:via_relation_class]
-          related_record = related_resource.find_record params[:via_record_id], params: params
+          @related_record = related_resource.find_record params[:via_record_id], params: params
 
-          @record.send(:"#{@reflection.foreign_key}=", related_record.id)
+          @record.send(:"#{@reflection.foreign_key}=", @related_record.id)
         end
 
         # For when working with has_one, has_one_through, has_many_through, has_and_belongs_to_many, polymorphic


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Uses an instance variable (`@related_record`) for `related_record` during `create`.  

This ensures it remains accessible within an `after_action` callback.

