### PR TITLE
Loop and register controllers

### DIFF
--- a/app/javascript/js/controllers.js
+++ b/app/javascript/js/controllers.js
@@ -1,111 +1,118 @@
 import { application } from './application'
 
-import ActionController from './controllers/action_controller'
-import ActionsOverflowController from './controllers/actions_overflow_controller'
-import ActionsPickerController from './controllers/actions_picker_controller'
-import AttachmentsController from './controllers/attachments_controller'
-import BelongsToFieldController from './controllers/fields/belongs_to_field_controller'
-import BooleanFilterController from './controllers/boolean_filter_controller'
-import CardFiltersController from './controllers/card_filters_controller'
-import ClearInputController from './controllers/fields/clear_input_controller'
-import CodeFieldController from './controllers/fields/code_field_controller'
-import CopyToClipboardController from './controllers/copy_to_clipboard_controller'
-import DashboardCardController from './controllers/dashboard_card_controller'
-import DateFieldController from './controllers/fields/date_field_controller'
-import DateTimeFilterController from './controllers/date_time_filter_controller'
-import EasyMdeController from './controllers/fields/easy_mde_controller'
-import FilterController from './controllers/filter_controller'
-import FormController from './controllers/form_controller'
-import HiddenInputController from './controllers/hidden_input_controller'
-import InputAutofocusController from './controllers/input_autofocus_controller'
-import ItemSelectAllController from './controllers/item_select_all_controller'
-import ItemSelectorController from './controllers/item_selector_controller'
-import KeyValueController from './controllers/fields/key_value_controller'
-import LoadingButtonController from './controllers/loading_button_controller'
-import MediaLibraryAttachController from './controllers/media_library_attach_controller'
-import MediaLibraryController from './controllers/media_library_controller'
-import MenuController from './controllers/menu_controller'
-import ModalController from './controllers/modal_controller'
-import MultipleSelectFilterController from './controllers/multiple_select_filter_controller'
-import NestedFormController from './controllers/nested_form_controller'
-import PanelRefreshController from './controllers/fields/panel_refresh_controller'
-import PerPageController from './controllers/per_page_controller'
-import PreviewController from './controllers/preview_controller'
-import ProgressBarFieldController from './controllers/fields/progress_bar_field_controller'
-import RecordSelectorController from './controllers/record_selector_controller'
-import ReloadBelongsToFieldController from './controllers/fields/reload_belongs_to_field_controller'
-import ResourceEditController from './controllers/resource_edit_controller'
-import ResourceIndexController from './controllers/resource_index_controller'
-import ResourceShowController from './controllers/resource_show_controller'
-import SearchController from './controllers/search_controller'
-import SelectController from './controllers/select_controller'
-import SelectFilterController from './controllers/select_filter_controller'
-import SelfDestroyController from './controllers/self_destroy_controller'
-import SidebarController from './controllers/sidebar_controller'
-import SignOutController from './controllers/sign_out_controller'
-import TableRowController from './controllers/table_row_controller'
-import TabsController from './controllers/tabs_controller'
-import TagsFieldController from './controllers/fields/tags_field_controller'
-import TextFilterController from './controllers/text_filter_controller'
-import TippyController from './controllers/tippy_controller'
-import TiptapFieldController from './controllers/fields/tiptap_field_controller'
-import ToggleController from './controllers/toggle_controller'
-import TrixBodyController from './controllers/trix_body_controller'
-import TrixFieldController from './controllers/fields/trix_field_controller'
+/**
+ * Auto-register Stimulus Controllers
+ * 
+ * Convention:
+ * - File names: snake_case_controller.js
+ * - Import names: PascalCase (e.g., ResourceSearchController)
+ * - Registration names: kebab-case (e.g., resource-search)
+ */
 
-application.register('action', ActionController)
-application.register('actions-overflow', ActionsOverflowController)
-application.register('actions-picker', ActionsPickerController)
-application.register('attachments', AttachmentsController)
-application.register('boolean-filter', BooleanFilterController)
-application.register('card-filters', CardFiltersController)
-application.register('clear-input', ClearInputController)
-application.register('copy-to-clipboard', CopyToClipboardController)
-application.register('dashboard-card', DashboardCardController)
-application.register('date-time-filter', DateTimeFilterController)
-application.register('filter', FilterController)
-application.register('form', FormController)
-application.register('hidden-input', HiddenInputController)
-application.register('input-autofocus', InputAutofocusController)
-application.register('item-select-all', ItemSelectAllController)
-application.register('item-selector', ItemSelectorController)
-application.register('loading-button', LoadingButtonController)
-application.register('media-library-attach', MediaLibraryAttachController)
-application.register('media-library', MediaLibraryController)
-application.register('menu', MenuController)
-application.register('modal', ModalController)
-application.register('multiple-select-filter', MultipleSelectFilterController)
-application.register('avo-nested-form', NestedFormController)
-application.register('panel-refresh', PanelRefreshController)
-application.register('per-page', PerPageController)
-application.register('preview', PreviewController)
-application.register('record-selector', RecordSelectorController)
-application.register('resource-edit', ResourceEditController)
-application.register('resource-index', ResourceIndexController)
-application.register('resource-show', ResourceShowController)
-application.register('search', SearchController)
-application.register('select-filter', SelectFilterController)
-application.register('select', SelectController)
-application.register('self-destroy', SelfDestroyController)
-application.register('sidebar', SidebarController)
-application.register('sign-out', SignOutController)
-application.register('table-row', TableRowController)
-application.register('tabs', TabsController)
-application.register('text-filter', TextFilterController)
-application.register('tippy', TippyController)
-application.register('toggle', ToggleController)
-application.register('trix-body', TrixBodyController)
+// Helper functions
+function toPascalCase(snakeCase) {
+  return snakeCase
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('')
+}
 
