### PR TITLE
fix: make country field work with country attributes

### DIFF
--- a/lib/avo/fields/country_field.rb
+++ b/lib/avo/fields/country_field.rb
@@ -34,6 +34,13 @@ module Avo
       def options_for_filter
         select_options
       end
+
+      def value
+        value = super
+        value.is_a?(ISO3166::Country) ?
+          value.alpha2 :
+          value
+      end
     end
   end
 end


### PR DESCRIPTION
# Description

In my app, I use `composed_of` to convert the database value of a `country` attribute to an `ISO3166::Country` like this:

```ruby
composed_of :country,
  class_name: ISO3166::Country.to_s,
  mapping:    %w[country alpha2],
  converter:  ISO3166::Country.method(:new)
```

This doesn't work with the `country` field though, since it will compare the value from `select_options` (string) with the attribute (ISO3166::Country) and thus not mark the selected country as the selected option in the dropdown.

To fix this, the `value` method must return the `alpha2` short code if it finds a ISO3166::Country.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

I haven't added any tests or updated the docs yet, since this is my first PR, I wanted to get some quick feedback if it looks ok and will be accepted if tests are added and docs are updated. 😀

## Manual review steps

1. Opened a model with a country attribute in edit view
2. Verified that the correct country is selected in the dropdown