### PR TITLE
fix: attach scope

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -114,19 +114,19 @@ module Avo
         grandparent = parent_resource_class.find params[:via_parent_resource_id]
         parent = reflection_class.new
 
-        # Whitelist allowed relations to prevent code injection
         via_relation = params[:via_relation].to_s
-        unless reflection_class.reflections.keys.map(&:to_s).include?(via_relation)
-          raise ArgumentError, "Invalid relation name: #{via_relation}"
-        end
-
-        # Verify if the relation is a collection proxy
-        # If it is, add the grandparent to the collection
-        # If it is not, set the grandparent as the parent of the relation
-        if parent.public_send(via_relation).is_a?(ActiveRecord::Associations::CollectionProxy)
-          parent.public_send(via_relation) << grandparent
+        # Whitelist allowed relations to prevent code injection
+        if reflection_class.reflections.keys.map(&:to_s).include?(via_relation)
+          # Verify if the relation is a collection proxy
+          # If it is, add the grandparent to the collection
+          # If it is not, set the grandparent as the parent of the relation
+          if parent.public_send(via_relation).is_a?(ActiveRecord::Associations::CollectionProxy)
+            parent.public_send(via_relation) << grandparent
+          else
+            parent.public_send(:"#{via_relation}=", grandparent)
+          end
         else
-          parent.public_send(:"#{via_relation}=", grandparent)
+          raise ArgumentError, "Invalid relation name: #{via_relation}"
         end
       end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #4028

`apply_attach_scope` on the `Avo::SearchController` was assuming a nested association chain like

User -> Create new Workspace -> Search for an Organization to attach to the workspace

In the above scenario, when creating a new workspace to hydrate the attach scope with a parent, the code was assuming that the workspace and user association was always a belongs to or has one. When the association is a collection, it breaks. This PR changes it by checking the parent and grandparent association type before assigning the grandparent to the parent record.

---

Thanks for the detailed issue and reproduction repository @icaroryan, that made my intervention in finding and fixing the bug really productive!
