### PR TITLE
fix: belongs_to create when associated with itself

### DIFF
--- a/app/components/avo/fields/belongs_to_field/edit_component.rb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.rb
@@ -62,6 +62,7 @@ class Avo::Fields::BelongsToField::EditComponent < Avo::Fields::EditComponent
 
     helpers.new_resource_path(**{
       via_relation: @field.id.to_s,
+      via_relation_class: resource.model_class.to_s,
       resource: target_resource || @field.target_resource,
       via_record_id: resource.record.persisted? ? resource.record.to_param : nil,
       via_belongs_to_resource_class: resource.class.name,

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -622,16 +622,16 @@ module Avo
 
               reflection = @record.class.reflect_on_association(@params[:via_relation]) if @params[:via_relation].present?
 
-              if field.polymorphic_as.present? && field.types.map(&:to_s).include?(@params[:via_relation_class])
+              if field.polymorphic_as.present? && field.types.map(&:to_s).include?(@params[:via_relation_class]) && @params[:via_record_id].present?
                 # set the value to the actual record
                 via_resource = Avo.resource_manager.get_resource_by_model_class(@params[:via_relation_class])
-                value = via_resource.find_record(@params[:via_record_id])
-              elsif reflection.present? && reflection.foreign_key.present? && field.id.to_s == @params[:via_relation].to_s
+                value = via_resource.find_record(@params[:via_record_id]) if via_resource.present?
+              elsif reflection.present? && reflection.foreign_key.present? && field.id.to_s == @params[:via_relation].to_s && @params[:via_record_id].present?
                 resource = Avo.resource_manager.get_resource_by_model_class params[:via_relation_class]
-                record = resource.find_record @params[:via_record_id], params: params
+                record = resource.find_record @params[:via_record_id], params: params if resource.present?
                 id_param = reflection.options[:primary_key] || :id
 
-                value = record.send(id_param)
+                value = record.send(id_param) if record.present?
               end
             end
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #4436

Fixes an edge case where creating a record on a belongs_to field would break when using a self-referential belongs_to association.