### PR TITLE
fix: missing method `color_scheme_path`

### DIFF
--- a/app/views/avo/partials/_color_scheme_switcher.html.erb
+++ b/app/views/avo/partials/_color_scheme_switcher.html.erb
@@ -6,13 +6,13 @@
     <%#= f.hidden_input color_scheme: :light %>
     <%#= f.button "Light" %>
   <%# end %>
-  <%= link_to color_scheme_path(color_scheme: :auto), data: {turbo_method: :post, turbo_frame: :_top} do %>
+  <%= link_to avo.color_scheme_path(color_scheme: :auto), data: {turbo_method: :post, turbo_frame: :_top} do %>
     Auto
   <% end %>
-  <%= link_to color_scheme_path(color_scheme: :light), data: {turbo_method: :post, turbo_frame: :_top} do %>
+  <%= link_to avo.color_scheme_path(color_scheme: :light), data: {turbo_method: :post, turbo_frame: :_top} do %>
     Light <span class="dark:hidden inline">✅</span>
   <% end %>
-  <%= link_to color_scheme_path(color_scheme: :dark), data: {turbo_method: :post, turbo_frame: :_top} do %>
+  <%= link_to avo.color_scheme_path(color_scheme: :dark), data: {turbo_method: :post, turbo_frame: :_top} do %>
     Dark <span class="hidden dark:inline">✅</span>
   <% end %>
 </div>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes missing method `color_scheme_path`
<img width="1279" height="458" alt="image" src="https://github.com/user-attachments/assets/19b1334a-eff4-46ab-83ba-120d13100e2e" />
