### PR TITLE
fix: populate `self.query` for standalone `index_control` actions

### DIFF
--- a/app/javascript/js/controllers/item_select_all_controller.js
+++ b/app/javascript/js/controllers/item_select_all_controller.js
@@ -97,7 +97,8 @@ export default class extends Controller {
       selectedQuery = this.element.dataset.itemSelectAllSelectedAllQueryValue
     }
 
-    document.querySelectorAll('[data-target="actions-list"] > a').forEach((link) => {
+    const actionButtons = document.querySelectorAll(`a[data-actions-picker-target][data-resource-name="${this.resourceName}"]`)
+    actionButtons.forEach((link) => {
       try {
         const url = new URL(link.href)
 

--- a/app/javascript/js/controllers/item_select_all_controller.js
+++ b/app/javascript/js/controllers/item_select_all_controller.js
@@ -88,15 +88,6 @@ export default class extends Controller {
   }
 
   updateLinks(param) {
-    let resourceIds = ''
-    let selectedQuery = ''
-
-    if (param === 'resourceIds') {
-      resourceIds = JSON.parse(this.element.dataset.selectedResources).join(',')
-    } else if (param === 'selectedQuery') {
-      selectedQuery = this.element.dataset.itemSelectAllSelectedAllQueryValue
-    }
-
     const actionButtons = document.querySelectorAll(`a[data-actions-picker-target][data-resource-name="${this.resourceName}"]`)
     actionButtons.forEach((link) => {
       try {
@@ -107,9 +98,11 @@ export default class extends Controller {
           .forEach((key) => url.searchParams.delete(key))
 
         if (param === 'resourceIds') {
+          const resourceIds = JSON.parse(this.element.dataset.selectedResources).join(',')
           url.searchParams.set('fields[avo_resource_ids]', resourceIds)
           url.searchParams.set('fields[avo_selected_all]', 'false')
         } else if (param === 'selectedQuery') {
+          const selectedQuery = this.element.dataset.itemSelectAllSelectedAllQueryValue
           url.searchParams.set('fields[avo_index_query]', selectedQuery)
           url.searchParams.set('fields[avo_selected_all]', 'true')
         }


### PR DESCRIPTION
# Description
Populate `self.query` for standalone actions defined on self.index_controls. 

When an action is defined within an `index_control` in Avo, and this action is triggered with records selected, the `query` variable (expected to contain the IDs of the selected records) is empty (`[]`) when accessed via `self.message` within the action's execution context. However, the `query` variable is correctly populated with the selected record IDs if accessed within the `def handle` method of the same action.

Fixes #3855

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->


https://github.com/user-attachments/assets/d30c775b-4494-4480-97da-051bf2d9b968

QA Scenarios
1. Trigger action with no selected records on Index Page => 0 count
2. Trigger action with selected records on Index Page => n counts
3. Trigger action on Show page => 0 count but 1 when executed
4. Trigger action from Has Many Association with/without selections => 0/n count
5. Trigger action on Show page with selections from the Has Many Associations => 0 count but 1 when executed
