### PR TITLE
fix: array resource actions query

### DIFF
--- a/lib/avo/resources/array_resource.rb
+++ b/lib/avo/resources/array_resource.rb
@@ -37,7 +37,12 @@ module Avo
 
         return super(id, query: fetched_records, params:) if is_active_record_relation?(fetched_records)
 
-        fetched_records.find { |i| i.id.to_s == id.to_s }
+        # Id is Array when find record is called from actions controller
+        if id.is_a?(Array)
+          return fetched_records.select { |record| id.map(&:to_s).include?(record.id.to_s) }
+        else
+          return fetched_records.find { |record| record.id.to_s == id.to_s }
+        end
       end
 
       def fetch_records(array_of_records = nil)

--- a/lib/avo/resources/array_resource.rb
+++ b/lib/avo/resources/array_resource.rb
@@ -39,9 +39,9 @@ module Avo
 
         # Id is Array when find record is called from actions controller
         if id.is_a?(Array)
-          return fetched_records.select { |record| id.map(&:to_s).include?(record.id.to_s) }
+          fetched_records.select { |record| id.map(&:to_s).include?(record.id.to_s) }
         else
-          return fetched_records.find { |record| record.id.to_s == id.to_s }
+          fetched_records.find { |record| record.id.to_s == id.to_s }
         end
       end
 

--- a/spec/dummy/app/avo/resources/movie.rb
+++ b/spec/dummy/app/avo/resources/movie.rb
@@ -283,4 +283,8 @@ class Avo::Resources::Movie < Avo::Resources::ArrayResource
 
     field :attendees, as: :array
   end
+
+  def actions
+    action Avo::Actions::Test::Query
+  end
 end

--- a/spec/system/avo/array_resource_spec.rb
+++ b/spec/system/avo/array_resource_spec.rb
@@ -50,5 +50,26 @@ RSpec.feature "ArrayResource", type: :system do
       all('a[data-control="show"]').last.click
       expect(page).to have_text("#{User.first(6).last.name} rendered as array resource")
     end
+
+    it "can access query on actions" do
+      visit avo.resources_movies_path
+
+      check_select_all
+      click_on "Select all matching"
+
+      movies_count = 50
+
+      open_panel_action(action_name: "Test query access ")
+
+      expect(page).to have_text("message #{movies_count} selected")
+      expect(page).to have_field("fields_selected", with: "#{movies_count} selected def fields")
+      expect(page).to have_text("cancel_button_label #{movies_count} selected")
+      expect(page).to have_text("confirm_button_label #{movies_count} selected")
+      expect(page).to have_text("Test query access #{movies_count}")
+
+      run_action
+
+      expect(page).to have_text("succeed #{movies_count} selected")
+    end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR resolves an issue with the `query` when an action is triggered on an array-based resource.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works