### PR TITLE
Add DuplicateRecord action for easy record cloning

### DIFF
--- a/lib/avo/actions/duplicate_record.rb
+++ b/lib/avo/actions/duplicate_record.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Avo
+  module Actions
+    class DuplicateRecord < Avo::BaseAction
+      self.name = -> { I18n.t("avo.duplicate_record", default: "Duplicate") }
+      self.no_confirmation = true
+      self.visible = -> { view.show? || view.index? }
+
+      class << self
+        def duplicate_config_for(resource_class)
+          resource_class.try(:duplicate_config) || {}
+        end
+      end
+
+      def handle(records:, **args)
+        record = records.first
+
+        if record.blank?
+          error I18n.t("avo.no_record_to_duplicate", default: "No record to duplicate")
+          return
+        end
+
+        config = self.class.duplicate_config_for(@resource.class)
+        new_record = duplicate_record(record, config)
+
+        if new_record.save
+          succeed I18n.t("avo.record_duplicated", default: "Record duplicated successfully")
+          reload
+        else
+          error I18n.t("avo.duplicate_failed", default: "Failed to duplicate: %{errors}") % {
+            errors: new_record.errors.full_messages.join(", ")
+          }
+        end
+      end
+
+      private
+
+      def duplicate_record(record, config)
+        new_record = record.dup
+
+        exclude_fields = Array(config[:exclude])
+        exclude_fields.each do |field|
+          new_record.send(:"#{field}=", nil) if new_record.respond_to?(:"#{field}=")
+        end
+
+        title_field = config[:title_field] || detect_title_field(record)
+        if title_field && new_record.respond_to?(:"#{title_field}=")
+          suffix = config[:title_suffix] || " Copy"
+          original_value = record.send(title_field)
+          new_record.send(:"#{title_field}=", "#{original_value}#{suffix}") if original_value.present?
+        end
+
+        defaults = config[:defaults] || {}
+        defaults.each do |field, value|
+          next unless new_record.respond_to?(:"#{field}=")
+
+          resolved_value = value.respond_to?(:call) ? value.call(record) : value
+          new_record.send(:"#{field}=", resolved_value)
+        end
+
+        copy_attachments(record, new_record, config)
+
+        new_record
+      end
+
+      def copy_attachments(original, duplicate, config)
+        return unless defined?(ActiveStorage)
+        return unless original.class.respond_to?(:reflect_on_all_attachments)
+
+        attachments_config = config[:copy_attachments]
+        return if attachments_config == false
+
+        attachments_to_copy = if attachments_config.is_a?(Array)
+          attachments_config.map(&:to_sym)
+        elsif attachments_config == true || attachments_config.nil?
+          original.class.reflect_on_all_attachments.map(&:name)
+        else
+          []
+        end
+
+        attachments_to_copy.each do |attachment_name|
+          reflection = original.class.reflect_on_attachment(attachment_name)
+          next unless reflection
+
+          if reflection.macro == :has_one_attached
+            copy_single_attachment(original, duplicate, attachment_name)
+          elsif reflection.macro == :has_many_attached
+            copy_multiple_attachments(original, duplicate, attachment_name)
+          end
+        end
+      end
+
+      def copy_single_attachment(original, duplicate, name)
+        attachment = original.send(name)
+        return unless attachment.attached?
+
+        duplicate.send(name).attach(
+          io: StringIO.new(attachment.download),
+          filename: attachment.filename.to_s,
+          content_type: attachment.content_type
+        )
+      end
+
+      def copy_multiple_attachments(original, duplicate, name)
+        attachments = original.send(name)
+        return unless attachments.attached?
+
+        attachments.each do |attachment|
+          duplicate.send(name).attach(
+            io: StringIO.new(attachment.download),
+            filename: attachment.filename.to_s,
+            content_type: attachment.content_type
+          )
+        end
+      end
+
+      def detect_title_field(record)
+        %i[name title label subject].find do |f|
+          record.respond_to?(f) && record.send(f).present?
+        end
+      end
+    end
+  end
+end

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -99,6 +99,7 @@ module Avo
       class_attribute :default_sort_column, default: :created_at
       class_attribute :default_sort_direction, default: :desc
       class_attribute :external_link, default: nil
+      class_attribute :duplicate_config, default: {}
 
       class_attribute :abstract, default: false
 

