### PR TITLE
fix: row actions on array resources

### DIFF
--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -64,7 +64,7 @@ module Avo
       end
 
       def path(resource:, arguments: {}, **args)
-        Avo::Services::URIService.parse(resource.record&.persisted? ? resource.record_path : resource.records_path)
+        Avo::Services::URIService.parse(resource.record&.to_param.present? ? resource.record_path : resource.records_path)
           .append_paths("actions")
           .append_query(
             **{
@@ -365,7 +365,7 @@ module Avo
     end
 
     def enabled?
-      self.class.standalone || @record&.persisted?
+      self.class.standalone || @record&.to_param.present?
     end
 
     def disabled?


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3859 

Changed the method for verifying if an action is active, and for generating the action URL, from using `record.persisted?` to `record.to_param.present?`.  
This is because, for array-based resources, the record may not be persisted but can still return a valid `to_param`.

