### PR TITLE
set sensible db names for dummy app

### DIFF
--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -9,12 +9,12 @@ default: &default
 
 development:
   <<: *default
-  database: dummy_3_development
+  database: avo_dummy_development
 
 test:
   <<: *default
-  database: dummy_3_test
+  database: avo_dummy_test
 
 production:
   <<: *default
-  database: dummy_3_development
+  database: avo_dummy_production


### PR DESCRIPTION
# Description

I updated the names of the databases that are created in the dummy app from "dummy_3_(dev|test)" to "avo_dummy_(dev|test|prod)".

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works