### PR TITLE
fix: multi line text on actions message

### DIFF
--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -31,9 +31,7 @@
         <% end %>
       <% end %>
 
-      <div class="flex-1 flex p-4 whitespace-pre-line">
-        <%= @action.get_message %>
-      </div>
+      <div class="flex-1 flex p-4 whitespace-pre-line"><%= @action.get_message %></div>
       <%= form.hidden_field :avo_resource_ids, value: params[:id] || params[:resource_ids], 'data-action-target': 'resourceIds' %>
       <%= form.hidden_field :avo_selected_all, 'data-action-target': 'selectedAll' %>
       <%= form.hidden_field :avo_index_query, 'data-action-target': 'indexQuery' %>

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -31,7 +31,7 @@
         <% end %>
       <% end %>
 
-      <div class="flex-1 flex p-4">
+      <div class="flex-1 flex p-4 whitespace-pre-line">
         <%= @action.get_message %>
       </div>
       <%= form.hidden_field :avo_resource_ids, value: params[:id] || params[:resource_ids], 'data-action-target': 'resourceIds' %>

--- a/spec/dummy/app/avo/actions/toggle_published.rb
+++ b/spec/dummy/app/avo/actions/toggle_published.rb
@@ -1,6 +1,13 @@
 class Avo::Actions::TogglePublished < Avo::BaseAction
   self.name = "Toggle post published"
-  self.message = "Are you sure, sure?"
+  self.message = <<~TEXT.chomp
+    Are you sure, sure?
+
+
+
+
+    Sure?
+  TEXT
   self.confirm_button_label = "Toggle"
   self.cancel_button_label = "Don't toggle yet"
   self.confirmation = -> { arguments.key?(:confirmation) ? arguments[:confirmation] : true }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue with multi-line message display.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adjusts CSS whitespace handling for the action message, with a dummy action updated to exercise multiline output.
> 
> **Overview**
> Action modal messages now preserve newlines/blank lines by rendering `@action.get_message` with `whitespace-pre-line` in `app/views/avo/actions/show.html.erb`.
> 
> The dummy `TogglePublished` action message was updated to a multiline heredoc to validate/display the new formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9944fc92a70ce5ad8b28176125b9d00fb6da2aaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->