### PR TITLE
sidebar menu, profile button and dropdown menu

### DIFF
--- a/app/assets/stylesheets/css/components/button.css
+++ b/app/assets/stylesheets/css/components/button.css
@@ -311,6 +311,15 @@
     }
   }
 
+  /* Chained with .button to win the
+     specificity battle against .button--style-outline:hover and friends.
+  */
+  .button.button--bare,
+  .button.button--bare:hover {
+    @apply border-none bg-transparent p-1.5;
+    box-shadow: none;
+  }
+
   /* Size variants */
   .button--size-xs {
     @apply text-xs px-2 py-1 gap-1 min-w-6;

--- a/app/assets/stylesheets/css/components/button.css
+++ b/app/assets/stylesheets/css/components/button.css
@@ -311,15 +311,6 @@
     }
   }
 
-  /* Chained with .button to win the
-     specificity battle against .button--style-outline:hover and friends.
-  */
-  .button.button--bare,
-  .button.button--bare:hover {
-    @apply border-none bg-transparent p-1.5;
-    box-shadow: none;
-  }
-
   /* Size variants */
   .button--size-xs {
     @apply text-xs px-2 py-1 gap-1 min-w-6;

--- a/app/assets/stylesheets/css/components/grid.css
+++ b/app/assets/stylesheets/css/components/grid.css
@@ -62,15 +62,6 @@
   @apply flex-1 shrink-0 basis-0 flex;
 }
 
-.grid-card__action {
-  @apply border-none bg-transparent p-1.5;
-  box-shadow: none;
-}
-
-.grid-card__action:hover {
-  @apply bg-transparent;
-}
-
 .grid-card__content {
   @apply flex flex-col items-start w-full px-2 pb-2;
 }

--- a/app/assets/stylesheets/css/components/ui/dropdown.css
+++ b/app/assets/stylesheets/css/components/ui/dropdown.css
@@ -61,8 +61,8 @@
 }
 
 .dropdown-menu__item,