--- a/spec/features/avo/duplicate_record_action_spec.rb
+++ b/spec/features/avo/duplicate_record_action_spec.rb
@@ -1,0 +1,123 @@
+require "rails_helper"
+
+RSpec.describe "DuplicateRecord Action", type: :feature do
+  # Simple test double that supports dup
+  class DummyRecord
+    attr_accessor :name, :title, :body, :slug, :status, :version
+
+    def initialize(attrs = {})
+      attrs.each { |k, v| send(:"#{k}=", v) if respond_to?(:"#{k}=") }
+    end
+
+    def dup
+      self.class.new(
+        name: name,
+        title: title,
+        body: body,
+        slug: slug,
+        status: status,
+        version: version
+      )
+    end
+  end
+
+  describe "duplicate_record" do
+    let(:action) { Avo::Actions::DuplicateRecord.new }
+
+    it "duplicates a simple record with excluded fields" do
+      original = DummyRecord.new(
+        name: "Original Post",
+        body: "Content here",
+        slug: "original-post"
+      )
+
+      config = { exclude: [:slug], title_field: :name }
+      duplicated = action.send(:duplicate_record, original, config)
+
+      expect(duplicated.name).to eq("Original Post Copy")
+      expect(duplicated.body).to eq("Content here")
+      expect(duplicated.slug).to be_nil
+    end
+
+    it "uses custom title suffix" do
+      original = DummyRecord.new(name: "Test")
+
+      config = { title_field: :name, title_suffix: " (duplicate)" }
+      duplicated = action.send(:duplicate_record, original, config)
+
+      expect(duplicated.name).to eq("Test (duplicate)")
+    end
+
+    it "applies default values" do
+      original = DummyRecord.new(name: "Test", status: "published")
+
+      config = {
+        title_field: :name,
+        defaults: { status: "draft" }
+      }
+      duplicated = action.send(:duplicate_record, original, config)
+
+      expect(duplicated.name).to eq("Test Copy")
+      expect(duplicated.status).to eq("draft")
+    end
+
+    it "applies callable defaults" do
+      original = DummyRecord.new(name: "Test", version: 5)
+
+      config = {
+        title_field: :name,
+        defaults: { version: ->(r) { r.version + 1 } }
+      }
+      duplicated = action.send(:duplicate_record, original, config)
+
+      expect(duplicated.version).to eq(6)
+    end
+
+    it "auto-detects title field from common names" do
+      original = DummyRecord.new(title: "My Title", body: "Content")
+
+      config = {}
+      duplicated = action.send(:duplicate_record, original, config)
+
+      expect(duplicated.title).to eq("My Title Copy")
+    end
+
+    it "handles missing title field gracefully" do
+      original = DummyRecord.new(body: "Just body, no title")
+
+      config = {}
+      duplicated = action.send(:duplicate_record, original, config)
+
+      expect(duplicated.body).to eq("Just body, no title")
+    end
+  end
+
+  describe "with Product model" do
+    let(:action) { Avo::Actions::DuplicateRecord.new }
+
+    it "duplicates a Product record" do
+      product = create(:product, title: "Original Product", description: "Test description", price_cents: 9999)
+
+      config = { title_field: :title }
+      duplicated = action.send(:duplicate_record, product, config)
+
+      expect(duplicated).to be_a(Product)
+      expect(duplicated.title).to eq("Original Product Copy")
+      expect(duplicated.description).to eq("Test description")
+      expect(duplicated.price_cents).to eq(9999)
+      expect(duplicated.id).to be_nil
+    end
+
+    it "saves duplicated Product to database" do
+      product = create(:product, title: "Saveable Product", price_cents: 5000)
+
+      config = { title_field: :title }
+      duplicated = action.send(:duplicate_record, product, config)
+      duplicated.save!
+
+      expect(duplicated).to be_persisted
+      expect(duplicated.id).not_to eq(product.id)
+      expect(Product.where(title: "Saveable Product Copy").count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
# Description

- Adds a **built-in row action** to duplicate any record with a single click.
- **No confirmation modal** — creates the copy immediately and shows a **toast** notification.
- Configurable via `self.duplicate_config` on the resource:
  - `title_field` — which field gets the " Copy" suffix (auto-detects `name`, `title`, `label`, `subject`).
  - `title_suffix` — customize the suffix (default: `" Copy"`).
  - `exclude` — fields to clear on the duplicate (e.g., `[:slug, :uuid]`).
  - `defaults` — static or callable values for the new record.
  - `copy_attachments` — `true` (all), `[:image]` (specific), or `false` (none).

Fixes # none

## What changed

- **`Avo::Actions::DuplicateRecord`** — new action class in `lib/avo/actions/`; uses `record.dup`, applies config, handles Active Storage attachments.
- **`Avo::Resources::Base`** — added `class_attribute :duplicate_config` so resources can configure duplication behavior.
- **Tests** — `spec/features/avo/duplicate_record_action_spec.rb` covers field exclusion, title suffix, defaults (static + callable), auto-detection, and real `Product` model integration.


<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording

<img width="468" height="245" alt="image" src="https://github.com/user-attachments/assets/fa07112f-7a8b-44e9-b8f3-813bd927e63f" />

<img width="1455" height="825" alt="image" src="https://github.com/user-attachments/assets/e0bd9807-5468-414f-8a7e-1c38d945933f" />


## How to verify manually

Add to any resource:

```ruby
self.duplicate_config = {
  title_field: :name,
  title_suffix: " Copy",
  exclude: [:slug],
  copy_attachments: true
}

def actions
  action Avo::Actions::DuplicateRecord
end
```

- **Index:** select a row → click "Duplicate" → new record created with " Copy" suffix.
- **Show:** actions dropdown → "Duplicate" → same result.
- **Attachments:** if `copy_attachments` is enabled, files are cloned to the new record.

Manual reviewer: please leave a comment with output from the test if that's the case.
