### PR TITLE
fix: hide polymorphic holder div

### DIFF
--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -28,7 +28,7 @@
         <%= @form.hidden_field @field.type_input_foreign_key %>
       <% end %>
     <% end %>
-    <div data-belongs-to-field-target="container" class="hidden></div>
+    <div data-belongs-to-field-target="container" class="hidden"></div>
     <% @field.types.each do |type| %>
       <template data-belongs-to-field-target="type" data-type="<%= type %>">
         <div data-polymorphic-type="<%= type %>">

--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -28,7 +28,7 @@
         <%= @form.hidden_field @field.type_input_foreign_key %>
       <% end %>
     <% end %>
-    <div data-belongs-to-field-target="container"></div>
+    <div data-belongs-to-field-target="container" class="hidden></div>
     <% @field.types.each do |type| %>
       <template data-belongs-to-field-target="type" data-type="<%= type %>">
         <div data-polymorphic-type="<%= type %>">

--- a/app/javascript/js/controllers/fields/belongs_to_field_controller.js
+++ b/app/javascript/js/controllers/fields/belongs_to_field_controller.js
@@ -14,11 +14,13 @@ export default class extends Controller {
 
   #hideAllTypes() {
     this.containerTarget.innerHTML = ''
+    this.containerTarget.classList.add('hidden')
   }
 
   #showType(type) {
     const target = this.typeTargets.find((typeTarget) => typeTarget.dataset.type === type)
     if (target) {
+      this.containerTarget.classList.remove('hidden')
       this.containerTarget.appendChild(target.content.cloneNode(true))
     }
   }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The polymorphic holder `div` was not hidden, causing the `divide-y` property to add an extra divider.

This PR adds a `hidden` class by default and changes visibility when the holder is populated.

### Before

![image](https://github.com/user-attachments/assets/ce23c6d0-bb01-4afa-b872-a1f5354c5014)


### After

![image](https://github.com/user-attachments/assets/f29208a5-1d79-454d-8302-41c07d076af9)
