### PR TITLE
Resolve herb crash

### DIFF
--- a/app/components/avo/panel_component.html.erb
+++ b/app/components/avo/panel_component.html.erb
@@ -20,9 +20,9 @@
     <% end %>
   <% end %>
   <% if body? %>
-    <div data-target="panel-body" class="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:gap-4 w-full <% if sidebar? %> has-sidebar <% end %>">
-      <div class="relative flex-1 w-full <% if sidebar? %> sm:w-2/3 <% end %>">
-        <% # The body is wrapped inside another div in order to avoid long & tall panels next to sidebars when the sidebar taller. %>
+    <div data-target="panel-body" class="<%= class_names("flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:gap-4 w-full", "has-sidebar": sidebar?) %>">
+      <div class="<%= class_names("relative flex-1 w-full", "sm:w-2/3": sidebar?) %>">
+        <%# The body is wrapped inside another div in order to avoid long & tall panels next to sidebars when the sidebar taller. %>
         <div class="relative <%= white_panel_classes %> <%= @body_classes %>">
           <%= body %>
         </div>

--- a/app/components/avo/turbo_frame_wrapper_component.html.erb
+++ b/app/components/avo/turbo_frame_wrapper_component.html.erb
@@ -1,10 +1,13 @@
-<% if @name.present? %><turbo-frame id="<%= @name %>"><% end %>
-<%
-  # When rendering the frames the flashed content gets lost.
-  # We're appending it back if it's a turbo_frame_request.
-%>
-<% if helpers.turbo_frame_request? %>
-  <%= helpers.turbo_stream_action_tag :append, target: "alerts", template: render(Avo::FlashAlertsComponent.new(flashes: helpers.flash)) %>
+<% if @name.present? %>
+  <turbo-frame id="<%= @name %>">
+    <% if helpers.turbo_frame_request? %>
+      <%= helpers.turbo_stream_action_tag :append, target: "alerts", template: render(Avo::FlashAlertsComponent.new(flashes: helpers.flash)) %>
+    <% end %>
+    <%= content %>
+  </turbo-frame>
+<% else %>
+  <% if helpers.turbo_frame_request? %>
+    <%= helpers.turbo_stream_action_tag :append, target: "alerts", template: render(Avo::FlashAlertsComponent.new(flashes: helpers.flash)) %>
+  <% end %>
+  <%= content %>
 <% end %>
-<%= content %>
-<% if @name.present? %></turbo-frame><% end %>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

While trying to use [ReactionView at RubyEvents](https://github.com/rubyevents/rubyevents/pull/992) I encountered some parsing error with Avo. 
Some a questionable and should probably be resolved at some point in Herb one was legitimate.
This PR updates 2 components ERB so that ReactionView compiles successfully in production environment

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Manual review steps

1. create a project with AVO and ReactionView
1. Start it in Production Environement

