### PR TITLE
feature: persistent color settings

### DIFF
--- a/app/assets/stylesheets/css/components/color_scheme_switcher.css
+++ b/app/assets/stylesheets/css/components/color_scheme_switcher.css
@@ -166,3 +166,58 @@
 .accent-rose .color-scheme-switcher__accent-badge-preview--rose {
   @apply inline-block;
 }
+
+/* Save button wrapper — slides in when dirty, collapses when clean */
+.color-scheme-switcher__save-wrapper {
+  @apply overflow-hidden inline-flex items-center;
+  max-width: 0;
+  opacity: 0;
+  transition: max-width 0.25s ease-in-out, opacity 0.2s ease-in-out;
+}
+
+.color-scheme-switcher__save-wrapper--visible {
+  max-width: 80px;
+  opacity: 1;
+}
+
+/* Save button */
+.color-scheme-switcher__save {
+  @apply inline-flex items-center justify-center px-2.5 py-1 rounded-md;
+  @apply text-xs font-medium whitespace-nowrap;
+  @apply bg-primary-500 text-white;
+  @apply hover:bg-primary-600 active:scale-95;
+  @apply focus:outline-none focus:ring-2 focus:ring-primary-400 focus:ring-offset-1;
+  @apply border-0 cursor-pointer;
+  transition: background-color 0.15s, transform 0.15s;
+}
+
+.color-scheme-switcher__save--success {
+  @apply bg-green-500 hover:bg-green-500;
+}
+
+.color-scheme-switcher__save--success .color-scheme-switcher__save-text::after {
+  content: attr(data-success-text);
+}
+
+.color-scheme-switcher__save--success .color-scheme-switcher__save-text {
+  font-size: 0;
+}
+
+.color-scheme-switcher__save--success .color-scheme-switcher__save-text::after {
+  @apply text-xs;
+}
+
+.color-scheme-switcher__save--error {
+  @apply bg-red-500 hover:bg-red-500;
+  animation: color-scheme-switcher-shake 0.3s ease-in-out;
+}
+
+.color-scheme-switcher__save-text {
+  @apply leading-none;
+}
+
+@keyframes color-scheme-switcher-shake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-2px); }
+  75% { transform: translateX(2px); }
+}

--- a/app/controllers/avo/user_preferences_controller.rb
+++ b/app/controllers/avo/user_preferences_controller.rb
@@ -1,0 +1,64 @@
+module Avo
+  class UserPreferencesController < BaseApplicationController
+    skip_before_action :set_resource_name
+    skip_before_action :set_authorization
+    skip_before_action :set_view
+    skip_before_action :_authenticate!
+
+    before_action :ensure_user_preferences_configured
+    before_action :ensure_authenticated
+
+    def show
+      render json: {preferences: user_preferences}
+    end
+
+    def update
+      prefs = preferences_params
+      return if prefs.nil? # already rendered error in preferences_params
+
+      allowed_keys = Avo.configuration.all_user_preference_keys.map(&:to_s)
+      filtered = prefs.select { |key, _| key.to_s.in?(allowed_keys) }
+
+      filtered.each do |key, value|
+        Avo.configuration.save_user_preferences(
+          user: _current_user,
+          request: request,
+          key: key.to_sym,
+          value: value,
+          preferences: filtered
+        )
+      end
+
+      render json: {status: "ok"}, status: :ok
+    rescue => error
+      render json: {error: error.message}, status: :unprocessable_entity
+    end
+
+    private
+
+    def ensure_user_preferences_configured
+      return if Avo.configuration.user_preferences_configured?
+
+      render json: {error: "not_configured"}, status: :not_found
+    end
+
+    def ensure_authenticated
+      return if _current_user.present?
+
+      render json: {error: "unauthorized"}, status: :unauthorized
+    end
+
+    def user_preferences
+      load_user_preferences
+      @user_preferences || {}
+    end
+
+    def preferences_params
+      body = JSON.parse(request.body.read)
+      body.fetch("preferences", {})
+    rescue JSON::ParserError
+      render json: {error: "invalid JSON body"}, status: :bad_request
+      nil
+    end
+  end
+end

