### PR TITLE
WIP: contribution setup improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ brakeman_results.html
 .env
 .env.test
 *~
+
+dev-setup

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -38,25 +38,44 @@ Thank you for considering to contribute to Avo. These are our recommendations to
 
 Thank you!
 
-## Getting your local environment set up
+## Getting Started with Local Development
 
-NOTE: We're using our local Postgres instance.
+Getting your local environment set up and running is easy - just run `bin/dev` from the root directory!
 
-You may use docker with the provided `docker-compose.yml` file.
+### First Time Setup
 
-Once you pull the code down to your machine, modify `spec/dummy/config/database.yml` as appropriate to your environment (no changes needed if you're using local Postgres). Do not commit these changes. From here, running `bin/init` will get you up-and-running.
+The first time you run `bin/dev`, it will automatically:
+1. Detect that you haven't set up the project yet
+2. Run the initial setup (`bin/init`) which will:
+   - Ask if you want to use Docker Compose for PostgreSQL or a local PostgreSQL instance
+   - Configure git remotes
+   - Install dependencies (gems and yarn packages)
+   - Create the database and seed it with dummy data
+   - Build assets
+3. Create a `dev-setup` configuration file in the project root with your preferences
 
-# Local development
+**Important:** Don't delete the `dev-setup` file - it stores your configuration choices. If you want to change your setup preferences (e.g., switch between Docker and local PostgreSQL), delete this file and run `bin/dev` again to reconfigure.
 
-## Running the dummy app
+### Regular Development
 
-You can run `bin/dev` from the root directory, which will start an overmind (similar to foreman) process for the rails server, jsbundling and cssbundling. Then, navigate to `localhost:3030` and enjoy the app.
+After the initial setup, simply run `bin/dev` to start the development server. This will:
+- Start the Docker PostgreSQL service (if you chose that option during setup)
+- Launch an overmind process (similar to foreman) that runs:
+  - Rails server
+  - JavaScript bundling
+  - CSS bundling
 
-## Seeding the database for local development
+Navigate to `http://localhost:3030` to access the dummy app. You can log in with:
+- **Email:** `avo@avohq.io`
+- **Password:** `secret`
 
-NOTE: If you used the `bin/init` script, this step has already been done for you.
+### Database Configuration
 
-Run `AVO_ADMIN_PASSWORD=secret bin/rails db:seed` to seed the database with dummy data and create a user for yourself with the email `avo@avohq.io` and password `secret`.
+The project is configured to work with PostgreSQL (port 5432 by default). The `spec/dummy/config/database.yml` file uses environment variables, so you typically won't need to modify it. If you do need custom database settings, you can set these environment variables:
+- `POSTGRES_HOST` (default: localhost)
+- `POSTGRES_PORT` (default: 5432)
+- `POSTGRES_USERNAME` (default: postgres)
+- `POSTGRES_PASSWORD` (default: nil)
 
 ## Using your fork from another project
 

--- a/bin/dev
+++ b/bin/dev
@@ -1,7 +1,49 @@
 #!/usr/bin/env sh
 
+set -e
+
 PORT="${PORT:-3030}"
 export PORT
+
+# Function to read config value from dev-setup file
+read_config() {
+  key="$1"
+  if [ -f "dev-setup" ]; then
+    grep "^${key}:" dev-setup | cut -d':' -f2- | sed 's/^ *//'
+  fi
+}
+
+# Run setup if dev-setup config file doesn't exist
+if [ ! -f "dev-setup" ]; then
+  echo "This is the first time you're running the development server."
+  echo "Let's setup the project for you. This should take under a minute."
+  echo "--------------------------------"
+  echo "Running initial setup (bin/init)..."
+  if bin/init; then
+    echo "Setup completed successfully."
+  else
+    echo "Setup failed. Please check the output above and try again."
+    exit 1
+  fi
+fi
+
+# Read configuration from dev-setup file
+use_docker=$(read_config "use-docker-db")
+docker_cmd=$(read_config "docker-cmd")
+
+# If using Docker DB, ensure the db service is up before starting dev processes
+if [ "$use_docker" = "true" ] && [ -n "$docker_cmd" ]; then
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is required but not found." >&2
+    exit 1
+  fi
+
+  # Start db service if not running
+  if ! $docker_cmd ps --services --filter "status=running" 2>/dev/null | grep -q '^db$'; then
+    echo "Starting Docker db service..."
+    $docker_cmd up -d db
+  fi
+fi
 
 if command -v overmind &> /dev/null; then
   overmind start -f Procfile.dev "$@"

--- a/bin/init
+++ b/bin/init
@@ -40,16 +40,35 @@ app_root do
   run! '(cd spec/dummy; yarn)'
   run! '(cp spec/dummy/.env.test.sample spec/dummy/.env.test)'
 
+  # Determine docker compose command
+  compose_cmd = ''
   if use_docker == 'y'
+    compose_cmd =
+      if system('docker compose version > /dev/null 2>&1')
+        'docker compose'
+      elsif system('docker-compose version > /dev/null 2>&1')
+        'docker-compose'
+      else
+        abort('Neither "docker compose" nor "docker-compose" is available. Please install Docker Compose.')
+      end
+
     header 'Creating the Docker volume'
     run! 'docker volume create --name=avo-db-data'
 
     header 'Creating and running the Docker image'
-    run! 'docker-compose up -d'
+    run! "#{compose_cmd} up -d"
   end
 
+  # Create dev-setup configuration file
+  header 'Creating dev-setup configuration'
+  config = []
+  config << "use-docker-db: #{use_docker == 'y' ? 'true' : 'false'}"
+  config << "docker-cmd: #{compose_cmd}" unless compose_cmd.empty?
+  config << "setup-completed: true"
+  File.write('dev-setup', config.join("\n") + "\n")
+
   header 'Preparing the database'
-  run! 'bin/rails db:setup'
+  # run! 'bin/rails db:setup'
 
   header 'Building assets'
   run! 'yarn build:js'
@@ -58,6 +77,6 @@ app_root do
 
   if use_docker == 'y'
     header 'Stopping the Docker image'
-    run! 'docker-compose stop'
+    run! "#{compose_cmd} stop"
   end
 end


### PR DESCRIPTION
- `bin/dev` checks a config file (`dev-setup`).
  If it’s present, it verifies whether the user chose Docker DB, and if the service isn’t running, it starts it.

- If `dev-setup` is not present, `bin/init` runs automatically and creates the configuration.

The goal is to be able to clone the repo and simply run `bin/dev` whenever you want to develop on Avo.  
The first time, it should take less than a minute to set everything up.  
On subsequent runs, it should automatically prepare the Docker service if it was selected, or skip that step if you’re using a local Postgres instance.