### PR TITLE
fix: avoid browser to open address bar on CTRL+K

### DIFF
--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -75,7 +75,13 @@ export default class extends Controller {
     })
 
     if (this.isGlobalSearch) {
-      Mousetrap.bind(['command+k', 'ctrl+k'], () => this.showSearchPanel())
+      Mousetrap.bind(['command+k', 'ctrl+k'], (e) => {
+        // Prevent browser from focusing the address bar
+        e.preventDefault()
+        e.stopPropagation()
+        this.showSearchPanel()
+        return false
+      })
     }
 
     // This line fixes a bug where the search box would be duplicated on back navigation.


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #4080

Avoid the browser to open address bar when CTRL+K keyboard shortcut is used