### PR TITLE
fix: applied filters counter for default filters

### DIFF
--- a/app/avo/base_resource.rb
+++ b/app/avo/base_resource.rb
@@ -1,5 +1,5 @@
 module Avo
   class BaseResource < Avo::Resources::Base
-    # Users can override this class to add custom methods for all resources.
+    # Users can  override this class to add custom methods for all resources.
   end
 end

--- a/app/avo/base_resource.rb
+++ b/app/avo/base_resource.rb
@@ -1,5 +1,5 @@
 module Avo
   class BaseResource < Avo::Resources::Base
-    # Users can  override this class to add custom methods for all resources.
+    # Users can override this class to add custom methods for all resources.
   end
 end

--- a/app/components/avo/filters_component.html.erb
+++ b/app/components/avo/filters_component.html.erb
@@ -8,8 +8,8 @@
       'data-action': 'click->toggle#togglePanel',
       'data-tippy': 'tooltip' do %>
       <%= t 'avo.filters' %>
-      <% if @applied_filters.present? %>
-        <span class="filters__count">(<%= "#{@applied_filters.count} #{t('avo.applied', count: @applied_filters.count)}" %>)</span>
+      <% if applied_filters_count.present? %>
+        <span class="filters__count">(<%= applied_filters_count %> <%= t('avo.applied', count: applied_filters_count) %>)</span>
       <% end %>
     <% end %>
     <%= tag.div class: 'filters__panel css-animate-slide-down',

--- a/app/components/avo/filters_component.rb
+++ b/app/components/avo/filters_component.rb
@@ -20,4 +20,8 @@ class Avo::FiltersComponent < Avo::BaseComponent
       helpers.resources_path(resource: @resource, encoded_filters: nil, reset_filter: true, keep_query_params: true)
     end
   end
+
+  def applied_filters_count
+    @applied_filters_count ||= Avo::Filters::BasicFilters.to_be_applied(resource: @resource, applied_filters: @applied_filters).count { |_, value| value.present? }
+  end
 end

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -449,17 +449,7 @@ module Avo
 
     # Get the default state of the filters and override with the user applied filters
     def filters_to_be_applied
-      filter_defaults = {}
-
-      @resource.get_filters.each do |filter|
-        filter = filter[:class].new arguments: filter[:arguments]
-
-        unless filter.default.nil?
-          filter_defaults[filter.class.to_s] = filter.default
-        end
-      end
-
-      filter_defaults.merge(@applied_filters)
+      Avo::Filters::BasicFilters.to_be_applied(resource: @resource, applied_filters: @applied_filters)
     end
 
     def set_edit_title_and_breadcrumbs

--- a/lib/avo/filters/basic_filters.rb
+++ b/lib/avo/filters/basic_filters.rb
@@ -16,4 +16,3 @@ module Avo
     end
   end
 end
-

--- a/lib/avo/filters/basic_filters.rb
+++ b/lib/avo/filters/basic_filters.rb
@@ -1,0 +1,19 @@
+module Avo
+  module Filters
+    class BasicFilters
+      def self.to_be_applied(resource:, applied_filters:)
+        filter_defaults = {}
+
+        resource.get_filters.each do |filter|
+          filter_instance = filter[:class].new arguments: filter[:arguments]
+          next if filter_instance.default.nil?
+
+          filter_defaults[filter_instance.class.to_s] = filter_instance.default
+        end
+
+        filter_defaults.merge(applied_filters || {})
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
## Summary
- Fix the Filters “(N applied)” counter so it includes filters with `default` values, not just filters explicitly set in params.
- Reuse the same “defaults + applied” merge logic across controller and UI to keep behavior consistent.

## Implementation details
- Introduced `Avo::Filters::BasicFilters.to_be_applied(resource:, applied_filters:)` to compute the effective filters hash.
- Updated `Avo::BaseController#filters_to_be_applied` to delegate to `BasicFilters`.
- Updated `Avo::FiltersComponent` to use `BasicFilters` for the applied counter, so defaults are counted.