### PR TITLE
fix: missing icon button

### DIFF
--- a/app/components/avo/button_component.rb
+++ b/app/components/avo/button_component.rb
@@ -168,7 +168,7 @@ class Avo::ButtonComponent < Avo::BaseComponent
   end
 
   def icon_size_classes
-    icon_classes = ""
+    icon_classes = " h-6"
     return icon_classes if is_icon?
 
     case @size


### PR DESCRIPTION
# Description
Icon buttons (`style: :icon`) don't show up on the UI because it doesn't have a size property.

I ran into this problem when trying to customize the `actions_list` in the row control -> `actions_list style: :icon`.
The icon was still present in the HTML, but it only showed up after adding `h-6`as a class.
Something else I noticed is that `stroke-width` also didn't match with the other icons, but I couldn't find out a way to change that in the code

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

### Before
![image](https://github.com/user-attachments/assets/4b76aa2d-9d82-4219-90fc-12fbf1ccaaa6)

### After
![image](https://github.com/user-attachments/assets/e4765198-269e-41f1-ab87-9d18e5c5c84f)

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Since I don't have access to avo_advanced, @Paul-Bob helped me reproduce this by adding a custom button in `admin/custom_tool`
```
<%= a_link 'javascript:void(0);',
           icon: 'plus',
           size: :sm,
           # style: :primary,
           style: :icon,
           color: :stale do %>
  Test
<% end %>
```

1. When using `style: :icon`, the button should be visible on the UI
2. The icons should have a similar style from the others on the page -> can use `row_controls` to test this