### PR TITLE
revert searchable fields compatibility

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -81,6 +81,7 @@
   @import './css/loader.css';
   @import './css/pagination.css';
   @import './css/breadcrumbs.css';
+  @import './css/search.css';
   @import './css/active-storage.css';
   @import './css/scrollbar.css';
   @import './css/sidebar.css';

--- a/app/assets/stylesheets/css/search.css
+++ b/app/assets/stylesheets/css/search.css
@@ -1,0 +1,90 @@
+:root {
+  --aa-primary-color: --tw-ring-color;
+  --aa-selected-color: --tw-ring-color;
+  --aa-primary-color-rgb: 117, 125, 138;
+}
+
+.global-search {
+  .aa-DetachedSearchButton:focus,
+  .aa-DetachedSearchButton {
+    border: none !important;
+    @apply text-gray-500 cursor-pointer;
+
+    .aa-DetachedSearchButtonPlaceholder {
+      @apply max-sm:hidden;
+    }
+  }
+}
+
+.resource-search {
+  .aa-Autocomplete {
+    @apply w-full;
+  }
+
+  .aa-DetachedSearchButton {
+    @apply rounded-sm border-gray-300 h-[34px];
+  }
+}
+
+.aa-SourceHeader {
+  @apply text-xs font-semibold;
+}
+
+.aa-DetachedFormContainer,
+.aa-DetachedContainer .aa-Panel {
+  @apply bg-gray-50 border-b-0;
+}
+
+.aa-Form {
+  &:focus-within {
+    @apply ring-0;
+  }
+
+  input {
+    @apply focus:ring-0;
+  }
+  &:focus-within {
+    .aa-InputWrapperPrefix{
+      .aa-SubmitButton {
+        @apply ring-0;
+      }
+    }
+  }
+}
+
+button.aa-DetachedCancelButton {
+  border: 1px solid #757D8A !important;
+  @apply bg-white;
+}
+
+.aa-Input {
+  @apply focus:ring-green-600;
+}
+
+.aa-DetachedContainer {
+  .aa-PanelLayout {
+    @apply pt-0 space-y-3;
+  }
+
+  .aa-Source {
+    .aa-List {
+      @apply space-y-2;
+
+      .aa-Item {
+        @apply bg-white rounded-sm px-3 py-4 shadow font-medium;
+
+        .aa-ItemDescription {
+          @apply text-gray-500 text-sm font-normal mt-1;
+        }
+
+        &[aria-selected=true]{
+          @apply bg-primary-500 text-white;
+
+          .aa-ItemDescription {
+            @apply text-white;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -1,0 +1,286 @@
+# Only used for searchable fields
+
+# This controller is currently only used for searchable fields, it keeps the old search controller without any changes
+# Possibly have much more logic that it uses, but it's not worth the effort to refactor it since we're going to replace it with a new searchable fields way
+
+require_dependency "avo/application_controller"
+
+module Avo
+  class SearchController < ApplicationController
+    include Rails.application.routes.url_helpers
+    include ActionView::Helpers::TextHelper
+
+    before_action :set_resource_name, only: :show
+    before_action :set_resource, only: :show
+
+    def show
+      render json: search_resources([resource], request:)
+    rescue => error
+      render_error error, _label: error.message
+    end
+
+    def process_results(results, request:)
+      results
+    end
+
+    private
+
+    def search_resources(resources, request: nil)
+      process_results search_results(resources, request:), request:
+    end
+
+    def search_results(resources, request: nil)
+      resources
+        .map do |resource|
+          # Apply authorization
+          next unless @authorization.set_record(resource.model_class).authorize_action(
+            :search,
+            policy_class: resource.authorization_policy,
+            raise_exception: false
+          )
+
+          search_resource resource
+        end
+        .select do |payload|
+          payload.present?
+        end
+        .sort_by do |payload|
+          payload.last[:count]
+        end
+        .reverse
+        .to_h
+    end
+
+    def search_resource(resource)
+      key = resource.name.pluralize.downcase
+
+      # If search query is not defined return error in dev and nil otwherwise.
+      if resource.search_query.blank?
+        return nil unless render_error?
+
+        search_query_undefined = error_payload(
+          header: "⚠️ Warning ⚠️",
+          help: "",
+          _label: "Search is disabled for #{resource}.\n To enable it please use this guide...",
+          _url: "https://docs.avohq.io/3.0/search.html#enable-search-for-a-resource"
+        )
+
+        return [key, search_query_undefined]
+      end
+
+      query = Avo::ExecutionContext.new(
+        target: resource.search_query,
+        params: params,
+        q: params[:q].strip,
+        query: resource.query_scope
+      ).handle
+
+      results_count, results = parse_results(query, resource)
+
+      header = resource.plural_name
+
+      if results_count > 0
+        header = "#{header} (#{results_count})"
+      end
+
+      result_object = {
+        header: header,
+        help: resource.fetch_search(:help) || "",
+        results: results,
+        count: results.count
+      }
+
+      [key, result_object]
+    end
+
+    # When searching in a `has_many` association and will scope out the records against the parent record.
+    # This is also used when looking for `belongs_to` associations, and this method applies the parents `attach_scope` if present.
+    def apply_scope(query)
+      if should_apply_has_many_scope?
+        apply_has_many_scope
+      elsif should_apply_attach_scope?
+        apply_attach_scope(query, parent)
+      end
+    end
+
+    # Parent passed as argument to be used as a variable instead of the method "def parent"
+    # Otherwise parent = params...safe_constantize... will try to call method "def parent="
+    def apply_attach_scope(query, parent)
+      # If the parent is nil it probably means that someone's creating the record so it's not attached yet.
+      # In these scenarios, try to find the grandparent for the new views where the parent is nil
+      # and initialize the parent record with the grandparent attached so the user has the required information
+      # to scope the query.
+      # Example usage: Got to a project, create a new review, and search for a user.
+      if parent.blank? && params[:via_parent_resource_id].present? && params[:via_parent_resource_class].present? && params[:via_relation].present?
+        parent_resource_class = BaseResource.get_model_by_name params[:via_parent_resource_class]
+
+        reflection_class = BaseResource.get_model_by_name params[:via_reflection_class]
+
+        grandparent = parent_resource_class.find params[:via_parent_resource_id]
+        parent = reflection_class.new(
+          params[:via_relation] => grandparent
+        )
+      end
+
+      Avo::ExecutionContext.new(target: attach_scope, query: query, parent: parent).handle
+    end
+
+    # This scope is applied if the search is being performed on a has_many association
+    def apply_has_many_scope
+      association_name = BaseResource.valid_association_name(parent, params[:via_association_id])
+
+      # Get association records
+      query = parent.send(association_name)
+
+      # Apply policy scope if authorization is present
+      query = resource.authorization&.apply_policy query
+
+      if field&.scope&.present?
+        query = Avo::ExecutionContext.new(target: field.scope, query:, parent:, resource:, parent_resource:).handle
+      end
+
+      Avo::ExecutionContext.new(target: @resource.class.search_query, params: params, query: query).handle
+    end
+
+    def apply_search_metadata(records, avo_resource)
+      records.map do |record|
+        resource = avo_resource.new(record: record)
+
+        fetch_result_information record, resource, resource.class.fetch_search(:item, record: record)
+      end
+    end
+
+    def fetch_result_information(record, resource, item)
+      title = item&.dig(:title) || resource.record_title
+      highlighted_title = highlight(title&.to_s, CGI.escapeHTML(params[:q] || ""))
+
+      record_path = if resource.link_to_child_resource
+        Avo.resource_manager.get_resource_by_model_class(record.class).new(record: record).record_path
+      else
+        resource.record_path
+      end
+
+      {
+        _id: record.to_param,
+        _label: highlighted_title,
+        _url: resource.class.fetch_search(:result_path, record: resource.record) || record_path
+      }
+    end
+
+    def should_apply_has_many_scope?
+      params[:via_association] == "has_many" && @resource.class.search_query.present?
+    end
+
+    def should_apply_attach_scope?
+      params[:via_association] == "belongs_to" && attach_scope.present?
+    end
+
+    def should_apply_any_scope?
+      should_apply_has_many_scope? || should_apply_attach_scope?
+    end
+
+    def attach_scope
+      @attach_scope ||= field&.attach_scope
+    end
+
+    def field
+      @field ||= fetch_field
+    end
+
+    def parent
+      @parent ||= fetch_parent
+    end
+
+    def fetch_field
+      return if params[:via_association_id].nil?
+
+      reflection_resource = parent_resource.new(
+        view: Avo::ViewInquirer.new(params[:via_reflection_view]),
+        record: parent,
+        params: params,
+        user: _current_user
+      )
+
+      reflection_resource.detect_fields.get_field(params[:via_association_id])
+    end
+
+    def fetch_parent
+      return unless params[:via_reflection_id].present?
+
+      parent_resource.find_record params[:via_reflection_id], params: params
+    end
+
+    def parent_resource
+      @parent_resource ||= Avo.resource_manager.get_resource_by_model_class(params[:via_reflection_class])
+    end
+
+    def render_error(error, ...)
+      raise error unless render_error?
+
+      render json: {
+        error: error_payload(...)
+      }, status: 500
+    end
+
+    def error_payload(
+      _label:,
+      _url: "",
+      header: "🚨 An error occurred during search 🚨",
+      help: "Please review and resolve the issue before deployment 🚨"
+    )
+      {
+        header:,
+        help:,
+        results: {
+          _label:,
+          _url:,
+          _error: true
+        },
+        count: 1
+      }
+    end
+
+    def search_results_count(resource)
+      if resource.search_results_count
+        Avo::ExecutionContext.new(
+          target: resource.search_results_count,
+          params: params
+        ).handle
+      else
+        Avo.configuration.search_results_count
+      end
+    end
+
+    def parse_results(query, resource)
+      # When using custom search services query should return an array of hashes
+      if query.is_a?(Array)
+        # Apply highlight
+        query.map do |result|
+          result[:_label] = highlight(result[:_label].to_s, CGI.escapeHTML(params[:q] || ""))
+        end
+
+        # Force count to 0 until implement an API to pass the count
+        results_count = 0
+
+        # Apply the limit
+        results = query.first(search_results_count(resource))
+      else
+        query = apply_scope(query) if should_apply_any_scope?
+
+        # Get the count
+        results_count = query.reselect(resource.model_class.primary_key).count
+
+        # Get the results
+        query = query.limit(search_results_count(resource))
+
+        results = apply_search_metadata(query, resource)
+      end
+
+      [results_count, results]
+    end
+
+    def render_error?
+      Rails.env.development?
+    end
+  end
+end

--- a/app/javascript/js/controllers.js
+++ b/app/javascript/js/controllers.js
@@ -52,6 +52,7 @@ import TiptapFieldController from './controllers/fields/tiptap_field_controller'
 import ToggleController from './controllers/toggle_controller'
 import TrixBodyController from './controllers/trix_body_controller'
 import TrixFieldController from './controllers/fields/trix_field_controller'
+import SearchController from './controllers/search_controller'
 
 application.register('action', ActionController)
 application.register('actions-overflow', ActionsOverflowController)
@@ -95,6 +96,7 @@ application.register('text-filter', TextFilterController)
 application.register('tippy', TippyController)
 application.register('toggle', ToggleController)
 application.register('trix-body', TrixBodyController)
+application.register('search', SearchController)
 
 // Field controllers
 application.register('belongs-to-field', BelongsToFieldController)

--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -1,0 +1,323 @@
+// Only used for searchable fields
+
+// This controller is currently only used for searchable fields, it keeps the old search controller without any changes
+// Possibly have much more logic that it uses, but it's not worth the effort to refactor it since we're going to replace it with a new searchable fields way
+
+/* eslint-disable no-underscore-dangle */
+import * as Mousetrap from 'mousetrap'
+import { Controller } from '@hotwired/stimulus'
+import { Turbo } from '@hotwired/turbo-rails'
+import { autocomplete } from '@algolia/autocomplete-js'
+import DOMPurify from 'dompurify'
+import URI from 'urijs'
+import debouncePromise from '../helpers/debounce_promise'
+
+/**
+ * The search controller is used in three places.
+ * 1. Resource search (on the Index page on top of the table panel) and will search one resource
+ * 2. belongs_to field. This requires a bit more cleanup because the user will not navigate away from the page.
+ * It will replace the id and label in some fields on the page and also needs a "clear" button which clears the information so the user can submit the form without a value.
+ */
+export default class extends Controller {
+  static targets = [
+    'autocomplete',
+    'button',
+    'hiddenId',
+    'visibleLabel',
+    'clearValue',
+    'clearButton',
+  ]
+
+  static values = {
+    extraParams: Object,
+  }
+
+  debouncedFetch = debouncePromise(fetch, this.searchDebounce)
+
+  destroyMethod
+
+  get dataset() {
+    return this.autocompleteTarget.dataset
+  }
+
+  get searchDebounce() {
+    return window.Avo.configuration.search_debounce
+  }
+
+  get translationKeys() {
+    let keys
+    try {
+      keys = JSON.parse(this.dataset.translationKeys)
+    } catch (error) {
+      keys = {}
+    }
+
+    return keys
+  }
+
+  get isBelongsToSearch() {
+    return this.dataset.viaAssociation === 'belongs_to'
+  }
+
+  get isHasManySearch() {
+    return this.dataset.viaAssociation === 'has_many'
+  }
+
+  connect() {
+    console.log('search controller connected')
+    const that = this
+
+    this.buttonTarget.onclick = () => this.showSearchPanel()
+
+    this.clearValueTargets.forEach((target) => {
+      if (target.getAttribute('value') && this.hasClearButtonTarget) {
+        this.clearButtonTarget.classList.remove('hidden')
+      }
+    })
+
+    // This line fixes a bug where the search box would be duplicated on back navigation.
+    this.autocompleteTarget.innerHTML = ''
+
+    const { destroy } = autocomplete({
+      container: this.autocompleteTarget,
+      placeholder: this.translationKeys.placeholder,
+      translations: {
+        detachedCancelButtonText: this.translationKeys.cancel_button,
+      },
+      autoFocus: true,
+      openOnFocus: true,
+      detachedMediaQuery: '',
+      onStateChange({ prevState, state }) {
+        // If is closed and was open clear query value
+        if (!state.isOpen && prevState.isOpen) {
+          state.query = ''
+        }
+      },
+      getSources: ({ query }) => {
+        document.body.classList.add('search-loading')
+        const endpoint = that.searchUrl(query)
+
+        return that
+          .debouncedFetch(endpoint)
+          .then((response) => {
+            document.body.classList.remove('search-loading')
+
+            return response.json()
+          })
+          .then((data) => Object.keys(data).map((resourceName) => that.addSource(resourceName, data[resourceName])))
+      },
+    })
+
+    // document.addEventListener('turbo:before-render', destroy)
+    this.destroyMethod = destroy
+
+    // When using search for belongs-to
+    if (this.buttonTarget.dataset.shouldBeDisabled !== 'true') {
+      this.buttonTarget.removeAttribute('disabled')
+    }
+  }
+
+  disconnect() {
+    // Don't leave open autocompletes around when disconnected. Otherwise it will still
+    // be visible when navigating back to this page.
+    if (this.destroyMethod) {
+      this.destroyMethod()
+      this.destroyMethod = null
+    }
+  }
+
+  addSource(resourceName, data) {
+    const that = this
+
+    return {
+      sourceId: resourceName,
+      getItems: () => data.results,
+      onSelect: that.handleOnSelect.bind(that),
+      templates: {
+        header() {
+          return `${data.header.toUpperCase()} ${data.help}`
+        },
+        item({ item, createElement }) {
+          const children = []
+
+          if (item._avatar) {
+            let classes
+
+            switch (item._avatar_type) {
+              default:
+              case 'circle':
+                classes = 'rounded-full'
+                break
+              case 'rounded':
+                classes = 'rounded-sm'
+                break
+              case 'square':
+                classes = 'rounded-none'
+                break
+            }
+
+            children.push(
+              createElement('img', {
+                src: item._avatar,
+                alt: item._label,
+                class: `shrink-0 w-8 h-8 my-[2px] inline mr-2 ${classes}`,
+              }),
+            )
+          }
+
+          const label = DOMPurify.sanitize(item._label)
+
+          const labelChildren = [
+            createElement(
+              'div',
+              {
+                dangerouslySetInnerHTML: { __html: label },
+              },
+              label,
+            ),
+          ]
+
+          if (item._description) {
+            const description = DOMPurify.sanitize(item._description)
+
+            labelChildren.push(
+              createElement(
+                'div',
+                {
+                  class: 'aa-ItemDescription',
+                  dangerouslySetInnerHTML: { __html: description },
+                },
+                description,
+              ),
+            )
+          }
+
+          children.push(createElement('div', null, labelChildren))
+
+          return createElement(
+            'div',
+            {
+              class: 'flex',
+            },
+            children,
+          )
+        },
+        noResults() {
+          return that.translationKeys.no_item_found.replace(
+            '%{item}',
+            resourceName,
+          )
+        },
+      },
+    }
+  }
+
+  handleOnSelect({ item }) {
+    if (this.isBelongsToSearch && !item._error) {
+      this.updateFieldAttribute(this.hiddenIdTarget, 'value', item._id)
+      this.updateFieldAttribute(this.buttonTarget, 'value', this.removeHTMLTags(item._label))
+
+      if (this.hasClearButtonTarget) {
+        this.clearButtonTarget.classList.remove('hidden')
+      }
+    } else {
+      Turbo.visit(item._url, { action: 'advance' })
+    }
+
+    // On searchable belongs to the class `aa-Detached` remains on the body making it unscrollable
+    document.body.classList.remove('aa-Detached')
+  }
+
+  searchUrl(query) {
+    const url = URI()
+
+    return url.segment([window.Avo.configuration.root_path, ...this.searchSegments()])
+      .search(this.searchParams(encodeURIComponent(query)))
+      .readable().toString()
+  }
+
+  searchSegments() {
+    let segments = [
+      'avo_api',
+      this.dataset.searchResource,
+      'search',
+    ]
+
+    return segments
+  }
+
+  searchParams(query) {
+    let params = {
+      ...Object.fromEntries(new URLSearchParams(window.location.search)),
+      q: query,
+      ...this.extraParamsValue,
+    }
+
+    if (this.isBelongsToSearch || this.isHasManySearch) {
+      params = this.addAssociationParams(params)
+      params = this.addReflectionParams(params)
+
+      if (this.isBelongsToSearch) {
+        params = {
+          ...params,
+          // eslint-disable-next-line camelcase
+          via_parent_resource_id: this.dataset.viaParentResourceId,
+          // eslint-disable-next-line camelcase
+          via_parent_resource_class: this.dataset.viaParentResourceClass,
+          // eslint-disable-next-line camelcase
+          via_relation: this.dataset.viaRelation,
+        }
+      }
+    }
+
+    return params
+  }
+
+  addAssociationParams(params) {
+    params = {
+      ...params,
+      // eslint-disable-next-line camelcase
+      via_association: this.dataset.viaAssociation,
+      // eslint-disable-next-line camelcase
+      via_association_id: this.dataset.viaAssociationId,
+    }
+
+    return params
+  }
+
+  addReflectionParams(params) {
+    params = {
+      ...params,
+      // eslint-disable-next-line camelcase
+      via_reflection_class: this.dataset.viaReflectionClass,
+      // eslint-disable-next-line camelcase
+      via_reflection_id: this.dataset.viaReflectionId,
+      // eslint-disable-next-line camelcase
+      via_reflection_view: this.dataset.viaReflectionView,
+    }
+
+    return params
+  }
+
+  showSearchPanel() {
+    this.autocompleteTarget.querySelector('button').click()
+  }
+
+  clearValue() {
+    this.clearValueTargets.map((target) => this.updateFieldAttribute(target, 'value', ''))
+    this.clearButtonTarget.classList.add('hidden')
+  }
+
+  // Private
+
+  updateFieldAttribute(target, attribute, value) {
+    target.setAttribute(attribute, value)
+    target.dispatchEvent(new Event('input'))
+  }
+
+  removeHTMLTags(str) {
+    const doc = new DOMParser().parseFromString(str, 'text/html')
+
+    return doc.body.textContent || ''
+  }
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Avo::Engine.routes.draw do
   post "/rails/active_storage/direct_uploads", to: "/active_storage/direct_uploads#create"
 
   scope "avo_api", as: "avo_api" do
+    # Only used for searchable fields
+    get "/:resource_name/search", to: "search#show"
     post "/resources/:resource_name/:id/attachments/", to: "attachments#create"
   end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I broke searchable fields by removing the search-related controllers here: https://github.com/avo-hq/avo/pull/3712

I reverted those controllers just to keep the searchable fields working until we migrate to an alternative for searchable fields.
