### PR TITLE
fix: update applied filters count logic and add related test case

### DIFF
--- a/app/components/avo/filters_component.html.erb
+++ b/app/components/avo/filters_component.html.erb
@@ -8,7 +8,7 @@
       'data-action': 'click->toggle#togglePanel',
       'data-tippy': 'tooltip' do %>
       <%= t 'avo.filters' %>
-      <% if applied_filters_count.present? %>
+      <% if applied_filters_count.positive? %>
         <span class="filters__count">(<%= applied_filters_count %> <%= t('avo.applied', count: applied_filters_count) %>)</span>
       <% end %>
     <% end %>

--- a/spec/system/avo/group_2/filters/filters_spec.rb
+++ b/spec/system/avo/group_2/filters/filters_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe "Filters", type: :system do
 
     let(:url) { "/admin/resources/posts?view_type=table" }
 
+    it "does not display the applied count label when no filters are applied" do
+      visit url
+
+      expect(page).not_to have_css(".filters__count")
+      expect(page).not_to have_text("(0 applied)")
+    end
+
     it "displays the filter" do
       visit url
       open_filters_menu


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
* Change the condition for displaying the applied filters count from `present?` to `positive?` to ensure accurate representation of applied filters.
* Add a test to verify that the applied count label is not displayed when no filters are applied.
<img width="2165" height="220" alt="image" src="https://github.com/user-attachments/assets/2593cf3f-1d3c-47b4-84f6-9f8c517bbe36" />
