### PR TITLE
fix: add disconnect() cleanup to Stimulus controllers

### DIFF
--- a/app/javascript/js/controllers/fields/easy_mde_controller.js
+++ b/app/javascript/js/controllers/fields/easy_mde_controller.js
@@ -28,9 +28,16 @@ export default class extends Controller {
       options.status = false
     }
 
-    const easyMde = new EasyMDE(options)
+    this.easyMde = new EasyMDE(options)
     if (this.view === 'show') {
-      easyMde.codemirror.options.readOnly = true
+      this.easyMde.codemirror.options.readOnly = true
+    }
+  }
+
+  disconnect() {
+    if (this.easyMde) {
+      this.easyMde.toTextArea()
+      this.easyMde = null
     }
   }
 }

--- a/app/javascript/js/controllers/fields/tags_field_controller.js
+++ b/app/javascript/js/controllers/fields/tags_field_controller.js
@@ -79,6 +79,13 @@ export default class extends Controller {
     }
   }
 
+  disconnect() {
+    if (this.tagify) {
+      this.tagify.destroy()
+      this.tagify = null
+    }
+  }
+
   initTagify() {
     this.tagify = new Tagify(this.inputTarget, this.tagifyOptions)
     const that = this

--- a/app/javascript/js/controllers/media_library_attach_controller.js
+++ b/app/javascript/js/controllers/media_library_attach_controller.js
@@ -77,6 +77,13 @@ export default class extends Controller {
     this.setupFileInput()
   }
 
+  disconnect() {
+    if (this.fileInput) {
+      this.fileInput.remove()
+      this.fileInput = null
+    }
+  }
+
   setupFileInput() {
     // Create a hidden file input element
     this.fileInput = document.createElement('input')

--- a/app/javascript/js/controllers/preview_controller.js
+++ b/app/javascript/js/controllers/preview_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
   connect() {
     const vm = this;
 
-    tippy(vm.context.element, {
+    this.tippyInstance = tippy(vm.context.element, {
       content: "loading...",
       allowHTML: true,
       theme: 'light',
@@ -20,5 +20,12 @@ export default class extends Controller {
         instance.setContent(content)
       },
     })
+  }
+
+  disconnect() {
+    if (this.tippyInstance) {
+      this.tippyInstance.destroy()
+      this.tippyInstance = null
+    }
   }
 }

--- a/app/javascript/js/controllers/record_selector_controller.js
+++ b/app/javascript/js/controllers/record_selector_controller.js
@@ -82,10 +82,14 @@ export default class extends Controller {
   }
 
   #addEventListeners() {
+    // Create bound handler references so the same functions are used for add and remove
+    this.boundMouseenterHandler = this.#selectorMouseenterHandler.bind(this)
+    this.boundMouseleaveHandler = this.#selectorMouseleaveHandler.bind(this)
+
     // Attach event listeners to item selector cells
     Array.from(this.itemSelectorCells).forEach((itemSelectorCell) => {
-      itemSelectorCell.addEventListener('mouseenter', this.#selectorMouseenterHandler.bind(this))
-      itemSelectorCell.addEventListener('mouseleave', this.#selectorMouseleaveHandler.bind(this))
+      itemSelectorCell.addEventListener('mouseenter', this.boundMouseenterHandler)
+      itemSelectorCell.addEventListener('mouseleave', this.boundMouseleaveHandler)
     })
 
     // Attach event listeners to keyboard events
@@ -94,13 +98,13 @@ export default class extends Controller {
   }
 
   #removeEventListeners() {
-    // Remove event listeners
+    // Remove event listeners using the same bound references from #addEventListeners
     Array.from(this.itemSelectorCells).forEach((itemSelectorCell) => {
-      itemSelectorCell.removeEventListener('mouseenter', this.#selectorMouseenterHandler.bind(this))
-      itemSelectorCell.removeEventListener('mouseleave', this.#selectorMouseleaveHandler.bind(this))
+      itemSelectorCell.removeEventListener('mouseenter', this.boundMouseenterHandler)
+      itemSelectorCell.removeEventListener('mouseleave', this.boundMouseleaveHandler)
     })
-    document.removeEventListener('keydown', this.#keydownHandler.bind(this))
-    document.removeEventListener('keyup', this.#keyupHandler.bind(this))
+    document.removeEventListener('keydown', this.#keydownHandler)
+    document.removeEventListener('keyup', this.#keyupHandler)
   }
 
   #selectorMouseenterHandler(event) {

--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -127,6 +127,10 @@ export default class extends Controller {
   }
 
   disconnect() {
+    if (this.isGlobalSearch) {
+      Mousetrap.unbind(['command+k', 'ctrl+k'])
+    }
+
     // Don't leave open autocompletes around when disconnected. Otherwise it will still
     // be visible when navigating back to this page.
     if (this.destroyMethod) {

--- a/app/javascript/js/controllers/table_row_controller.js
+++ b/app/javascript/js/controllers/table_row_controller.js
@@ -3,7 +3,15 @@ import { Controller } from '@hotwired/stimulus'
 export default class extends Controller {
   connect() {
     this.isSelecting = false
-    this.#bindSelectionEvents()
+    this.boundHandleMouseDown = this.#handleMouseDown.bind(this)
+    this.boundHandleMouseMove = this.#handleMouseMove.bind(this)
+    this.element.addEventListener('mousedown', this.boundHandleMouseDown)
+    this.element.addEventListener('mousemove', this.boundHandleMouseMove)
+  }
+
+  disconnect() {
+    this.element.removeEventListener('mousedown', this.boundHandleMouseDown)
+    this.element.removeEventListener('mousemove', this.boundHandleMouseMove)
   }
 
   visitRecord(event) {
@@ -40,11 +48,6 @@ export default class extends Controller {
     } else {
       this.#visitInSameTab(url)
     }
-  }
-
-  #bindSelectionEvents() {
-    this.element.addEventListener('mousedown', this.#handleMouseDown.bind(this))
-    this.element.addEventListener('mousemove', this.#handleMouseMove.bind(this))
   }
 
   #handleMouseDown() {

--- a/app/javascript/js/controllers/tippy_controller.js
+++ b/app/javascript/js/controllers/tippy_controller.js
@@ -5,10 +5,17 @@ export default class extends Controller {
   static targets = ['source', 'content']
 
   connect() {
-    tippy(this.sourceTarget, {
+    this.tippyInstance = tippy(this.sourceTarget, {
       content: this.contentTarget.innerHTML,
       allowHTML: true,
       theme: 'light',
     })
+  }
+
+  disconnect() {
+    if (this.tippyInstance) {
+      this.tippyInstance.destroy()
+      this.tippyInstance = null
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Fixes `TypeError: Cannot read properties of null (reading 'scrollTop')`) and similar errors caused by Stimulus controllers not cleaning up in `disconnect()`
- Adds `disconnect()` to 7 controllers: `tags_field`, `easy_mde`, `tippy`, `preview`, `table_row`, `media_library_attach`, `search`
- Fixes broken `removeEventListener` in `record_selector` (`.bind()` created non-matching refs so removal was a no-op)

## Test plan
- [x] Visit an Avo page with tag fields, navigate away via Turbo, confirm no console errors
- [x] Test EasyMDE markdown fields across Turbo navigations
- [x] Test tooltip (tippy) fields across Turbo navigations
- [x] Test shift-click multi-select on index tables (record_selector) — previously accumulated duplicate listeners on each shift-click
- [x] Test global search keyboard shortcut (Cmd+K / Ctrl+K) works after Turbo navigation
- [x] Test media library file upload after Turbo navigation (no duplicate file inputs)