### PR TITLE
Fix non-ASCII string in tab name

### DIFF
--- a/lib/avo/resources/items/tab.rb
+++ b/lib/avo/resources/items/tab.rb
@@ -34,8 +34,8 @@ class Avo::Resources::Items::Tab
   alias_method :to_param, :id
 
   def turbo_frame_id(parent: nil)
-    id = "#{Avo::Resources::Items::Tab.to_s.parameterize} #{name}".parameterize
-
+    digest_name = Digest::MD5.hexdigest(name)
+    id = "#{Avo::Resources::Items::Tab.to_s.parameterize} #{digest_name}".parameterize
     return id if parent.nil?
 
     "#{parent.turbo_frame_id} #{id}".parameterize

--- a/spec/system/avo/tabs_spec.rb
+++ b/spec/system/avo/tabs_spec.rb
@@ -279,4 +279,37 @@ RSpec.describe "Tabs", type: :system do
       expect(value.text(:all).strip).to eq("+1 (555) 123-4567")
     end
   end
+
+  describe "tabs with non-ASCII names" do
+    let!(:store) {create :store}
+
+    it "generates a unique turbo frame id for non-ASCII strings" do
+      visit avo.resources_store_path(store)
+
+      # Get all tab elements
+      emoji_tab = '📖 store'
+      map_tab = 'store 🧭'
+      chinese_tab = '其他store'
+
+      # Get digest name for each tab
+      book_emoji_tab_digest_name = Digest::MD5.hexdigest(emoji_tab)
+      map_emoji_tab_digest_name = Digest::MD5.hexdigest(map_tab)
+      chinese_tab_digest_name = Digest::MD5.hexdigest(chinese_tab)
+
+      # Generate turbo frame id for each tab
+      book_emoji_tab_turbo_frame_id = "#{Avo::Resources::Items::Tab.to_s.parameterize} #{book_emoji_tab_digest_name}".parameterize
+      map_emoji_tab_turbo_frame_id = "#{Avo::Resources::Items::Tab.to_s.parameterize} #{map_emoji_tab_digest_name}".parameterize
+      chinese_tab_turbo_frame_id = "#{Avo::Resources::Items::Tab.to_s.parameterize} #{chinese_tab_digest_name}".parameterize
+
+      # Verify uniqueness of each of the turbo frame ids
+      expect(book_emoji_tab_turbo_frame_id).not_to eq(map_emoji_tab_turbo_frame_id)
+      expect(book_emoji_tab_turbo_frame_id).not_to eq(chinese_tab_turbo_frame_id)
+      expect(map_emoji_tab_turbo_frame_id).not_to eq(chinese_tab_turbo_frame_id)
+
+      # Verify that the turbo frame ids are properly formatted (parameterized)
+      expect(book_emoji_tab_turbo_frame_id).to match(/\A[a-z0-9-]+\z/)
+      expect(map_emoji_tab_turbo_frame_id).to match(/\A[a-z0-9-]+\z/)
+      expect(chinese_tab_turbo_frame_id).to match(/\A[a-z0-9-]+\z/)
+    end
+  end
 end


### PR DESCRIPTION
# Description
Allows turbo frames of different ids to be generated for non-ASCII strings such as those including emojis. 

If we have the tabs below, we expect each of them to have a unique turbo frame id:
```ruby
  tabs do
    field :stores, as: :has_many, name: '📖 store'
    field :addresses, as: :has_many, name: 'store 🧭'
    field :others, as: :has_many, name: '其他store '
  end
```
Currently, the turbo frame id generated for all the 3 will be the same, therefore when we switch between the tabs, content rendering will be messed up. 

Fixes #1908

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works
