### PR TITLE
refactor: mobile tweaks and auto-wrap fields in cards (AVO-1171)

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -152,6 +152,7 @@
   @import "./css/components/hotkey.css";
   @import "./css/components/modal.css";
   @import "./css/components/filters.css";
+  @import "./css/components/tab_group.css";
   @import "./css/css-animations.css";
   @import "./css/sidebar.css";
 

--- a/app/assets/stylesheets/css/components/breadcrumbs.css
+++ b/app/assets/stylesheets/css/components/breadcrumbs.css
@@ -12,6 +12,10 @@
 
 .breadcrumb-element {
   @apply inline-flex items-center gap-2 font-medium leading-6 text-sm rounded-lg px-2 py-0.5 text-content-secondary;
+
+  &:first-child {
+    @apply ps-0;
+  }
 }
 
 .breadcrumb-element__icon {

--- a/app/assets/stylesheets/css/components/filters.css
+++ b/app/assets/stylesheets/css/components/filters.css
@@ -3,7 +3,7 @@
 }
 
 .filters__count {
-  @apply inline-flex items-center justify-center ms-1 rounded-sm dark:bg-accent/30 bg-accent/10 text-accent-content font-medium text-xs leading-none w-4 py-px px-0.5;
+  @apply inline-flex items-center justify-center ms-1 rounded-sm dark:bg-accent/30 bg-accent/10 text-accent-content font-medium text-xs leading-none min-w-4 py-px px-1;
 }
 
 .filters__panel {

--- a/app/assets/stylesheets/css/components/filters.css
+++ b/app/assets/stylesheets/css/components/filters.css
@@ -3,7 +3,7 @@
 }
 
 .filters__count {
-  @apply ms-1 text-content-secondary;
+  @apply inline-flex items-center justify-center ms-1 rounded-sm dark:bg-accent/30 bg-accent/10 text-accent-content font-medium text-xs leading-none w-4 py-px px-0.5;
 }
 
 .filters__panel {

--- a/app/assets/stylesheets/css/components/tab_group.css
+++ b/app/assets/stylesheets/css/components/tab_group.css
@@ -1,0 +1,13 @@
+/* Tab Group Component */
+@layer components {
+  /* Dashed border wraps both the tabs list and the active tab's content.
+     The element extends 5px past each side of its container so the border
+     sits outside the panel padding without requiring the parent to know
+     about it. Uses width + negative margin-inline (RTL-safe) instead of
+     left/right. */
+  .tab-group {
+    @apply relative border border-dashed border-tertiary rounded-2xl p-2;
+    width: calc(100% + --spacing(4));
+    margin-inline: calc((--spacing(2)) * -1);
+  }
+}

--- a/app/assets/stylesheets/css/components/tab_group.css
+++ b/app/assets/stylesheets/css/components/tab_group.css
@@ -6,8 +6,13 @@
      about it. Uses width + negative margin-inline (RTL-safe) instead of
      left/right. */
   .tab-group {
-    @apply relative border border-dashed border-tertiary rounded-2xl p-2;
-    width: calc(100% + --spacing(4));
-    margin-inline: calc((--spacing(2)) * -1);
+    @apply relative border border-dashed border-tertiary rounded-2xl;
+    --tab-group-modifier: 8;
+    --tab-group-padding: calc(var(--tab-group-modifier) - (var(--tab-group-modifier)/2));
+
+    width: calc(100% + calc(var(--spacing) * var(--tab-group-modifier)));
+    margin-inline: calc(var(--spacing) * var(--tab-group-padding) * -1);
+    padding: calc(var(--spacing) * var(--tab-group-padding));
+
   }
 }

