### PR TITLE
refactor: allow progress field to submit nil values

### DIFF
--- a/app/components/avo/fields/progress_bar_field/edit_component.html.erb
+++ b/app/components/avo/fields/progress_bar_field/edit_component.html.erb
@@ -5,14 +5,22 @@
         <span data-progress-bar-field-target="label"><%= @field.value %></span><%= @field.value_suffix if @field.value_suffix.present? %>
       </div>
     <% end %>
-    <%= @form.range_field @field.id,
+    <%= @form.text_field @field.id,
+      value: @field.value,
+      class: classes("w-full #{"hidden" unless params[:avo_show_hidden_inputs]}"),
+      data: {
+        progress_bar_field_target: "valueInput"
+      }
+    %>
+    <%= @form.range_field "visible_#{@field.id}",
       value: @field.value,
       class: "w-full #{@field.get_html(:classes, view: view, element: :input)}",
       data: {
         action: "input->progress-bar-field#update",
+        progress_bar_field_target: "visibleInput",
         **@field.get_html(:data, view: view, element: :input)
       },
-      disabled: disabled?,
+      disabled: true,
       max: @field.max,
       min: 0,
       placeholder: @field.placeholder,

--- a/app/components/avo/fields/progress_bar_field/edit_component.html.erb
+++ b/app/components/avo/fields/progress_bar_field/edit_component.html.erb
@@ -12,7 +12,7 @@
         progress_bar_field_target: "valueInput"
       }
     %>
-    <%= @form.range_field "visible_#{@field.id}",
+    <%= tag.input type: "range",
       value: @field.value,
       class: "w-full #{@field.get_html(:classes, view: view, element: :input)}",
       data: {
@@ -20,13 +20,14 @@
         progress_bar_field_target: "visibleInput",
         **@field.get_html(:data, view: view, element: :input)
       },
-      disabled: true,
+      disabled: disabled?,
       max: @field.max,
       min: 0,
       placeholder: @field.placeholder,
       step: @field.step,
       autofocus: @autofocus,
-      style: @field.get_html(:style, view: view, element: :input)
+      style: @field.get_html(:style, view: view, element: :input),
+      name: nil
     %>
   <% end %>
 <% end %>

--- a/app/javascript/js/controllers/fields/progress_bar_field_controller.js
+++ b/app/javascript/js/controllers/fields/progress_bar_field_controller.js
@@ -1,9 +1,10 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ['label']
+  static targets = ['label', 'valueInput', 'visibleInput']
 
-  update(e) {
-    this.labelTarget.textContent = e.target.value
+  update() {
+    this.valueInputTarget.value = this.visibleInputTarget.value
+    this.labelTarget.textContent = this.valueInputTarget.value
   }
 }

--- a/spec/dummy/app/avo/resources/project.rb
+++ b/spec/dummy/app/avo/resources/project.rb
@@ -35,7 +35,6 @@ class Avo::Resources::Project < Avo::BaseResource
       filterable: true,
       summarizable: true
     field :name, as: :text, required: true, sortable: true, default: "New project default name", copyable: true
-    field :visible_progress, as: :number, visible: false
     field :progress,
       as: :progress_bar,
       value_suffix: "%",

--- a/spec/dummy/app/avo/resources/project.rb
+++ b/spec/dummy/app/avo/resources/project.rb
@@ -35,6 +35,7 @@ class Avo::Resources::Project < Avo::BaseResource
       filterable: true,
       summarizable: true
     field :name, as: :text, required: true, sortable: true, default: "New project default name", copyable: true
+    field :visible_progress, as: :number, visible: false
     field :progress,
       as: :progress_bar,
       value_suffix: "%",

--- a/spec/system/avo/progress_bar_field_spec.rb
+++ b/spec/system/avo/progress_bar_field_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "ProgressBarField", type: :system do
+  describe "able to contain nil value" do
+    context "create" do
+      it "progress field remains blank" do
+        visit "/admin/resources/projects/new"
+
+        fill_in "project[users_required]", with: 10
+
+        click_button "Save"
+        sleep 2
+
+        expect(Project.last.progress).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description
Fix progress bar field to allow a nil value during creation and update if the bar was untouched and the default field value is nil.

Fixes #3846

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

[Screencast from 15.05.2025 17:22:41.webm](https://github.com/user-attachments/assets/dae790a6-c806-4480-8b4e-5f32ad77c9ca)