--- a/app/views/avo/partials/_color_scheme_switcher.html.erb
+++ b/app/views/avo/partials/_color_scheme_switcher.html.erb
@@ -1,6 +1,21 @@
-<div class="color-scheme-switcher"
-     data-controller="color-scheme-switcher toggle"
-     data-toggle-exemption-containers-value='["[data-controller*=\"color-scheme-switcher\"]"]'>
+<% persistable = Avo.configuration.user_preferences_configured? && _current_user.present? %>
+<% data_attrs = {
+  controller: "color-scheme-switcher toggle",
+  toggle_exemption_containers_value: '["[data-controller*=\"color-scheme-switcher\"]"]'
+}.merge(persistable ? { color_scheme_switcher_save_url_value: avo.user_preference_path, color_scheme_switcher_persistable_value: "true" } : {}) %>
+<%= tag.div class: "color-scheme-switcher", data: data_attrs do %>
+  <% if persistable %>
+    <div data-color-scheme-switcher-target="saveWrapper"
+         class="color-scheme-switcher__save-wrapper">
+      <button type="button"
+              data-color-scheme-switcher-target="saveButton"
+              data-action="click->color-scheme-switcher#save"
+              class="color-scheme-switcher__save">
+        <span class="color-scheme-switcher__save-text" data-default-text="Save" data-success-text="Saved!">Save</span>
+      </button>
+    </div>
+  <% end %>
+
   <button type="button"
           data-color-scheme-switcher-target="button"
           data-action="click->color-scheme-switcher#setTheme"
@@ -99,4 +114,5 @@
     <%= svg "heroicons/outline/moon", class: "color-scheme-switcher__icon" %>
     <span class="sr-only">Dark</span>
   </button>
-</div>
+
+<% end %>

--- a/app/views/avo/partials/_navbar.html.erb
+++ b/app/views/avo/partials/_navbar.html.erb
@@ -10,7 +10,10 @@
     <%= render Avo::Pro::GlobalSearch::InputComponent.new(resource:) if defined?(Avo::Pro::GlobalSearch::InputComponent) %>
     <div class="flex justify-between w-full h-full items-center m-0">
       <%= render partial: "avo/partials/header" %>
-      <%= render partial: "avo/partials/color_scheme_switcher" %>
+      <div class="flex items-center space-x-2 rtl:space-x-reverse">
+        <%= render Avo::Notifications::BellComponent.new if defined?(Avo::Notifications::BellComponent) %>
+        <%= render partial: "avo/partials/color_scheme_switcher" %>
+      </div>
     </div>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Avo::Engine.routes.draw do
   root "home#index"
 
+  resource :user_preference, only: [:show, :update]
+
   get "resources", to: redirect(Avo.configuration.root_path), as: :avo_resources_redirect
   get "dashboards", to: redirect(Avo.configuration.root_path), as: :avo_dashboards_redirect
 

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -7,7 +7,8 @@ loader = Zeitwerk::Loader.for_gem
 loader.inflector.inflect(
   "html" => "HTML",
   "uri_service" => "URIService",
-  "has_html_attributes" => "HasHTMLAttributes"
+  "has_html_attributes" => "HasHTMLAttributes",
+  "db_config_adapter" => "DBConfigAdapter"
 )
 loader.ignore("#{__dir__}/generators")
 loader.setup
@@ -32,6 +33,8 @@ module Avo
   class NoPolicyError < StandardError; end
 
   class MissingGemError < StandardError; end
+
+  class ConfigurationError < StandardError; end
 
   class DeprecatedAPIError < StandardError; end
 

