### PR TITLE
AVO - fix: validate key and value for radio button checked state

### DIFF
--- a/app/components/avo/fields/radio_field/edit_component.html.erb
+++ b/app/components/avo/fields/radio_field/edit_component.html.erb
@@ -4,7 +4,7 @@
       <% @field.options.each do |key, value| %>
         <div class="tabs__item-wrapper tabs__item-wrapper--switcher">
           <label class="tabs__item tabs__item--switcher">
-            <%= form.radio_button @field.id, key, checked: (@field.value.to_s == key.to_s), class: "hidden" %>
+            <%= form.radio_button @field.id, key, checked: @field.option_checked?(key, value), class: "hidden" %>
             <span class="tabs__item-label"><%= value %></span>
           </label>
         </div>
@@ -14,7 +14,7 @@
     <div class="flex flex-col gap-2">
       <% @field.options.each do |key, value| %>
         <div class="flex items-center gap-1">
-          <%= form.radio_button @field.id, key, checked: (@field.value.to_s == key.to_s) %>
+          <%= form.radio_button @field.id, key, checked: @field.option_checked?(key, value) %>
           <%= form.label @field.id, value, value: key %>
         </div>
       <% end %>

--- a/lib/avo/fields/radio_field.rb
+++ b/lib/avo/fields/radio_field.rb
@@ -34,6 +34,15 @@ module Avo
       def display_as_tabs?
         @display_as == :tabs
       end
+
+      # Returns true when the field's value matches an option's key or value.
+      # Supports both `{stored_value: "Label"}` and `{"Label": stored_value}` styles
+      # so `default:` can be specified using either side of the options hash.
+      def option_checked?(key, option_value)
+        return false if value.nil?
+
+        value.to_s == key.to_s || value.to_s == option_value.to_s
+      end
     end
   end
 end

--- a/spec/dummy/app/avo/resources/fish.rb
+++ b/spec/dummy/app/avo/resources/fish.rb
@@ -23,7 +23,7 @@ class Avo::Resources::Fish < Avo::BaseResource
     field :id, as: :id
     field :id, as: :number, only_on: :forms, readonly: -> { !view.new? }
     field :name, as: :text, required: -> { view.new? }, help: "help text"
-    field :size, as: :radio, options: {small: "Small", medium: "Medium", large: "Large"}
+    field :size, as: :radio, options: {small: "Small", "medium one": :Medium, "large two": :Large}, default: :Large
     field :secondary_field_for_name,
       as: :text,
       for_attribute: :name,

--- a/spec/features/avo/radio_field_spec.rb
+++ b/spec/features/avo/radio_field_spec.rb
@@ -31,20 +31,20 @@ RSpec.describe "RadioField", type: :feature do
         )
 
         expect(page).to have_checked_field "fish_size_small", visible: :all
-        expect(page).to_not have_checked_field "fish_size_medium", visible: :all
-        expect(page).to_not have_checked_field "fish_size_large", visible: :all
+        expect(page).to_not have_checked_field "fish_size_medium_one", visible: :all
+        expect(page).to_not have_checked_field "fish_size_large_two", visible: :all
 
-        find("#fish_size_large", visible: :all).click
+        find("#fish_size_large_two", visible: :all).click
 
         expect(page).to_not have_checked_field "fish_size_small", visible: :all
-        expect(page).to_not have_checked_field "fish_size_medium", visible: :all
-        expect(page).to have_checked_field "fish_size_large", visible: :all
+        expect(page).to_not have_checked_field "fish_size_medium_one", visible: :all
+        expect(page).to have_checked_field "fish_size_large_two", visible: :all
 
         save
 
         fish.reload
 
-        expect(fish.size).to eq "large"
+        expect(fish.size).to eq "large two"
       end
     end
   end
@@ -57,7 +57,69 @@ RSpec.describe "RadioField", type: :feature do
         visit "/admin/resources/fish/#{fish.id}/edit"
 
         expect(page).to_not have_checked_field "fish_size_small", visible: :all
+        expect(page).to_not have_checked_field "fish_size_medium_one", visible: :all
+        expect(page).to_not have_checked_field "fish_size_large_two", visible: :all
+      end
+    end
+  end
+
+  describe "default option on new view" do
+    context "when default matches an option key" do
+      before(:all) do
+        Avo::Resources::Fish.with_temporary_items do
+          field :id, as: :id
+          field :name, as: :text
+          field :size, as: :radio, options: {small: "Small", medium: "Medium", large: "Large"}, default: :medium
+        end
+      end
+
+      after(:all) { Avo::Resources::Fish.restore_items_from_backup }
+
+      it "checks the matching radio" do
+        visit "/admin/resources/fish/new"
+
+        expect(page).to_not have_checked_field "fish_size_small", visible: :all
+        expect(page).to have_checked_field "fish_size_medium", visible: :all
+        expect(page).to_not have_checked_field "fish_size_large", visible: :all
+      end
+    end
+
+    context "when default matches an option value (select-style options)" do
+      before(:all) do
+        Avo::Resources::Fish.with_temporary_items do
+          field :id, as: :id
+          field :name, as: :text
+          field :size, as: :radio, options: {small: "Small", medium: "Medium", large: "Large"}, default: "Large"
+        end
+      end
+
+      after(:all) { Avo::Resources::Fish.restore_items_from_backup }
+
+      it "checks the radio whose value matches the default" do
+        visit "/admin/resources/fish/new"
+
+        expect(page).to_not have_checked_field "fish_size_small", visible: :all
         expect(page).to_not have_checked_field "fish_size_medium", visible: :all
+        expect(page).to have_checked_field "fish_size_large", visible: :all
+      end
+    end
+
+    context "when default matches a key and display_as is :tabs" do
+      before(:all) do
+        Avo::Resources::Fish.with_temporary_items do
+          field :id, as: :id
+          field :name, as: :text
+          field :size, as: :radio, options: {small: "Small", medium: "Medium", large: "Large"}, default: :medium, display_as: :tabs
+        end
+      end
+
+      after(:all) { Avo::Resources::Fish.restore_items_from_backup }
+
+      it "checks the matching tab" do
+        visit "/admin/resources/fish/new"
+
+        expect(page).to_not have_checked_field "fish_size_small", visible: :all
+        expect(page).to have_checked_field "fish_size_medium", visible: :all
         expect(page).to_not have_checked_field "fish_size_large", visible: :all
       end
     end


### PR DESCRIPTION
# Description
fix: validate key and value for radio button checked state

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<img width="988" height="35" alt="Screenshot 2026-04-17 at 08 14 50" src="https://github.com/user-attachments/assets/f3f8f814-fce0-47a5-8ffe-8157e26d2161" />
</br>
<img width="769" height="85" alt="Screenshot 2026-04-17 at 08 15 21" src="https://github.com/user-attachments/assets/edcb4fe6-652b-4b91-b325-c6b436116729" />