--- a/app/assets/stylesheets/css/components/ui/panel_header.css
+++ b/app/assets/stylesheets/css/components/ui/panel_header.css
@@ -1,13 +1,15 @@
+/* Main breaking point: md */
+
 .header {
   @apply flex flex-col gap-2 items-start justify-center pe-0 py-0;
 }
 
 .header__main {
-  @apply flex flex-col sm:flex-row gap-4 items-center w-full;
+  @apply flex flex-col md:flex-row gap-4 items-center w-full;
 }
 
 .header__content {
-  @apply flex gap-3 items-center grow shrink basis-0;
+  @apply w-full flex gap-3 items-center grow shrink basis-0;
 }
 
 .header__avatar {
@@ -31,7 +33,7 @@
 }
 
 .header__controls {
-  @apply flex gap-3 items-center cursor-pointer shrink-0 flex-wrap;
+  @apply w-full md:w-auto flex gap-3 items-center cursor-pointer shrink-0 flex-wrap justify-center md:justify-end;
 }
 
 .header__discreet-information {

--- a/app/assets/stylesheets/css/components/ui/tabs.css
+++ b/app/assets/stylesheets/css/components/ui/tabs.css
@@ -6,7 +6,43 @@
 
   /* Container */
   .tabs {
-    @apply flex flex-wrap;
+    @apply flex flex-nowrap overflow-x-auto sm:flex-wrap sm:overflow-visible;
+    scrollbar-width: none;
+
+    /* Scroll shadows (Lea Verou's background-attachment: local technique).
+       Two solid-color "cover" blocks scroll with the content (local) and sit
+       on top of two radial "shadow" gradients that stay fixed (scroll). When
+       scrolled to an edge, the cover completely hides the shadow on that
+       side; as the user scrolls away, the cover moves with the content and
+       the shadow below is revealed. Covers are hard-edged (no fade through
+       `transparent`, which in CSS is rgba(0,0,0,0) and bleeds dark pixels). */
+    background-image:
+      linear-gradient(var(--color-background), var(--color-background)),
+      linear-gradient(var(--color-background), var(--color-background)),
+      radial-gradient(
+        farthest-side at 0 50%,
+        rgb(0 0 0 / 0.18),
+        rgb(0 0 0 / 0)
+      ),
+      radial-gradient(
+        farthest-side at 100% 50%,
+        rgb(0 0 0 / 0.18),
+        rgb(0 0 0 / 0)
+      );
+    background-position: 0 0, 100% 0, 0 0, 100% 0;
+    background-repeat: no-repeat;
+    background-size: 1rem 100%, 1rem 100%, 0.75rem 100%, 0.75rem 100%;
+    background-attachment: local, local, scroll, scroll;
+  }
+
+  @media (min-width: 640px) {
+    .tabs {
+      background: none;
+    }
+  }
+
+  .tabs::-webkit-scrollbar {
+    display: none;
   }
 
   /* Base Item */

--- a/app/assets/stylesheets/css/components/ui/tabs.css
+++ b/app/assets/stylesheets/css/components/ui/tabs.css
@@ -28,12 +28,12 @@
       linear-gradient(var(--color-primary), var(--color-primary)),
       radial-gradient(
         farthest-side at 0 50%,
-        color-mix(var(--color-foreground), transparent 80%),
+        color-mix(in oklab, var(--color-foreground), transparent 80%),
         rgb(0 0 0 / 0)
       ),
       radial-gradient(
         farthest-side at 100% 50%,
-        color-mix(var(--color-foreground), transparent 80%),
+        color-mix(in oklab, var(--color-foreground), transparent 80%),
         rgb(0 0 0 / 0)
       );
     background-position: 0 0, 100% 0, 0 0, 100% 0;

--- a/app/assets/stylesheets/css/components/ui/tabs.css
+++ b/app/assets/stylesheets/css/components/ui/tabs.css
@@ -4,9 +4,16 @@
      BASE STYLES (Common to both variants)
      ============================================ */
 
-  /* Container */
+  /* Container - wraps by default; the `tabs-overflow` Stimulus controller
+     adds the `tabs--scrollable` modifier when wrapping is detected. */
   .tabs {
-    @apply flex flex-nowrap overflow-x-auto sm:flex-wrap sm:overflow-visible;
+    @apply flex flex-wrap;
+  }
+
+  /* Scrollable modifier - single-row, horizontally scrollable with edge
+     shadows. Toggled on by the `tabs-overflow` controller. */
+  .tabs--scrollable {
+    @apply flex-nowrap overflow-x-auto;
     scrollbar-width: none;
 
     /* Scroll shadows (Lea Verou's background-attachment: local technique).
@@ -17,16 +24,16 @@
        the shadow below is revealed. Covers are hard-edged (no fade through
        `transparent`, which in CSS is rgba(0,0,0,0) and bleeds dark pixels). */
     background-image:
-      linear-gradient(var(--color-background), var(--color-background)),
-      linear-gradient(var(--color-background), var(--color-background)),
+      linear-gradient(var(--color-primary), var(--color-primary)),
+      linear-gradient(var(--color-primary), var(--color-primary)),
       radial-gradient(
         farthest-side at 0 50%,
-        rgb(0 0 0 / 0.18),
+        color-mix(var(--color-foreground), transparent 80%),
         rgb(0 0 0 / 0)
       ),
       radial-gradient(
         farthest-side at 100% 50%,
-        rgb(0 0 0 / 0.18),
+        color-mix(var(--color-foreground), transparent 80%),
         rgb(0 0 0 / 0)
       );
     background-position: 0 0, 100% 0, 0 0, 100% 0;
@@ -35,13 +42,7 @@
     background-attachment: local, local, scroll, scroll;
   }
 
-  @media (min-width: 640px) {
-    .tabs {
-      background: none;
-    }
-  }
-
-  .tabs::-webkit-scrollbar {
+  .tabs--scrollable::-webkit-scrollbar {
     display: none;
   }
 

--- a/app/assets/stylesheets/css/layout.css
+++ b/app/assets/stylesheets/css/layout.css
@@ -40,7 +40,7 @@
   @apply mt-(--top-navbar-height);
 
   .main-content-area {
-    @apply w-(--content-width) ms-1 flex flex-1 flex-col z-50 fixed rounded-2xl bg-primary shadow-content p-4 h-full;
+    @apply w-(--content-width) ms-1 flex flex-1 flex-col z-50 fixed rounded-2xl bg-primary shadow-content py-4 px-1 lg:px-4 h-full;
 
     transition: margin 0.1s ease-in-out, width 0.1s ease-in-out;
 

--- a/app/assets/stylesheets/css/layout.css
+++ b/app/assets/stylesheets/css/layout.css
@@ -40,14 +40,15 @@
   @apply mt-(--top-navbar-height);
 
   .main-content-area {
-    @apply w-(--content-width) ms-1 flex flex-1 flex-col z-50 fixed rounded-2xl bg-primary shadow-content py-4 px-1 lg:px-4 h-full;
+    @apply w-(--content-width) ms-1 flex flex-1 flex-col z-50 fixed rounded-2xl bg-primary shadow-content py-2 lg:py-4 px-2 lg:px-4 h-full;
 
     transition: margin 0.1s ease-in-out, width 0.1s ease-in-out;
 
     height: calc(100dvh - var(--spacing) - var(--top-navbar-height));
 
     .scrollable-wrapper {
-      @apply overflow-y-auto h-full flex-1 flex flex-col px-2;
+      @apply overflow-y-auto h-full flex-1 flex flex-col;
+      @apply px-0.5; /* add some space for the view type toggle buttons to not be cut off by the overflow. this might be needed to be handled differently with a wrapper inside the scrolling area */
       @apply pt-1; /* add some space for the button focus ring to not be cut off by the overflow */
     }
     .avo-container {

--- a/app/components/avo/actions_component.html.erb
+++ b/app/components/avo/actions_component.html.erb
@@ -1,5 +1,5 @@
 <div
-  class="actions-dropdown relative flex w-full flex-col sm:w-auto"
+  class="actions-dropdown relative flex flex-col sm:w-auto"
   data-component-name="<%= self.class.to_s.underscore %>"
   data-controller="actions-picker"
   data-actions-picker-enabled-class="text-content hover:bg-secondary"

--- a/app/components/avo/filters_component.html.erb
+++ b/app/components/avo/filters_component.html.erb
@@ -9,7 +9,7 @@
       'data-tippy': 'tooltip' do %>
       <%= t 'avo.filters' %>
       <% if applied_filters_count.positive? %>
-        <span class="filters__count">(<%= applied_filters_count %> <%= t('avo.applied', count: applied_filters_count) %>)</span>
+        <span class="filters__count"><%= applied_filters_count %></span>
       <% end %>
     <% end %>
     <%= tag.div class: 'filters__panel css-animate-slide-down',

--- a/app/components/avo/items/panel_component.html.erb
+++ b/app/components/avo/items/panel_component.html.erb
@@ -1,8 +1,5 @@
 <%= render ui.panel(title: @item.title, description: @item.description, index: @index) do |panel| %>
   <% panel.with_body do %>
-    <% if fields_outside_card? %>
-      <%= render Avo::DeveloperWarningComponent.new(card_background_warning_message) %>
-    <% end %>
     <%= render Avo::Items::VisibleItemsComponent.new resource: @resource, item: @item, view: @view, form: @form, parent_component: @parent_component, reflection: @reflection %>
   <% end %>
 

--- a/app/components/avo/items/panel_component.rb
+++ b/app/components/avo/items/panel_component.rb
@@ -21,37 +21,4 @@ class Avo::Items::PanelComponent < Avo::ResourceComponent
     :can_see_the_destroy_button?,
     :can_see_the_save_button?,
     to: :@parent_component
-
-  # Warn in development/test when a developer declares fields directly inside a `panel`
-  # without wrapping them in a `card do ... end` block.
-  #
-  # This matters because cards are the thing that provides the consistent background/spacing.
-  def fields_outside_card?
-    return false unless Rails.env.development? || Rails.env.test?
-    return false unless @item.respond_to?(:visible_items)
-    return false if @item.respond_to?(:dev_warnings?) && !@item.dev_warnings?
-
-    @item.visible_items.any? do |item|
-      # Direct field under the panel will render without card background.
-      if item.is_field?
-        true
-      # Row is rendered directly by the panel too; it can contain fields rendered without card background.
-      elsif item.is_row?
-        item.visible_items.any?(&:is_field?)
-      else
-        false
-      end
-    end
-  end
-
-  def card_background_warning_message
-    # Keep the message deterministic for specs.
-    # docs_url = "https://docs.avohq.io/4.0/resource-cards.html"
-    docs_message = ""
-    # docs_message = "See the <a href=\"#{docs_url}\" target=\"_blank\" rel=\"noopener\" class=\"underline underline-offset-2\">resource cards</a> docs."
-    code_classes = "inline-flex items-center align-middle rounded bg-orange-500/10 px-1 py-px font-mono text-[0.85em] font-semibold leading-none text-orange-950 dark:bg-orange-500/15 dark:text-orange-50"
-    disable_snippet = "<code class=\"#{code_classes}\">panel dev_warnings: false do ... end</code>"
-
-    "Some fields are declared directly inside a <code class=\"#{code_classes}\">panel</code> without a <code class=\"#{code_classes}\">card do ... end</code> wrapper. Wrap them in a <code class=\"#{code_classes}\">card</code> to get the expected card background and spacing. If this is intentional and you want to avoid this warning please use #{disable_snippet}. #{docs_message}"
-  end
 end

--- a/app/components/avo/items/visible_items_component.html.erb
+++ b/app/components/avo/items/visible_items_component.html.erb
@@ -1,4 +1,4 @@
-<% @item.visible_items.each_with_index do |field, index| %>
+<% @item.get_items.each_with_index do |field, index| %>
   <%= render Avo::Items::SwitcherComponent.new(
     resource: @resource,
     reflection: @reflection,

--- a/app/components/avo/tab_content_component.html.erb
+++ b/app/components/avo/tab_content_component.html.erb
@@ -1,5 +1,5 @@
 <div class="space-y-12">
-  <% @tab.visible_items.each do |item| %>
+  <% @tab.get_items.each do |item| %>
     <%= render Avo::Items::SwitcherComponent.new item: item, **@kwargs %>
   <% end %>
 </div>

--- a/app/components/avo/tab_group_component.html.erb
+++ b/app/components/avo/tab_group_component.html.erb
@@ -1,4 +1,5 @@
 <%= content_tag :div,
+  class: "tab-group",
   data: {
     target: "tab-group",
     index: index,

--- a/app/components/avo/u_i/tabs/tabs_component.html.erb
+++ b/app/components/avo/u_i/tabs/tabs_component.html.erb
@@ -2,6 +2,7 @@
   class: class_names("tabs", "tabs--#{@variant}": @variant == :switcher),
   role: :tablist,
   id: @id,
-  "aria-label": @aria_label do %>
+  "aria-label": @aria_label,
+  data: { controller: "tabs-overflow" } do %>
   <%= content %>
 <% end %>

--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -78,7 +78,7 @@
             <div class="flex flex-col gap-y-4">
               <%= render scopes_list if can_render_scopes? %>
 
-              <div class="flex flex-col xs:flex-row xs:justify-between">
+              <div class="flex flex-col xs:flex-row xs:justify-between gap-4">
                 <div class="flex w-64 items-center">
                   <% if show_search_input %>
                     <%= render ui.search_input(
@@ -94,10 +94,12 @@
                   <% end %>
                 </div>
 
-                <div class="flex items-center justify-start space-x-3 rtl:space-x-reverse justify-self-end px-4 xs:justify-end">
-                  <div class="index-missing-resources:hidden">
-                    <%= render_dynamic_filters_button %>
-                  </div>
+                <div class="flex items-center justify-between space-x-3 rtl:space-x-reverse justify-self-end xs:justify-end">
+                  <% if show_dynamic_filters_button? %>
+                    <div class="index-missing-resources:hidden">
+                      <%= render_dynamic_filters_button %>
+                    </div>
+                  <% end %>
 
                   <% unless field&.hide_filter_button %>
                     <%= render Avo::FiltersComponent.new filters: @filters, resource: @resource, applied_filters: @applied_filters, parent_record: @parent_record %>

--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -11,7 +11,7 @@
 
   <%= render ui.panel(
       cover: resource.cover,
-      class: "w-full px-2",
+      class: "w-full",
       data: {
         component_name:,
         controller: "resource-search",

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -128,13 +128,9 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
   end
 
   def render_dynamic_filters_button
-    return unless Avo.avo_dynamic_filters_installed?
-    return unless @resource.has_filters?
-    return unless has_resources?
-    return if field&.hide_filter_button
-    return if Avo::DynamicFilters.configuration.always_expanded
+    return unless show_dynamic_filters_button?
 
-    a_button size: :sm,
+    a_button size: :md,
       color: :primary,
       icon: "tabler/outline/filter",
       data: {
@@ -245,5 +241,13 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
 
   def has_resources?
     @resources.present?
+  end
+
+  def show_dynamic_filters_button?
+    Avo.avo_dynamic_filters_installed? &&
+      @resource.has_filters? &&
+      has_resources? &&
+      !field&.hide_filter_button &&
+      !Avo::DynamicFilters.configuration.always_expanded
   end
 end

--- a/app/javascript/js/controllers.js
+++ b/app/javascript/js/controllers.js
@@ -56,6 +56,7 @@ import SignOutController from './controllers/sign_out_controller'
 import StarsFieldController from './controllers/fields/stars_field_controller'
 import TableRowController from './controllers/table_row_controller'
 import TabsController from './controllers/tabs_controller'
+import TabsOverflowController from './controllers/tabs_overflow_controller'
 import TagsFieldController from './controllers/fields/tags_field_controller'
 import TextFilterController from './controllers/text_filter_controller'
 import TippyController from './controllers/tippy_controller'
@@ -109,6 +110,7 @@ application.register('sidebar', SidebarController)
 application.register('sign-out', SignOutController)
 application.register('table-row', TableRowController)
 application.register('tabs', TabsController)
+application.register('tabs-overflow', TabsOverflowController)
 application.register('text-filter', TextFilterController)
 application.register('tippy', TippyController)
 application.register('toggle', ToggleController)

--- a/app/javascript/js/controllers/tabs_overflow_controller.js
+++ b/app/javascript/js/controllers/tabs_overflow_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from '@hotwired/stimulus'
+
+const MODIFIER_CLASS = 'tabs--scrollable'
+
+// Detects when the tabs would wrap onto more than one row and toggles the
+// `tabs--scrollable` modifier so they collapse to a single, horizontally
+// scrollable row instead.
+export default class extends Controller {
+  connect() {
+    this.update = this.update.bind(this)
+    this.resizeObserver = new ResizeObserver(this.update)
+    this.resizeObserver.observe(this.element)
+    this.update()
+  }
+
+  disconnect() {
+    this.resizeObserver?.disconnect()
+  }
+
+  update() {
+    // Drop the modifier so we can measure the natural (wrapping) layout.
+    this.element.classList.remove(MODIFIER_CLASS)
+
+    const items = Array.from(this.element.children)
+    if (items.length < 2) return
+
+    const firstTop = items[0].offsetTop
+    const wraps = items.some((item) => item.offsetTop !== firstTop)
+
+    this.element.classList.toggle(MODIFIER_CLASS, wraps)
+  }
+}

--- a/lib/avo/concerns/has_items.rb
+++ b/lib/avo/concerns/has_items.rb
@@ -171,42 +171,32 @@ module Avo
         end
       end
 
+      # Default renderable items for any HasItems container. Subclasses that
+      # need to auto-wrap (Tab, Panel, Sidebar, Resource) override this.
+      # Card, Row, TabGroup fall through to the raw visible_items.
       def get_items
-        # Each group is built only by standalone items or items that have their own panel, keeping the items order
+        visible_items
+      end
+
+      # Groups consecutive "standalone" fields (fields that don't bring their
+      # own panel — text, select, date, etc.) into cards, so containers like
+      # Panel/Sidebar/Tab render a nice card background around them even when
+      # the user forgot to write `card do ... end` themselves. Fields that
+      # have their own panel (has_many, has_and_belongs_to_many, has_one,
+      # belongs_to) and explicit panels/cards pass through untouched and
+      # break the run, so you get separate cards around each group.
+      def items_with_standalone_fields_wrapped_in_cards
         grouped_items = visible_items.slice_when do |prev, curr|
-          # Slice when the item type changes from standalone to panel or vice-versa
           is_standalone?(prev) != is_standalone?(curr)
         end.to_a.map do |group|
           {elements: group, is_standalone: is_standalone?(group.first)}
         end
 
-        # Add the header automatically as first item if the user didn't define one
-        # This is to ensure that the header is always present
-        if items.none? { |item| item.is_header? }
-          header = Avo::Resources::Items::Header.new
-          hydrate_item header
-          grouped_items.unshift({elements: [header], is_standalone: false})
-        end
-
-        # For each standalone group, wrap items in a panel and card
-        # If the resource has at least one panel defined, we compute nothing, user took control of the panels
-        if items.none? { |item| item.is_panel? }
-          grouped_items.select { |group| group[:is_standalone] }.each do |group|
-            calculated_panel = Avo::Resources::Items::Panel.new
-            hydrate_item calculated_panel
-
-            # Create a card
-            card = Avo::Resources::Items::Card.new
-            hydrate_item card
-
-            # Add the items to the card
-            card.items_holder.items = group[:elements]
-
-            # Add the card to the main panel
-            calculated_panel.items_holder.items = [card]
-
-            group[:elements] = calculated_panel
-          end
+        grouped_items.select { |group| group[:is_standalone] }.each do |group|
+          card = Avo::Resources::Items::Card.new
+          hydrate_item card
+          card.items_holder.items = group[:elements]
+          group[:elements] = card
         end
 
         grouped_items.flat_map { |group| group[:elements] }

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -304,6 +304,40 @@ module Avo
         self
       end
 
+      # Renderable items for the resource view. Injects a header if none is
+      # defined and, when the user hasn't taken control by declaring at least
+      # one panel, wraps standalone field groups in a Panel + Card so they
+      # render with the expected chrome at the top level.
+      def get_items
+        grouped_items = visible_items.slice_when do |prev, curr|
+          is_standalone?(prev) != is_standalone?(curr)
+        end.to_a.map do |group|
+          {elements: group, is_standalone: is_standalone?(group.first)}
+        end
+
+        if items.none? { |item| item.is_header? }
+          header = Avo::Resources::Items::Header.new
+          hydrate_item header
+          grouped_items.unshift({elements: [header], is_standalone: false})
+        end
+
+        if items.none? { |item| item.is_panel? }
+          grouped_items.select { |group| group[:is_standalone] }.each do |group|
+            calculated_panel = Avo::Resources::Items::Panel.new
+            hydrate_item calculated_panel
+
+            card = Avo::Resources::Items::Card.new
+            hydrate_item card
+            card.items_holder.items = group[:elements]
+            calculated_panel.items_holder.items = [card]
+
+            group[:elements] = calculated_panel
+          end
+        end
+
+        grouped_items.flat_map { |group| group[:elements] }
+      end
+
       unless defined? VIEW_METHODS_MAPPING
         VIEW_METHODS_MAPPING = {
           index: [:index, :display],

--- a/lib/avo/resources/items/item_group.rb
+++ b/lib/avo/resources/items/item_group.rb
@@ -23,10 +23,6 @@ class Avo::Resources::Items::ItemGroup
     post_initialize if respond_to?(:post_initialize)
   end
 
-  def dev_warnings?
-    @args.fetch(:dev_warnings, true) != false
-  end
-
   class Builder
     include Avo::Concerns::BorrowItemsHolder
 

--- a/lib/avo/resources/items/panel.rb
+++ b/lib/avo/resources/items/panel.rb
@@ -1,2 +1,5 @@
 class Avo::Resources::Items::Panel < Avo::Resources::Items::ItemGroup
+  def get_items
+    items_with_standalone_fields_wrapped_in_cards
+  end
 end

--- a/lib/avo/resources/items/sidebar.rb
+++ b/lib/avo/resources/items/sidebar.rb
@@ -20,6 +20,10 @@ class Avo::Resources::Items::Sidebar
     post_initialize if respond_to?(:post_initialize)
   end
 
+  def get_items
+    items_with_standalone_fields_wrapped_in_cards
+  end
+
   class Builder
     include Avo::Concerns::BorrowItemsHolder
     include Avo::Concerns::HasFieldDiscovery

--- a/lib/avo/resources/items/tab.rb
+++ b/lib/avo/resources/items/tab.rb
@@ -41,6 +41,10 @@ class Avo::Resources::Items::Tab
     "#{parent.turbo_frame_id} #{id}".parameterize
   end
 
+  def get_items
+    items_with_standalone_fields_wrapped_in_cards
+  end
+
   class Builder
     include Avo::Concerns::BorrowItemsHolder
 

--- a/spec/dummy/app/avo/resources/user.rb
+++ b/spec/dummy/app/avo/resources/user.rb
@@ -25,9 +25,7 @@ class Avo::Resources::User < Avo::BaseResource
 
   self.discreet_information = [
     :id,
-    :timestamps,
-    :created_at,
-    :updated_at
+    :timestamps
   ]
 
   self.includes = [:posts, :post]

--- a/spec/dummy/app/avo/resources/user.rb
+++ b/spec/dummy/app/avo/resources/user.rb
@@ -23,6 +23,13 @@ class Avo::Resources::User < Avo::BaseResource
     query.order(last_name: :asc)
   end
 
+  self.discreet_information = [
+    :id,
+    :timestamps,
+    :created_at,
+    :updated_at
+  ]
+
   self.includes = [:posts, :post]
   self.attachments = [:cv]
   self.devise_password_optional = true


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR does a few things:

- Some tweaks to make Avo better on mobile around the panel header.
- tab groups auto-scrollable
- tab groups visual tweaks
- auto-wrap fields into `card`s


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect core resource item rendering (`get_items` and auto-wrapping) and UI layout, which may alter view structure and spacing across many screens; tab overflow behavior also introduces new JS/CSS interactions to verify across browsers.
> 
> **Overview**
> Improves mobile responsiveness and visual polish across resource views: panel headers now switch layout at `md`, index header controls/search/filter area spacing is adjusted, breadcrumbs/filters badges are refined, and overall panel/content padding is tweaked.
> 
> Tab groups get a new dashed-border wrapper (`tab-group`) and tabs now automatically collapse into a single horizontally scrollable row when they would wrap, via a new `tabs-overflow` Stimulus controller plus accompanying `tabs--scrollable` styling.
> 
> Refactors item rendering to use `get_items` and adds automatic wrapping of consecutive “standalone” fields into `Card`s for `Panel`, `Sidebar`, and `Tab` (and top-level `Resource` when no panels are defined), removing the prior dev-only warning logic for fields declared directly under a panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a36015548afe3e4bdb3c607c01e75f80de5b6fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->