### PR TITLE
fix: ensure consistent cache store reuse in avo

### DIFF
--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -235,17 +235,20 @@ module Avo
     # If it's one of rejected cache stores, we'll use the FileStore.
     # We decided against the MemoryStore in production because it will not be shared between multiple processes (when using Puma).
     def computed_cache_store
+      memory_store_instance = ActiveSupport::Cache.lookup_store(:memory_store)
+      file_store_instance = ActiveSupport::Cache.lookup_store(:file_store, Rails.root.join("tmp", "cache"))
+
       -> {
         if Rails.env.production?
           if Rails.cache.class.to_s.in?(production_rejected_cache_stores)
-            ActiveSupport::Cache.lookup_store(:file_store, Rails.root.join("tmp", "cache"))
+            file_store_instance
           else
             Rails.cache
           end
         elsif Rails.env.test?
           Rails.cache
         else
-          ActiveSupport::Cache.lookup_store(:memory_store)
+          memory_store_instance
         end
       }
     end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an internal cache issue.

`ActiveSupport::Cache.lookup_store` always returns a new cache store instance. Since the block returned by `computed_cache_store` is being executed every time the Avo cache store is requested, a new instance was created each time — effectively not using any caching unless the developer had explicitly configured one.

This commit ensures Avo consistently reuses a single cache instance. If no cache is configured, Avo will now default to:
- `:memory_store` in development
- `:file_store` in production


