### PR TITLE
refactor: clean up obsolete code and fix STI resource lookup

### DIFF
--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -59,7 +59,7 @@ class Avo::ResourceComponent < Avo::BaseComponent
   def can_see_the_actions_button?
     return authorize_association_for(:act_on) if @reflection.present?
 
-    @resource.authorization.authorize_action(:act_on, raise_exception: false) && !has_reflection_and_is_read_only
+    @resource.authorization.authorize_action(:act_on, raise_exception: false)
   end
 
   def destroy_path
@@ -91,22 +91,6 @@ class Avo::ResourceComponent < Avo::BaseComponent
       .map do |sidebar|
         sidebar.hydrate(view: view, resource: resource)
       end
-  end
-
-  def has_reflection_and_is_read_only
-    if @reflection.present? && @reflection.active_record.name && @reflection.name
-      resource = Avo.resource_manager.get_resource_by_model_class(@reflection.active_record.name).new(params: helpers.params, view: view, user: helpers._current_user)
-      fields = resource.get_field_definitions
-      filtered_fields = fields.filter { |f| f.id == @reflection.name }
-    else
-      return false
-    end
-
-    if filtered_fields.present?
-      filtered_fields.find { |f| f.id == @reflection.name }.is_disabled?
-    else
-      false
-    end
   end
 
   def render_control(control)

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -37,12 +37,10 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
 
     return authorize_association_for(:create) if @reflection.present?
 
-    @resource.authorization.authorize_action(:new, raise_exception: false) && !has_reflection_and_is_read_only
+    @resource.authorization.authorize_action(:new, raise_exception: false)
   end
 
   def can_attach?
-    return false if has_reflection_and_is_read_only
-
     reflection_class = if @reflection.is_a?(::ActiveRecord::Reflection::ThroughReflection)
       @reflection.through_reflection.class
     else


### PR DESCRIPTION
  # Description

  When using STI with a polymorphic `has_many` association defined in the parent class, `@reflection.active_record.name` returns the parent class name instead of the actual record's class. This causes `get_resource_by_model_class` to return `nil` when no resource exists for the parent class.
  
  The solution is removing the method `has_reflection_and_is_read_only` and all the calls to it, since it always returns false.

  Fixes [4146](https://github.com/avo-hq/avo/issues/4146)

  # Checklist:

  - [x] I have performed a self-review of my own code

  ## Manual review steps

  1. Clone https://github.com/bruno-costanzo/avo-sti-reproduction-repo
  2. Run `bin/setup`
  3. Navigate to `http://localhost:3000/avo`
  4. Click on "Admins" → Click on any Admin record
  5. Before fix: `undefined method 'new' for nil` / After fix: page loads correctly