### PR TITLE
fix: allow textarea index field

### DIFF
--- a/lib/avo/fields/textarea_field.rb
+++ b/lib/avo/fields/textarea_field.rb
@@ -4,6 +4,8 @@ module Avo
       attr_reader :rows
 
       def initialize(id, **args, &block)
+        hide_on :index
+
         super(id, **args, &block)
 
         @rows = args[:rows].present? ? args[:rows].to_i : 5

--- a/lib/avo/fields/textarea_field.rb
+++ b/lib/avo/fields/textarea_field.rb
@@ -6,8 +6,6 @@ module Avo
       def initialize(id, **args, &block)
         super(id, **args, &block)
 
-        hide_on :index
-
         @rows = args[:rows].present? ? args[:rows].to_i : 5
       end
     end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR moves the `hide_on: :index` call before `super`, allowing the behavior to be overridden with `show_on: :index` for `textarea` fields.
