### PR TITLE
fix: `label` on row controls when using `style: :icon`

### DIFF
--- a/app/components/avo/button_component.rb
+++ b/app/components/avo/button_component.rb
@@ -78,7 +78,7 @@ class Avo::ButtonComponent < Avo::BaseComponent
 
   def render_content
     concat helpers.svg(@icon, class: class_names("button__icon", @icon_class)) if @icon.present?
-    concat content if content.present?
+    concat content if content.present? && @style != :icon
     concat hotkey_badge(@args.dig(:data, :hotkey)) if @args.dig(:data, :hotkey) && @args.dig(:data, :show_hotkey_badge) != false
   end
 end

--- a/app/components/avo/button_component.rb
+++ b/app/components/avo/button_component.rb
@@ -82,3 +82,4 @@ class Avo::ButtonComponent < Avo::BaseComponent
     concat hotkey_badge(@args.dig(:data, :hotkey)) if @args.dig(:data, :hotkey) && @args.dig(:data, :show_hotkey_badge) != false
   end
 end
+#

--- a/app/components/avo/button_component.rb
+++ b/app/components/avo/button_component.rb
@@ -82,4 +82,3 @@ class Avo::ButtonComponent < Avo::BaseComponent
     concat hotkey_badge(@args.dig(:data, :hotkey)) if @args.dig(:data, :hotkey) && @args.dig(:data, :show_hotkey_badge) != false
   end
 end
-#


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #4424

On Avo 3, all buttons with `style: :icon` were rendered while ignoring the `label:` option. https://github.com/avo-hq/avo/issues/4424 is a symptom of a regression introduced at the button component level, where icon styled buttons now allow labels. This PR fixes the root issue at the component level, addressing the reported symptom as well as other possible cases where this was occurring.