### PR TITLE
fix: url inflection causes zeitwerk error

### DIFF
--- a/app/helpers/avo/url_helpers.rb
+++ b/app/helpers/avo/url_helpers.rb
@@ -89,4 +89,7 @@ module Avo
       end
     end
   end
+  # Host apps may configure `inflect.acronym "URL"`, which makes Zeitwerk fail
+  URLHelpers = UrlHelpers unless const_defined?(:URLHelpers, false)
+  UrlHelpers = URLHelpers unless const_defined?(:UrlHelpers, false)
 end

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -2,6 +2,7 @@ require "zeitwerk"
 require "net/http"
 require_relative "avo/version"
 require_relative "avo/engine" if defined?(Rails)
+require_relative "avo/acronym_support" if defined?(Rails)
 
 loader = Zeitwerk::Loader.for_gem
 loader.inflector.inflect(
@@ -11,6 +12,7 @@ loader.inflector.inflect(
 )
 loader.ignore("#{__dir__}/generators")
 loader.setup
+Avo::AcronymSupport.apply!
 
 module Avo
   ROOT_PATH = Pathname.new(File.join(__dir__, ".."))

--- a/lib/avo/acronym_support.rb
+++ b/lib/avo/acronym_support.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Avo
+  # Handles host-app acronym inflections (e.g. `inflect.acronym "URL"`)
+  module AcronymSupport
+    module_function
+
+    def apply!
+      return unless defined?(Rails)
+
+      require_relative "../../app/helpers/avo/url_helpers"
+
+      if const_defined?(:UrlHelpers, false) && !const_defined?(:URLHelpers, false)
+        const_set(:URLHelpers, const_get(:UrlHelpers))
+      elsif const_defined?(:URLHelpers, false) && !const_defined?(:UrlHelpers, false)
+        const_set(:UrlHelpers, const_get(:URLHelpers))
+      end
+    end
+  end
+end

--- a/spec/helpers/avo/url_helpers_inflection_spec.rb
+++ b/spec/helpers/avo/url_helpers_inflection_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe Avo::UrlHelpers, type: :helper do
+  before do
+    ActiveSupport::Inflector.inflections(:en) do |inflect|
+      inflect.acronym "URL"
+    end
+  end
+
+  it "loads url_helpers without Zeitwerk errors" do
+    # This will trigger Zeitwerk to autoload the file
+    expect {
+      Avo::UrlHelpers
+    }.not_to raise_error
+
+    expect(Avo::URLHelpers).to eq(Avo::UrlHelpers)
+  end
+end


### PR DESCRIPTION
# Description
If a Rails application inflects 'url', Avo installation fails. This fixes it.

Before:
```bash
/rails# bundle exec bin/rails g avo:install
bundler: failed to load command: bin/rails (bin/rails)
/usr/local/bundle/gems/zeitwerk-2.7.4/lib/zeitwerk/loader/callbacks.rb:31:in `on_file_autoloaded': expected file /usr/local/bundle/bundler/gems/avo-81ac4b40002c/lib/avo/acronym_support.rb to define constant Avo::AcronymSupport, but didn't (Zeitwerk::NameError)
```

After:
```bash
/rails# bundle exec bin/rails g avo:install
Starting application configuration...
Avo community 3.28.0
       route  mount_avo
      create  config/initializers/avo.rb
  ActiveRecord::SchemaMigration Load (3.8ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
```

Fixes https://github.com/avo-hq/avo/issues/4097

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- (not relevant) I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs) 
- [x] I have added tests that prove my fix is effective or that my feature works

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Create a rails repo that inflects url

Run `bundle install` and then `bundle exec bin/rails g avo:install` - it will fail

Add to Gemfile:
```ruby 
gem "avo", git: "https://github.com/hmk/avo.git", branch: "fix/url-helper-inflection"
```
It should pass
