### PR TITLE
fix: tailwincss soruces

### DIFF
--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -12,6 +12,8 @@ module Avo
     attr_writer :persistence
     attr_writer :resource_row_controls_config
     attr_writer :hotkeys
+    # When unset, Tailwind scans Rails.root.join("app"). Each entry is an absolute path or a path relative to Rails.root.
+    attr_writer :tailwindcss_content_sources
     attr_accessor :timezone
     attr_accessor :per_page
     attr_accessor :per_page_steps
@@ -114,6 +116,14 @@ module Avo
 
     def container_width
       @container_width || CONTAINER_WIDTH_DEFAULTS
+    end
+
+    def tailwindcss_content_sources
+      if @tailwindcss_content_sources.nil?
+        [Rails.root.join("app")]
+      else
+        Array(@tailwindcss_content_sources)
+      end
     end
 
     def initialize

--- a/lib/avo/tailwind_builder.rb
+++ b/lib/avo/tailwind_builder.rb
@@ -83,9 +83,26 @@ module Avo
         lines << %(@import "#{path}";)
       end
 
-      lines << %(@source "../../";)
+      append_host_tailwind_sources(lines)
 
       File.write(input_path, lines.join("\n") + "\n")
+    end
+
+    def append_host_tailwind_sources(lines)
+      resolved_host_content_source_paths.each do |path|
+        lines << %(@source "#{relative_to_tmp(path)}";)
+      end
+    end
+
+    def resolved_host_content_source_paths
+      Avo.configuration.tailwindcss_content_sources.filter_map do |raw|
+        path = Pathname.new(raw)
+        path = Rails.root.join(path) unless path.absolute?
+        path = path.expand_path
+        next unless path.directory?
+
+        path
+      end.uniq
     end
 
     def append_plugin_engine_tailwind_sources(lines)

--- a/spec/lib/avo/configuration/tailwindcss_content_sources_spec.rb
+++ b/spec/lib/avo/configuration/tailwindcss_content_sources_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe Avo::Configuration, "#tailwindcss_content_sources" do
+  let(:config) { described_class.new }
+
+  it "defaults to app under Rails.root when unset" do
+    expect(config.tailwindcss_content_sources).to eq([Rails.root.join("app")])
+  end
+
+  it "returns the configured list when set" do
+    config.tailwindcss_content_sources = ["lib", Rails.root.join("config")]
+    expect(config.tailwindcss_content_sources).to eq(["lib", Rails.root.join("config")])
+  end
+end

--- a/spec/lib/avo/tailwind_builder_spec.rb
+++ b/spec/lib/avo/tailwind_builder_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe Avo::TailwindBuilder do
+  let(:builder) { described_class.new }
+  let(:config) { Avo.configuration }
+  let(:input_path) { Rails.root.join("tmp", "avo", "avo.tailwind.input.css") }
+
+  around do |example|
+    previous = config.instance_variable_get(:@tailwindcss_content_sources)
+    example.run
+    config.instance_variable_set(:@tailwindcss_content_sources, previous)
+  end
+
+  describe "#generate_input_file" do
+    after do
+      FileUtils.rm_f(input_path)
+    end
+
+    it "includes a host @source for Rails.root/app by default" do
+      config.instance_variable_set(:@tailwindcss_content_sources, nil)
+      builder.send(:generate_input_file)
+      expect(File.read(input_path)).to include(%(@source "../../app"))
+    end
+
+    it "includes @source lines for each configured directory" do
+      config.tailwindcss_content_sources = [Rails.root.join("app"), Rails.root.join("lib")]
+      builder.send(:generate_input_file)
+      content = File.read(input_path)
+      expect(content).to include(%(@source "../../app"))
+      expect(content).to include(%(@source "../../lib"))
+    end
+
+    it "resolves entries relative to Rails.root when not absolute" do
+      config.tailwindcss_content_sources = ["app"]
+      builder.send(:generate_input_file)
+      expect(File.read(input_path)).to include(%(@source "../../app"))
+    end
+
+    it "does not emit host @source lines when configured as empty" do
+      config.tailwindcss_content_sources = []
+      builder.send(:generate_input_file)
+      expect(File.read(input_path)).not_to include(%(@source "../../app"))
+    end
+  end
+end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Adds `tailwindcss_content_sources` so apps can control which host directories Tailwind scans for utility classes when building `tmp/avo/avo.tailwind.input.css`.
- Default host scan is `Rails.root.join("app")` instead of the whole project root (`../../` → `Rails.root`).
- Paths may be absolute or relative to `Rails.root`; missing directories are skipped; duplicates are deduped.