### PR TITLE
Remove readable call from search controller.

### DIFF
--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -242,7 +242,7 @@ export default class extends Controller {
 
     return url.segment([window.Avo.configuration.root_path, ...this.searchSegments()])
       .search(this.searchParams(encodeURIComponent(query)))
-      .readable().toString()
+      .toString()
   }
 
   searchSegments() {


### PR DESCRIPTION
# Description
Ensures that global search still works when a properly formatted `#` character is in the query params.

Fixes #4179 

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<img width="1155" height="826" alt="Screenshot 2026-01-09 at 11 20 17 AM" src="https://github.com/user-attachments/assets/989337b5-5e2c-42b5-bbf1-13c1a2a921ed" />

## Manual review steps
I applied the change and then updated my bug report branch locally to use my fixed version, and the search correctly loads with the query param in the URL. (worth mentioning that this was quite difficult, as I had to precompile assets and force them into a different version of the fork, as my bug report test app was on 3.24.1. I actually did this on another fork, becuase I assume you guys build your assets through a pipeline or something.)

To do from a new bug report app:

1. Instantiate the avo pro bug report app on the latest version
2. point the gemfile to this fork.
3. Bundle (you'll need to precompile to make this work)
4. Go to any AVO route with a query param with a correctly encoded `#` character (you can just type it in, it's `%23`)
5. Successfully use the global search.

This is NOT possible in main.
