### PR TITLE
POC with FormDirtyConfirmNavigationController

### DIFF
--- a/app/javascript/js/controllers/form_controller.js
+++ b/app/javascript/js/controllers/form_controller.js
@@ -1,11 +1,44 @@
-import { Controller } from '@hotwired/stimulus'
+import { FormDirtyConfirmNavigationController } from 'stimulus-library'
 
 // Connects to data-controller="form"
-export default class extends Controller {
+export default class extends FormDirtyConfirmNavigationController {
   submit(event) {
     // return if event.key is undefined preventing the form submit on autocomplete event
     if (!event.key) return
 
     this.element.requestSubmit()
+  }
+
+  /*eslint no-underscore-dangle:*/
+  _enable() {
+    if (this._enabled) {
+      return
+    }
+
+    super._enable()
+
+    // Push dummy state to intercept back button
+    history.pushState(null, '');
+    this._historyTrapActive = true
+  }
+
+  _disable() {
+    super._disable()
+
+    if (this._historyTrapActive) {
+      this._historyTrapActive = false
+      history.back() // remove dummy history entry
+    }
+  }
+
+  _confirmNavigation() {
+    if (!this._enabled || !this._historyTrapActive) return;
+
+    if (confirm(this._message)) {
+      this._disable()
+      history.back() // go to previous page
+    } else {
+      history.pushState(null, '') // stay on page
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@tiptap/extension-text": "^2.11.7",
     "@tiptap/extension-underline": "^2.11.7",
     "@tiptap/pm": "^2.11.7",
+    "stimulus-library": "1.3.0",
     "@yaireo/tagify": "^4.33.2",
     "add": "^2.0.6",
     "autoprefixer": "^10.4.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1594,7 +1594,7 @@
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.0.1.tgz#141f15645acaa3b133b7c247cad58ae252ffae85"
   integrity sha512-oHsJhgY2cip+K2ED7vKUNd2P+BEswVhrCYcJ802DSsblJFv7mPFVk3cQKvm2vHgHeDVdnj7oOKrBbzp1u8D+KA==
 
-"@hotwired/stimulus@^3.2.2":
+"@hotwired/stimulus@^3.0.0", "@hotwired/stimulus@^3.2.1", "@hotwired/stimulus@^3.2.2":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.2.tgz#071aab59c600fed95b97939e605ff261a4251608"
   integrity sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==
@@ -1773,6 +1773,32 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@stimulus-components/password-visibility/-/password-visibility-3.0.0.tgz#314c1bae571ba13b9a4da6014f3e5c5b776fe4cc"
   integrity sha512-ikyuZ/4VX4YrCckVHDc4H6UkTr5UjtkxSH+UdlEIgP9v93W1Bbvnoao0hgQODm8cvNWigmpLpKoGUzgyjBlrdw==
+
+"@stimulus-library/controllers@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@stimulus-library/controllers/-/controllers-1.3.0.tgz#100d073aa9df79ac30834008cfda9944754e7c5a"
+  integrity sha512-mn6PZweXg/1axbaoBX7TUEQIxQn+wd9FY4cgX7MW3NkiaRm7qwxyKisRG9IaOxW0trY2bRr+E4FaxHv/Ec0vKA==
+  dependencies:
+    "@stimulus-library/mixins" "^1.3.0"
+    "@stimulus-library/utilities" "^1.3.0"
+    date-fns "^4.1.0"
+
+"@stimulus-library/mixins@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@stimulus-library/mixins/-/mixins-1.3.0.tgz#ff6340dd6736eb522e00d7ce7c821ea4bf7c776f"
+  integrity sha512-/aC20bbbRFSggLltd0O40iGHrUmg+gy6h533XD8mEc7Qq1q9SzlyVGPphojuxcmNFqIDXMUEULA49lljP6lPdw==
+  dependencies:
+    "@hotwired/stimulus" "^3.0.0"
+    "@stimulus-library/utilities" "^1.3.0"
+
+"@stimulus-library/utilities@^1.0.2", "@stimulus-library/utilities@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@stimulus-library/utilities/-/utilities-1.3.0.tgz#5ecf9e3180f902f1daac4af47eb6ba081ae805e0"
+  integrity sha512-Ap0kEdls3KQRvgOAcm8S667HPyNqborkUpLGM9cOY4mnq22/7rhQSAZp82UqBMKPdGFtKThb59XaophoVICUHg==
+  dependencies:
+    "@hotwired/stimulus" "^3.0.0"
+    "@stimulus-library/utilities" "^1.0.2"
+    mitt "^3.0.0"
 
 "@tailwindcss/container-queries@^0.1.1":
   version "0.1.1"
@@ -2541,6 +2567,11 @@ date-fns@>=2.0.0:
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
   integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
 debug@^3.2.7:
   version "3.2.7"
@@ -3986,6 +4017,11 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
+mitt@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
+  integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
+
 mousetrap@^1.6.5:
   version "1.6.5"
   resolved "https://registry.yarnpkg.com/mousetrap/-/mousetrap-1.6.5.tgz#8a766d8c272b08393d5f56074e0b5ec183485bf9"
@@ -5228,6 +5264,16 @@ spark-md5@^3.0.0:
   resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.1.tgz#83a0e255734f2ab4e5c466e5a2cfc9ba2aa2124d"
   integrity sha512-0tF3AGSD1ppQeuffsLDIOWlKUd3lS92tFxcsrh5Pe3ZphhnoK+oXIBTzOAThZCiuINZLvpiLH/1VS1/ANEJVig==
 
+stimulus-library@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/stimulus-library/-/stimulus-library-1.3.0.tgz#1bec0c9580b8560342af6687f3c43210a33dbe0d"
+  integrity sha512-ZkYmbWPNJhtTcw6xNNE36RqHYIVKGX1Op0pzNxzkCYHk+Wmn12c94Psq7zVOBs9mDNlkBnMgFEgIjWaxSMkxkA==
+  dependencies:
+    "@hotwired/stimulus" "^3.2.1"
+    "@stimulus-library/controllers" "^1.3.0"
+    "@stimulus-library/mixins" "^1.3.0"
+    "@stimulus-library/utilities" "^1.3.0"
+
 stimulus-rails-nested-form@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/stimulus-rails-nested-form/-/stimulus-rails-nested-form-4.1.0.tgz#bfce185cff908170a4eb9973875b72517c3bc83a"
@@ -5245,8 +5291,16 @@ stimulus-use@^0.50.0:
   dependencies:
     hotkeys-js ">=3"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5346,8 +5400,14 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5739,8 +5799,16 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I think the trix limitation can be fixed with ([from here](https://github.com/avo-hq/avo/pull/3346/files#diff-d9526b33df68e8832a3db97a10947287c8daf44dbf578708815e525e6c15b86bR90)):

```
this.editorTarget.addEventListener('trix-change', () => {
      this.textareaTarget.dispatchEvent(new Event('input', { bubbles: true }))
    })
```

 
https://www.loom.com/share/6c330d6052a643dc8b1405255938e45b