### PR TITLE
fix: searchable on custom associations

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -115,6 +115,7 @@ module Avo
         parent = reflection_class.new
 
         via_relation = params[:via_relation].to_s
+
         # Whitelist allowed relations to prevent code injection
         if reflection_class.reflections.keys.map(&:to_s).include?(via_relation)
           # Verify if the relation is a collection proxy
@@ -125,8 +126,10 @@ module Avo
           else
             parent.public_send(:"#{via_relation}=", grandparent)
           end
-        else
-          raise ArgumentError, "Invalid relation name: #{via_relation}"
+        # else
+          # There are some cases where the relation is not in the whitelist
+          # Don't raise an error in these cases since it could be a custom relation or a delegation
+          # raise ArgumentError, "Invalid relation name: #{via_relation}"
         end
       end
 
@@ -288,7 +291,7 @@ module Avo
     end
 
     def render_error?
-      Rails.env.development?
+      false
     end
   end
 end

--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -291,7 +291,7 @@ module Avo
     end
 
     def render_error?
-      false
+      Rails.env.development?
     end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #4057

[This PR](https://github.com/avo-hq/avo/issues/4029) introduced a strict whitelist validation on associations during search. However, some associations are more complex and work through delegation. In those cases, the delegation cannot be found in the model's reflections. This PR removes the strict verification by eliminating the error raise.