-.dropdown-menu__list > :is(a, button),
-.sidebar-profile__sign-out {
+.dropdown-menu__list a,
+.dropdown-menu__list button {
   @apply flex items-center w-full justify-start focus:outline-none gap-2 px-2 py-1.5 min-h-8 rounded-md border-none bg-transparent overflow-hidden text-ellipsis whitespace-nowrap text-content font-medium text-sm cursor-pointer leading-5;
 
   &.dropdown-menu__item--disabled {

--- a/app/assets/stylesheets/css/components/ui/dropdown.css
+++ b/app/assets/stylesheets/css/components/ui/dropdown.css
@@ -61,7 +61,8 @@
 }
 
 .dropdown-menu__item,
-.dropdown-menu__list > :is(a, button) {
+.dropdown-menu__list > :is(a, button),
+.sidebar-profile__sign-out {
   @apply flex items-center w-full justify-start focus:outline-none gap-2 px-2 py-1.5 min-h-8 rounded-md border-none bg-transparent overflow-hidden text-ellipsis whitespace-nowrap text-content font-medium text-sm cursor-pointer leading-5;
 
   &.dropdown-menu__item--disabled {

--- a/app/assets/stylesheets/css/css-animations.css
+++ b/app/assets/stylesheets/css/css-animations.css
@@ -28,27 +28,3 @@
     display 75ms allow-discrete;
 }
 
-/* Sidebar Profile Dropdown Animation (slides up from bottom) */
-.css-animate-slide-up {
-  opacity: 1;
-  transform: translateY(0);
-
-  transition:
-    opacity 100ms ease-in-out,
-    transform 100ms ease-in-out,
-    display 100ms allow-discrete;
-
-  @starting-style {
-    opacity: 0;
-    transform: translateY(0.75rem);
-  }
-}
-
-.css-animate-slide-up[hidden] {
-  opacity: 0;
-  transform: translateY(0.75rem);
-  transition:
-    opacity 75ms ease-in,
-    transform 75ms ease-in,
-    display 75ms allow-discrete;
-}

--- a/app/assets/stylesheets/css/sidebar.css
+++ b/app/assets/stylesheets/css/sidebar.css
@@ -247,36 +247,19 @@
   @apply flex items-center justify-center gap-1 shrink-0;
 }
 
-.sidebar-profile__action-trigger {
-  @apply flex items-center cursor-pointer text-content-secondary;
-}
-
-.sidebar-profile__action-trigger:hover {
-  @apply text-content;
-}
-
-.sidebar-profile__panel {
-  @apply absolute flex flex-col items-center inset-auto end-0 bottom-0 mb-8 bg-primary rounded-sm min-w-[200px] shadow-2xl z-40;
-}
-
 .sidebar-profile__form {
-  @apply flex-1;
+  @apply flex w-full;
+}
+
+/* Menu rows inherit the dropdown row layout — override text size and,
+   for sign-out, the danger color + hover. */
+.sidebar-profile__menu-item,
+.sidebar-profile__sign-out {
+  @apply !text-base;
 }
 
 .sidebar-profile__sign-out {
-  @apply flex items-center justify-start gap-1 w-full px-4 py-3 rounded-sm cursor-pointer text-danger font-semibold bg-primary hover:bg-danger/10;
-}
-
-.sidebar-profile__sign-out-icon {
-  @apply me-1 shrink-0;
-}
-
-.sidebar-profile__menu-item {
-  @apply flex-1 flex items-center justify-center text-start cursor-pointer font-semibold px-4 py-3 w-full rounded-sm bg-primary text-content hover:bg-tertiary;
-}
-
-.sidebar-profile__menu-item .sidebar-icon {
-  @apply me-1;
+  @apply !text-danger hover:!bg-danger/10 hover:!text-danger;
 }
 
 /* ================================================ */

--- a/app/components/avo/index/grid_item_component.html.erb
+++ b/app/components/avo/index/grid_item_component.html.erb
@@ -21,7 +21,7 @@
         <%= render Avo::ButtonComponent.new(
           icon: "tabler/outline/dots-vertical",
           size: :lg,
-          class: "grid-card__action",
+          class: "button--bare",
           popovertarget: component.popover_id
         ) %>
       <% end %>

--- a/app/components/avo/index/grid_item_component.html.erb
+++ b/app/components/avo/index/grid_item_component.html.erb
@@ -20,8 +20,8 @@
       <% component.with_trigger do %>
         <%= render Avo::ButtonComponent.new(
           icon: "tabler/outline/dots-vertical",
-          size: :lg,
-          class: "button--bare",
+          size: :md,
+          style: :text,
           popovertarget: component.popover_id
         ) %>
       <% end %>

--- a/app/components/avo/sidebar_profile_component.html.erb
+++ b/app/components/avo/sidebar_profile_component.html.erb
@@ -1,4 +1,4 @@
-<div class="sidebar-profile" data-controller="toggle">
+<div class="sidebar-profile">
   <div class="sidebar-profile__body">
     <div class="sidebar-profile__avatar-wrapper">
     <div class="sidebar-profile__avatar">
@@ -23,28 +23,35 @@
     </div>
   </div>
   <div class="sidebar-profile__actions">
-    <button type="button" class="sidebar-profile__action-trigger" data-control="profile-dots" data-action="click->toggle#togglePanel">
-      <%= helpers.svg "tabler/outline/dots", class: 'sidebar-profile__action-icon sidebar-icon' %>
-    </button>
-    <div class="css-animate-slide-up sidebar-profile__panel" data-toggle-target="panel" hidden>
-      <% if render_custom_profile_menu? %>
-        <%= render custom_profile_component %>
+    <%= render Avo::UI::DropdownComponent.new(popover_mode: true) do |component| %>
+      <% component.with_trigger do %>
+        <%= render Avo::ButtonComponent.new(
+          icon: "tabler/outline/dots",
+          size: :lg,
+          class: "button--bare",
+          popovertarget: component.popover_id
+        ) %>
       <% end %>
-      <%= render "avo/partials/profile_menu_extra" %>
-      <% if can_sign_out_user? %>
-        <%= form_with url: helpers.main_app.send(sign_out_path),
-          method: sign_out_method,
-          data: {
-            controller: :"sign-out",
-            sign_out_confirm_value: t('avo.are_you_sure'),
-            action: "submit->sign-out#handle",
-          },
-          class: 'sidebar-profile__form' do |form| %>
-          <%= form.button turbo_confirm: t('avo.are_you_sure'), class: "sidebar-profile__sign-out" do %>
-            <%= helpers.svg "tabler/outline/logout", class: 'sidebar-profile__sign-out-icon sidebar-icon' %> <%= t('avo.sign_out') %>
+      <% component.with_items do %>
+        <% if render_custom_profile_menu? %>
+          <%= render custom_profile_component %>
+        <% end %>
+        <%= render "avo/partials/profile_menu_extra" %>
+        <% if can_sign_out_user? %>
+          <%= form_with url: helpers.main_app.send(sign_out_path),
+            method: sign_out_method,
+            data: {
+              controller: :"sign-out",
+              sign_out_confirm_value: t('avo.are_you_sure'),
+              action: "submit->sign-out#handle",
+            },
+            class: 'sidebar-profile__form' do |form| %>
+            <%= form.button turbo_confirm: t('avo.are_you_sure'), class: "sidebar-profile__sign-out" do %>
+              <%= helpers.svg "tabler/outline/logout", class: 'sidebar-icon' %> <%= t('avo.sign_out') %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>
-    </div>
+    <% end %>
   </div>
 </div>

--- a/app/components/avo/sidebar_profile_component.html.erb
+++ b/app/components/avo/sidebar_profile_component.html.erb
@@ -27,8 +27,8 @@
       <% component.with_trigger do %>
         <%= render Avo::ButtonComponent.new(
           icon: "tabler/outline/dots",
-          size: :lg,
-          class: "button--bare",
+          size: :md,
+          style: :text,
           popovertarget: component.popover_id
         ) %>
       <% end %>

--- a/lib/avo/test_helpers.rb
+++ b/lib/avo/test_helpers.rb
@@ -348,8 +348,8 @@ module Avo
     def click_row_action(record, control:)
       row = find("[data-record-id='#{record.to_param}']")
 
-      if row.has_css?(".grid-card__action", wait: 0)
-        row.find(".grid-card__action").click
+      if row.has_css?(".grid-card__actions-row .button--bare", wait: 0)
+        row.find(".grid-card__actions-row .button--bare").click
       end
 
       find("a[data-control='#{control}'][data-resource-id='#{record.to_param}']").click

--- a/spec/system/avo/group_1/sign_out_dropdown_spec.rb
+++ b/spec/system/avo/group_1/sign_out_dropdown_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "SignOutDropdown", type: :system do
       expect(page.body).to have_text admin.name
       expect(page.body).to have_css("form[data-controller='sign-out'][data-action='submit->sign-out#handle']", visible: false)
 
-      dots_link = find("[data-control='profile-dots']")
+      dots_link = find(".sidebar-profile__actions button[popovertarget]")
 
       dots_link.click
 


### PR DESCRIPTION
# Description
Replace the sidebar profile dots menu with the standard popover dropdown (same chrome as the grid card's 3-dots), and extract the shared "bare" icon-button styling as .button--bare so both triggers share it.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<img width="202" height="109" alt="Screenshot 2026-05-18 at 09 59 49" src="https://github.com/user-attachments/assets/12c59d91-8e66-4ecf-80fa-1a1d8c6a1777" />
</br>
<img width="202" height="109" alt="Screenshot 2026-05-18 at 10 00 23" src="https://github.com/user-attachments/assets/b7bd1443-e530-4d6d-a810-34c272f69c2d" />
</br>
<img width="202" height="109" alt="Screenshot 2026-05-18 at 10 03 06" src="https://github.com/user-attachments/assets/39db54d8-d95c-4b8c-a14d-5d987d236aa9" />
