### PR TITLE
refactor: default alert component background class

### DIFF
--- a/app/components/avo/alert_component.rb
+++ b/app/components/avo/alert_component.rb
@@ -26,7 +26,7 @@ class Avo::AlertComponent < Avo::BaseComponent
       " bg-green-500 border-green-600"
     elsif is_warning?
       " bg-orange-400 border-orange-600"
-    elsif is_info?
+    else
       " bg-blue-400 border-blue-600"
     end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Default alert component to info background color when type can't be identified.