### PR TITLE
fix: eject generator for components ejection

### DIFF
--- a/lib/generators/avo/eject_generator.rb
+++ b/lib/generators/avo/eject_generator.rb
@@ -122,7 +122,7 @@ module Generators
             # If component is a constant, find the source location
             source_location = component_constant.identifier
 
-            [source_location, source_location.gsub(".rb", ".html.erb")]
+            [source_location, source_location.gsub(/\.rb\z/, ".html.erb")]
           else
             ["app/components/#{component}.rb", "app/components/#{component}.html.erb"]
           end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### 🐛 Bug Fix
Fixed `gsub(".rb", ".html.erb")` in eject generator to only replace the file extension (`.rb` at end of string) rather than all occurrences of "rb" in the filename. 

This prevents issues with files like 

```
/home/bob/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/avo-4.0.0.pre.dev.2/app/components/avo/fields/text_field/index_component.rb
```

 being incorrectly transformed to 

```
/home/bob/.html.erbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/avo-4.0.0.pre.dev.2/app/components/avo/fields/text_field/index_component.html.erb
```