### PR TITLE
feature: pluggable view types

### DIFF
--- a/app/components/avo/resource_listing_component.rb
+++ b/app/components/avo/resource_listing_component.rb
@@ -11,16 +11,7 @@ class Avo::ResourceListingComponent < Avo::BaseComponent
   prop :index_params
 
   def specific_view_component
-    case @resource.view_type.to_sym
-    when :grid
-      Avo::ViewTypes::GridComponent
-    when :map
-      Avo::ViewTypes::MapComponent
-    when :table
-      Avo::ViewTypes::TableComponent
-    else
-      raise "Invalid view type: #{@resource.view_type}"
-    end
+    Avo.view_type_manager.component_for(@resource.view_type)
   end
 
   def paginator_component

--- a/app/views/avo/partials/_view_toggle_button.html.erb
+++ b/app/views/avo/partials/_view_toggle_button.html.erb
@@ -1,35 +1,12 @@
 <% if available_view_types.count > 1 %>
-  <%
-    info = {
-      table: {
-        icon: "tabler/outline/layout-list",
-        active_icon: "tabler/filled/layout-list",
-        translation_key: 'avo.table_view',
-      },
-      grid: {
-        icon: "tabler/outline/layout-grid",
-        active_icon: "tabler/filled/layout-grid",
-        translation_key: 'avo.grid_view',
-      },
-      map: {
-        icon: "tabler/outline/compass",
-        active_icon: "tabler/filled/compass",
-        translation_key: 'avo.map_view',
-      },
-      list: {
-        icon: "tabler/outline/layout-list",
-        active_icon: "tabler/filled/layout-list",
-        translation_key: 'avo.list_view',
-      },
-    }
-  %>
   <div class="flex">
     <div class="button-group">
       <% available_view_types.each do |type| %>
+        <% view_info = Avo.view_type_manager.find(type) %>
         <% is_active_view = view_type.to_s == type.to_s %>
 
         <%= a_link url_for(params.permit!.merge(view_type: type)).to_s,
-          icon: is_active_view ? info[type][:active_icon] : info[type][:icon],
+          icon: is_active_view ? view_info&.[](:active_icon) : view_info&.[](:icon),
           color: :primary,
           class: is_active_view ? "button--active" : "",
           title: t('avo.switch_to_view', view_type: type),

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -70,7 +70,6 @@ module Avo
     attr_reader :logger
     attr_reader :cache_store
     attr_reader :field_manager
-
     delegate :app, :error_manager, :tool_manager, :resource_manager, to: Avo::Current
 
     # Runs when the app boots up
@@ -78,6 +77,7 @@ module Avo
       Turbo::Streams::TagBuilder.prepend(Avo::TurboStreamActionsHelper)
       @logger = Avo.configuration.logger
       @field_manager = Avo::Fields::FieldManager.build
+      @view_type_manager = nil # force re-init with defaults on next access
       @cache_store = Avo.configuration.cache_store
       Avo.plugin_manager.reset
       # Run load hooks for plugins to include them in the app.

--- a/lib/avo/plugin_manager.rb
+++ b/lib/avo/plugin_manager.rb
@@ -19,6 +19,10 @@ module Avo
       @plugins << Plugin.new(name:, priority: priority)
     end
 
+    def register_view_type(name, component:, icon:, active_icon:, translation_key: nil)
+      Avo.view_type_manager.register(name, component:, icon:, active_icon:, translation_key:)
+    end
+
     def register_field(method_name, klass)
       # Avo.boot method is executed multiple times.
       # During the first run, it correctly loads descendants of Avo::Fields::Base.

--- a/lib/avo/view_types/view_type_manager.rb
+++ b/lib/avo/view_types/view_type_manager.rb
@@ -1,0 +1,70 @@
+module Avo
+  module ViewTypes
+    class ViewTypeManager
+      attr_reader :registry
+
+      def initialize
+        @registry = {}
+      end
+
+      def register(name, component:, icon:, active_icon:, translation_key: nil)
+        @registry[name.to_sym] = {
+          component: component,
+          icon: icon,
+          active_icon: active_icon,
+          translation_key: translation_key
+        }
+      end
+
+      def find(name)
+        @registry[name.to_sym]
+      end
+
+      def component_for(name)
+        entry = find(name)
+
+        raise Avo::ViewTypeComponentNotFoundError, "No component registered for view type '#{name}'" unless entry
+
+        component = entry[:component]
+        component.is_a?(String) ? component.constantize : component
+      end
+
+      def registered?(name)
+        @registry.key?(name.to_sym)
+      end
+
+      def reset
+        @registry = {}
+        register_defaults
+      end
+
+      private
+
+      def register_defaults
+        register :table,
+          component: Avo::ViewTypes::TableComponent,
+          icon: "tabler/outline/layout-list",
+          active_icon: "tabler/filled/layout-list"
+
+        register :grid,
+          component: Avo::ViewTypes::GridComponent,
+          icon: "tabler/outline/layout-grid",
+          active_icon: "tabler/filled/layout-grid"
+
+        register :map,
+          component: Avo::ViewTypes::MapComponent,
+          icon: "tabler/outline/compass",
+          active_icon: "tabler/filled/compass"
+
+        register :list,
+          component: Avo::ViewTypes::TableComponent,
+          icon: "tabler/outline/layout-list",
+          active_icon: "tabler/filled/layout-list"
+      end
+    end
+  end
+
+  def self.view_type_manager
+    @view_type_manager ||= Avo::ViewTypes::ViewTypeManager.new.tap(&:reset)
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds the ability to add new view types using plugins.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core resource index rendering and view switching; mis-registrations or missing entries can raise at runtime or render toggles without icons.
> 
> **Overview**
> Adds a new `Avo.view_type_manager` registry (`ViewTypeManager`) that centralizes view type metadata (component + icons) and supports runtime registration/reset with default view types.
> 
> Replaces hardcoded view-type branching in `ResourceListingComponent` and the view toggle button partial with lookups through the manager, and exposes `PluginManager#register_view_type` so plugins can add custom view types. `Avo.boot` now clears the manager to ensure defaults are re-initialized on next access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7213a9c3a0643e288d95981a4ec42c5faf5215ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->