### PR TITLE
Fix a tiny typo in the eject generator

### DIFF
--- a/lib/generators/avo/eject_generator.rb
+++ b/lib/generators/avo/eject_generator.rb
@@ -233,7 +233,7 @@ module Generators
         end
 
         def confirm_ejection_on(path, is_directory: false)
-          say("By ejecting the '#{path}'#{" directory" if is_directory} \033[1myou'll take on the responsibility for maintain it.", :yellow)
+          say("By ejecting the '#{path}'#{" directory" if is_directory} \033[1myou'll take on the responsibility for maintaining it.", :yellow)
           yes?("Are you sure you want to eject the '#{path}'#{" directory" if is_directory}? [y/N]", :yellow)
         end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes a tiny typo in the eject generator.

(P.S. Adrian, great talk at SF Ruby last night!)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

N/A, I think 😄 

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

None needed, I think.

Manual reviewer: please leave a comment with output from the test if that's the case.
