### PR TITLE
Fix mobile field label text wrapping with responsive width classes

### DIFF
--- a/app/components/avo/field_wrapper_component.html.erb
+++ b/app/components/avo/field_wrapper_component.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag :div,
   class: classes,
-  style: style,  
+  style: style,
   data: data do %>
   <%= content_tag :div, class: class_names("pt-4 flex self-start items-center flex-shrink-0 w-full px-6 uppercase font-semibold text-gray-500 text-sm", @field.get_html(:classes, view: @view, element: :label), {
     "md:pt-4": stacked?,


### PR DESCRIPTION
### Problem
Long field names were wrapping to multiple lines on mobile due to the fixed `w-48` are applied to field labels at all screen sizes. This created poor readability and inconsistent spacing on mobile.

### Solution
Implemented a mobile-first responsive approach:

- **Mobile**: We use `w-full` for all field labels since they're stacked anyway
- **Desktop**: Apply contextually appropriate fixed widths:
  - Stacked layouts: Continue using `w-full` 
  - Inline + Compact: Use `md:w-48`
  - Inline + Regular: Use `md:w-64`

Fixes #2588