### PR TITLE
add jsonb to fields mapping

### DIFF
--- a/lib/avo/mappings.rb
+++ b/lib/avo/mappings.rb
@@ -74,6 +74,9 @@ module Avo
         },
         json: {
           field: "code"
+        },
+        jsonb: {
+          field: "code"
         }
       }.freeze
     end


### PR DESCRIPTION
# Description

JSONB fields should be displayed as `code`, just like JSON fields.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Manual review steps

Use `discover_columns` with a model that has a JSONB column. Without this PR, the column is not displayed, with this PR it is.

Happy to add tests if necessary.
Also, defining the `FIELDS_MAPPING` const could be cleaned up a bit, since many fields have the same value, e.g.:

```ruby
FIELDS_MAPPING = {
  belongs_to: %i[references belongs_to],
  boolean:    %i[boolean],
  code:       %i[json jsonb],
  date_time:  %i[datetime timestamp time],
  date:       %i[date],
  id:         %i[primary_key],
  number:     %i[integer float decimal binary],
  text:       %i[string],
  textarea:   %i[text]
}.each_with_object({}) do |(key, value), hash|
  value.each {
    hash[_1] = {
      field: key.to_s
    }
  }
end.freeze
```