### PR TITLE
refactor: scope progress bar field styles

### DIFF
--- a/app/assets/stylesheets/css/fields/progress.css
+++ b/app/assets/stylesheets/css/fields/progress.css
@@ -1,13 +1,15 @@
-progress {
-  @apply h-2 bg-white border border-slate-400 rounded shadow-inner;
-}
-progress[value]::-webkit-progress-bar {
-  @apply bg-white border border-gray-500 rounded shadow-inner;
-}
-progress[value]::-webkit-progress-value{
-  @apply bg-primary-500 rounded;
+[data-component="avo/fields/common/progress_bar_component"] {
+  & progress {
+    @apply h-2 bg-white border border-slate-400 rounded shadow-inner;
+  }
+  & progress[value]::-webkit-progress-bar {
+    @apply bg-white border border-gray-500 rounded shadow-inner;
+  }
+  & progress[value]::-webkit-progress-value{
+    @apply bg-primary-500 rounded;
 
-}
-progress[value]::-moz-progress-bar {
-  @apply bg-primary-500 rounded appearance-none;
+  }
+  & progress[value]::-moz-progress-bar {
+    @apply bg-primary-500 rounded appearance-none;
+  }
 }

--- a/app/components/avo/fields/common/progress_bar_component.html.erb
+++ b/app/components/avo/fields/common/progress_bar_component.html.erb
@@ -1,4 +1,4 @@
-<div class="flex items-center">
+<div class="flex items-center" data-component="<%= component_name %>">
   <% if @display_value %>
     <div class="text-right text-sm font-semibold leading-none mr-2 min-w-[2rem]">
       <%= @value %><%= @value_suffix if @value_suffix.present? %>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Before, all `progress` elements got the same styling. Now we scoped them down at the field-level.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
