### PR TITLE
fix - text wrapping in the state card for small screen

### DIFF
--- a/app/assets/stylesheets/css/components/ui/state.css
+++ b/app/assets/stylesheets/css/components/ui/state.css
@@ -66,12 +66,12 @@
 }
 
 .state__message {
-  @apply text-base font-normal leading-6 text-content-secondary;
+  @apply text-base font-normal leading-6 text-content-secondary break-words whitespace-normal ;
 }
 
 /*  Frame Load Failed Component */
 .state--frame-load-failed {
-  @apply max-w-96 gap-1;
+  @apply max-w-96 gap-1 min-w-0;
 }
 
 .state__document {
@@ -121,7 +121,7 @@
 }
 
 .state__note {
-  @apply text-center text-sm font-normal leading-5 text-content;
+  @apply text-center text-sm font-normal leading-5 text-content break-words whitespace-normal;
 }
 
 .state__link {

--- a/app/assets/stylesheets/css/components/ui/state.css
+++ b/app/assets/stylesheets/css/components/ui/state.css
@@ -66,7 +66,7 @@
 }
 
 .state__message {
-  @apply text-base font-normal leading-6 text-content-secondary break-words whitespace-normal ;
+  @apply text-base font-normal leading-6 text-content-secondary;
 }
 
 /*  Frame Load Failed Component */


### PR DESCRIPTION
# Description
text wrapping in the state card for small screen

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<img width="378" height="266" alt="Screenshot 2026-04-09 at 18 32 05" src="https://github.com/user-attachments/assets/2fbbe886-e5d5-44c7-85fc-8b88a93acb58" />
