### PR TITLE
refactor: tweak button styles

### DIFF
--- a/app/assets/stylesheets/css/components/button.css
+++ b/app/assets/stylesheets/css/components/button.css
@@ -10,7 +10,7 @@
   }
 
   .button {
-    @apply inline-flex justify-center grow-0 items-center font-medium leading-none fill-current whitespace-nowrap transition-transform duration-50 cursor-pointer disabled:cursor-not-allowed disabled:opacity-60 data-[disabled='true']:opacity-60 gap-1.5 border border-transparent rounded-lg;
+    @apply inline-flex justify-center grow-0 items-center font-medium leading-[14px] fill-current whitespace-nowrap transition-transform duration-100 cursor-pointer disabled:cursor-not-allowed disabled:opacity-60 data-[disabled='true']:opacity-60 gap-1.5 border border-transparent rounded-lg;
 
     --btn-text-color: color-mix(in oklab, var(--btn-color-accent), var(--color-content) 20%);
 
@@ -203,15 +203,15 @@
     }
 
     box-shadow:
-      0 -0.5px 0 0.1px var(--btn-color-accent-content) inset,
-      0 0.8px 0 0.1px color-mix(in oklab, var(--color-white) 45%, transparent) inset;
+      0 -1.4px 0 0.1px var(--btn-color-accent-content) inset,
+      0 0.8px 0 0.4px color-mix(in oklab, var(--color-white) 45%, transparent) inset;
 
     &.button--hover,
     &:hover {
       @apply text-(--btn-color-accent-foreground);
 
       background: linear-gradient(180deg, color-mix(in oklab, var(--btn-color-accent-content) 90%, var(--color-black)) 0%, color-mix(in oklab, var(--btn-color-accent) 90%, var(--color-black)) 100%), var(--color-primary);
-      box-shadow: 0 -0.5px 0 0.1px var(--btn-color-accent-content) inset, 0 0.8px 0 0.1px color-mix(in oklab, var(--color-white) 45%, transparent) inset;
+      box-shadow: 0 -1.4px 0 0.1px var(--btn-color-accent-content) inset, 0 0.8px 0 0.4px color-mix(in oklab, var(--color-white) 45%, transparent) inset;
     }
 
     &.button--active,
@@ -257,7 +257,7 @@
 
     border-color: var(--btn-color-accent);
     background: var(--color-primary);
-    box-shadow: 0 -1.5px 0 0 var(--btn-box-shadow-color) inset, 0 0.8px 0 0px var(--color-primary) inset;
+    box-shadow: 0 -1.4px 0 0.1px var(--btn-box-shadow-color) inset, 0 0.8px 0 0.4px var(--color-primary) inset;
 
     &.button--hover,
     &:hover {
@@ -313,19 +313,19 @@
 
   /* Size variants */
   .button--size-xs {
-    @apply text-xs px-2 py-1.5;
+    @apply text-xs px-2 py-1 gap-1 min-w-6;
   }
 
   .button--size-sm {
-    @apply text-xs px-2 py-1.5;
+    @apply text-xs px-2 py-1 gap-1 min-w-6;
   }
 
   .button--size-md {
-    @apply text-sm px-3 py-2;
+    @apply text-sm px-3 py-2 gap-[5px] min-w-8;
   }
 
   .button--size-lg {
-    @apply text-sm px-3 py-3;
+    @apply text-sm p-3 gap-1.5 min-w-10;
   }
 
   /* Icon button sizes */

--- a/app/assets/stylesheets/css/typography.css
+++ b/app/assets/stylesheets/css/typography.css
@@ -22,7 +22,7 @@ kbd {
   @apply inline-flex min-w-5 items-center justify-center rounded-sm border border-tertiary bg-tertiary px-1 py-px text-[10px] leading-[14px] font-medium text-content-secondary;
 
   box-shadow: var(--box-shadow-search-input-shortcut);
-  transition: transform 0.08s ease-out, box-shadow 0.08s ease-out;
+  transition: transform 0.08s ease-out;
 }
 
 kbd.kbd--called {


### PR DESCRIPTION
Tweaks the button styles a bit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to broad asset-pipeline/CSS refactors (Tailwind v4, Propshaft) and significant CI workflow restructuring that could break builds or styling across themes/RTL if misconfigured.
> 
> **Overview**
> Upgrades dependencies to Rails/ActiveStorage `>= 8.1`, switches the asset pipeline to `propshaft`, and bumps several key gems (notably `view_component`) alongside a large Tailwind v4–oriented stylesheet rework (replaces `avo.base.css` with a new `application.css` that imports Tailwind and many newly-split component/field styles).
> 
> Reworks CI by deleting the separate feature/system/components/i18n workflows in favor of a single sharded `Tests` workflow (adds `parallel_tests` usage and artifacts), updates the Tailwind integration workflow for the `4-dev` branch and new compiled CSS output path, and introduces a `Danger` workflow + `Dangerfile` to fail PRs that use non-RTL-safe directional Tailwind classes.
> 
> Includes assorted repo hygiene/docs tweaks: PR template checklist update, new `.herb.yml`, expanded `.standard.yml` ignores, updated contribution docs, ignore `vendor/bundle`, and minor dev procfile/manifest/image path adjustments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae0147b51f537bfd84385d5eaa9bc81132b52045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->