### PR TITLE
Add ``` hide_filter_button ``` for associations

### DIFF
--- a/app/components/avo/filters_component.html.erb
+++ b/app/components/avo/filters_component.html.erb
@@ -1,17 +1,19 @@
 <div data-controller="toggle" data-component-name="<%= self.class.to_s.underscore %>">
   <div class="relative w-full flex justify-between">
-    <%= a_button class: 'focus:outline-none',
-      color: :primary,
-      size: :sm,
-      icon: "avo/filter",
-      title: t('avo.click_to_reveal_filters'),
-      'data-button': 'resource-filters',
-      'data-action': 'click->toggle#togglePanel',
-      'data-tippy': 'tooltip' do %>
-      <%= t 'avo.filters' %>
-      <% if @applied_filters.present? %>
-        <span class="ml-1">(<%= "#{@applied_filters.count} #{t('avo.applied', count: @applied_filters.count)}" %>)</span>
-      <% end %>
+    <% unless @field&.hide_filter_button %>
+      <%= a_button class: 'focus:outline-none',
+        color: :primary,
+        size: :sm,
+        icon: "avo/filter",
+        title: t('avo.click_to_reveal_filters'),
+        'data-button': 'resource-filters',
+        'data-action': 'click->toggle#togglePanel',
+        'data-tippy': 'tooltip' do %>
+       <%= t 'avo.filters' %>
+        <% if @applied_filters.present? %>
+          <span class="ml-1">(<%= "#{@applied_filters.count} #{t('avo.applied', count: @applied_filters.count)}" %>)</span>
+        <% end %>
+       <% end %>
     <% end %>
     <div
       class="absolute block inset-auto sm:right-0 top-full bg-white min-w-[300px] mt-2 z-40 shadow-modal rounded divide-y divide-gray-300 <%= 'hidden' unless params[:keep_filters_panel_open] == '1' %>"

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -132,6 +132,7 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
   def render_dynamic_filters_button
     return unless Avo.avo_dynamic_filters_installed?
     return unless @resource.has_filters?
+    return unless show_filters_button?
     return if Avo::DynamicFilters.configuration.always_expanded
 
     a_button size: :sm,
@@ -144,6 +145,15 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
       } do
       Avo::DynamicFilters.configuration.button_label
     end
+  end
+
+  def show_filters_button?
+    return false if field&.hide_filter_button
+    return false unless Avo.avo_dynamic_filters_installed?
+    return false unless @resource.has_filters?
+    return false if Avo::DynamicFilters.configuration.always_expanded
+
+    true
   end
 
   def scopes_list

--- a/lib/avo/fields/many_frame_base_field.rb
+++ b/lib/avo/fields/many_frame_base_field.rb
@@ -6,6 +6,7 @@ module Avo
 
       attr_reader :scope,
         :hide_search_input,
+        :hide_filter_button,
         :discreet_pagination
 
       def initialize(id, **args, &block)
@@ -28,6 +29,7 @@ module Avo
         @searchable = args[:searchable]
         @scope = args[:scope]
         @hide_search_input = args[:hide_search_input]
+        @hide_filter_button = args[:hide_filter_button]
         @discreet_pagination = args[:discreet_pagination]
       end
     end


### PR DESCRIPTION
# Description
This PR allows us to hide the ```filter``` button similar to how we are able to hide the``` search ``` input.

Fixes #2884 

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
