### PR TITLE
fix: `belongs_to` resource generator

### DIFF
--- a/lib/avo/mappings.rb
+++ b/lib/avo/mappings.rb
@@ -69,6 +69,9 @@ module Avo
         references: {
           field: "belongs_to"
         },
+        belongs_to: {
+          field: "belongs_to"
+        },
         json: {
           field: "code"
         }

--- a/spec/dummy/app/models/city.rb
+++ b/spec/dummy/app/models/city.rb
@@ -23,7 +23,7 @@ class City < ApplicationRecord
     include Hashid::Rails
   end
 
-  if Gem::Version.new(Rails.version) >= Gem::Version.new("7.3.0")
+  if Gem::Version.new(Rails.version) >= Gem::Version.new("7.1.0")
     enum :status, {Open: "open", Closed: "closed", Quarantine: "On Quarantine"}
   else
     enum status: {Open: "open", Closed: "closed", Quarantine: "On Quarantine"}

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -14,7 +14,7 @@
 #  slug         :string
 #
 class Post < ApplicationRecord
-  if Gem::Version.new(Rails.version) >= Gem::Version.new("7.3.0")
+  if Gem::Version.new(Rails.version) >= Gem::Version.new("7.1.0")
     enum :status, [:draft, :published, :archived]
   else
     enum status: [:draft, :published, :archived]

--- a/spec/dummy/app/models/product.rb
+++ b/spec/dummy/app/models/product.rb
@@ -13,7 +13,7 @@
 #
 class Product < ApplicationRecord
   monetize :price_cents
-  if Gem::Version.new(Rails.version) >= Gem::Version.new("7.3.0")
+  if Gem::Version.new(Rails.version) >= Gem::Version.new("7.1.0")
     enum :category, [
       "Music players",
       "Phones",

--- a/spec/dummy/app/models/project.rb
+++ b/spec/dummy/app/models/project.rb
@@ -17,7 +17,7 @@
 #  progress       :integer
 #
 class Project < ApplicationRecord
-  if Gem::Version.new(Rails.version) >= Gem::Version.new("7.3.0")
+  if Gem::Version.new(Rails.version) >= Gem::Version.new("7.1.0")
     enum :stage, {
       Discovery: "discovery",
       Idea: "idea",

--- a/spec/features/avo/generators/resource_generator_spec.rb
+++ b/spec/features/avo/generators/resource_generator_spec.rb
@@ -28,20 +28,6 @@ RSpec.feature "resource generator", type: :feature do
         check_files_and_clean_up files
       end
     end
-
-    it "generates from model generation" do
-      files = [
-        Rails.root.join("app", "avo", "resources", "blog_article.rb").to_s,
-        Rails.root.join("app", "controllers", "avo", "blog_articles_controller.rb").to_s,
-        Rails.root.join("app", "models", "blog_article.rb").to_s
-      ]
-
-      system("cd spec/dummy && bin/rails generate model BlogArticle user:belongs_to title:string --skip-migration --skip-controller --skip-helper --skip-assets --skip-routes")
-
-      expect(File.read(files[0])).to include("field :user, as: :belongs_to")
-
-      check_files_and_clean_up files
-    end
   end
 
   context "when generating resources from a rich texts" do

--- a/spec/features/avo/generators/resource_generator_spec.rb
+++ b/spec/features/avo/generators/resource_generator_spec.rb
@@ -36,22 +36,7 @@ RSpec.feature "resource generator", type: :feature do
         Rails.root.join("app", "models", "blog_article.rb").to_s
       ]
 
-      Rails::Generators.invoke(
-        "model",
-        [
-          "BlogArticle",
-          "user:belongs_to",
-          "title:string",
-          "--skip-migration",
-          "--skip-controller",
-          "--skip-helper",
-          "--skip-assets",
-          "--skip-routes"
-        ],
-        {
-          destination_root: Rails.root
-        }
-      )
+      Rails::Generators.invoke("model", ["BlogArticle", "user:belongs_to", "title:string", "--skip-migration", "--skip-controller", "--skip-helper", "--skip-assets", "--skip-routes"], {destination_root: Rails.root})
 
       expect(File.read(files[0])).to include("field :user, as: :belongs_to")
 

--- a/spec/features/avo/generators/resource_generator_spec.rb
+++ b/spec/features/avo/generators/resource_generator_spec.rb
@@ -28,6 +28,35 @@ RSpec.feature "resource generator", type: :feature do
         check_files_and_clean_up files
       end
     end
+
+    it "generates from model generation" do
+      files = [
+        Rails.root.join("app", "avo", "resources", "blog_article.rb").to_s,
+        Rails.root.join("app", "controllers", "avo", "blog_articles_controller.rb").to_s,
+        Rails.root.join("app", "models", "blog_article.rb").to_s
+      ]
+
+      Rails::Generators.invoke(
+        "model",
+        [
+          "BlogArticle",
+          "user:belongs_to",
+          "title:string",
+          "--skip-migration",
+          "--skip-controller",
+          "--skip-helper",
+          "--skip-assets",
+          "--skip-routes"
+        ],
+        {
+          destination_root: Rails.root
+        }
+      )
+
+      expect(File.read(files[0])).to include("field :user, as: :belongs_to")
+
+      check_files_and_clean_up files
+    end
   end
 
   context "when generating resources from a rich texts" do

--- a/spec/features/avo/generators/resource_generator_spec.rb
+++ b/spec/features/avo/generators/resource_generator_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "resource generator", type: :feature do
         Rails.root.join("app", "models", "blog_article.rb").to_s
       ]
 
-      Rails::Generators.invoke("model", ["BlogArticle", "user:belongs_to", "title:string", "--skip-migration", "--skip-controller", "--skip-helper", "--skip-assets", "--skip-routes"], {destination_root: Rails.root})
+      system("bin/rails generate model BlogArticle user:belongs_to title:string --skip-migration --skip-controller --skip-helper --skip-assets --skip-routes")
 
       expect(File.read(files[0])).to include("field :user, as: :belongs_to")
 

--- a/spec/features/avo/generators/resource_generator_spec.rb
+++ b/spec/features/avo/generators/resource_generator_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "resource generator", type: :feature do
         Rails.root.join("app", "models", "blog_article.rb").to_s
       ]
 
-      system("bin/rails generate model BlogArticle user:belongs_to title:string --skip-migration --skip-controller --skip-helper --skip-assets --skip-routes")
+      system("cd spec/dummy && bin/rails generate model BlogArticle user:belongs_to title:string --skip-migration --skip-controller --skip-helper --skip-assets --skip-routes")
 
       expect(File.read(files[0])).to include("field :user, as: :belongs_to")
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1677 

This PR fixes an issue where using `belongs_to` in `rails g model` would generate a `text` field instead of a proper association. The generator now treats `belongs_to` the same as `references`.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
