### PR TITLE
Fix: Country field copies wrong clipboard value when ```copyable: true```

### DIFF
--- a/app/components/avo/field_wrapper_component.html.erb
+++ b/app/components/avo/field_wrapper_component.html.erb
@@ -33,7 +33,14 @@
             <%= content %>
           <% end %>
           <% if @field.copyable %>
-            <%= render Avo::ClipboardComponent.new(value: @field.value) %>
+            <% 
+              copy_value = if @field.is_a?(Avo::Fields::CountryField) && !@field.display_code
+                @field.countries[@field.value]
+              else
+                @field.value
+              end
+            %>
+            <%= render Avo::ClipboardComponent.new(value: copy_value) %>
           <% end %>
         </div>
       <% elsif on_edit? %>

--- a/app/components/avo/index/field_wrapper_component.html.erb
+++ b/app/components/avo/index/field_wrapper_component.html.erb
@@ -17,7 +17,14 @@
       <%= content %>
     <% end %>
     <% if @field.copyable %>
-      <%= render Avo::ClipboardComponent.new(value: @field.value) %>
+      <% 
+        copy_value = if @field.is_a?(Avo::Fields::CountryField) && !@field.display_code
+          @field.countries[@field.value]
+        else
+          @field.value
+        end
+      %>
+      <%= render Avo::ClipboardComponent.new(value: copy_value) %>
     <% end %>
   <% end %>
   <% if params[:avo_debug].present? %>


### PR DESCRIPTION
Fixes #3938 

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works