### PR TITLE
refactor: access `view_type` from resource

### DIFF
--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag :div,
-  class: class_names("index-#{@index_params[:view_type]}-view", {"has-record-selector": @resource.record_selector}),
+  class: class_names("index-#{@resource.view_type}-view", {"has-record-selector": @resource.record_selector}),
   data: {
     component_name: self.class.to_s.underscore,
     model_name: @resource.model_name.to_s,
@@ -48,7 +48,7 @@
 
               <%= render Avo::FiltersComponent.new filters: @filters, resource: @resource, applied_filters: @applied_filters, parent_record: @parent_record %>
 
-              <%= render partial: "avo/partials/view_toggle_button", locals: { available_view_types: available_view_types, view_type: view_type, turbo_frame: @turbo_frame } %>
+              <%= render partial: "avo/partials/view_toggle_button", locals: { available_view_types: @resource.available_view_types, view_type: @resource.view_type, turbo_frame: @turbo_frame } %>
             </div>
           </div>
           <% if has_dynamic_filters? %>
@@ -56,34 +56,34 @@
           <% end %>
         </div>
       </div>
-      <% if view_type.to_sym == :table %>
+      <% if @resource.view_type.to_sym == :table %>
         <% if @resources.present? %>
           <div class="w-full relative flex-1 flex mt-0">
             <%= render(@resource.resolve_component(Avo::Index::ResourceTableComponent).new(resources: @resources, resource: @resource, reflection: @reflection, parent_record: @parent_record, parent_resource: @parent_resource, pagy: @pagy, query: @query, actions: @actions)) %>
           </div>
         <% else %>
-          <%= helpers.empty_state by_association: params[:related_name].present?, view_type: view_type, add_background: true %>
+          <%= helpers.empty_state by_association: params[:related_name].present?, view_type: @resource.view_type, add_background: true %>
         <% end %>
       <% end %>
     <% end %>
     <% c.with_bare_content do %>
-     <% if view_type.to_sym == :map %>
+     <% if @resource.view_type.to_sym == :map %>
         <% if @resources.present? %>
           <div>
             <%= render(@resource.resolve_component(Avo::Index::ResourceMapComponent).new(resources: @resources, resource: @resource, reflection: @reflection, parent_record: @parent_record, parent_resource: @parent_resource, pagy: @pagy, query: @query)) %>
           </div>
         <% else %>
-          <%= helpers.empty_state by_association: params[:related_name].present?, view_type: view_type, add_background: true %>
+          <%= helpers.empty_state by_association: params[:related_name].present?, view_type: @resource.view_type, add_background: true %>
         <% end %>
       <% end %>
-      <% if view_type.to_sym == :table || view_type.to_sym == :map %>
+      <% if @resource.view_type.to_sym == :table || @resource.view_type.to_sym == :map %>
         <% if @records.present? %>
           <div class="mt-4 w-full">
             <%= render Avo::PaginatorComponent.new pagy: @pagy, turbo_frame: @turbo_frame, index_params: @index_params, resource: @resource, parent_record: @parent_record, parent_resource: @parent_resource, discreet_pagination: field&.discreet_pagination %>
           </div>
         <% end %>
       <% end %>
-      <% if view_type.to_sym == :grid %>
+      <% if @resource.view_type.to_sym == :grid %>
         <div id="records_panel">
           <%= render Avo::Index::ResourceGridComponent.new(resources: @resources, resource: @resource, reflection: @reflection, parent_record: @parent_record, parent_resource: @parent_resource, actions: @actions) %>
         </div>

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -29,14 +29,6 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
     end
   end
 
-  def view_type
-    @index_params[:view_type]
-  end
-
-  def available_view_types
-    @index_params[:available_view_types]
-  end
-
   # The Create button is dependent on the new? policy method.
   # The create? should be called only when the user clicks the Save button so the developers gets access to the params from the form.
   def can_see_the_create_button?
@@ -219,7 +211,7 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
   end
 
   def has_many_view_types?
-    available_view_types.count > 1
+    @resource.available_view_types.count > 1
   end
 
   # Generate a unique component id for the current component.

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -331,22 +331,6 @@ module Avo
 
       @index_params[:sort_direction] = params[:sort_direction] || @resource.default_sort_direction
 
-      # View types
-      available_view_types = @resource.available_view_types
-      @index_params[:available_view_types] = available_view_types
-
-      @index_params[:view_type] = if params[:view_type].present?
-        params[:view_type]
-      elsif available_view_types.size == 1
-        available_view_types.first
-      else
-        Avo::ExecutionContext.new(
-          target: @resource.default_view_type || Avo.configuration.default_view_type,
-          resource: @resource,
-          view: @view
-        ).handle
-      end
-
       if @resource.available_view_types.exclude? @resource.view_type.to_sym
         raise "View type '#{@resource.view_type}' is unavailable for #{@resource.class}."
       end

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -347,8 +347,8 @@ module Avo
         ).handle
       end
 
-      if available_view_types.exclude? @index_params[:view_type].to_sym
-        raise "View type '#{@index_params[:view_type]}' is unavailable for #{@resource.class}."
+      if @resource.available_view_types.exclude? @resource.view_type.to_sym
+        raise "View type '#{@resource.view_type}' is unavailable for #{@resource.class}."
       end
     end
 

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -678,8 +678,8 @@ module Avo
       def sorting_supported? = true
 
       def view_type
-        @view_type ||= if params[:view_type].present?
-          params[:view_type]
+        @view_type ||= if @params[:view_type].present?
+          @params[:view_type]
         elsif available_view_types.size == 1
           available_view_types.first
         else


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This refactor moves `view_type` from `@index_params` into the `resource` object.

In [this PR](https://github.com/avo-hq/avo/pull/3780), we need to pass `view_type` to the action through params. With this change, we don't have to manually pass it to the action path generator. Since the action path generator already has access to the `resource`, it can just grab the `view_type` directly from there.

Without this refactor manual `view_type` would be required, such as:

```ruby
        path, data = Avo::Actions::City::Update.link_arguments(
          resource: resource,
          view_type: ... # this would be required in order to enable grid item reload when using reload_records feature
        )
 ```