--- a/lib/avo/user_preferences/db_config_adapter.rb
+++ b/lib/avo/user_preferences/db_config_adapter.rb
@@ -1,0 +1,32 @@
+module Avo
+  module UserPreferences
+    class DBConfigAdapter
+      def initialize(key_prefix: "avo_preferences")
+        @key_prefix = key_prefix
+
+        unless defined?(::DBConfig)
+          raise Avo::ConfigurationError,
+            "The db_config gem is required to use Avo::UserPreferences::DBConfigAdapter. " \
+            "Add `gem 'db_config'` to your Gemfile."
+        end
+      end
+
+      def load(user:, request:)
+        stored = ::DBConfig.get(storage_key(user))
+        return {} if stored.nil?
+
+        stored.symbolize_keys
+      end
+
+      def save(user:, request:, key:, value:, preferences:)
+        ::DBConfig.set(storage_key(user), preferences)
+      end
+
+      private
+
+      def storage_key(user)
+        "#{@key_prefix}_#{user.id}"
+      end
+    end
+  end
+end

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -34,6 +34,16 @@ Avo.configure do |config|
   # Shouldn't impact on community only if custom authorization service was configured.
   config.explicit_authorization = true
 
+  ## == User Preferences ==
+  config.user_preferences = {
+    load: ->(user:, request:) {
+      user.avo_preferences || {}
+    },
+    save: ->(user:, request:, key:, value:, preferences:) {
+      user.update(avo_preferences: preferences)
+    }
+  }
+
   ## == Customization ==
   config.id_links_to_resource = true
   config.full_width_container = false

--- a/spec/dummy/db/migrate/20260213120000_add_avo_preferences_to_users.rb
+++ b/spec/dummy/db/migrate/20260213120000_add_avo_preferences_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvoPreferencesToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :avo_preferences, :jsonb, default: {}
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_02_133623) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_13_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -174,9 +174,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_02_133623) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "price_cents", default: 0, null: false
-    t.string "price_currency", default: "'USD'::character varying", null: false
-    t.integer "rating", default: 0, null: false
+    t.string "price_currency", default: "USD", null: false
     t.string "sizes", default: [], array: true
+    t.integer "rating", default: 0, null: false
     t.index ["rating"], name: "index_products_on_rating"
     t.check_constraint "rating >= 0 AND rating <= 5", name: "rating_range_check"
   end
@@ -296,6 +296,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_02_133623) do
     t.datetime "updated_at", null: false
     t.boolean "active", default: true
     t.string "slug"
+    t.jsonb "avo_preferences", default: {}
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["slug"], name: "index_users_on_slug", unique: true

