### PR TITLE
refactor: turbo stream helpers

### DIFF
--- a/app/helpers/avo/turbo_stream_actions_helper.rb
+++ b/app/helpers/avo/turbo_stream_actions_helper.rb
@@ -22,4 +22,3 @@ module Avo
   end
 end
 
-Turbo::Streams::TagBuilder.prepend(Avo::TurboStreamActionsHelper)

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -74,6 +74,7 @@ module Avo
 
     # Runs when the app boots up
     def boot
+      Turbo::Streams::TagBuilder.prepend(Avo::TurboStreamActionsHelper)
       @logger = Avo.configuration.logger
       @field_manager = Avo::Fields::FieldManager.build
       @cache_store = Avo.configuration.cache_store


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR relocates the execution of:

```ruby
Turbo::Streams::TagBuilder.prepend(Avo::TurboStreamActionsHelper)
```

from the file-level to the `boot` method.

This adjustment ensures consistent execution across all applications, including private repositories like `avo-advanced`, where it was previously unreliable on development.
