### PR TITLE
Adds a format_display_using option for the number field

### DIFF
--- a/lib/avo/fields/number_field.rb
+++ b/lib/avo/fields/number_field.rb
@@ -1,9 +1,11 @@
 module Avo
   module Fields
     class NumberField < TextField
+      include ActionView::Helpers::NumberHelper
       attr_reader :min
       attr_reader :max
       attr_reader :step
+      attr_reader :format_display_using
 
       def initialize(id, **args, &block)
         super(id, **args, &block)
@@ -11,7 +13,21 @@ module Avo
         @min = args[:min].present? ? args[:min].to_f : nil
         @max = args[:max].present? ? args[:max].to_f : nil
         @step = args[:step].present? ? args[:step].to_f : nil
+        @format_display_using = args[:format_display_using]
       end
+
+      def value(property = nil)
+        raw_value = super
+        if @format_display_using && view == :show || view == :index
+          return raw_value if @formatting
+          @formatting = true
+            formatted_value = instance_exec(&@format_display_using)
+          @formatting = false
+          return formatted_value
+        elsif view == :edit
+          raw_value
+        end
+      end 
     end
   end
 end


### PR DESCRIPTION
This PR adds a format_display_using option for the number field such that instead of this:
```ruby
field :amount, as: number, format_using: -> do
  if view == :index || view == :show
    number_to_currency value
  else
    value
  end
end
```
We can do this instead which is more cleaner and allows us to apply appropriate formatting on a value for both the index and show views at once :
```ruby
field :amount, as: number, format_display_using: -> { number_to_currency value }
```
Solves #1902

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
