### PR TITLE
chore: revert debug code in the `render_error?` method

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -289,8 +289,6 @@ module Avo
 
     def render_error?
       Rails.env.development?
-
-      false
     end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I left a debug piece of code by mistake in the `render_error?` method. This PR removes it.
