### PR TITLE
fix: frame id when using `use_resource`

### DIFF
--- a/lib/avo/fields/frame_base_field.rb
+++ b/lib/avo/fields/frame_base_field.rb
@@ -20,7 +20,7 @@ module Avo
       end
 
       def turbo_frame
-        "#{self.class.name.demodulize.to_s.underscore}_show_#{frame_id}"
+        "#{self.class.name.demodulize.to_s.underscore}_show_#{@id}"
       end
 
       def frame_url(add_turbo_frame: true)
@@ -118,10 +118,6 @@ module Avo
       end
 
       private
-
-      def frame_id
-        @id
-      end
 
       def default_view
         Avo.configuration.skip_show_view ? :edit : :show

--- a/spec/system/avo/use_resource_spec.rb
+++ b/spec/system/avo/use_resource_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Post comments use_resource PhotoComment", type: :system do
     it "if attach persist" do
       visit avo.resources_post_path(post)
 
-      scroll_to find('turbo-frame[id="has_many_field_show_photo_comments"]')
+      scroll_to find('turbo-frame[id="has_many_field_show_comments"]')
 
       click_on "Attach photo comment"
 


### PR DESCRIPTION
# Description

Fixes #4037

The frame id of a has_many field was using the resource specified in `use_resource`. But when using two fields with the same `use_resource`, for example:

```ruby
tabs do
  tab "Links odd" do
    field :links_odd, as: :has_many, for_attribute: :links,
      discreet_pagination: true,
      scope: -> { query.odd },
      use_resource: Avo::Resources::CourseLink
  end
  tab "Links even" do
    field :links_even, as: :has_many, for_attribute: :links,
      discreet_pagination: true,
      scope: -> { query.even },
      use_resource: Avo::Resources::CourseLink
  end
end
 ```

For both fields the same frame id would be used, which breaks a bunch of functionalities. This PR fixes it to always use the field id instead of the provided resource.