### PR TITLE
refactor: preview popup uses Card component

### DIFF
--- a/app/assets/stylesheets/css/components/field-wrapper.css
+++ b/app/assets/stylesheets/css/components/field-wrapper.css
@@ -105,3 +105,20 @@
     @apply w-full;
   }
 }
+
+/* Compact modifier - tighter spacing for previews/popovers */
+.field-wrapper.field-wrapper--compact {
+  @apply py-0.5 gap-y-0;
+
+  .field-wrapper__label {
+    @apply min-h-0 py-1;
+  }
+
+  .field-wrapper__content {
+    @apply py-0;
+  }
+}
+
+.field-wrapper.field-wrapper--compact.field-wrapper--stacked {
+  @apply py-1 gap-y-0.5;
+}

--- a/app/assets/stylesheets/css/components/field-wrapper.css
+++ b/app/assets/stylesheets/css/components/field-wrapper.css
@@ -106,8 +106,8 @@
   }
 }
 
-/* Compact modifier - tighter spacing for previews/popovers */
-.field-wrapper.field-wrapper--compact {
+/* Density: compact - tighter spacing for previews/popovers */
+.field-wrapper.field-wrapper--density-compact {
   @apply py-0.5 gap-y-0;
 
   .field-wrapper__label {
@@ -119,6 +119,6 @@
   }
 }
 
-.field-wrapper.field-wrapper--compact.field-wrapper--stacked {
+.field-wrapper.field-wrapper--density-compact.field-wrapper--stacked {
   @apply py-1 gap-y-0.5;
 }

--- a/app/assets/stylesheets/css/components/tooltip.css
+++ b/app/assets/stylesheets/css/components/tooltip.css
@@ -23,3 +23,16 @@
   @apply text-content;
 }
 
+/* Preview theme: transparent wrapper so the card inside provides all the chrome */
+.tippy-box[data-theme~='preview'] {
+  @apply bg-transparent border-0 shadow-none text-content;
+}
+
+.tippy-box[data-theme~='preview'] .tippy-content {
+  @apply p-0 text-content;
+}
+
+.tippy-box[data-theme~='preview'] .tippy-arrow {
+  @apply hidden;
+}
+

--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -35,7 +35,7 @@ class Avo::FieldWrapperComponent < Avo::BaseComponent
       {
         "field-wrapper--stacked": stacked?,
         "field-wrapper--full-width": full_width?,
-        "field-wrapper--#{@density}": @density && @density != :default,
+        "field-wrapper--density-#{@density}": @density && @density != :default,
       })
   end
 

--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -5,7 +5,7 @@ class Avo::FieldWrapperComponent < Avo::BaseComponent
 
   prop :dash_if_blank, default: true
   prop :data, default: {}.freeze
-  prop :compact, default: false
+  prop :density, default: :default
   prop :help
   prop :label_help
   prop :field
@@ -35,7 +35,7 @@ class Avo::FieldWrapperComponent < Avo::BaseComponent
       {
         "field-wrapper--stacked": stacked?,
         "field-wrapper--full-width": full_width?,
-        "field-wrapper--compact": @compact,
+        "field-wrapper--#{@density}": @density && @density != :default,
       })
   end
 

--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -35,6 +35,7 @@ class Avo::FieldWrapperComponent < Avo::BaseComponent
       {
         "field-wrapper--stacked": stacked?,
         "field-wrapper--full-width": full_width?,
+        "field-wrapper--compact": @compact,
       })
   end
 

--- a/app/components/avo/fields/show_component.rb
+++ b/app/components/avo/fields/show_component.rb
@@ -10,8 +10,9 @@ class Avo::Fields::ShowComponent < Avo::BaseComponent
   attr_reader :stacked
   attr_reader :view
   attr_reader :full_width
+  attr_reader :compact
 
