### PR TITLE
fix `initializer "avo.tailwindcss"` to run only when server is detected

### DIFF
--- a/lib/avo/engine.rb
+++ b/lib/avo/engine.rb
@@ -44,7 +44,7 @@ module Avo
 
     initializer "avo.tailwindcss", after: :load_config_initializers do
       next unless Rails.env.development?
-      next if defined?(Rails::Console)
+      next unless defined?(Rails::Server)
 
       Rails.application.config.after_initialize do
         next unless Avo::TailwindBuilder.enabled?


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Run tailwind css initializer only when server is detected