### PR TITLE
fix: search with spaces

### DIFF
--- a/app/javascript/js/controllers/search_controller.js
+++ b/app/javascript/js/controllers/search_controller.js
@@ -241,7 +241,7 @@ export default class extends Controller {
     const url = URI()
 
     return url.segment([window.Avo.configuration.root_path, ...this.searchSegments()])
-      .search(this.searchParams(encodeURIComponent(query)))
+      .search(this.searchParams(query))
       .toString()
   }
 

--- a/spec/system/avo/search_spec.rb
+++ b/spec/system/avo/search_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Search", type: :system do
+  let!(:course) { create :course, name: "Ruby on Rails" }
+
+  describe "resource search with multi-word query" do
+    it "finds the record when searching with multiple words" do
+      visit "admin/resources/courses"
+
+      click_resource_search_input
+      write_in_search("Ruby on Rails")
+      select_first_result_in_search
+
+      expect(page).to have_current_path("/admin/resources/courses/#{course.to_param}")
+    end
+
+    it "finds the record when searching with a partial multi-word query" do
+      visit "admin/resources/courses"
+
+      click_resource_search_input
+      write_in_search("Ruby on")
+      select_first_result_in_search
+
+      expect(page).to have_current_path("/admin/resources/courses/#{course.to_param}")
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #4248

This PR fixes a regression introduced in 3.29 where searching by multiple words separated by spaces was broken.
