### PR TITLE
enhancement: add clear_license_response_on_deploy configuration option

### DIFF
--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -58,6 +58,7 @@ module Avo
     attr_accessor :associations_lookup_list_limit
     attr_accessor :column_names_mapping
     attr_accessor :column_types_mapping
+    attr_accessor :clear_license_response_on_deploy
 
     def initialize
       @root_path = "/avo"
@@ -127,6 +128,7 @@ module Avo
       @column_names_mapping = {}
       @column_types_mapping = {}
       @resource_row_controls_config = {}
+      @clear_license_response_on_deploy = true
     end
 
     unless defined?(RESOURCE_ROW_CONTROLS_CONFIG_DEFAULTS)

--- a/lib/avo/engine.rb
+++ b/lib/avo/engine.rb
@@ -32,7 +32,7 @@ module Avo
       # After deploy we want to make sure the license response is being cleared.
       # We need a fresh license response.
       # This is disabled in development because the initialization process might be triggered more than once.
-      unless Rails.env.development?
+      if !Rails.env.development? && Avo.configuration.clear_license_response_on_deploy
         begin
           Licensing::HQ.new.clear_response
         rescue => exception


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds `clear_license_response_on_deploy`, which is set to `true` by default and can be configured as `false`.

This setting is introduced to handle a very specific use case where an application could send thousands of license verification requests per day, whereas the expected amount, assuming the cache is functioning correctly, is roughly one request every 6 hours.

By default, the license response is cleared on each deploy to ensure freshness. However, in certain environments where deploys are frequent and predictable, and excessive license calls are undesirable, setting this option to `false` can significantly reduce the number of redundant license verifications.

An example where this might happen is when the application is configured to start a large number of pods. Each pod, when booting Avo, clears the cached response and triggers a new license request, resulting in a high volume of redundant calls.
