### PR TITLE
enhancement: `mount_avo` accepts custom routes block

### DIFF
--- a/lib/avo/engine.rb
+++ b/lib/avo/engine.rb
@@ -65,12 +65,16 @@ module Avo
       # Add the mount_avo method to Rails
       # rubocop:disable Style/ArgumentsForwarding
       ActionDispatch::Routing::Mapper.include(Module.new {
-        def mount_avo(at: Avo.configuration.root_path, **options)
+        def mount_avo(at: Avo.configuration.root_path, **options, &block)
           mount Avo::Engine, at:, **options
 
           scope at do
             Avo.plugin_manager.engines.each do |engine|
               mount engine[:klass], **engine[:options].dup
+            end
+
+            if block_given?
+              Avo::Engine.routes.draw(&block)
             end
           end
         end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -12,7 +12,14 @@ Rails.application.routes.draw do
       get "custom_tool", to: "avo/tools#custom_tool", as: :custom_tool
     end
 
-    mount_avo
+    mount_avo do
+      scope :resources do
+        get "courses/cities", to: "courses#cities"
+        get "users/get_users", to: "users#get_users"
+      end
+
+      put "switch_accounts/:id", to: "switch_accounts#update", as: :switch_account
+    end
 
     # Uncomment to test constraints /123/en/admin
     # scope ":course", constraints: {course: /\w+(-\w+)*/} do
@@ -25,16 +32,5 @@ Rails.application.routes.draw do
     scope "(:locale)" do
       # mount_avo
     end
-  end
-end
-
-if defined? ::Avo
-  Avo::Engine.routes.draw do
-    scope :resources do
-      get "courses/cities", to: "courses#cities"
-      get "users/get_users", to: "users#get_users"
-    end
-
-    put "switch_accounts/:id", to: "switch_accounts#update", as: :switch_account
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Accepts following syntax:

```rb
Rails.application.routes.draw do
  mount_avo do
    scope :resources do
      get "courses/cities", to: "courses#cities"
      get "users/get_users", to: "users#get_users"
    end

    put "switch_accounts/:id", to: "switch_accounts#update", as: :switch_account
  end
end
```

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.
