### PR TITLE
fix: mark BaseResource as abstract in resource manager initialization

### DIFF
--- a/app/avo/base_resource.rb
+++ b/app/avo/base_resource.rb
@@ -1,7 +1,5 @@
 module Avo
   class BaseResource < Avo::Resources::Base
-    abstract_resource!
-
     # Users can override this class to add custom methods for all resources.
   end
 end

--- a/lib/avo/resources/resource_manager.rb
+++ b/lib/avo/resources/resource_manager.rb
@@ -41,7 +41,6 @@ module Avo
           end
 
           # All descendants from Avo::Resources::Base except the internal abstract ones
-
           Base.descendants.reject { _1.is_abstract? }
         end
 
@@ -59,6 +58,11 @@ module Avo
       end
 
       def initialize
+        # Mark the BaseResource as abstract so it doesn't get loaded by the resource manager
+        # This is made here instead of in the BaseResource class because this class can be overridden
+        # And we don't want to force the developer that overrides this class to add the abstract resource flag to the overridden class.
+        Avo::BaseResource.abstract_resource!
+
         @resources = self.class.fetch_resources
       end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3820

This change moves the abstract resource flag to the ResourceManager's initialize method, ensuring that the BaseResource is treated as abstract without requiring developers to modify the BaseResource class directly.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