--- a/spec/features/avo/load_user_preferences_spec.rb
+++ b/spec/features/avo/load_user_preferences_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe "Load user preferences before_action", type: :system do
+  let!(:user) { create :user }
+
+  describe "cookie syncing from server preferences" do
+    around do |example|
+      original = Avo.configuration.user_preferences
+      example.run
+      Avo.configuration.user_preferences = original
+    end
+
+    context "when persistence is configured and user has saved preferences" do
+      it "syncs server preferences to cookies on page load" do
+        # Return preferences for any user — the signed-in user comes from DisableAuthentication
+        Avo.configuration.user_preferences = {
+          load: ->(user:, request:) { {"color_scheme" => "dark", "theme" => "slate", "accent_color" => "blue"} },
+          save: ->(user:, request:, key:, value:, preferences:) { }
+        }
+
+        visit "/admin"
+
+        # Server-loaded preferences are synced to cookies which the FOUC script reads.
+        # Verify via the DOM state that dark mode and slate theme were applied.
+        expect(page).to have_css("html.dark")
+        expect(page).to have_css("html.theme-slate")
+      end
+
+      it "removes cookie when value matches the default" do
+        # "auto" is the default for color_scheme
+        Avo.configuration.user_preferences = {
+          load: ->(user:, request:) { {"color_scheme" => "auto"} },
+          save: ->(user:, request:, key:, value:, preferences:) { }
+        }
+
+        visit "/admin"
+
+        # "auto" is the default for color_scheme, so the cookie should be removed
+        cookie_value = page.evaluate_script("document.cookie.match(/color_scheme=([^;]+)/)?.[1]")
+        expect(cookie_value).to be_nil
+      end
+    end
+
+    context "when persistence is not configured" do
+      it "does not interfere with existing cookie behavior" do
+        Avo.configuration.user_preferences = nil
+
+        visit "/admin"
+
+        # Page loads normally without errors
+        expect(page).to have_current_path(/\/admin/)
+      end
+    end
+
+    context "when load callback raises an error" do
+      it "logs the error and continues normally" do
+        Avo.configuration.user_preferences = {
+          load: ->(user:, request:) { raise "Database connection lost" },
+          save: ->(user:, request:, key:, value:, preferences:) { }
+        }
+
+        # Should not break the page
+        visit "/admin"
+        expect(page).to have_current_path(/\/admin/)
+      end
+    end
+
+    context "with adapter object (duck-typing)" do
+      it "calls the adapter's load method" do
+        adapter_class = Class.new do
+          attr_reader :loaded_for
+
+          def load(user:, request:)
+            @loaded_for = user.id
+            {"color_scheme" => "dark"}
+          end
+
+          def save(user:, request:, key:, value:, preferences:)
+          end
+        end
+
+        adapter = adapter_class.new
+        Avo.configuration.user_preferences = adapter
+
+        visit "/admin"
+
+        # The page should load with dark mode applied (proves cookie was set and read)
+        expect(page).to have_css("html.dark")
+      end
+    end
+  end
+end

