### PR TITLE
Fix disabled and readonly on trix field

### DIFF
--- a/app/components/avo/fields/trix_field/edit_component.html.erb
+++ b/app/components/avo/fields/trix_field/edit_component.html.erb
@@ -1,25 +1,48 @@
-<%= field_wrapper(**field_wrapper_args) do %>
-  <%= content_tag :div,
-    class: class_names("relative block overflow-x-auto max-w-4xl", @input_id),
-    data: do %>
-    <%= content_tag 'trix-editor',
-      class: 'trix-content',
+<% if is_readonly? %>
+  <%= field_wrapper(**field_wrapper_args, full_width: true) do %>
+    <% button_classes = 'font-semibold inline-block pt-3 text-sm' %>
+    <%= content_tag :div,
       data: {
-        "trix-field-target": "editor",
-        **@field.get_html(:data, view: view, element: :input)
-      },
-      input: @input_id,
-      placeholder: @field.placeholder do %>
-      <%= sanitize @field.value.to_s %>
+        controller: "trix-body",
+        trix_body_always_show_value: @field.always_show
+      } do %>
+      <div class="<%= class_names("trix-content border-none px-0 py-2 max-w-4xl", "hidden": !@field.always_show) %>" data-trix-body-target="content">
+        <%= sanitize @field.value.to_s %>
+      </div>
+      <% unless @field.always_show %>
+        <div class="hidden" data-trix-body-target="moreContentButton">
+          <%= link_to t('avo.more_content'), 'javascript:void(0);', class: button_classes, data: { action: 'click->trix-body#toggleContent' } %>
+        </div>
+        <div class="hidden" data-trix-body-target="lessContentButton">
+          <%= link_to t('avo.less_content'), 'javascript:void(0);', class: button_classes, data: { action: 'click->trix-body#toggleContent' } %>
+        </div>
+      <% end %>
     <% end %>
-    <%= @form.text_area @field.id,
-      value: @field.value.try(:to_trix_html) || @field.value,
-      class: classes("w-full hidden"),
-      data: @field.get_html(:data, view: view, element: :input),
-      disabled: disabled?,
-      id: @input_id,
-      placeholder: @field.placeholder,
-      style: @field.get_html(:style, view: view, element: :input)
-    %>
+  <% end %>
+<% else %>
+  <%= field_wrapper(**field_wrapper_args) do %>
+    <%= content_tag :div,
+      class: class_names("relative block overflow-x-auto max-w-4xl", @input_id),
+      data: do %>
+      <%= content_tag 'trix-editor',
+        class: 'trix-content',
+        data: {
+          "trix-field-target": "editor",
+          **@field.get_html(:data, view: view, element: :input)
+        },
+        input: @input_id,
+        placeholder: @field.placeholder do %>
+        <%= sanitize @field.value.to_s %>
+      <% end %>
+      <%= @form.text_area @field.id,
+        value: @field.value.try(:to_trix_html) || @field.value,
+        class: classes("w-full hidden"),
+        data: @field.get_html(:data, view: view, element: :input),
+        disabled: disabled?,
+        id: @input_id,
+        placeholder: @field.placeholder,
+        style: @field.get_html(:style, view: view, element: :input)
+      %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/avo/fields/trix_field/edit_component.rb
+++ b/app/components/avo/fields/trix_field/edit_component.rb
@@ -42,4 +42,8 @@ class Avo::Fields::TrixField::EditComponent < Avo::Fields::EditComponent
       **values,
     }
   end
+
+  def is_readonly?
+    @field.readonly == true || @field.disabled == true
+  end
 end


### PR DESCRIPTION
# Description
The Trix field has no straightforward way to render disabled input. To bypass this, the suggested approach was to render the Trix show component within the edit form if either ```disabled``` or ```readonly``` is set to true. 

Show page
![image](https://github.com/user-attachments/assets/8687a7e2-8f6e-4e9b-9bb2-6c9800364232)

Edit page
![image](https://github.com/user-attachments/assets/de0ca024-6801-4459-8685-c25e538d252e)

The body of the event is shown instead of the Trix field editor on the Edit page when ```disabled``` or ```readonly``` are set to true like below:

```ruby
field :body, as: :trix, disabled: true
```
Fixes # (3888)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works