### PR TITLE
fix: tag fields on nested forms

### DIFF
--- a/lib/avo/fields/tags_field.rb
+++ b/lib/avo/fields/tags_field.rb
@@ -34,6 +34,15 @@ module Avo
         @mode&.to_sym == :select
       end
 
+      # Reset the field_value to nil when hydrating
+      # This keeps the performance of the memoized field_value when used in different components
+      # And avoid the wrong memoized value to be used when field is hydrated with new data
+      def hydrate(...)
+        @field_value = nil
+
+        super
+      end
+
       def field_value
         @field_value ||= if acts_as_taggable_on.present?
           acts_as_taggable_on_values.map { |value| {value:} }.as_json


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3837

The `tags` field gets initialized with an empty record (`Model.new`) when the nested (hidden) template renders.

Later on, the same field object is used to render content inside the nested forms.

The initial value is memoized, so it keeps representing that empty record.

My first approach was to remove the memoization altogether. That works, but the field value is being called multiple times during a single render, which could cause a slightly performance decrease, especially when `acts_as_taggable_on` is enabled and extra computation kicks in. I didn't run any benchmarks, but any minor performance tweak is worth keeping.


I landed on a better fix: resetting the memoization variable right before each hydration. That way, we preserve the current performance and still get a fresh value every time the field is hydrated with new data.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works
