### PR TITLE
fix: add URLHelpers inflection

### DIFF
--- a/app/components/avo/tab_switcher_component.rb
+++ b/app/components/avo/tab_switcher_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Avo::TabSwitcherComponent < Avo::BaseComponent
-  include Avo::UrlHelpers
+  include Avo::URLHelpers
   include Avo::ApplicationHelper
 
   delegate :white_panel_classes, to: :helpers

--- a/app/controllers/avo/base_application_controller.rb
+++ b/app/controllers/avo/base_application_controller.rb
@@ -9,7 +9,7 @@ module Avo
     include Avo::InitializesAvo
     include Avo::CommonController
     include Avo::ApplicationHelper
-    include Avo::UrlHelpers
+    include Avo::URLHelpers
     include Avo::Concerns::Breadcrumbs
     include Avo::Concerns::FindAssociationField
 

--- a/app/helpers/avo/url_helpers.rb
+++ b/app/helpers/avo/url_helpers.rb
@@ -1,5 +1,5 @@
 module Avo
-  module UrlHelpers
+  module URLHelpers
     def resources_path(resource:, keep_query_params: false, **args)
       return if resource.nil?
 

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -6,6 +6,7 @@ require_relative "avo/engine" if defined?(Rails)
 loader = Zeitwerk::Loader.for_gem
 loader.inflector.inflect(
   "html" => "HTML",
+  "url_helpers" => "URLHelpers",
   "uri_service" => "URIService",
   "has_html_attributes" => "HasHTMLAttributes"
 )


### PR DESCRIPTION
# Description

I added the "URL" acronym in my app and afterwards got this error:

```
NameError: uninitialized constant Avo::UrlHelpers (NameError)

    include Avo::UrlHelpers
               ^^^^^^^^^^^^
Did you mean?  Avo::URLHelpers
```

I found the PR #2518 that addressed this but was abandoned.

Are you still open to adding this?
If so, I can add documentation and tests.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Manual review steps

1. Add "URL" acronym in host app
2. Run with Avo 3.20.x -> NameError: uninitialized constant Avo::UrlHelpers (NameError)
3. Run with this PR -> no error