--- a/spec/lib/avo/configuration/user_preferences_spec.rb
+++ b/spec/lib/avo/configuration/user_preferences_spec.rb
@@ -1,0 +1,142 @@
+require "rails_helper"
+
+RSpec.describe Avo::Configuration do
+  subject(:configuration) { described_class.new }
+
+  describe "#user_preferences" do
+    it "defaults to nil" do
+      expect(configuration.user_preferences).to be_nil
+    end
+
+    it "accepts a hash with load and save lambdas" do
+      prefs = {
+        load: ->(user:, request:) { {} },
+        save: ->(user:, request:, key:, value:, preferences:) { }
+      }
+      configuration.user_preferences = prefs
+      expect(configuration.user_preferences).to eq(prefs)
+    end
+
+    it "accepts an adapter object responding to load and save" do
+      adapter = double("adapter", load: {}, save: nil)
+      configuration.user_preferences = adapter
+      expect(configuration.user_preferences).to eq(adapter)
+    end
+  end
+
+  describe "#user_preferences_configured?" do
+    it "returns false when user_preferences is nil" do
+      configuration.user_preferences = nil
+      expect(configuration.user_preferences_configured?).to be false
+    end
+
+    it "returns true when user_preferences is a hash" do
+      configuration.user_preferences = {
+        load: ->(user:, request:) { {} },
+        save: ->(user:, request:, key:, value:, preferences:) { }
+      }
+      expect(configuration.user_preferences_configured?).to be true
+    end
+
+    it "returns true when user_preferences is an adapter object" do
+      adapter = double("adapter", load: {}, save: nil)
+      configuration.user_preferences = adapter
+      expect(configuration.user_preferences_configured?).to be true
+    end
+  end
+
+  describe "#user_preference_keys" do
+    it "defaults to an empty array" do
+      expect(configuration.user_preference_keys).to eq([])
+    end
+
+    it "accepts an array of custom key names" do
+      configuration.user_preference_keys = [:sidebar_collapsed, :items_per_page]
+      expect(configuration.user_preference_keys).to eq([:sidebar_collapsed, :items_per_page])
+    end
+  end
+
+  describe "#all_user_preference_keys" do
+    it "includes built-in keys" do
+      expect(configuration.all_user_preference_keys).to include(:color_scheme, :theme, :accent_color)
+    end
+
+    it "includes custom keys" do
+      configuration.user_preference_keys = [:sidebar_collapsed]
+      expect(configuration.all_user_preference_keys).to include(:sidebar_collapsed)
+    end
+
+    it "merges built-in and custom keys" do
+      configuration.user_preference_keys = [:sidebar_collapsed, :items_per_page]
+      expect(configuration.all_user_preference_keys).to eq([:color_scheme, :theme, :accent_color, :sidebar_collapsed, :items_per_page])
+    end
+  end
+
+  describe "#load_user_preferences" do
+    let(:user) { double("user", id: 1) }
+    let(:request) { double("request") }
+
+    context "with hash of lambdas" do
+      it "calls the load lambda with user and request" do
+        loaded_prefs = {color_scheme: "dark", theme: "slate"}
+        configuration.user_preferences = {
+          load: ->(user:, request:) { loaded_prefs },
+          save: ->(user:, request:, key:, value:, preferences:) { }
+        }
+
+        result = configuration.load_user_preferences(user: user, request: request)
+        expect(result).to eq(loaded_prefs)
+      end
+    end
+
+    context "with adapter object" do
+      it "calls the adapter's load method" do
+        loaded_prefs = {color_scheme: "light"}
+        adapter = double("adapter")
+        allow(adapter).to receive(:load).with(user: user, request: request).and_return(loaded_prefs)
+        allow(adapter).to receive(:save)
+
+        configuration.user_preferences = adapter
+        result = configuration.load_user_preferences(user: user, request: request)
+        expect(result).to eq(loaded_prefs)
+      end
+    end
+  end
+
+  describe "#save_user_preferences" do
+    let(:user) { double("user", id: 1) }
+    let(:request) { double("request") }
+
+    context "with hash of lambdas" do
+      it "calls the save lambda with all arguments" do
+        saved_args = nil
+        configuration.user_preferences = {
+          load: ->(user:, request:) { {} },
+          save: ->(user:, request:, key:, value:, preferences:) { saved_args = {key: key, value: value, preferences: preferences} }
+        }
+
+        preferences = {color_scheme: "dark", theme: "slate"}
+        configuration.save_user_preferences(user: user, request: request, key: :color_scheme, value: "dark", preferences: preferences)
+
+        expect(saved_args).to eq({key: :color_scheme, value: "dark", preferences: preferences})
+      end
+    end
+
+    context "with adapter object" do
+      it "calls the adapter's save method" do
+        adapter = double("adapter")
+        allow(adapter).to receive(:load)
+        expect(adapter).to receive(:save).with(
+          user: user,
+          request: request,
+          key: :theme,
+          value: "slate",
+          preferences: {theme: "slate"}
+        )
+
+        configuration.user_preferences = adapter
+        configuration.save_user_preferences(user: user, request: request, key: :theme, value: "slate", preferences: {theme: "slate"})
+      end
+    end
+  end
+end

