### PR TITLE
fix: run actions from custom controls

### DIFF
--- a/app/controllers/avo/actions_controller.rb
+++ b/app/controllers/avo/actions_controller.rb
@@ -115,9 +115,7 @@ module Avo
     def action_class
       @resource.hydrate(view: action_params[:resource_view].presence, user: _current_user, params: params)
 
-      registered_action = @resource.get_actions.find do |action|
-        action[:class].to_s == params[:action_id]
-      end
+      registered_action = @resource.find_action(params[:action_id])
 
       if registered_action.nil?
         if Rails.env.development?

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -406,7 +406,7 @@ module Avo
           .uniq { |action| action[:class].to_s }
           .find { |action| action[:class].to_s == action_id.to_s }
       end
-      
+
       def hydrate(...)
         super
 

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -399,6 +399,14 @@ module Avo
         end
       end
 
+      def find_action(action_id)
+        actions = get_actions + Array(safe_call(:get_actions_from_custom_controls))
+
+        actions
+          .uniq { |action| action[:class].to_s }
+          .find { |action| action[:class].to_s == action_id.to_s }
+      end
+      
       def hydrate(...)
         super
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When getting the `action_class` in `app/controllers/avo/actions_controller.rb`, verify actions defined in `def actions` as well as those from custom controls.

A regression was introduced in `3.31.1` where actions from custom controls stopped working unless they were also present inside `def actions`.