### PR TITLE
fix: prevent initialization in Rails console for TailwindCSS integration

### DIFF
--- a/lib/avo/engine.rb
+++ b/lib/avo/engine.rb
@@ -44,6 +44,7 @@ module Avo
 
     initializer "avo.tailwindcss", after: :load_config_initializers do
       next unless Rails.env.development?
+      next if defined?(Rails::Console)
 
       Rails.application.config.after_initialize do
         next unless Avo::TailwindBuilder.enabled?


### PR DESCRIPTION
## Summary

This PR prevents Avo's Tailwind auto-build from running when launching Rails console.

Avo currently triggers `Avo::TailwindBuilder.build` from an `after_initialize` hook in development, which also runs during `rails c`. This caused Tailwind to execute on console startup.  
The initializer now exits early in console mode by adding:

`next if defined?(Rails::Console)`

This keeps Tailwind auto-build behavior unchanged for normal development app boot, while avoiding unnecessary work and noise in console sessions.

## Why

- `rails c` should not trigger frontend asset build steps.
- Avoids extra startup time and Tailwind output during console usage.
- Keeps existing Tailwind integration intact for development server/application boot.
