### PR TITLE
fix: add missing error param

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -11,7 +11,7 @@ module Avo
     def show
       render json: search_resources([resource], request:)
     rescue => error
-      render_error _label: error.message
+      render_error error, _label: error.message
     end
 
     def process_results(results, request:)
@@ -208,7 +208,7 @@ module Avo
       @parent_resource ||= Avo.resource_manager.get_resource_by_model_class(params[:via_reflection_class])
     end
 
-    def render_error(...)
+    def render_error(error, ...)
       raise error unless render_error?
 
       render json: {


### PR DESCRIPTION
# Description

A parameter was missing for the method `render_error` in `Avo::SearchController`.
Maybe it was dropped when the params were converted to `...`?

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Manual review steps

Without this fix, if an error is raised performing a search in a non-dev environment, it will raise an error that the `error` variable is not defined.