### PR TITLE
rename `no_confirmation` action option to `confirmation`

### DIFF
--- a/app/javascript/js/controllers/action_controller.js
+++ b/app/javascript/js/controllers/action_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
   static targets = ['resourceIds', 'form', 'selectedAll', 'indexQuery']
 
   static values = {
-    noConfirmation: Boolean,
+    confirmation: Boolean,
     resourceName: String,
   }
 
@@ -21,10 +21,10 @@ export default class extends Controller {
       this.indexQueryTarget.value = this.selectionOptions.itemSelectAllSelectedAllQueryValue
     }
 
-    if (this.noConfirmationValue) {
-      this.formTarget.requestSubmit()
-    } else {
+    if (this.confirmationValue) {
       this.element.classList.remove('hidden')
+    } else {
+      this.formTarget.requestSubmit()
     }
   }
 

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -5,7 +5,7 @@
 <%= turbo_frame_tag Avo::MODAL_FRAME_ID do %>
   <div
     data-controller="<%= ["action", @action.get_stimulus_controllers].join(" ") %>"
-    data-action-no-confirmation-value="<%= @action.no_confirmation? %>"
+    data-action-confirmation-value="<%= @action.confirmation? %>"
     data-action-resource-name-value="<%= @resource.model_key %>"
     data-resource-id="<%= params[:id] %>"
     class="hidden text-slate-800"

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -12,7 +12,7 @@ module Avo
     class_attribute :message
     class_attribute :confirm_button_label
     class_attribute :cancel_button_label
-    class_attribute :no_confirmation, default: false
+    class_attribute :confirmation, default: true
     class_attribute :standalone, default: false
     class_attribute :visible, default: -> {
       # Hide on the :new view by default
@@ -372,9 +372,9 @@ module Avo
       !enabled?
     end
 
-    def no_confirmation?
+    def confirmation?
       Avo::ExecutionContext.new(
-        target: no_confirmation,
+        target: confirmation,
         action: self,
         resource: @resource,
         view: @view,

--- a/spec/dummy/app/avo/actions/export_csv.rb
+++ b/spec/dummy/app/avo/actions/export_csv.rb
@@ -2,7 +2,7 @@ require "csv"
 
 class Avo::Actions::ExportCsv < Avo::BaseAction
   self.name = "Export CSV"
-  self.no_confirmation = false
+  self.confirmation = true
   self.standalone = true
   self.close_modal_on_backdrop_click = false
 

--- a/spec/dummy/app/avo/actions/test/no_confirmation_posts_redirect.rb
+++ b/spec/dummy/app/avo/actions/test/no_confirmation_posts_redirect.rb
@@ -1,6 +1,6 @@
 class Avo::Actions::Test::NoConfirmationPostsRedirect < Avo::BaseAction
   self.name = "Redirect to Posts"
-  self.no_confirmation = true
+  self.confirmation = false
   self.standalone = true
 
   def handle(**args)

--- a/spec/dummy/app/avo/actions/test/no_confirmation_redirect.rb
+++ b/spec/dummy/app/avo/actions/test/no_confirmation_redirect.rb
@@ -1,6 +1,6 @@
 class Avo::Actions::Test::NoConfirmationRedirect < Avo::BaseAction
   self.name = "Test No Confirmation Redirect"
-  self.no_confirmation = true
+  self.confirmation = false
   self.standalone = true
 
   def handle(**args)

--- a/spec/dummy/app/avo/actions/toggle_admin.rb
+++ b/spec/dummy/app/avo/actions/toggle_admin.rb
@@ -1,6 +1,6 @@
 class Avo::Actions::ToggleAdmin < Avo::BaseAction
   self.name = "Toggle admin"
-  self.no_confirmation = true
+  self.confirmation = false
   self.visible = -> {
     # puts ["view->", view].inspect
     # view.edit?

--- a/spec/dummy/app/avo/actions/toggle_published.rb
+++ b/spec/dummy/app/avo/actions/toggle_published.rb
@@ -3,7 +3,7 @@ class Avo::Actions::TogglePublished < Avo::BaseAction
   self.message = "Are you sure, sure?"
   self.confirm_button_label = "Toggle"
   self.cancel_button_label = "Don't toggle yet"
-  self.no_confirmation = -> { arguments[:no_confirmation] || false }
+  self.confirmation = -> { arguments.key?(:confirmation) ? arguments[:confirmation] : true }
 
   def fields
     field :notify_user, as: :boolean, default: true

--- a/spec/dummy/app/avo/resources/post.rb
+++ b/spec/dummy/app/avo/resources/post.rb
@@ -43,7 +43,7 @@ class Avo::Resources::Post < Avo::BaseResource
           resource: resource,
           arguments: {
             records: Array.wrap(record.id),
-            no_confirmation: true
+            confirmation: false
           }
         )
       },


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Rename `no_confirmation` action option to `confirmation`