### PR TITLE
refactor: remove dead code

### DIFF
--- a/app/components/avo/items/panel_component.rb
+++ b/app/components/avo/items/panel_component.rb
@@ -21,7 +21,6 @@ class Avo::Items::PanelComponent < Avo::ResourceComponent
     :edit_path,
     :can_see_the_destroy_button?,
     :can_see_the_save_button?,
-    :view_for,
     :display_breadcrumbs,
     to: :@parent_component
 

--- a/app/components/avo/views/resource_edit_component.rb
+++ b/app/components/avo/views/resource_edit_component.rb
@@ -55,11 +55,6 @@ class Avo::Views::ResourceEditComponent < Avo::ResourceComponent
     @resource.render_edit_controls
   end
 
-  # Render :show view for read only trix fields
-  def view_for(field)
-    (field.is_a?(Avo::Fields::TrixField) && field.is_disabled?) ? :show : @view
-  end
-
   private
 
   def via_index?

--- a/app/components/avo/views/resource_show_component.rb
+++ b/app/components/avo/views/resource_show_component.rb
@@ -66,10 +66,6 @@ class Avo::Views::ResourceShowComponent < Avo::ResourceComponent
     @resource.render_show_controls
   end
 
-  def view_for(field)
-    @view
-  end
-
   private
 
   # In development and test environments we should show the invalid field errors


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Identified this dead code and removed it.  
I noticed it was related to the Trix field, where it was supposed to render a show component when disabled.  
I went ahead and tested it, this behavior doesn't seem to apply (with or without this code),  so that might be a regression. I created an [issue](https://github.com/avo-hq/avo/issues/3888) to track and fix it.
