### PR TITLE
enhancement: show cache operational on status page

### DIFF
--- a/app/components/avo/debug/status_component.html.erb
+++ b/app/components/avo/debug/status_component.html.erb
@@ -1,6 +1,6 @@
 <div class="flex flex-col">
-  <%= render Avo::PanelComponent.new(name: 'Avo Status', description: 'Use this page to debug your Avo instance.') do |c| %>
-    <% c.with_bare_content do %>
+  <%= render ui.panel(title: 'Avo Status', description: 'Use this page to debug your Avo instance.') do |panel| %>
+    <% panel.with_card do %>
       <div class="grid gap-4 grid-cols-2">
         <div class="relative flex flex-col bg-white rounded-sm shadow-panel p-4 space-y-4 h-full">
           <div class="flex justify-between w-full">
@@ -19,8 +19,6 @@
                     <dt><%= key.humanize %></dt>
                     <dd><%= value %></dd>
                   <% end %>
-                  <dt>Cache store</dt>
-                  <dd><%= Avo.cache_store.class %></dd>
                 </dl>
               </div>
               <div class="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-sm">

--- a/app/components/avo/debug/status_component.rb
+++ b/app/components/avo/debug/status_component.rb
@@ -13,6 +13,18 @@ class Avo::Debug::StatusComponent < Avo::BaseComponent
       port: Avo::Current.request&.port,
       ip: Avo::Current.request&.ip,
       app_name: Avo.configuration.app_name,
+      cache_store: Avo.cache_store.class,
+      cache_operational:,
     }.stringify_keys.except(*Avo.configuration.exclude_from_status)
+  end
+
+  def cache_operational
+    icon, color = if Avo::Services::TelemetryService.cache_operational?
+      ["heroicons/outline/check-circle", "text-green-500"]
+    else
+      ["heroicons/outline/x-circle", "text-red-500"]
+    end
+
+    helpers.svg(icon, class: "h-5 inline -mt-1 relative #{color}")
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Show if cache is operational on status page

<img width="1565" height="667" alt="image" src="https://github.com/user-attachments/assets/499bb716-2476-49d3-bb77-4823c3845dca" />
