### PR TITLE
refactor: abstract resources

### DIFF
--- a/app/avo/base_resource.rb
+++ b/app/avo/base_resource.rb
@@ -1,5 +1,7 @@
 module Avo
   class BaseResource < Avo::Resources::Base
+    abstract_resource!
+
     # Users can override this class to add custom methods for all resources.
   end
 end

--- a/lib/avo/concerns/abstract_resource.rb
+++ b/lib/avo/concerns/abstract_resource.rb
@@ -1,0 +1,12 @@
+module Avo
+  module Concerns
+    module AbstractResource
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def abstract_resource! = @abstract_resource = true
+        def is_abstract? = @abstract_resource == true
+      end
+    end
+  end
+end

--- a/lib/avo/concerns/abstract_resource.rb
+++ b/lib/avo/concerns/abstract_resource.rb
@@ -5,6 +5,7 @@ module Avo
 
       class_methods do
         def abstract_resource! = @abstract_resource = true
+
         def is_abstract? = @abstract_resource == true
       end
     end

--- a/lib/avo/resources/array_resource.rb
+++ b/lib/avo/resources/array_resource.rb
@@ -1,6 +1,8 @@
 module Avo
   module Resources
     class ArrayResource < Base
+      abstract_resource!
+
       extend ActiveSupport::DescendantsTracker
 
       include Avo::Concerns::FindAssociationField

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -19,6 +19,9 @@ module Avo
       include Avo::Concerns::HasDiscreetInformation
       include Avo::Concerns::RowControlsConfiguration
       include Avo::Concerns::SafeCall
+      include Avo::Concerns::AbstractResource
+
+      abstract_resource!
 
       # Avo::Current methods
       delegate :context, to: Avo::Current
@@ -83,6 +86,8 @@ module Avo
       class_attribute :default_sort_column, default: :created_at
       class_attribute :default_sort_direction, default: :desc
       class_attribute :external_link, default: nil
+
+      class_attribute :abstract, default: false
 
       # EXTRACT:
       class_attribute :ordering

--- a/lib/avo/resources/resource_manager.rb
+++ b/lib/avo/resources/resource_manager.rb
@@ -40,12 +40,9 @@ module Avo
             load_resources_namespace
           end
 
-          # All descendants from Avo::Resources::Base except the internal ones
-          Base.descendants - internal_resources
-        end
+          # All descendants from Avo::Resources::Base except the internal abstract ones
 
-        def internal_resources
-          [Avo::BaseResource, Avo::Resources::ArrayResource]
+          Base.descendants.reject { _1.is_abstract? }
         end
 
         def load_resources_namespace


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR introduces a concern that allows certain resources to be designated as abstract.

Such resources will be excluded during the resource-fetching process. This is particularly useful for omitting routes and menu entries for abstract resources, such as `Avo::Resources::ArrayResource`

This is beneficial because plugins can introduce new abstract resources without requiring modifications to Avo’s core, simply marking the plugin's resource as abstract is enough.