### PR TITLE
fix: index field wrapper extra div

### DIFF
--- a/app/components/avo/clipboard_component.html.erb
+++ b/app/components/avo/clipboard_component.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag :div,
-  class: "opacity-0 group-hover:opacity-100 transition-opacity duration-200",
+  class: "opacity-0 group-hover:opacity-100 transition-opacity duration-200 inline-block",
   data: {
     controller: "clipboard",
     clipboard_success_duration_value: @duration_value,

--- a/app/components/avo/clipboard_component.html.erb
+++ b/app/components/avo/clipboard_component.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag :div,
-  class: "opacity-0 group-hover/td:opacity-100 transition-opacity duration-200 inline-block",
+  class: "opacity-0 group-hover/clipboard:opacity-100 transition-opacity duration-200 inline-block",
   data: {
     controller: "clipboard",
     clipboard_success_duration_value: @duration_value,

--- a/app/components/avo/clipboard_component.html.erb
+++ b/app/components/avo/clipboard_component.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag :div,
-  class: "opacity-0 group-hover:opacity-100 transition-opacity duration-200 inline-block",
+  class: "opacity-0 group-hover/td:opacity-100 transition-opacity duration-200 inline-block",
   data: {
     controller: "clipboard",
     clipboard_success_duration_value: @duration_value,

--- a/app/components/avo/field_wrapper_component.html.erb
+++ b/app/components/avo/field_wrapper_component.html.erb
@@ -26,7 +26,7 @@
       }), data: {slot: "value"} do %>
     <div class="self-center w-full <% unless full_width? || compact? || stacked? %> md:w-8/12 has-sidebar:w-full <% end %>">
       <% if on_show? %>
-        <div class="flex flex-row items-center group gap-x-1">
+        <div class="flex flex-row items-center group gap-x-1 group/clipboard">
           <% if render_dash? %>
             —
           <% else %>

--- a/app/components/avo/index/field_wrapper_component.html.erb
+++ b/app/components/avo/index/field_wrapper_component.html.erb
@@ -9,18 +9,16 @@
   <% if render_dash? %>
     —
   <% else %>
-    <div class="flex flex-row items-center gap-x-1 group">
-      <% if @center_content %>
-        <div class="flex items-center justify-center">
-          <%= content %>
-        </div>
-      <% else %>
+    <% if @center_content %>
+      <div class="flex items-center justify-center">
         <%= content %>
-      <% end %>
-      <% if @field.copyable %>
-        <%= render Avo::ClipboardComponent.new(value: @field.value) %>
-      <% end %>
-    </div>
+      </div>
+    <% else %>
+      <%= content %>
+    <% end %>
+    <% if @field.copyable %>
+      <%= render Avo::ClipboardComponent.new(value: @field.value) %>
+    <% end %>
   <% end %>
   <% if params[:avo_debug].present? %>
     <!-- Raw value: -->

--- a/app/components/avo/index/field_wrapper_component.html.erb
+++ b/app/components/avo/index/field_wrapper_component.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag :td,
-  class: "min-h-[3rem] px-3 leading-tight whitespace-nowrap h-full text-slate-800 text-base #{classes}",
+  class: "group/td min-h-[3rem] px-3 leading-tight whitespace-nowrap h-full text-slate-800 text-base #{classes}",
   data: {
     field_id: @field.id,
     field_type: @field.type,

--- a/app/components/avo/index/field_wrapper_component.html.erb
+++ b/app/components/avo/index/field_wrapper_component.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag :td,
-  class: "group/td min-h-[3rem] px-3 leading-tight whitespace-nowrap h-full text-slate-800 text-base #{classes}",
+  class: "group/clipboard min-h-[3rem] px-3 leading-tight whitespace-nowrap h-full text-slate-800 text-base #{classes}",
   data: {
     field_id: @field.id,
     field_type: @field.type,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3562

Removes an unnecessary `<div>` from the field wrapper, enabling content alignment with `text-right`. To maintain the functionality of the `copyable` feature, the `Avo::ClipboardComponent` has been converted into an `inline-block`.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