--- a/spec/lib/avo/user_preferences/db_config_adapter_spec.rb
+++ b/spec/lib/avo/user_preferences/db_config_adapter_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+
+RSpec.describe Avo::UserPreferences::DBConfigAdapter do
+  let(:user) { double("user", id: 42) }
+  let(:request) { double("request") }
+
+  describe "#initialize" do
+    context "when DBConfig is defined" do
+      before do
+        stub_const("DBConfig", Class.new)
+      end
+
+      it "creates an adapter with default key prefix" do
+        adapter = described_class.new
+        expect(adapter).to be_a(described_class)
+      end
+
+      it "accepts a custom key prefix" do
+        adapter = described_class.new(key_prefix: "my_app_prefs")
+        expect(adapter).to be_a(described_class)
+      end
+    end
+
+    context "when DBConfig is not defined" do
+      before do
+        hide_const("DBConfig") if defined?(DBConfig)
+      end
+
+      it "raises Avo::ConfigurationError" do
+        expect { described_class.new }.to raise_error(Avo::ConfigurationError, /db_config/i)
+      end
+    end
+  end
+
+  describe "#load" do
+    before do
+      stub_const("DBConfig", Class.new do
+        def self.get(key)
+          nil
+        end
+
+        def self.set(key, value)
+        end
+      end)
+    end
+
+    let(:adapter) { described_class.new }
+
+    it "returns a hash of preferences" do
+      stored = {color_scheme: "dark", theme: "slate"}
+      allow(DBConfig).to receive(:get).with("avo_preferences_42").and_return(stored)
+
+      result = adapter.load(user: user, request: request)
+      expect(result).to eq(stored)
+    end
+
+    it "returns an empty hash when no preferences are stored" do
+      allow(DBConfig).to receive(:get).with("avo_preferences_42").and_return(nil)
+
+      result = adapter.load(user: user, request: request)
+      expect(result).to eq({})
+    end
+
+    it "uses the custom key prefix" do
+      adapter = described_class.new(key_prefix: "my_prefs")
+      allow(DBConfig).to receive(:get).with("my_prefs_42").and_return({})
+
+      adapter.load(user: user, request: request)
+      expect(DBConfig).to have_received(:get).with("my_prefs_42")
+    end
+  end
+
+  describe "#save" do
+    before do
+      stub_const("DBConfig", Class.new do
+        def self.get(key)
+          nil
+        end
+
+        def self.set(key, value)
+        end
+      end)
+    end
+
+    let(:adapter) { described_class.new }
+
+    it "stores the full preferences hash" do
+      preferences = {color_scheme: "dark", theme: "slate", accent_color: "blue"}
+      allow(DBConfig).to receive(:set)
+
+      adapter.save(user: user, request: request, key: :color_scheme, value: "dark", preferences: preferences)
+
+      expect(DBConfig).to have_received(:set).with("avo_preferences_42", preferences)
+    end
+
+    it "uses the custom key prefix for storage" do
+      adapter = described_class.new(key_prefix: "custom")
+      allow(DBConfig).to receive(:set)
+
+      adapter.save(user: user, request: request, key: :theme, value: "slate", preferences: {theme: "slate"})
+
+      expect(DBConfig).to have_received(:set).with("custom_42", {theme: "slate"})
+    end
+  end
+end

