### PR TITLE
refactor: rename `/dashboards` and `/resources` redirect path helpers

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Avo::Engine.routes.draw do
   root "home#index"
 
-  get "resources", to: redirect(Avo.configuration.root_path)
-  get "dashboards", to: redirect(Avo.configuration.root_path)
+  get "resources", to: redirect(Avo.configuration.root_path), as: :avo_resources_redirect
+  get "dashboards", to: redirect(Avo.configuration.root_path), as: :avo_dashboards_redirect
 
   resources :media_library, only: [:index, :show, :update, :destroy], path: "media-library"
   get "attach-media", to: "media_library#attach"


### PR DESCRIPTION
This route is sort of duplicated with the root route in the `avo-dashboards` gem which defines a similarly unused route by default. Having two identically named routes may result in unpredictable behaviour outside of Avo when named routes are being used for things like client-side routing.

# Description
Renames the path helpers for the redirect routes `/dashboards` and `/resources`.

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Manual review steps
This issue was discovered via an edge case scenario where using the js-routes gem (https://github.com/railsware/js-routes) produces invalid JavaScript where the `avoDashboardsPath` route was being generated twice -- once by the route in `config/routes.rb` and once in the `avo-dashboards` gem. This leads to two identically named routes being set up in Rails, which causes two identically named routes to be produced by js-routes. When js-routes produces two identically named constants, it results in an invalid JavaScript file.

To see this behaviour in js-routes:

1. add the `js-routes` gem to a Rails application `Gemfile`
2. run `rake js:routes`
3. check the produced `routes.js` file for multiple instances of `avoDashboardsPath`. There should only be one.
