### PR TITLE
tweak sidebar

### DIFF
--- a/app/components/avo/resource_sidebar_component.html.erb
+++ b/app/components/avo/resource_sidebar_component.html.erb
@@ -1,4 +1,4 @@
-<div class="resource-sidebar-component divide-y divide-gray-200"
+<div class="resource-sidebar-component space-y-4"
   data-component-name="<%= self.class.to_s.underscore %>"
   data-component-index="<%= @index %>"
   data-resource-name="<%= @resource.class.to_s %>"

--- a/lib/avo/resources/items/sidebar.rb
+++ b/lib/avo/resources/items/sidebar.rb
@@ -30,8 +30,6 @@ class Avo::Resources::Items::Sidebar
     delegate :heading, to: :items_holder
     delegate :card, to: :items_holder
 
-    # TODO: since we retired the panel_wrapper we probably don't need to automatically wrap everything in another sidebar.
-    # I'll let Paul refactor this (AVO-900)
     def initialize(parent:, **args)
       @sidebar = Avo::Resources::Items::Sidebar.new(**args)
       @items_holder = Avo::Resources::Items::Holder.new(parent: parent)

--- a/spec/dummy/app/avo/resource_tools/product_info.rb
+++ b/spec/dummy/app/avo/resource_tools/product_info.rb
@@ -1,0 +1,4 @@
+class Avo::ResourceTools::ProductInfo < Avo::BaseResourceTool
+  self.name = "Product info"
+  # self.partial = "avo/resource_tools/product_info"
+end

--- a/spec/dummy/app/avo/resources/product.rb
+++ b/spec/dummy/app/avo/resources/product.rb
@@ -40,25 +40,35 @@ class Avo::Resources::Product < Avo::BaseResource
   }
 
   def fields
-    field :id, as: :id
-    field :title, as: :text, html: {
-      show: {
-        label: {
-          classes: "bg-gray-50 !text-pink-600"
-        },
-        content: {
-          classes: "bg-gray-50 !text-pink-600"
-        },
-        wrapper: {
-          classes: "bg-gray-50"
+    panel do
+      card do
+        field :id, as: :id
+        field :title, as: :text, html: {
+          show: {
+            label: {
+              classes: "bg-gray-50 !text-pink-600"
+            },
+            content: {
+              classes: "bg-gray-50 !text-pink-600"
+            },
+            wrapper: {
+              classes: "bg-gray-50"
+            }
+          }
         }
-      }
-    }
-    field :price, as: :money, currencies: %w[EUR USD RON PEN]
-    field :description, as: :tiptap, placeholder: "Enter text", always_show: false
-    field :image, as: :file, is_image: true
-    field :category, as: :select, enum: ::Product.categories
-    field :sizes, as: :select, multiple: true, options: {Large: :large, Medium: :medium, Small: :small}
-    field :rating, as: :stars
+        field :price, as: :money, currencies: %w[EUR USD RON PEN]
+        field :description, as: :tiptap, placeholder: "Enter text", always_show: false
+        field :image, as: :file, is_image: true
+        field :category, as: :select, enum: ::Product.categories
+        field :sizes, as: :select, multiple: true, options: {Large: :large, Medium: :medium, Small: :small}
+      end
+
+      sidebar do
+        tool Avo::ResourceTools::ProductInfo
+        card do
+          field :rating, as: :stars
+        end
+      end
+    end
   end
 end

--- a/spec/dummy/app/avo/resources/user.rb
+++ b/spec/dummy/app/avo/resources/user.rb
@@ -152,7 +152,7 @@ class Avo::Resources::User < Avo::BaseResource
   def test_sidebar
     return unless ENV["testing_methods"]
 
-    sidebar panel_wrapper: false do
+    sidebar do
       tool Avo::ResourceTools::SidebarTool, render_panel: true
       card do
         test_field("Inside test_sidebar")

--- a/spec/dummy/app/views/avo/resource_tools/_product_info.html.erb
+++ b/spec/dummy/app/views/avo/resource_tools/_product_info.html.erb
@@ -1,0 +1,37 @@
+<div class="flex flex-col">
+  <%= render ui.card(title: "Quick Stats") do |card| %>
+    <div class="flex flex-col p-4 space-y-4">
+      <%# Status & Category %>
+      <div class="flex items-center justify-between">
+        <span class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-emerald-100 text-emerald-700">
+          <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
+          In Stock
+        </span>
+      </div>
+
+      <%# Price Card %>
+      <div class="bg-gradient-to-br from-violet-50 via-purple-50 to-fuchsia-50 rounded-xl p-4 border border-purple-100/50 shadow-sm">
+        <div class="text-[10px] uppercase tracking-widest text-purple-500 font-bold mb-1">Retail Price</div>
+        <div class="text-xs text-green-600 mt-1 font-medium">↓ 15% from last month</div>
+      </div>
+
+      <%# Quick Stats %>
+      <div class="grid grid-cols-3 gap-2">
+        <div class="text-center p-2 bg-gray-50 rounded-lg">
+          <div class="text-lg font-bold text-gray-800">847</div>
+          <div class="text-[10px] text-gray-500 uppercase tracking-wide">Sold</div>
+        </div>
+        <div class="text-center p-2 bg-gray-50 rounded-lg">
+          <div class="text-lg font-bold text-gray-800">124</div>
+          <div class="text-[10px] text-gray-500 uppercase tracking-wide">In Stock</div>
+        </div>
+        <div class="text-center p-2 bg-gray-50 rounded-lg">
+          <div class="text-lg font-bold text-gray-800"><%= @record.rating %></div>
+          <div class="text-[10px] text-gray-500 uppercase tracking-wide">Rating</div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Removed visible division between sidebar items
- Added sidebar with tool + card on product as example

<img width="1705" height="913" alt="image" src="https://github.com/user-attachments/assets/5098821a-cc38-4f27-926b-182d89e79a8e" />