--- a/spec/requests/avo/user_preferences_request_spec.rb
+++ b/spec/requests/avo/user_preferences_request_spec.rb
@@ -1,0 +1,161 @@
+require "rails_helper"
+
+RSpec.describe "UserPreferences", type: :request do
+  let(:admin_user) { create :user, roles: {admin: true} }
+  let(:preference_store) { {} }
+
+  let(:user_preferences_config) do
+    store = preference_store
+    {
+      load: ->(user:, request:) { store[user.id] || {} },
+      save: ->(user:, request:, key:, value:, preferences:) { store[user.id] = preferences }
+    }
+  end
+
+  describe "GET /admin/user_preference (show)" do
+    context "when user_preferences is configured and user is signed in" do
+      before do
+        login_as admin_user
+        Avo.configuration.user_preferences = user_preferences_config
+        preference_store[admin_user.id] = {"color_scheme" => "dark", "theme" => "slate"}
+      end
+
+      after do
+        Avo.configuration.user_preferences = nil
+      end
+
+      it "returns 200 with current preferences" do
+        get "/admin/user_preference"
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body["preferences"]).to include("color_scheme" => "dark", "theme" => "slate")
+      end
+    end
+
+    context "when user_preferences is not configured" do
+      before do
+        login_as admin_user
+        Avo.configuration.user_preferences = nil
+      end
+
+      it "returns 404" do
+        get "/admin/user_preference"
+
+        expect(response).to have_http_status(:not_found)
+        body = JSON.parse(response.body)
+        expect(body["error"]).to eq("not_configured")
+      end
+    end
+  end
+
+  describe "PATCH /admin/user_preference (update)" do
+    context "when user_preferences is configured and user is signed in" do
+      before do
+        login_as admin_user
+        Avo.configuration.user_preferences = user_preferences_config
+      end
+
+      after do
+        Avo.configuration.user_preferences = nil
+      end
+
+      it "returns 200 and saves preferences" do
+        patch "/admin/user_preference",
+          params: {preferences: {color_scheme: "dark", theme: "slate", accent_color: "blue"}}.to_json,
+          headers: {"Content-Type" => "application/json"}
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body["status"]).to eq("ok")
+        expect(preference_store[admin_user.id]).to include("color_scheme" => "dark")
+      end
+
+      it "silently ignores unregistered keys" do
+        patch "/admin/user_preference",
+          params: {preferences: {color_scheme: "dark", unknown_key: "value"}}.to_json,
+          headers: {"Content-Type" => "application/json"}
+
+        expect(response).to have_http_status(:ok)
+
+        saved = preference_store[admin_user.id]
+        expect(saved).to have_key("color_scheme")
+        expect(saved).not_to have_key("unknown_key")
+      end
+
+      it "accepts registered custom keys" do
+        Avo.configuration.user_preference_keys = [:sidebar_collapsed]
+
+        patch "/admin/user_preference",
+          params: {preferences: {sidebar_collapsed: "true"}}.to_json,
+          headers: {"Content-Type" => "application/json"}
+
+        expect(response).to have_http_status(:ok)
+
+        Avo.configuration.user_preference_keys = []
+      end
+    end
+
+    context "when user_preferences is not configured" do
+      before do
+        login_as admin_user
+        Avo.configuration.user_preferences = nil
+      end
+
+      it "returns 404" do
+        patch "/admin/user_preference",
+          params: {preferences: {color_scheme: "dark"}}.to_json,
+          headers: {"Content-Type" => "application/json"}
+
+        expect(response).to have_http_status(:not_found)
+        body = JSON.parse(response.body)
+        expect(body["error"]).to eq("not_configured")
+      end
+    end
+
+    context "when no user is signed in" do
+      before do
+        Avo.configuration.user_preferences = user_preferences_config
+      end
+
+      after do
+        Avo.configuration.user_preferences = nil
+      end
+
+      # The controller returns 401 JSON for unauthenticated requests, but in the
+      # dummy app Devise's `authenticate :user` route constraint intercepts the
+      # request first and redirects to sign-in before the controller ever runs.
+      it "redirects to sign-in (Devise intercepts before controller)" do
+        patch "/admin/user_preference",
+          params: {preferences: {color_scheme: "dark"}}.to_json,
+          headers: {"Content-Type" => "application/json"}
+
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context "when save callback raises an error" do
+      before do
+        login_as admin_user
+        Avo.configuration.user_preferences = {
+          load: ->(user:, request:) { {} },
+          save: ->(user:, request:, key:, value:, preferences:) { raise "Storage failure" }
+        }
+      end
+
+      after do
+        Avo.configuration.user_preferences = nil
+      end
+
+      it "returns 422 with error details" do
+        patch "/admin/user_preference",
+          params: {preferences: {color_scheme: "dark"}}.to_json,
+          headers: {"Content-Type" => "application/json"}
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        body = JSON.parse(response.body)
+        expect(body["error"]).to include("Storage failure")
+      end
+    end
+  end
+end

