### PR TITLE
feature: Add indeterminate state for boolean field

### DIFF
--- a/app/components/avo/fields/boolean_field/index_component.html.erb
+++ b/app/components/avo/fields/boolean_field/index_component.html.erb
@@ -1,3 +1,7 @@
 <%= index_field_wrapper(**field_wrapper_args, flush: true) do %>
-  <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
+  <% if @field.value == :indeterminate %>
+    <%= render Avo::Fields::Common::IndeterminateStateComponent.new %>
+  <% else %>
+    <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
+  <% end %>
 <% end %>

--- a/app/components/avo/fields/boolean_field/index_component.rb
+++ b/app/components/avo/fields/boolean_field/index_component.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class Avo::Fields::BooleanField::IndexComponent < Avo::Fields::IndexComponent
+  raise "Value is #{@field.value.inspect}, Class is #{@field.value.class}" unless @field.nil?
+
+  def show_indeterminate?
+    field_args = @field.instance_variable_get(:@args)
+
+    @field.value.nil? && field_args[:nil_as_indeterminate] == true
+  end
 end

--- a/app/components/avo/fields/boolean_field/show_component.html.erb
+++ b/app/components/avo/fields/boolean_field/show_component.html.erb
@@ -1,3 +1,8 @@
 <%= field_wrapper(**field_wrapper_args) do %>
-  <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
+  <% if @field.value == :indeterminate %>
+    <%= render Avo::Fields::Common::IndeterminateStateComponent.new %>
+  <% else %>
+    <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
+  <% end %>
+  
 <% end %>

--- a/app/components/avo/fields/boolean_field/show_component.rb
+++ b/app/components/avo/fields/boolean_field/show_component.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class Avo::Fields::BooleanField::ShowComponent < Avo::Fields::ShowComponent
+  raise "Value is #{@field.value.inspect}, Class is #{@field.value.class}" unless @field.nil?
+
+  def show_indeterminate?
+    field_args = @field.instance_variable_get(:@args)
+
+    @field.value.nil? && field_args[:nil_as_indeterminate] == true
+  end
 end

--- a/app/components/avo/fields/common/indeterminate_state_component.html.erb
+++ b/app/components/avo/fields/common/indeterminate_state_component.html.erb
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 text-gray-500">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M15 12H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+</svg>

--- a/app/components/avo/fields/common/indeterminate_state_component.rb
+++ b/app/components/avo/fields/common/indeterminate_state_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Avo::Fields::Common::IndeterminateStateComponent < Avo::BaseComponent
+end

--- a/lib/avo/fields/boolean_field.rb
+++ b/lib/avo/fields/boolean_field.rb
@@ -12,7 +12,13 @@ module Avo
       end
 
       def value
-        resolve_attribute super
+        val = super
+
+        if val.nil? && @args[:nil_as_indeterminate] == true
+          return :indeterminate
+        end
+
+        resolve_attribute val
       end
 
       def resolve_attribute(value)

--- a/spec/dummy/app/avo/resources/city.rb
+++ b/spec/dummy/app/avo/resources/city.rb
@@ -84,7 +84,7 @@ class Avo::Resources::City < Avo::BaseResource
         link_to resource.record.name, path, data: data
       end
       field :population, as: :number, filterable: true, format_display_using: -> { number_with_delimiter(value, delimiter: ".") }
-      field :is_capital, as: :boolean, filterable: true
+      field :is_capital, as: :boolean, filterable: true #, nil_as_indeterminate: true
       field :features, as: :key_value
       field :image_url, as: :external_image
       field :tiny_description, as: :easy_mde


### PR DESCRIPTION
This change introduces a new nil_as_indeterminate option to the BooleanField to provide a more distinct visual state for nil values.

When this option is set to true, the field will display a grey minus-circle heroicon instead of the default em dash (—).

Fixes #3873

I have used city.rb as an example since it has is_capital which is boolean. When nil_as_indeterminate is made true, the icon is shown under is_capital: 

field :is_capital, as: :boolean, filterable: true, nil_as_indeterminate: true


This is how it appears:

<img width="1485" height="350" alt="image" src="https://github.com/user-attachments/assets/1a281b65-3c85-4869-8382-1c2ae7d877dd" />