-  def initialize(field: nil, resource: nil, index: 0, form: nil, stacked: nil, full_width: nil, **kwargs)
+  def initialize(field: nil, resource: nil, index: 0, form: nil, stacked: nil, full_width: nil, compact: false, **kwargs)
     @field = field
     @index = index
     @resource = resource
@@ -19,6 +20,7 @@ class Avo::Fields::ShowComponent < Avo::BaseComponent
     @kwargs = kwargs
     @view = Avo::ViewInquirer.new("show")
     @full_width = full_width
+    @compact = compact
   end
 
   def wrapper_data
@@ -51,6 +53,7 @@ class Avo::Fields::ShowComponent < Avo::BaseComponent
       resource: resource,
       stacked: stacked,
       full_width: full_width,
+      compact: compact,
       view: view
     }
   end

--- a/app/components/avo/fields/show_component.rb
+++ b/app/components/avo/fields/show_component.rb
@@ -10,9 +10,9 @@ class Avo::Fields::ShowComponent < Avo::BaseComponent
   attr_reader :stacked
   attr_reader :view
   attr_reader :full_width
-  attr_reader :compact
+  attr_reader :density
 
-  def initialize(field: nil, resource: nil, index: 0, form: nil, stacked: nil, full_width: nil, compact: false, **kwargs)
+  def initialize(field: nil, resource: nil, index: 0, form: nil, stacked: nil, full_width: nil, density: :default, **kwargs)
     @field = field
     @index = index
     @resource = resource
@@ -20,7 +20,7 @@ class Avo::Fields::ShowComponent < Avo::BaseComponent
     @kwargs = kwargs
     @view = Avo::ViewInquirer.new("show")
     @full_width = full_width
-    @compact = compact
+    @density = density
   end
 
   def wrapper_data
@@ -53,7 +53,7 @@ class Avo::Fields::ShowComponent < Avo::BaseComponent
       resource: resource,
       stacked: stacked,
       full_width: full_width,
-      compact: compact,
+      density: density,
       view: view
     }
   end

