### PR TITLE
refactor: UI tweaks, better browser detection and new neutrals

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -66,6 +66,9 @@
 @custom-variant theme-mist (&:where(.theme-mist, .theme-mist *));
 @custom-variant theme-olive (&:where(.theme-olive, .theme-olive *));
 
+@custom-variant os-mac (&:where(.os-mac, .os-mac *));
+@custom-variant os-pc (&:where(.os-pc, .os-pc *));
+
 @custom-variant has-cover (&:where(.has-cover *));
 @custom-variant has-sidebar (&:where(.has-sidebar *));
 @custom-variant has-record-selector (&:where(.has-record-selector *));
@@ -183,14 +186,6 @@
 
   .turbo-progress-bar {
     @apply bg-primary-400;
-  }
-
-  body.os-mac .mac\:hidden {
-    display: none;
-  }
-
-  body.os-pc .pc\:hidden {
-    display: none;
   }
 
   body.modal-open {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Tailwidn OS variants

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, CSS-only refactor that changes how OS-specific visibility is expressed; risk is limited to potential UI regressions if any elements still rely on the removed `mac:hidden`/`pc:hidden` rules.
> 
> **Overview**
> Adds Tailwind CSS `@custom-variant` definitions for `os-mac` and `os-pc`, enabling OS-targeted utility variants (e.g., `os-mac:...`, `os-pc:...`) throughout the UI.
> 
> Removes the old `body.os-mac .mac:hidden` / `body.os-pc .pc:hidden` CSS rules, shifting OS-specific visibility behavior to Tailwind variants instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16d483224823e25d7403324d2100d26351a77d10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->