### PR TITLE
fix: `key_value` field truncates keys and values containing double quotes

### DIFF
--- a/app/javascript/js/controllers/fields/key_value_controller.js
+++ b/app/javascript/js/controllers/fields/key_value_controller.js
@@ -151,6 +151,15 @@ export default class extends Controller {
     return result
   }
 
+  escapeAttribute(str) {
+    if (str === null || str === undefined) return ''
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+  }
+
   inputField(id = 'key', index, key, value) {
     const inputValue = id === 'key' ? key : value
 
@@ -160,7 +169,7 @@ export default class extends Controller {
   placeholder="${this.options[`${id}_label`]}"
   data-index="${index}"
   ${this[`${id}InputDisabled`] ? "disabled='disabled'" : ''}
-  value="${typeof inputValue === 'undefined' || inputValue === null ? '' : inputValue}"
+  value="${this.escapeAttribute(inputValue)}"
 />`
   }
 

--- a/spec/system/avo/key_value_field/key_value_field_spec.rb
+++ b/spec/system/avo/key_value_field/key_value_field_spec.rb
@@ -343,6 +343,56 @@ RSpec.describe "KeyValueFields", type: :system do
     end
   end
 
+  describe "with double quotes in keys and values" do
+    let!(:meta_data) { {'key with "quotes"' => 'value with "quotes"', "normal" => "plain"} }
+    let!(:project) { create :project, meta: meta_data }
+
+    context "show" do
+      it "displays the full untruncated keys and values" do
+        visit "/admin/resources/projects/#{project.id}"
+        wait_for_loaded
+
+        keys = page.all('input[placeholder="Meta key"][disabled="disabled"]')
+        values = page.all('input[placeholder="Meta value"][disabled="disabled"]')
+
+        expect(keys[0].value).to eq 'key with "quotes"'
+        expect(values[0].value).to eq 'value with "quotes"'
+
+        expect(keys[1].value).to eq "normal"
+        expect(values[1].value).to eq "plain"
+      end
+    end
+
+    context "edit" do
+      it "displays and round-trips keys and values with double quotes" do
+        visit "/admin/resources/projects/#{project.id}/edit"
+        wait_for_loaded
+
+        keys = page.all('input[placeholder="Meta key"]')
+        values = page.all('input[placeholder="Meta value"]')
+
+        expect(keys[0].value).to eq 'key with "quotes"'
+        expect(values[0].value).to eq 'value with "quotes"'
+
+        expect(keys[1].value).to eq "normal"
+        expect(values[1].value).to eq "plain"
+
+        save
+
+        expect(current_path).to eql "/admin/resources/projects/#{project.id}"
+
+        keys = page.all('input[placeholder="Meta key"][disabled="disabled"]')
+        values = page.all('input[placeholder="Meta value"][disabled="disabled"]')
+
+        expect(keys[0].value).to eq 'key with "quotes"'
+        expect(values[0].value).to eq 'value with "quotes"'
+
+        expect(keys[1].value).to eq "normal"
+        expect(values[1].value).to eq "plain"
+      end
+    end
+  end
+
   describe "with 0 and false" do
     let!(:comment) { create :comment }
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #https://github.com/avo-hq/avo/issues/4252

The inputField method in the `key_value` Stimulus controller built HTML via string interpolation, so double quotes in keys/values broke out of the `value="..."` attribute and truncated the displayed text.

Add an `escapeAttribute` helper that encodes `&`, `"`, `<`, `>` as HTML entities and use it when rendering the value attribute. Also add regression tests for show and edit round-trip with double-quoted data.

---

`{"This is a \"key\""=>"This is a value\""}`

<img width="1493" height="112" alt="image" src="https://github.com/user-attachments/assets/700c0a92-f889-4316-980a-0f44f7b2f06b" />