--- a/spec/system/avo/user_preferences_spec.rb
+++ b/spec/system/avo/user_preferences_spec.rb
@@ -1,0 +1,116 @@
+require "rails_helper"
+
+RSpec.describe "User Preferences Persistence", type: :system do
+  let!(:user) { create :user }
+
+  describe "when persistence is configured" do
+    let(:preference_store) { {} }
+
+    around do |example|
+      store = preference_store
+      original = Avo.configuration.user_preferences
+      Avo.configuration.user_preferences = {
+        load: ->(user:, request:) { store[user.id] || {} },
+        save: ->(user:, request:, key:, value:, preferences:) { store[user.id] = preferences }
+      }
+
+      example.run
+
+      Avo.configuration.user_preferences = original
+    end
+
+    it "shows the Save button in the color scheme switcher" do
+      visit "/admin"
+
+      expect(page).to have_css(".color-scheme-switcher__save")
+    end
+
+    it "saves preferences when clicking the Save button" do
+      visit "/admin"
+
+      # Click dark mode
+      find("[data-action='click->color-scheme-switcher#setScheme'][data-scheme='dark']").click
+
+      # Click Save
+      find(".color-scheme-switcher__save").click
+
+      # Wait for success feedback
+      expect(page).to have_css(".color-scheme-switcher__save--success")
+    end
+
+    it "restores preferences after page reload" do
+      # Pre-populate the store with dark scheme preference
+      preference_store[user.id] = {"color_scheme" => "dark"}
+
+      visit "/admin"
+
+      # The page should have dark mode applied via cookie synced from server preferences
+      expect(page).to have_css("html.dark")
+    end
+
+    it "shows success feedback that reverts after ~2 seconds" do
+      visit "/admin"
+
+      find(".color-scheme-switcher__save").click
+
+      # Success state appears
+      expect(page).to have_css(".color-scheme-switcher__save--success")
+
+      # Success state disappears after timeout
+      expect(page).not_to have_css(".color-scheme-switcher__save--success", wait: 5)
+    end
+  end
+
+  describe "when persistence is not configured" do
+    around do |example|
+      original = Avo.configuration.user_preferences
+      Avo.configuration.user_preferences = nil
+
+      example.run
+
+      Avo.configuration.user_preferences = original
+    end
+
+    it "does not show the Save button" do
+      visit "/admin"
+
+      expect(page).not_to have_css(".color-scheme-switcher__save")
+    end
+
+    it "theme switching still works via cookies" do
+      visit "/admin"
+
+      # Click dark mode
+      find("[data-action='click->color-scheme-switcher#setScheme'][data-scheme='dark']").click
+
+      # Dark mode should be applied immediately via cookie/JS
+      expect(page).to have_css("html.dark")
+    end
+  end
+
+  describe "when user is not signed in" do
+    before do
+      Avo.configuration.user_preferences = {
+        load: ->(user:, request:) { {} },
+        save: ->(user:, request:, key:, value:, preferences:) { }
+      }
+    end
+
+    after do
+      Avo.configuration.user_preferences = nil
+    end
+
+    it "does not show the Save button for anonymous users" do
+      # Sign out current user
+      logout
+
+      # Visiting without being signed in should redirect to sign-in
+      # or show the page without the Save button
+      # Since the dummy app requires authentication, this test verifies
+      # the button is not rendered when _current_user is nil
+      visit "/admin"
+
+      expect(page).not_to have_css(".color-scheme-switcher__save")
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Makes the color settings persistent.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new server-backed user-preferences API and request-time cookie syncing, which affects per-request behavior and introduces new persistence hooks. Risk is mitigated by opt-in configuration and key allowlisting, but bugs could impact UI theming and preference storage.
> 
> **Overview**
> Enables **optional persistence** of UI color settings by introducing a configurable `user_preferences` interface (hash callbacks or adapter object) plus support for custom preference keys.
> 
> On each request, `BaseApplicationController#load_user_preferences` loads server preferences (when configured) and **syncs them into cookies** (removing defaults) to keep the existing cookie-driven theming while preventing FOUC.
> 
> Adds `GET/PATCH /user_preference` JSON endpoints to read/update allowed preference keys, and updates the color-scheme switcher to show a **dirty-state “Save” button** that PATCHes current cookie values and provides success/error feedback. Includes a `DBConfigAdapter`, dummy-app storage via `users.avo_preferences`, and request/system specs covering load/sync/save flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d625e4690853a450cbcf23708cb528ce035d5c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->