### PR TITLE
[AVO-597] Boolean field: optional toggle UI

### DIFF
--- a/app/components/avo/fields/boolean_field/edit_component.html.erb
+++ b/app/components/avo/fields/boolean_field/edit_component.html.erb
@@ -21,6 +21,7 @@
         </div>
       </label>
       <script>
+        //event listener to the rails checkbox to update the visual toggle
         document.getElementById('<%= @field.id %>_checkbox').addEventListener('change', function(e) {
           const track = document.querySelector('label[for="<%= @field.id %>_checkbox"] .toggle-track');
           const circle = document.querySelector('label[for="<%= @field.id %>_checkbox"] .toggle-circle');

--- a/app/components/avo/fields/boolean_field/edit_component.html.erb
+++ b/app/components/avo/fields/boolean_field/edit_component.html.erb
@@ -1,13 +1,48 @@
 <%= field_wrapper(**field_wrapper_args) do %>
   <div class="h-8 flex items-center">
-    <%= @form.check_box @field.id,
-      value: @field.value,
-      checked: @field.value,
-      class: "text-lg h-4 w-4 checked:bg-primary-400 focus:checked:!bg-primary-400 rounded #{@field.get_html(:classes, view: view, element: :input)}",
-      data: @field.get_html(:data, view: view, element: :input),
-      disabled: disabled?,
-      autofocus: @autofocus,
-      style: @field.get_html(:style, view: view, element: :input)
-    %>
+    <% if @field.instance_variable_get(:@args)&.dig(:as_toggle) %>
+      <%= @form.check_box @field.id, 
+          value: @field.value, 
+          checked: @field.value, 
+          class: "sr-only", 
+          data: @field.get_html(:data, view: view, element: :input), 
+          disabled: disabled?, 
+          autofocus: @autofocus,
+          id: "#{@field.id}_checkbox" %>
+      
+      <!-- toggle switch -->
+      <label for="<%= @field.id %>_checkbox" class="relative inline-flex items-center cursor-pointer <%= 'cursor-not-allowed opacity-50' if disabled? %>">
+        <!-- toggle track -->
+        <div class="toggle-track relative w-11 h-6 rounded-full transition-all duration-200" 
+             style="background-color: <%= @field.value ? '#3b82f6' : '#d1d5db' %>;">
+          <!-- toggle circle -->
+          <div class="toggle-circle absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform duration-200 shadow-sm"
+               style="transform: translateX(<%= @field.value ? '20px' : '0px' %>);"></div>
+        </div>
+      </label>
+      <script>
+        document.getElementById('<%= @field.id %>_checkbox').addEventListener('change', function(e) {
+          const track = document.querySelector('label[for="<%= @field.id %>_checkbox"] .toggle-track');
+          const circle = document.querySelector('label[for="<%= @field.id %>_checkbox"] .toggle-circle');
+          
+          if (this.checked) {
+            track.style.backgroundColor = '#3b82f6';
+            circle.style.transform = 'translateX(20px)';
+          } else {
+            track.style.backgroundColor = '#d1d5db';
+            circle.style.transform = 'translateX(0px)';
+          }
+        });
+      </script>
+    <% else %>
+      <%= @form.check_box @field.id, 
+          value: @field.value, 
+          checked: @field.value, 
+          class: "text-lg h-4 w-4 checked:bg-primary-400 focus:checked:!bg-primary-400 rounded #{@field.get_html(:classes, view: view, element: :input)}", 
+          data: @field.get_html(:data, view: view, element: :input), 
+          disabled: disabled?, 
+          autofocus: @autofocus, 
+          style: @field.get_html(:style, view: view, element: :input) %>
+    <% end %>
   </div>
 <% end %>

--- a/spec/dummy/app/avo/resources/course.rb
+++ b/spec/dummy/app/avo/resources/course.rb
@@ -45,7 +45,7 @@ class Avo::Resources::Course < Avo::BaseResource
     }
 
     panel do
-      field :has_skills, as: :boolean, filterable: true, html: -> do
+      field :has_skills, as: :boolean, as_toggle: true, filterable: true, html: -> do
         edit do
           input do
             # classes('block')


### PR DESCRIPTION
# Description

Hey, I worked on the issue, this PR adds an opt-in toggle-switch UI for boolean fields in Avo. When a field is declared with as_toggle: true, the standard checkbox is rendered as an accessible toggle with a sliding thumb and animated track. The default behaviour remains unchanged—boolean fields still render as checkboxes unless explicitly opted in. The change is fully backward-compatible.

Fixes #3960 

No new dependencies are introduced.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
![Screen Recording 2025-08-12 at 12 07 00 PM (1)](https://github.com/user-attachments/assets/53a771dd-863c-42d4-90d7-0e745dd43b90)

## Manual review steps

1. Add a boolean field to a resource with the as_toggle: true option, e.g.:
`field :has_skills, as: :boolean, as_toggle: true, filterable: true`

2. Open the New and Edit pages for that resource in the admin panel and verify the field renders as a toggle switch instead of a checkbox.

3. Check the toggle to see if you can use it properly.

Let me know if there is anything I am missing out on and if it can be improved. Thanks. 

