### PR TITLE
fix: fail to load frame

### DIFF
--- a/app/javascript/avo.base.js
+++ b/app/javascript/avo.base.js
@@ -124,6 +124,8 @@ document.addEventListener('turbo:before-fetch-response', async (e) => {
     // Don't try to redirect to failed to load if this is already a redirection to failed to load and crashed somewhere.
     // You'll end up with a request loop.
     if (!e.detail.fetchResponse?.response?.url?.includes('/failed_to_load')) {
+      e.target.removeAttribute('loading')
+
       e.target.src = `${window.Avo.configuration.root_path}/failed_to_load?turbo_frame=${id}&src=${src}`
     }
   }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The fail to load mechanism to pretty render some messages when an error is raised within a turbo frame has been broken for a while now and we noticed it recently.

The issue is related to this [hotwire issue](https://github.com/hotwired/turbo/issues/886) that is familiar to Avo since we fixed another similar issue a while ago with the fix found on that issue.

<img width="1552" height="672" alt="image" src="https://github.com/user-attachments/assets/ef802e8e-1d71-4c1c-9fc2-60c8b777eeb2" />
