### PR TITLE
Drop disabled_features and add navigation section toggle

### DIFF
--- a/app/javascript/js/controllers/sidebar_controller.js
+++ b/app/javascript/js/controllers/sidebar_controller.js
@@ -56,7 +56,7 @@ export default class extends Controller {
     this.attachScrollVisibilityAnchor()
 
     // Restore sidebar scroll position
-    if (this.sidebarScrollPosition && window.Avo.configuration.preserve_sidebar_scroll) {
+    if (this.sidebarScrollPosition) {
       document.querySelector('.avo-sidebar .mac-styled-scrollbar').scrollTo({
         top: this.sidebarScrollPosition,
         behavior: 'instant',
@@ -77,9 +77,7 @@ export default class extends Controller {
   }
 
   attachScrollVisibilityAnchor() {
-    if (window.Avo.configuration.focus_sidebar_menu_item) {
-      scrollSidebarMenuItemIntoView()
-    }
+    scrollSidebarMenuItemIntoView()
   }
 
   toggleSidebar() {

--- a/app/views/avo/partials/_javascript.html.erb
+++ b/app/views/avo/partials/_javascript.html.erb
@@ -4,8 +4,6 @@
   Avo.configuration.root_path = '<%= root_path_without_url %>'
   Avo.configuration.search_debounce = '<%= Avo.configuration.search_debounce %>'
   Avo.configuration.cookies_key = '<%= Avo::COOKIES_KEY %>'
-  Avo.configuration.preserve_sidebar_scroll = '<%= ::Avo.configuration.feature_enabled?(:preserve_sidebar_scroll) %>'
-  Avo.configuration.focus_sidebar_menu_item = '<%= ::Avo.configuration.feature_enabled?(:focus_sidebar_menu_item) %>'
   <% if Avo.avo_dynamic_filters_installed? %>
   Avo.configuration.avo_filters = {
     param_key: '<%= Avo::DynamicFilters.configuration.param_key %>'

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -36,7 +36,7 @@ module Avo
     attr_accessor :display_license_request_timeout_error
     attr_accessor :current_user_resource_name
     attr_accessor :raise_error_on_missing_policy
-    attr_writer :disabled_features
+    attr_accessor :global_search
     attr_accessor :buttons_on_form_footers
     attr_accessor :main_menu
     attr_accessor :profile_menu
@@ -102,7 +102,6 @@ module Avo
       @display_license_request_timeout_error = true
       @current_user_resource_name = "user"
       @raise_error_on_missing_policy = false
-      @disabled_features = []
       @buttons_on_form_footers = false
       @main_menu = nil
       @profile_menu = nil
@@ -129,6 +128,10 @@ module Avo
       @column_types_mapping = {}
       @resource_row_controls_config = {}
       @clear_license_response_on_deploy = true
+      @global_search = {
+        enabled: true,
+        navigation_section: true
+      }
     end
 
     unless defined?(RESOURCE_ROW_CONTROLS_CONFIG_DEFAULTS)
@@ -181,14 +184,6 @@ module Avo
       return "" if @root_path === "/"
 
       @root_path
-    end
-
-    def disabled_features
-      Avo::ExecutionContext.new(target: @disabled_features).handle
-    end
-
-    def feature_enabled?(feature)
-      !disabled_features.map(&:to_sym).include?(feature.to_sym)
     end
 
     def branding

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -111,7 +111,6 @@ Avo.configure do |config|
   # config.search_debounce = 300
   # config.view_component_path = "app/components"
   # config.display_license_request_timeout_error = true
-  # config.disabled_features = []
   # config.buttons_on_form_footers = true
   # config.field_wrapper_layout = true
   # config.resource_parent_controller = "Avo::ResourcesController"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

`disabled_features` has been around for more than 4 years, and we only used it for `global_search`. Recently, Adrian added uses for it with `focus_sidebar_menu_item` and `preserve_sidebar_scroll`. I just noticed it's not even documented, and the behavior these options control is actually a good UX improvement, so I'm not sure why anyone would want to turn them off.  

For that reason, we're dropping support for `disabled_features`. This comes after I added a new global search configuration and realized that global search should have a dedicated configuration that wraps both the new option, the enable toggle, and any future options.

```ruby
Avo.configure do |config|
  config.global_search = {
    enabled: true,
    navigation_section: true,
  }
end
```