### PR TITLE
chore: refactor resource_generator_spec.rb to ensure original files are restored after yielding

### DIFF
--- a/spec/features/avo/generators/resource_generator_spec.rb
+++ b/spec/features/avo/generators/resource_generator_spec.rb
@@ -76,10 +76,12 @@ def keeping_original_files(files)
     FileUtils.mv(file_path, "#{file_path}_temp")
   end
 
-  yield
-
-  # Remove the _temp from the end of the files name in order to restore the original ones
-  files.each do |file_path|
-    FileUtils.mv("#{file_path}_temp", file_path)
+  begin
+    yield
+  ensure
+    # Remove the _temp from the end of the files name in order to restore the original ones
+    files.each do |file_path|
+      FileUtils.mv("#{file_path}_temp", file_path)
+    end
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fix `spec/features/avo/generators/resource_generator_spec.rb` to remove temp files even if test fails