### PR TITLE
refactor: tweak CSS build pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   "private": true,
   "scripts": {
     "js:visualize": "yarn build:js -- --metafile=js_bundle_metadata.json && esbuild-visualizer --metadata=js_bundle_metadata.json --filename=js_bundle_stats.html",
-    "build": "yarn build:js && yarn build:dependencies-css && yarn build:css",
+    "build": "yarn build:js && yarn build:css",
     "prod:build": "yarn build",
     "build:js": "esbuild app/javascript/*.js --bundle --sourcemap --minify --outdir=app/assets/builds/avo",
     "build:custom-js": "esbuild spec/dummy/app/javascript/*.js --bundle --sourcemap --minify --outdir=app/assets/builds/avo",
     "build:dependencies-css": "npx @tailwindcss/cli -i ./app/assets/stylesheets/dependencies.css -o ./app/assets/builds/avo/dependencies.css --postcss",
-    "build:css": "npx @tailwindcss/cli -i ./app/assets/stylesheets/application.css -o ./app/assets/builds/avo/application.css --postcss",
+    "build:css": "yarn build:dependencies-css && npx @tailwindcss/cli -i ./app/assets/stylesheets/application.css -o ./app/assets/builds/avo/application.css --postcss",
     "export": "yarn export:heroicons && yarn export:tailwind-safelist",
     "export:tailwind-safelist": "node scripts/export-tailwind-safelist.js"
   },


### PR DESCRIPTION
Tweaks the order of CSS jobs.
We should have it in `build:css` because that's what we run in `Procfile.dev`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only rearranges Yarn build scripts, with the main impact being build/dev pipeline behavior if CSS tasks now run in a different order or more often.
> 
> **Overview**
> Updates the Yarn build pipeline so `build` no longer runs `build:dependencies-css` as a separate step, and instead `build:css` now explicitly runs `build:dependencies-css` before compiling `application.css`.
> 
> This centralizes CSS build ordering under `build:css`, aligning the behavior with workflows that invoke `build:css` directly (e.g., in development process configs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a98a95fcd12eb2d4175fca8b07a9f2642d3515f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->