### PR TITLE
fix/ add assets to precompile path (sprockets compatibility)

### DIFF
--- a/lib/avo/engine.rb
+++ b/lib/avo/engine.rb
@@ -106,7 +106,13 @@ module Avo
       end
 
       if app.config.respond_to?(:assets)
+        # Add Avo's assets to the asset pipeline
         app.config.assets.paths << Engine.root.join("app", "assets", "builds").to_s
+
+        # Add Avo's assets to the precompile list
+        app.config.assets.precompile += Dir.glob(Engine.root.join("app", "assets", "builds", "avo", "**", "*").to_s)
+        app.config.assets.precompile += Dir.glob(Engine.root.join("app", "assets", "images", "avo", "**", "*").to_s)
+        app.config.assets.precompile += Dir.glob(Engine.root.join("app", "assets", "svgs", "**", "*").to_s)
       end
     end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds Sprockets compatibility so we don't have to force the parent app to add our assets to the `manifest.js` file.

```js
// this is not necesarry anymore

//= link avo/favicon.ico
//= link avo/application.css
//= link avo/application.js
//= link avo/late-registration.js
//= link avo/logo.png
//= link avo/logomark.png
```