### PR TITLE
fix: update `partial_card_partial.tt` to include `@parent`, `@resource`, and `@dashboard` variables

### DIFF
--- a/lib/generators/avo/templates/cards/partial_card_partial.tt
+++ b/lib/generators/avo/templates/cards/partial_card_partial.tt
@@ -1,6 +1,8 @@
 <div class="flex-1 flex p-4">
   <div class="place-self-end">
-    Dashboard ID: <%%= @dashboard.id %>
+    @parent: <%%= @parent %><br />
+    @resource: <%%= @resource %><br />
+    @dashboard: <%%= @dashboard %>
     <br />
     <br />
     Customize this partial under <code class='p-1 rounded bg-gray-500 text-white text-sm'>app/views/avo/cards/_<%= name.underscore %>.html.erb</code>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Previously, using a generated partial card on a **resource page** would result in a failure due to `@dashboard.id` not being defined. This occurred when users followed this workflow:

1. Generate a partial card via the standard documented command
2. Add the card to a **resource** instead of a **dashboard**

This PR resolves that issue by exposing the correct context-aware instance variables to the template, preventing undefined variable errors and improving developer clarity.

### Instance Variables Now Presented

- `@dashboard` - present only when the card is rendered **within a dashboard**
- `@resource` - present only when the card is rendered **within a resource**
- `@parent` - always present, representing either a dashboard or a resource instance depending on where the card is loaded

This ensures partial cards work seamlessly out of the box across both contexts while giving developers the information they need to properly configure their UI elements.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

<img width="1051" height="277" alt="image" src="https://github.com/user-attachments/assets/4a8458d2-db23-4a66-aba2-9744c0694a4f" />

