### PR TITLE
fix: boolean edit component

### DIFF
--- a/app/components/avo/fields/boolean_field/edit_component.html.erb
+++ b/app/components/avo/fields/boolean_field/edit_component.html.erb
@@ -1,6 +1,7 @@
 <%= field_wrapper(**field_wrapper_args) do %>
   <div class="h-8 flex items-center">
-    <%= @form.label @field.id,
+    <%= content_tag :label,
+      for: "#{@form.object_name}_#{@field.id}",
       class: class_names(
         "relative flex items-center",
         "opacity-50": disabled?,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://discord.com/channels/740892036978442260/1449109571317661858
Fixes https://discord.com/channels/740892036978442260/1443218031219048518

Using `content_tag :label` instead of `@form.label` for the boolean edit component fixes the extra labels close to the boolean checkboxes, like in the example above.


<img width="858" height="98" alt="image" src="https://github.com/user-attachments/assets/7a2d04fd-f821-4425-b1ad-fc45945e4a95" />

