### PR TITLE
fix: large actions on mobile

### DIFF
--- a/app/components/avo/modal_component.rb
+++ b/app/components/avo/modal_component.rb
@@ -19,7 +19,7 @@ class Avo::ModalComponent < Avo::BaseComponent
   end
 
   def height_classes
-    "max-h-full min-h-1/4 max-h-11/12"
+    "max-h-[calc(100dvh-5rem)] min-h-1/4"
   end
 
   def overflow_classes

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -80,4 +80,6 @@ Rails.application.configure do
   config.hotwire_livereload.listen_paths << Avo::Engine.root.join("app/javascript")
   config.hotwire_livereload.listen_paths << Avo::Engine.root.join("app/views")
   config.hotwire_livereload.listen_paths << Avo::Engine.root.join("lib")
+
+  config.hosts << '.ngrok-free.app'
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #3927 

Fixing the modal component max height to ensure that on mobile,  large actions can always scroll and see the action cancel and submit controls. 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
