### PR TITLE
fix: mark `BaseResource` as abstract in resource manager `fetch_resources`

### DIFF
--- a/lib/avo/resources/resource_manager.rb
+++ b/lib/avo/resources/resource_manager.rb
@@ -35,7 +35,7 @@ module Avo
         # ]
         def fetch_resources
           # Mark the BaseResource as abstract so it doesn't get loaded by the resource manager
-          # This is made here instead of in the BaseResource class because this class can be overridden
+          # This is made here instead of in the BaseResource class because BaseResource class can be overridden
           # And we don't want to force the developer that overrides this class to add the abstract resource flag to the overridden class.
           Avo::BaseResource.abstract_resource!
 

--- a/lib/avo/resources/resource_manager.rb
+++ b/lib/avo/resources/resource_manager.rb
@@ -34,6 +34,11 @@ module Avo
         #   "FishResource",
         # ]
         def fetch_resources
+          # Mark the BaseResource as abstract so it doesn't get loaded by the resource manager
+          # This is made here instead of in the BaseResource class because this class can be overridden
+          # And we don't want to force the developer that overrides this class to add the abstract resource flag to the overridden class.
+          Avo::BaseResource.abstract_resource!
+
           if Avo.configuration.resources.present?
             load_configured_resources
           else
@@ -58,11 +63,6 @@ module Avo
       end
 
       def initialize
-        # Mark the BaseResource as abstract so it doesn't get loaded by the resource manager
-        # This is made here instead of in the BaseResource class because this class can be overridden
-        # And we don't want to force the developer that overrides this class to add the abstract resource flag to the overridden class.
-        Avo::BaseResource.abstract_resource!
-
         @resources = self.class.fetch_resources
       end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Complementary to https://github.com/avo-hq/avo/pull/3893