### PR TITLE
fix: avoid engine options mutation on mount

### DIFF
--- a/lib/avo/engine.rb
+++ b/lib/avo/engine.rb
@@ -70,7 +70,7 @@ module Avo
 
           scope at do
             Avo.plugin_manager.engines.each do |engine|
-              mount engine[:klass], **engine[:options]
+              mount engine[:klass], **engine[:options].dup
             end
           end
         end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

`mount engine[:klass], **engine[:options]` is mutating the `engine[:options]` making the app crash on reload.

This PR duplicates the options when calling mount to avoid the mutation.