### PR TITLE
Join paths resiliently

### DIFF
--- a/lib/generators/avo/templates/tool/sidebar_item.tt
+++ b/lib/generators/avo/templates/tool/sidebar_item.tt
@@ -1,1 +1,1 @@
-<%%= render Avo::Sidebar::LinkComponent.new label: '<%= human_name %>', path: "#{avo.root_path}<%= file_name %>" %>
+<%%= render Avo::Sidebar::LinkComponent.new label: '<%= human_name %>', path: File.join(avo.root_path, "<%= file_name %>") %>

--- a/spec/dummy/app/views/avo/sidebar/items/_custom_tool.html.erb
+++ b/spec/dummy/app/views/avo/sidebar/items/_custom_tool.html.erb
@@ -1,1 +1,1 @@
-<%= render Avo::Sidebar::LinkComponent.new label: 'Custom tool', path: "#{avo.root_path}custom_tool" %>
+<%= render Avo::Sidebar::LinkComponent.new label: 'Custom tool', path: File.join(avo.root_path, "custom_tool") %>


### PR DESCRIPTION
# Description

I was irritated by avo-generated templates: What if there is no slash in the root path. So I propose to join paths a bit more verbosely.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works