### PR TITLE
fix: disabled clear button on date fields

### DIFF
--- a/app/components/avo/fields/date_time_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_time_field/edit_component.html.erb
@@ -37,10 +37,11 @@
       style: @field.get_html(:style, view: view, element: :input)
     %>
     <%= content_tag :button,
-      class: "absolute right-0 self-center mr-4 uppercase font-semibold text-xs",
+      class: "absolute right-0 self-center mr-4 uppercase font-semibold text-xs disabled:cursor-not-allowed disabled:opacity-50",
       id: :reset,
       type: :button,
       title: t("avo.reset").capitalize,
+      disabled: disabled?,
       data: {
         action: "click->date-field#clear",
         tippy: :tooltip

--- a/app/components/avo/fields/time_field/edit_component.html.erb
+++ b/app/components/avo/fields/time_field/edit_component.html.erb
@@ -37,10 +37,11 @@
       style: @field.get_html(:style, view: view, element: :input)
     %>
     <%= content_tag :button,
-      class: "absolute right-0 self-center mr-4 uppercase font-semibold text-xs",
+      class: "absolute right-0 self-center mr-4 uppercase font-semibold text-xs disabled:cursor-not-allowed disabled:opacity-50",
       id: :reset,
       type: :button,
       title: t("avo.reset").capitalize,
+      disabled: disabled?,
       data: {
         action: "click->date-field#clear",
         tippy: :tooltip


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #4058

Add disabled state to the clear button for `date` and `date_time` fields.
