### PR TITLE
Fix: Keep actions dropdown visible and on top when opened

### DIFF
--- a/app/assets/stylesheets/avo.base.css
+++ b/app/assets/stylesheets/avo.base.css
@@ -111,6 +111,10 @@ dl {
     content: "";
     @apply absolute z-10 inset-auto left-0 top-0 mt-0 -translate-x-full w-3 h-full bg-gradient-to-l from-white to-transparent group-hover:from-gray-50;
   }
+
+  &:has([data-toggle-target="panel"]:not(.hidden)) {
+    @apply z-30 opacity-100
+  }
 }
 
 .shift-pressed {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
When using the `float: true` option in `row_controls_config`, the actions dropdown becomes unusable. The dropdown disappears as soon as the mouse leaves the table row to interact with the dropdown items, making it impossible to select any actions.

Fixes #3867

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->
https://www.loom.com/share/206275a7a6424663a19811b153a1964e

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Configure a resource with `float: true` in row_controls_config:
2. Setup `row_controls` with an `actions_list`
3. View the resource index page
4. Click on the "Actions" dropdown button for any row
5. Try to move the mouse cursor to select an item in the dropdown
