### PR TITLE
enhancement: access `record` on array block

### DIFF
--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -29,7 +29,7 @@ module Avo
       # When other field type, like has_many the @query is directly fetched from the parent record
       # Don't apply policy on array type since it can return an array of hashes where `.all` and other methods used on policy will fail.
       @query = if @field.type == "array"
-        @resource.fetch_records(Avo::ExecutionContext.new(target: @field.block).handle || @parent_record.try(@field.id))
+        @resource.fetch_records(Avo::ExecutionContext.new(target: @field.block, record: @parent_record).handle || @parent_record.try(@field.id))
       else
         @related_authorization.apply_policy(
           @parent_record.send(

--- a/lib/avo/resources/array_resource.rb
+++ b/lib/avo/resources/array_resource.rb
@@ -55,7 +55,7 @@ module Avo
 
           association_field = find_association_field(resource: via_resource, association: route_key)
 
-          records_from_field_or_record = Avo::ExecutionContext.new(target: association_field.block).handle || via_record.try(route_key)
+          records_from_field_or_record = Avo::ExecutionContext.new(target: association_field.block, record: via_record).handle || via_record.try(route_key)
 
           array_of_records = records_from_field_or_record || array_of_records
         end

--- a/spec/dummy/app/avo/resources/event.rb
+++ b/spec/dummy/app/avo/resources/event.rb
@@ -49,28 +49,8 @@ class Avo::Resources::Event < Avo::BaseResource
 
     # this field demonstrated how one can use the array field to display an arbitrary array of objects as a "has_many field"
     field :attendees, as: :array do
-      [
-        {id: 1, name: "John Doe", role: "Software Developer", organization: "TechCorp"},
-        {id: 2, name: "Jane Smith", role: "Data Scientist", organization: "DataPros"},
-        {id: 3, name: "Emily Davis", role: "Product Manager", organization: "Startup Inc."},
-        {id: 4, name: "Kevin Roberts", role: "CTO", organization: "FutureTech"},
-        {id: 5, name: "Sarah Johnson", role: "UI/UX Designer", organization: "DesignWorks"},
-        {id: 6, name: "Michael Lee", role: "Backend Engineer", organization: "CodeBase"},
-        {id: 7, name: "Olivia Brown", role: "Project Coordinator", organization: "BuildIt"},
-        {id: 8, name: "Ethan Williams", role: "AI Specialist", organization: "InnoBots"},
-        {id: 9, name: "Sophia Martinez", role: "Marketing Strategist", organization: "Brandify"},
-        {id: 10, name: "Jacob Wilson", role: "DevOps Engineer", organization: "OpsWorld"},
-        {id: 11, name: "Ava Taylor", role: "Business Analyst", organization: "AnalyzeNow"},
-        {id: 12, name: "William Hernandez", role: "Full Stack Developer", organization: "Webify"},
-        {id: 13, name: "Mia Moore", role: "HR Manager", organization: "PeopleFirst"},
-        {id: 14, name: "James Anderson", role: "Blockchain Developer", organization: "ChainWorks"},
-        {id: 15, name: "Charlotte White", role: "Product Designer", organization: "Cre8tive"},
-        {id: 16, name: "Benjamin Green", role: "Cybersecurity Analyst", organization: "SecureNet"},
-        {id: 17, name: "Amelia Clark", role: "Data Engineer", organization: "BigData Solutions"},
-        {id: 18, name: "Lucas Carter", role: "Scrum Master", organization: "AgileHub"},
-        {id: 19, name: "Ella Thompson", role: "Software Architect", organization: "CodeVision"},
-        {id: 20, name: "Alexander Scott", role: "Solutions Consultant", organization: "Innovate Consulting"}
-      ]
+      # This is testing that array block can access the record.something
+      record.attendees_from_block
     end
   end
 end

--- a/spec/dummy/app/models/event.rb
+++ b/spec/dummy/app/models/event.rb
@@ -25,4 +25,30 @@ class Event < ApplicationRecord
   def attendees
     raise "Test array resource, this method should not be called"
   end
+
+  # This is testing that array block can access the record.something
+  def attendees_from_block
+    [
+      {id: 1, name: "John Doe", role: "Software Developer", organization: "TechCorp"},
+      {id: 2, name: "Jane Smith", role: "Data Scientist", organization: "DataPros"},
+      {id: 3, name: "Emily Davis", role: "Product Manager", organization: "Startup Inc."},
+      {id: 4, name: "Kevin Roberts", role: "CTO", organization: "FutureTech"},
+      {id: 5, name: "Sarah Johnson", role: "UI/UX Designer", organization: "DesignWorks"},
+      {id: 6, name: "Michael Lee", role: "Backend Engineer", organization: "CodeBase"},
+      {id: 7, name: "Olivia Brown", role: "Project Coordinator", organization: "BuildIt"},
+      {id: 8, name: "Ethan Williams", role: "AI Specialist", organization: "InnoBots"},
+      {id: 9, name: "Sophia Martinez", role: "Marketing Strategist", organization: "Brandify"},
+      {id: 10, name: "Jacob Wilson", role: "DevOps Engineer", organization: "OpsWorld"},
+      {id: 11, name: "Ava Taylor", role: "Business Analyst", organization: "AnalyzeNow"},
+      {id: 12, name: "William Hernandez", role: "Full Stack Developer", organization: "Webify"},
+      {id: 13, name: "Mia Moore", role: "HR Manager", organization: "PeopleFirst"},
+      {id: 14, name: "James Anderson", role: "Blockchain Developer", organization: "ChainWorks"},
+      {id: 15, name: "Charlotte White", role: "Product Designer", organization: "Cre8tive"},
+      {id: 16, name: "Benjamin Green", role: "Cybersecurity Analyst", organization: "SecureNet"},
+      {id: 17, name: "Amelia Clark", role: "Data Engineer", organization: "BigData Solutions"},
+      {id: 18, name: "Lucas Carter", role: "Scrum Master", organization: "AgileHub"},
+      {id: 19, name: "Ella Thompson", role: "Software Architect", organization: "CodeVision"},
+      {id: 20, name: "Alexander Scott", role: "Solutions Consultant", organization: "Innovate Consulting"}
+    ]
+  end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3786

Adding access to `record` on the array field block:

```ruby
    field :attendees, as: :array do
      record.some_attendees
    end
```

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works