--- a/app/javascript/js/controllers/preview_controller.js
+++ b/app/javascript/js/controllers/preview_controller.js
@@ -12,7 +12,7 @@ export default class extends Controller {
     this.tippyInstance = tippy(vm.context.element, {
       content: "loading...",
       allowHTML: true,
-      theme: 'basic',
+      theme: 'preview',
       maxWidth: 550,
       async onShow(instance) {
         const response = await fetch(vm.urlValue)

--- a/app/views/avo/base/preview.html.erb
+++ b/app/views/avo/base/preview.html.erb
@@ -1,26 +1,23 @@
-<%# TODO: update this %>
 <%= turbo_frame_tag params[:turbo_frame] do %>
   <% if @authorized %>
-    <%= content_tag :div, class: "-mx-2" do %>
-      <%= content_tag :div, class: "px-6 py-4" do %>
-        <div class="text-md font-semibold uppercase text-content">Previewing <%= @resource.record_title %></div>
-      <% end %>
-
+    <%= render ui.card(title: "Previewing #{@resource.record_title}") do |card| %>
       <% if @preview_fields.present? %>
-        <div class="description-list">
-          <% @preview_fields.each_with_index do |field, index| %>
-            <%= render field
-              .hydrate(
-                resource: @resource,
-                record: @resource.record,
-                user: @resource.user,
-                view: Avo::ViewInquirer.new(:show)
-              )
-              .component_for_view(:show)
-              .new(field: field, resource: @resource, index: index, stacked: true)
-            %>
+        <% card.with_body do %>
+          <%= render ui.description_list do %>
+            <% @preview_fields.each_with_index do |field, index| %>
+              <%= render field
+                .hydrate(
+                  resource: @resource,
+                  record: @resource.record,
+                  user: @resource.user,
+                  view: Avo::ViewInquirer.new(:show)
+                )
+                .component_for_view(:show)
+                .new(field: field, resource: @resource, index: index, stacked: true, compact: true)
+              %>
+            <% end %>
           <% end %>
-        </div>
+        <% end %>
       <% end %>
     <% end %>
   <% else %>

--- a/app/views/avo/base/preview.html.erb
+++ b/app/views/avo/base/preview.html.erb
@@ -13,7 +13,7 @@
                   view: Avo::ViewInquirer.new(:show)
                 )
                 .component_for_view(:show)
-                .new(field: field, resource: @resource, index: index, stacked: true, compact: true)
+                .new(field: field, resource: @resource, index: index, stacked: true, density: :compact)
               %>
             <% end %>
           <% end %>

--- a/spec/dummy/app/views/avo/resource_tools/_fish_information.html.erb
+++ b/spec/dummy/app/views/avo/resource_tools/_fish_information.html.erb
@@ -10,7 +10,7 @@
       <% panel.with_card do %>
         <%= tag.div class: "description-list w-full" do %>
           <%= avo_edit_field :fish_type, as: :text, form: form, help: "Set the fish type", required: true, width: 50 %>
-          <%= avo_edit_field :properties, as: :text, form: form, name: "Property 1", help: "Prop 1", required: true, width:50, component_options: {multiple: true} %>
+          <%= avo_edit_field :properties, as: :text, form: form, name: "Property 1", help: "Prop 1", required: true, width: 50, component_options: {multiple: true} %>
 
           <%= avo_edit_field :properties, as: :text, form: form, name: "Property 2", help: "Prop 2", required: true, component_options: {multiple: true} %>
 


### PR DESCRIPTION
## Summary

- Renders the resource preview popup through `Avo::UI::CardComponent` so it picks up the standard card chrome (rounded-xl, `border-tertiary`, `bg-secondary`, header/body split) instead of the old ad-hoc `-mx-2` + manual title markup.
- Adds a `preview` tippy theme that strips the tippy wrapper's bg/border/shadow/padding so the card inside provides all the chrome. The theme also sets `text-content` explicitly — without it, tippy's default `color: #fff` made field *values* invisible on the white card body (labels were fine because `.field-wrapper__label` sets `text-content` itself).
- Wires up the previously unused `compact` prop on `Avo::FieldWrapperComponent` end-to-end (through `Avo::Fields::ShowComponent#field_wrapper_args`) and adds a `.field-wrapper--compact` modifier with tighter vertical padding and no row gap. The preview popup passes `compact: true` to keep the popup tight. Opt-in only — regular show/edit pages are unaffected.
- Drive-by: whitespace fix in `_fish_information.html.erb` (`width:50` → `width: 50`).

## Test plan

- [ ] On a resource index page that exposes a preview field, hover the preview icon and confirm the popup renders with card styling (rounded corner, secondary background, distinct header).
- [ ] Confirm field **values** are visible in the popup (light + dark mode).
- [ ] Confirm the field rows are noticeably tighter than the regular show view.
- [ ] Confirm regular show/edit pages are unchanged (compact is opt-in).
- [ ] Confirm the unauthorized branch of `preview.html.erb` still renders the alert.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes: updates preview tooltip theming/markup and adds an opt-in `density` modifier for field wrappers, with minimal impact outside the preview flow.
> 
> **Overview**
> **Preview popover styling is standardized.** The preview tooltip now uses a new Tippy `preview` theme (transparent wrapper/no padding or chrome) so the rendered content provides its own styling.
> 
> **Preview content is refactored to `ui.card` and tightened.** `preview.html.erb` now renders fields inside `ui.card` + `ui.description_list`, and introduces an opt-in `density: :compact` path (new `density` prop on `Avo::FieldWrapperComponent`/`Avo::Fields::ShowComponent` plus `.field-wrapper--density-compact` CSS) to reduce spacing specifically for previews.
> 
> Minor: fixes a spacing typo (`width:50` -> `width: 50`) in the dummy `_fish_information.html.erb`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 977a1241ca14c694c7535a8dcb84c7bec8c79b72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->