### PR TITLE
fix: copyable date style

### DIFF
--- a/app/components/avo/fields/date_field/index_component.html.erb
+++ b/app/components/avo/fields/date_field/index_component.html.erb
@@ -1,5 +1,5 @@
 <%= index_field_wrapper(**field_wrapper_args) do %>
-   <%= content_tag :div, data: {
+   <%= content_tag :div, class: "inline-block", data: {
     controller: "date-field",
     date_field_view_value: @view,
     date_field_format_value: @field.format,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3825

This PR sets the date content to `"inline-block"` on the index view, so the copyable component renders next to it instead of incorrectly appearing below.


## After
![image](https://github.com/user-attachments/assets/fb57add5-8dea-47eb-b691-cc1b993e8e55)

## Before
![image](https://github.com/user-attachments/assets/a562d587-aa58-4794-98e9-ee94bad31882)
