### PR TITLE
chore: remove invalid `style: 'hidden'` from filter url_redirect links

### DIFF
--- a/app/views/avo/base/_boolean_filter.html.erb
+++ b/app/views/avo/base/_boolean_filter.html.erb
@@ -23,7 +23,7 @@
           <% end %>
         </div>
       <% end %>
-      <%= link_to 'url_redirect', request.url, data: { 'boolean-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, style: 'hidden', class: 'hidden' %>
+      <%= link_to 'url_redirect', request.url, data: { 'boolean-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
     </div>
   <% end %>
 </div>

--- a/app/views/avo/base/_date_time_filter.html.erb
+++ b/app/views/avo/base/_date_time_filter.html.erb
@@ -32,6 +32,6 @@
         <%= filter.button_label || "#{t("avo.filter_by")} #{filter.name}" %>
       <% end %>
     </div>
-    <%= link_to 'url_redirect', request.url, data: { 'date-time-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, style: 'hidden', class: 'hidden' %>
+    <%= link_to 'url_redirect', request.url, data: { 'date-time-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
   <% end %>
 <% end %>

--- a/app/views/avo/base/_multiple_select_filter.html.erb
+++ b/app/views/avo/base/_multiple_select_filter.html.erb
@@ -16,6 +16,6 @@
         <%= filter.button_label || "#{t("avo.filter_by")} #{filter.name}" %>
       <% end %>
     </div>
-    <%= link_to 'url_redirect', request.url, data: { 'multiple-select-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, style: 'hidden', class: 'hidden' %>
+    <%= link_to 'url_redirect', request.url, data: { 'multiple-select-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
   <% end %>
 </div>

--- a/app/views/avo/base/_select_filter.html.erb
+++ b/app/views/avo/base/_select_filter.html.erb
@@ -12,6 +12,6 @@
       'data-select-filter-target': 'selector',
       'data-action': "change->select-filter#changeFilter"
     %>
-    <%= link_to 'url_redirect', request.url, data: { 'select-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, style: 'hidden', class: 'hidden' %>
+    <%= link_to 'url_redirect', request.url, data: { 'select-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
   <% end %>
 </div>

--- a/app/views/avo/base/_text_filter.html.erb
+++ b/app/views/avo/base/_text_filter.html.erb
@@ -17,6 +17,6 @@
         <%= filter.button_label || "#{t("avo.filter_by")} #{filter.name}" %>
       <% end %>
     </div>
-    <%= link_to 'url_redirect', request.url, data: { 'text-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, style: 'hidden', class: 'hidden' %>
+    <%= link_to 'url_redirect', request.url, data: { 'text-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
   <% end %>
 </div>


### PR DESCRIPTION
# Description

The `url_redirect` `link_to` calls in the filter partials pass `style: 'hidden'`, which generates an invalid `style="hidden"` attribute (`hidden` is not a valid CSS property/value).

The same elements already use `class: 'hidden'` (Tailwind's `display: none`), so the `style` option is redundant and has no effect on the rendered output. This change just removes the dead option.

Files touched:

- `app/views/avo/base/_boolean_filter.html.erb`
- `app/views/avo/base/_date_time_filter.html.erb`
- `app/views/avo/base/_multiple_select_filter.html.erb`
- `app/views/avo/base/_select_filter.html.erb`
- `app/views/avo/base/_text_filter.html.erb`

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Manual review steps

1. Open any resource index page that has filters (boolean / date-time / multiple-select / select / text).
1. Open the filters panel and inspect the `<a>` element that has `class="hidden"` inside each filter partial.
1. Confirm there is no longer a `style="hidden"` attribute on the link, and that the link continues to be hidden via the existing `hidden` class.
1. Apply / change a filter and confirm the URL-redirect behavior driven by the corresponding Stimulus controller still works as before.