### PR TITLE
Enhance Avo by adding configuration file requirement in lib/avo.rb

### DIFF
--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -2,6 +2,7 @@ require "zeitwerk"
 require "net/http"
 require "active_support/inflector"
 require_relative "avo/version"
+require_relative "avo/configuration"
 require_relative "avo/engine" if defined?(Rails)
 
 loader = Zeitwerk::Loader.for_gem


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #4301

`require_relative "avo/configuration"` on `lib/avo.rb`