### PR TITLE
Avo 4 - Fix design of invalid field type alert

### DIFF
--- a/app/assets/stylesheets/css/components/alert.css
+++ b/app/assets/stylesheets/css/components/alert.css
@@ -70,3 +70,17 @@
   --alert-background: color-mix(in oklab, var(--color-danger) 15%, var(--color-primary));
   --alert-border: var(--color-danger-foreground);
 }
+
+.alert__title code,
+.alert__message code {
+  @apply rounded px-1 py-px font-mono text-xs;
+
+  background: color-mix(in oklab, var(--alert-color) 15%, transparent);
+  color: var(--alert-color);
+}
+
+.alert__message a {
+  @apply underline underline-offset-2;
+
+  color: var(--alert-color);
+}

--- a/app/assets/stylesheets/css/components/alert.css
+++ b/app/assets/stylesheets/css/components/alert.css
@@ -8,7 +8,7 @@
 
   --alert-color: var(--color-foreground);
   --alert-title-color: color-mix(in oklab, var(--color-content) 20%, var(--alert-color));
-  --alert-message-color: color-mix(in oklab, var(--color-content) 10%, var(--alert-color));
+  --alert-message-color: var(--alert-title-color);
   --alert-background: var(--color-background);
   --alert-border: var(--color-tertiary);
 }

--- a/app/components/avo/views/resource_show_component.html.erb
+++ b/app/components/avo/views/resource_show_component.html.erb
@@ -29,7 +29,7 @@
     <turbo-stream action="append" target="alerts">
       <template>
         <% @resource.invalid_fields.each do |error| %>
-          <%= render Avo::AlertComponent.new error[:alert_type], error[:message] %>
+          <%= render Avo::AlertComponent.new error[:alert_type], error[:message], description: error[:description], timeout: :forever %>
         <% end %>
       </template>
     </turbo-stream>

--- a/lib/avo/resources/items/holder.rb
+++ b/lib/avo/resources/items/holder.rb
@@ -29,20 +29,22 @@ class Avo::Resources::Items::Holder
       as = args.fetch(:as, nil)
 
       alert_type = :error
-      message = "There's an invalid field configuration for this resource. <br/> <code class='px-1 py-px rounded-sm bg-red-600'>field :#{field_name}, as: :#{as}</code>"
+      message = "Invalid field configuration"
+      description = "Check your resource file for: <code>field :#{field_name}, as: :#{as}</code>"
 
       if as == :markdown
         alert_type = :warning
-        message = "In Avo 3.16.2 we renamed the <code>:markdown</code> field to <code>:easy_mde</code>. <br/><br/>You may continue to use that one or the new and improved one with Active Storage support. <br/><br/> Read more about it in the <a href=\"https://docs.avohq.io/3.0/fields/markdown.html\" target=\"_blank\">docs</a>."
+        message = "Deprecated field type :markdown"
+        description = "In Avo 3.16.2 we renamed <code>:markdown</code> to <code>:easy_mde</code>. You may continue to use that one or the new and improved one with Active Storage support. Read more about it in the <a href=\"https://docs.avohq.io/3.0/fields/markdown.html\" target=\"_blank\">docs</a>."
       end
 
-      # End execution ehre and add the field to the invalid_fileds payload so we know to wanr the developer about that.
-      # @todo: Make sure this warning is still active
+      # End execution here and add the field to the invalid_fields payload so we know to warn the developer about that.
       return add_invalid_field({
         name: field_name,
         as:,
         alert_type:,
-        message:
+        message:,
+        description:
       })
     end
 

--- a/spec/features/avo/invalid_field_spec.rb
+++ b/spec/features/avo/invalid_field_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "InvalidField", type: :feature do
     it "shows an alert" do
       visit "/admin/resources/teams/#{team.id}"
 
-      expect(page.body).to include "There's an invalid field configuration for this resource."
+      expect(page.body).to include "Invalid field configuration"
       expect(page.body).to include "field :invalid, as: :invalid_field"
     end
   end
@@ -17,7 +17,7 @@ RSpec.feature "InvalidField", type: :feature do
     it "shows an alert" do
       visit "/admin/resources/posts/#{post.to_param}"
 
-      expect(page.body).not_to include "There's an invalid field configuration for this resource."
+      expect(page.body).not_to include "Invalid field configuration"
       expect(page.body).not_to include "field :invalid, as: invalid_field"
     end
   end


### PR DESCRIPTION
# Description
Fix design of invalid field type alert

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<img width="392" height="101" alt="Screenshot 2026-04-08 at 09 47 22" src="https://github.com/user-attachments/assets/4b60dd38-38d2-4d71-a4e2-14d40b5aa924" />
<img width="392" height="101" alt="Screenshot 2026-04-08 at 09 47 40" src="https://github.com/user-attachments/assets/634480b9-5978-4d62-a767-23b8c7ef014b" />