-// Field controllers
-application.register('belongs-to-field', BelongsToFieldController)
-application.register('code-field', CodeFieldController)
-application.register('date-field', DateFieldController)
-application.register('easy-mde', EasyMdeController)
-application.register('key-value', KeyValueController)
-application.register('progress-bar-field', ProgressBarFieldController)
-application.register('reload-belongs-to-field', ReloadBelongsToFieldController)
-application.register('tags-field', TagsFieldController)
-application.register('tiptap-field', TiptapFieldController)
-application.register('trix-field', TrixFieldController)
+function toKebabCase(snakeCase) {
+  return snakeCase.replace(/_/g, '-')
+}
+
+// Regular controllers (alphabetical order)
+const regularControllers = [
+  'action',
+  'actions_overflow',
+  'actions_picker',
+  'attachments',
+  'boolean_filter',
+  'card_filters',
+  'copy_to_clipboard',
+  'dashboard_card',
+  'date_time_filter',
+  'filter',
+  'form',
+  'hidden_input',
+  'input_autofocus',
+  'item_select_all',
+  'item_selector',
+  'loading_button',
+  'media_library_attach',
+  'media_library',
+  'menu',
+  'modal',
+  'multiple_select_filter',
+  'nested_form',
+  'per_page',
+  'preview',
+  'record_selector',
+  'resource_edit',
+  'resource_index',
+  'resource_show',
+  'search',
+  'select_filter',
+  'select',
+  'self_destroy',
+  'sidebar',
+  'sign_out',
+  'table_row',
+  'tabs',
+  'text_filter',
+  'tippy',
+  'toggle',
+  'trix_body'
+]
+
+// Field controllers (alphabetical order)
+const fieldControllers = [
+  'belongs_to_field',
+  'clear_input',
+  'code_field',
+  'date_field',
+  'easy_mde',
+  'key_value',
+  'panel_refresh',
+  'progress_bar_field',
+  'reload_belongs_to_field',
+  'tags_field',
+  'tiptap_field',
+  'trix_field'
+]
+
+// Dynamic imports and registration
+async function registerControllers() {
+  // Register regular controllers
+  for (const controllerName of regularControllers) {
+    try {
+      const module = await import(`./controllers/${controllerName}_controller.js`)
+      const ControllerClass = module.default
+      const registrationName = controllerName === 'nested_form' ? 'avo-nested-form' : toKebabCase(controllerName)
+      application.register(registrationName, ControllerClass)
+    } catch (error) {
+      console.warn(`Failed to load controller: ${controllerName}_controller.js`, error)
+    }
+  }
+
+  // Register field controllers
+  for (const controllerName of fieldControllers) {
+    try {
+      const module = await import(`./controllers/fields/${controllerName}_controller.js`)
+      const ControllerClass = module.default
+      const registrationName = toKebabCase(controllerName)
+      application.register(registrationName, ControllerClass)
+    } catch (error) {
+      console.warn(`Failed to load field controller: ${controllerName}_controller.js`, error)
+    }
+  }
+}
+
+// Initialize controllers
+registerControllers()
 
 // Custom controllers
+// To add a new controller:
+// 1. Create the file: ./controllers/my_new_controller.js or ./controllers/fields/my_field_controller.js
+// 2. Add 'my_new' to regularControllers array or 'my_field' to fieldControllers array
+// 3. The controller will be auto-registered as 'my-new' or 'my-field'


### PR DESCRIPTION
# Description
Automates Stimulus controller registration in `app/javascript/js/controllers.js`. This refactor replaces manual imports and registrations with a dynamic loop, significantly simplifying the process of adding new controllers by adhering to a clear naming convention.

This change:
- Reduces boilerplate and manual effort for new controller additions.
- Improves maintainability by centralizing controller definitions.
- Ensures consistent naming and registration conventions (snake_case file names to kebab-case Stimulus registration names).

Fixes # (issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
N/A

## Manual review steps
1. Verify that `app/javascript/js/controllers.js` now uses dynamic imports and loops for controller registration.
2. Ensure all existing Stimulus controllers (e.g., `action`, `resource-index`, `belongs-to-field`) continue to function as expected across the application.
3. (Optional) Create a new dummy Stimulus controller file (e.g., `app/javascript/js/controllers/my_test_controller.js`), add its base name (`'my_test'`) to the `regularControllers` array in `controllers.js`, and confirm it registers and works correctly.

Manual reviewer: please leave a comment with output from the test if that's the case.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3cbf935-d6e6-4787-9049-214700c9a4a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e3cbf935-d6e6-4787-9049-214700c9a4a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>