### PR TITLE
fix: already initialized constant on array resources

### DIFF
--- a/lib/avo/resources/array_resource.rb
+++ b/lib/avo/resources/array_resource.rb
@@ -80,6 +80,8 @@ module Avo
           # Dynamically create a class with accessors for all unique keys from the records
           keys = array_of_records.flat_map(&:keys).uniq
 
+          Avo.send(:remove_const, class_name) if Avo.const_defined?(class_name, false)
+
           Avo.const_set(
             class_name,
             Class.new do


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes `/avo/lib/avo/resources/array_resource.rb:83: warning: already initialized constant Avo::Attendee`