### PR TITLE
fix: nested records hidden class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,7 +295,6 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (~> 0.7)
-    ffi (1.17.1-arm64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     flay (2.13.3)
       erubi (~> 1.10)
@@ -437,10 +436,6 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.7-aarch64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.7-arm64-darwin)
-      racc (~> 1.4)
     nokogiri (1.18.7-x86_64-linux-gnu)
       racc (~> 1.4)
     observer (0.1.2)
@@ -460,6 +455,7 @@ GEM
       rails (>= 6.0.0)
     prettier_print (1.2.1)
     prettyprint (0.2.0)
+    prism (1.4.0)
     prop_initializer (0.2.0)
       zeitwerk (>= 2.6.18)
     psych (5.2.3)
@@ -577,7 +573,7 @@ GEM
       rubocop-ast (>= 1.44.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.44.0)
+    rubocop-ast (1.44.1)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     rubocop-performance (1.25.0)
@@ -720,7 +716,6 @@ GEM
     zeitwerk (2.7.2)
 
 PLATFORMS
-  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/app/javascript/js/controllers/nested_form_controller.js
+++ b/app/javascript/js/controllers/nested_form_controller.js
@@ -30,7 +30,7 @@ export default class extends NestedForm {
 
   toggleAddButton() {
     if (this.limitValue > 0) {
-      this.addButtonTarget.classList.toggle('hidden', this.nestedRecordTargets.length >= this.limitValue)
+      this.addButtonTarget.classList.toggle('!hidden', this.nestedRecordTargets.length >= this.limitValue)
     }
   }
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes the nested records add button visibility by using `hidden` instead of `!hidden`, this is a Tailwind 4 breaking change 

Related PR https://github.com/avo-hq/avo-advanced/pull/62