### PR TITLE
refactor: use HTML `hidden` attribute instead `hidden` class

### DIFF
--- a/app/javascript/js/controllers/nested_form_controller.js
+++ b/app/javascript/js/controllers/nested_form_controller.js
@@ -30,7 +30,7 @@ export default class extends NestedForm {
 
   toggleAddButton() {
     if (this.limitValue > 0) {
-      this.addButtonTarget.classList.toggle('hidden', this.nestedRecordTargets.length >= this.limitValue)
+      this.addButtonTarget.hidden = this.nestedRecordTargets.length >= this.limitValue
     }
   }
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Refactor to use the `hidden` HTML attribute for toggling visibility of nested records add button, instead of relying on the `hidden` class.
