### PR TITLE
refactor: use file_store cache on development

### DIFF
--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -230,7 +230,7 @@ module Avo
       ).handle
     end
 
-    # When not in production or test we'll just use the MemoryStore which is good enough.
+    # When not in production or test we'll just use the FileStore which is good enough.
     # When running in production we'll use Rails.cache if it's not ActiveSupport::Cache::MemoryStore or ActiveSupport::Cache::NullStore.
     # If it's one of rejected cache stores, we'll use the FileStore.
     # We decided against the MemoryStore in production because it will not be shared between multiple processes (when using Puma).


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Use `file_store` cache instead of `memory_store` on development to avoid unnecessary multiple license calls during development.