### PR TITLE
Allow style customisation of the profile photo

### DIFF
--- a/app/components/avo/profile_photo_component.html.erb
+++ b/app/components/avo/profile_photo_component.html.erb
@@ -1,6 +1,9 @@
-<%= image_tag helpers.main_app.url_for(@profile_photo.value), class: class_names(
-  "relative rounded-full object-cover aspect-square border-4 border-application",
+<%= image_tag helpers.main_app.url_for(@profile_photo.value),
+  style: "background-color: #{ @profile_photo.options[:background_color] || '#ffffff' }",
+  class: class_names(
+  "relative rounded-full aspect-square border-4 border-application",
   "has-cover-photo:sm:ml-8 sm:mr-2",
   "self-center sm:self-start",
   "size-24 has-cover-photo:size-36 has-cover-photo:sm:size-48 has-cover-photo:-mt-12",
+  extra_classes
 ), data: {component: self.class.to_s.underscore} %>

--- a/app/components/avo/profile_photo_component.rb
+++ b/app/components/avo/profile_photo_component.rb
@@ -6,4 +6,17 @@ class Avo::ProfilePhotoComponent < Avo::BaseComponent
   def render?
     @profile_photo.present? && @profile_photo.visible_in_current_view?
   end
+
+  def extra_classes
+    classes = []
+
+    classes << "object-#{object_fit}" if object_fit.present?
+    classes << "p-#{@profile_photo.options[:padding]}" if @profile_photo.options[:padding]
+
+    classes.join(" ")
+  end
+
+  def object_fit
+    @profile_photo.options[:object_fit] || :cover
+  end
 end

--- a/spec/dummy/app/avo/resources/event.rb
+++ b/spec/dummy/app/avo/resources/event.rb
@@ -14,9 +14,14 @@ class Avo::Resources::Event < Avo::BaseResource
       end
     }
   }
+
   self.profile_photo = {
-    source: :profile_photo
+    source: :profile_photo,
+    background_color: "#ffffff",
+    object_fit: :contain,
+    padding: 4
   }
+
   self.discreet_information = :timestamps
 
   self.row_controls_config = {


### PR DESCRIPTION
# Description
A couple of options on the profile photo option to allow users to improve the look of the selected image.

I can use these to make this:
<img width="646" alt="Screenshot 2025-03-26 at 22 01 38" src="https://github.com/user-attachments/assets/6e016d26-fa4b-48c3-a882-6140466832d5" />

look like this:
<img width="639" alt="Screenshot 2025-03-26 at 22 01 26" src="https://github.com/user-attachments/assets/965c195e-8ca6-4fbb-a26b-23dd1238d4ff" />

Fixes # (issue)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
Screenshots above

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
