### PR TITLE
remove `preload: true`, since it's the default

### DIFF
--- a/lib/generators/avo/js/install_generator.rb
+++ b/lib/generators/avo/js/install_generator.rb
@@ -38,7 +38,7 @@ module Generators
 
             # pin to importmap
             say "Pin the new entrypoint to your importmap config"
-            append_to_file Rails.root.join("config", "importmap.rb"), "\n# Avo custom JS entrypoint\npin \"avo.custom\", preload: true\n"
+            append_to_file Rails.root.join("config", "importmap.rb"), "\n# Avo custom JS entrypoint\npin \"avo.custom\"\n"
           end
 
           def install_for_esbuild


### PR DESCRIPTION
The `preload` param can be removed, since "true" is the default value.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works