### PR TITLE
fix: array field on array resource

### DIFF
--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -126,7 +126,9 @@ module Avo
     private
 
     def set_reflection
-      @reflection = @record.class.reflect_on_association(association_from_params)
+      @reflection = @record.class.try(:reflect_on_association, association_from_params)
+
+      return if @reflection.blank? && @field.type == "array"
 
       # Ensure inverse_of is present on STI
       if !@record.class.descends_from_active_record? && @reflection.inverse_of.blank? && Rails.env.development?

--- a/spec/dummy/app/avo/resources/movie.rb
+++ b/spec/dummy/app/avo/resources/movie.rb
@@ -280,5 +280,7 @@ class Avo::Resources::Movie < Avo::Resources::ArrayResource
         end
       end
     end
+
+    field :attendees, as: :array
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3741 

Ignore `set_reflection` if the model class does not respond to `reflect_on_association` and the field is of type Array.

This allows rendering array fields from an array resource.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works
