### PR TITLE
refactor: accesible table kbd navigation

### DIFF
--- a/app/assets/stylesheets/css/scrollbar.css
+++ b/app/assets/stylesheets/css/scrollbar.css
@@ -1,15 +1,3 @@
-/* Keep auto-scrolled targets (focus, scrollIntoView, anchor jumps, hash links)
-   below the sticky navbar. Applied to every likely scroll container so it
-   works whether the document, the body, or the main content area is what
-   actually scrolls. */
-html,
-body,
-.main-content-area,
-.scrollable-wrapper {
-  scroll-padding-top: calc(var(--top-navbar-height) + var(--spacing) * 2);
-  scroll-padding-bottom: calc(var(--spacing) * 2);
-}
-
 /* total width */
 body.os-pc .mac-styled-scrollbar::-webkit-scrollbar {
     background-color: none;

--- a/app/assets/stylesheets/css/scrollbar.css
+++ b/app/assets/stylesheets/css/scrollbar.css
@@ -1,3 +1,15 @@
+/* Keep auto-scrolled targets (focus, scrollIntoView, anchor jumps, hash links)
+   below the sticky navbar. Applied to every likely scroll container so it
+   works whether the document, the body, or the main content area is what
+   actually scrolls. */
+html,
+body,
+.main-content-area,
+.scrollable-wrapper {
+  scroll-padding-top: calc(var(--top-navbar-height) + var(--spacing) * 2);
+  scroll-padding-bottom: calc(var(--spacing) * 2);
+}
+
 /* total width */
 body.os-pc .mac-styled-scrollbar::-webkit-scrollbar {
     background-color: none;

--- a/app/assets/stylesheets/css/table.css
+++ b/app/assets/stylesheets/css/table.css
@@ -62,3 +62,15 @@
 .table-row.is-keyboard-focused {
   background: color-mix(in oklab, var(--color-primary), var(--color-accent) 10%);
 }
+
+table[role="grid"] {
+  @apply outline-none;
+}
+
+/* The table sits inside .card > .card__wrapper.overflow-auto, which clips any
+   box-shadow ring drawn on the <table> itself. Lift the ring to the outer
+   .card so it can sit outside the wrapper, matching the card's own border
+   radius and visible bounds. */
+.card:has(table[role="grid"]:focus-visible) {
+  @apply ring-2 ring-accent ring-offset-2 ring-offset-background;
+}

--- a/app/components/avo/keyboard_shortcuts_component.rb
+++ b/app/components/avo/keyboard_shortcuts_component.rb
@@ -55,14 +55,20 @@ class Avo::KeyboardShortcutsComponent < Avo::BaseComponent
           shortcut(action: "Focus search", keys: ["/"]),
           shortcut(action: "Create new record", keys: ["C"]),
           shortcut(action: "Open actions", keys: ["A"]),
+          shortcut(action: "Focus table", keys: ["Shift", "T"]),
           shortcut(
-            action: "Navigate rows / actions",
+            action: "Focus table and move to next / previous row",
+            any_of: [["J"], ["K"]],
+            keys_aria_label: "J or K"
+          ),
+          shortcut(
+            action: "Navigate rows (when table is focused)",
             any_of: [["↑"], ["↓"]],
             keys_aria_label: "Up arrow or down arrow"
           ),
           shortcut(action: "Open record", keys: ["↵"]),
           shortcut(action: "Select / deselect row", keys: ["Space"]),
-          shortcut(action: "Deselect rows", keys: ["Esc"]),
+          shortcut(action: "Clear row focus / deselect rows", keys: ["Esc"]),
           shortcut(action: "Table view", keys: ["V", "T"]),
           shortcut(action: "Grid view", keys: ["V", "G"]),
           shortcut(action: "Map view", keys: ["V", "M"])

--- a/app/components/avo/view_types/table_component.html.erb
+++ b/app/components/avo/view_types/table_component.html.erb
@@ -44,11 +44,7 @@
         </div>
       <% end %>
 
-      <table class="w-full border-separate border-spacing-0"
-        tabindex="0"
-        role="grid"
-        aria-label="<%= @resource.plural_name %>"
-        data-index-row-navigator-target="table">
+      <%= content_tag :table, class: "w-full border-separate border-spacing-0", **table_attrs do %>
         <%= render partial: 'avo/partials/table_header', locals: {fields: @header_fields, resource: @resource} %>
 
         <%= content_tag :tbody, class: "card__body table-row-group rounded-lg tr>td:first:rounded-t-lg tr>td:last:rounded-b-lg",
@@ -59,7 +55,7 @@
             <%= render table_row_component %>
           <% end %>
         <% end %>
-      </table>
+      <% end %>
 
       </div>
     <div class="card__footer"><%= render paginator_component %></div>

--- a/app/components/avo/view_types/table_component.html.erb
+++ b/app/components/avo/view_types/table_component.html.erb
@@ -44,7 +44,11 @@
         </div>
       <% end %>
 
-      <table class="w-full border-separate border-spacing-0">
+      <table class="w-full border-separate border-spacing-0"
+        tabindex="0"
+        role="grid"
+        aria-label="<%= @resource.plural_name %>"
+        data-index-row-navigator-target="table">
         <%= render partial: 'avo/partials/table_header', locals: {fields: @header_fields, resource: @resource} %>
 
         <%= content_tag :tbody, class: "card__body table-row-group rounded-lg tr>td:first:rounded-t-lg tr>td:last:rounded-b-lg",

--- a/app/components/avo/view_types/table_component.rb
+++ b/app/components/avo/view_types/table_component.rb
@@ -8,6 +8,21 @@ class Avo::ViewTypes::TableComponent < Avo::ViewTypes::BaseViewTypeComponent
     @header_fields, @table_row_components = cache_table_rows
   end
 
+  # ARIA grid affordances and the row-navigator binding are only added on
+  # top-level index pages. On a parent record's show view (where @reflection
+  # is present), the has-many table is not keyboard-navigable as a grid, so
+  # the global Shift+T / j / k shortcuts find no target.
+  def table_attrs
+    return {} if @reflection.present?
+
+    {
+      tabindex: "0",
+      role: "grid",
+      "aria-label": @resource.plural_name,
+      data: {"index-row-navigator-target": "table"}
+    }
+  end
+
   def encrypted_query
     # TODO: move this to the resource where we can apply the adapter pattern
     if Module.const_defined?("Ransack::Search") && @query.instance_of?(Ransack::Search)

--- a/app/javascript/js/controllers/index_row_navigator_controller.js
+++ b/app/javascript/js/controllers/index_row_navigator_controller.js
@@ -50,10 +50,6 @@ export default class extends Controller {
     document.addEventListener('dropdown-menu:open', this.handleDropdownOpen)
     document.addEventListener('avo:advance-resource-table', this.handleAdvanceRequest)
 
-    if (this.hasTableTarget) {
-      this.tableTarget.addEventListener('blur', this.handleTableBlur)
-    }
-
     // Remove data-hotkey from row controls before @github/hotkey library scans
     // Store the original values so we can restore them for the focused row only
     if (this.hotkeysEnabled) {
@@ -70,10 +66,16 @@ export default class extends Controller {
     document.removeEventListener('keydown', this.handleKeydown)
     document.removeEventListener('dropdown-menu:open', this.handleDropdownOpen)
     document.removeEventListener('avo:advance-resource-table', this.handleAdvanceRequest)
+  }
 
-    if (this.hasTableTarget) {
-      this.tableTarget.removeEventListener('blur', this.handleTableBlur)
-    }
+  tableTargetConnected(table) {
+    table.addEventListener('blur', this.handleTableBlur)
+    // Turbo frame refreshes swap the <table>; reset stale row index from the old DOM.
+    this.currentIndex = -1
+  }
+
+  tableTargetDisconnected(table) {
+    table.removeEventListener('blur', this.handleTableBlur)
   }
 
   handleDropdownOpen() {

--- a/app/javascript/js/controllers/index_row_navigator_controller.js
+++ b/app/javascript/js/controllers/index_row_navigator_controller.js
@@ -4,11 +4,18 @@
  * Enables keyboard-driven navigation and hotkeys on table rows.
  *
  * FEATURES:
- * - Arrow keys (↑↓) to cycle through rows with visual focus indicator
+ * - Tab into the table (or press Shift+T) to focus it; then ↑/↓ navigate rows
+ * - j / k focus the table AND advance one row (Gmail/GitHub-style power shortcut)
  * - Enter key to navigate to the focused row's detail page
  * - Space bar to toggle row selection checkbox
- * - Escape to clear focus (or deselect all if no row is focused)
+ * - Escape clears row focus, then blurs the table on a second press
  * - Row hotkeys: when a row is focused, hotkeys work for that row's controls
+ *
+ * FOCUS MODEL:
+ * The <table> is focusable (tabindex=0, role=grid). Arrow keys / Enter / Space
+ * are only handled when document.activeElement is inside the table — this lets
+ * keyboard users scroll the page freely when the table isn't focused.
+ * `aria-activedescendant` on the table points to the currently focused row.
  *
  * ROW HOTKEY HANDLING:
  * The @github/hotkey library scans data-hotkey attributes on page load.
@@ -29,13 +36,23 @@ import { Controller } from '@hotwired/stimulus'
 const TYPING_SELECTOR = 'input, textarea, select, [contenteditable]'
 
 export default class extends Controller {
+  static targets = ['table']
+
   connect() {
     this.currentIndex = -1
     this.hotkeysEnabled = window.Avo?.configuration?.hotkeys?.enabled !== false
     this.handleKeydown = this.handleKeydown.bind(this)
     this.handleDropdownOpen = this.handleDropdownOpen.bind(this)
+    this.handleAdvanceRequest = this.handleAdvanceRequest.bind(this)
+    this.handleTableBlur = this.handleTableBlur.bind(this)
+
     document.addEventListener('keydown', this.handleKeydown)
     document.addEventListener('dropdown-menu:open', this.handleDropdownOpen)
+    document.addEventListener('avo:advance-resource-table', this.handleAdvanceRequest)
+
+    if (this.hasTableTarget) {
+      this.tableTarget.addEventListener('blur', this.handleTableBlur)
+    }
 
     // Remove data-hotkey from row controls before @github/hotkey library scans
     // Store the original values so we can restore them for the focused row only
@@ -52,10 +69,31 @@ export default class extends Controller {
   disconnect() {
     document.removeEventListener('keydown', this.handleKeydown)
     document.removeEventListener('dropdown-menu:open', this.handleDropdownOpen)
+    document.removeEventListener('avo:advance-resource-table', this.handleAdvanceRequest)
+
+    if (this.hasTableTarget) {
+      this.tableTarget.removeEventListener('blur', this.handleTableBlur)
+    }
   }
 
   handleDropdownOpen() {
-    const rows = Array.from(this.element.querySelectorAll('tr[data-visit-path]'))
+    const rows = this.rows()
+    if (rows.length) this.clearFocus(rows)
+  }
+
+  // Fired by global hotkeys (j / k): focus the table AND advance one row.
+  handleAdvanceRequest(event) {
+    if (!this.hasTableTarget) return
+    const direction = event.detail?.direction === 'previous' ? 'previous' : 'next'
+    const rows = this.rows()
+    if (!rows.length) return
+
+    this.tableTarget.focus({ preventScroll: true })
+    this.moveFocus(rows, direction)
+  }
+
+  handleTableBlur() {
+    const rows = this.rows()
     if (rows.length) this.clearFocus(rows)
   }
 
@@ -66,8 +104,12 @@ export default class extends Controller {
     if (event.target.closest(TYPING_SELECTOR)) return
     if (event.repeat && (event.key === 'Enter' || event.key === 'Escape' || event.key === ' ')) return
 
-    const rows = Array.from(this.element.querySelectorAll('tr[data-visit-path]'))
+    const rows = this.rows()
     if (!rows.length) return
+
+    // All navigation keys require the table to have focus. This frees ↑/↓ for
+    // browser scrolling when the user hasn't engaged the table.
+    if (!this.tableHasFocus()) return
 
     // Check for row hotkeys when a row is focused (only when hotkeys are enabled)
     if (this.hotkeysEnabled && this.currentIndex !== -1) {
@@ -89,7 +131,8 @@ export default class extends Controller {
         return
       }
 
-      // No keyboard-focused row — clear checkbox selection if any
+      // No keyboard-focused row: try clearing checkbox selection first; otherwise
+      // blur the table so the user lands back on the body.
       const selectAllController = this.application.getControllerForElementAndIdentifier(
         this.element.querySelector('[data-controller~="item-select-all"]'),
         'item-select-all',
@@ -99,8 +142,13 @@ export default class extends Controller {
         if (selected.length > 0) {
           event.preventDefault()
           selectAllController.deselectAll()
+
+          return
         }
       }
+
+      event.preventDefault()
+      this.tableTarget.blur()
 
       return
     }
@@ -125,7 +173,11 @@ export default class extends Controller {
 
     // ArrowDown / ArrowUp
     event.preventDefault()
-    if (event.key === 'ArrowDown') {
+    this.moveFocus(rows, event.key === 'ArrowDown' ? 'next' : 'previous')
+  }
+
+  moveFocus(rows, direction) {
+    if (direction === 'next') {
       this.currentIndex = this.currentIndex < rows.length - 1 ? this.currentIndex + 1 : 0
     } else {
       this.currentIndex = this.currentIndex > 0 ? this.currentIndex - 1 : rows.length - 1
@@ -133,7 +185,26 @@ export default class extends Controller {
 
     rows.forEach((r, i) => r.classList.toggle('is-keyboard-focused', i === this.currentIndex))
     rows[this.currentIndex].scrollIntoView({ block: 'nearest' })
+    this.syncActiveDescendant(rows[this.currentIndex])
     if (this.hotkeysEnabled) this.syncRowHotkeys(rows)
+  }
+
+  rows() {
+    return Array.from(this.element.querySelectorAll('tr[data-visit-path]'))
+  }
+
+  tableHasFocus() {
+    if (!this.hasTableTarget) return false
+    return this.tableTarget === document.activeElement || this.tableTarget.contains(document.activeElement)
+  }
+
+  syncActiveDescendant(row) {
+    if (!this.hasTableTarget) return
+    if (row?.id) {
+      this.tableTarget.setAttribute('aria-activedescendant', row.id)
+    } else {
+      this.tableTarget.removeAttribute('aria-activedescendant')
+    }
   }
 
   normalizeCurrentIndex(rowsLength) {
@@ -178,6 +249,7 @@ export default class extends Controller {
   clearFocus(rows) {
     rows.forEach((r) => r.classList.remove('is-keyboard-focused'))
     this.currentIndex = -1
+    if (this.hasTableTarget) this.tableTarget.removeAttribute('aria-activedescendant')
     // Clear all hotkeys when focus is cleared
     rows.forEach((row) => {
       row.querySelectorAll('[data-hotkey-original]').forEach((control) => {

--- a/app/javascript/js/controllers/resource_search_controller.js
+++ b/app/javascript/js/controllers/resource_search_controller.js
@@ -20,7 +20,12 @@ export default class extends Controller {
   }
 
   blurOnEscape(event) {
-    if (event.key === 'Escape') this.inputTarget.blur()
+    if (event.key !== 'Escape') return
+
+    // <input type="search"> clears itself on Escape by default. Suppress that so
+    // a pressed Escape only unfocuses the input and preserves the typed query.
+    event.preventDefault()
+    this.inputTarget.blur()
   }
 
   search() {

--- a/app/javascript/js/global_hotkeys.js
+++ b/app/javascript/js/global_hotkeys.js
@@ -12,6 +12,9 @@ import { install } from '@github/hotkey'
 const RESOURCE_SEARCH_INPUT_SELECTOR = '[data-resource-search-target="input"]'
 const findResourceSearchInput = () => document.querySelector(RESOURCE_SEARCH_INPUT_SELECTOR)
 
+const RESOURCE_TABLE_SELECTOR = '[data-index-row-navigator-target="table"]'
+const findResourceTable = () => document.querySelector(RESOURCE_TABLE_SELECTOR)
+
 // Find any mounted appearance Stimulus controller and call `method` on it.
 // Multiple appearance switchers can be on the page (inline + dropdown fallback);
 // either works since they share state via DOM classes + cookies/database.
@@ -67,6 +70,27 @@ const DIRECT_HOTKEYS = [
     // Shift+A → cycle accent color (brand → red → orange → …)
     match: (e) => e.shiftKey && e.key === 'A',
     handle: () => callAppearance('cycleAccent'),
+  },
+  {
+    // Shift+T → focus the resource index table; arrow keys then navigate rows.
+    match: (e) => e.shiftKey && e.key === 'T' && !!findResourceTable(),
+    handle: () => findResourceTable()?.focus({ preventScroll: true }),
+  },
+  {
+    // j → focus the resource table AND move to the next row (Gmail/GitHub style)
+    match: (e) => e.key === 'j' && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && !!findResourceTable(),
+    handle: () => {
+      findResourceTable()?.focus({ preventScroll: true })
+      document.dispatchEvent(new CustomEvent('avo:advance-resource-table', { detail: { direction: 'next' } }))
+    },
+  },
+  {
+    // k → focus the resource table AND move to the previous row
+    match: (e) => e.key === 'k' && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && !!findResourceTable(),
+    handle: () => {
+      findResourceTable()?.focus({ preventScroll: true })
+      document.dispatchEvent(new CustomEvent('avo:advance-resource-table', { detail: { direction: 'previous' } }))
+    },
   },
   {
     // Shift+K → toggle kbd badge visibility (only when developer config allows badges)

--- a/spec/system/avo/group_1/hotkey_spec.rb
+++ b/spec/system/avo/group_1/hotkey_spec.rb
@@ -43,10 +43,13 @@ RSpec.describe "Keyboard shortcuts", type: :system do
   end
 
   def focus_resource_table
-    page.execute_script(<<~JS)
-      const table = document.querySelector('[data-index-row-navigator-target="table"]')
-      if (table) table.focus({ preventScroll: true })
-    JS
+    expect(page).to have_css('[data-index-row-navigator-target="table"]')
+    expect(page).to have_css("tr[data-visit-path]", minimum: 1)
+
+    table = find('[data-index-row-navigator-target="table"]', visible: :all)
+    page.execute_script("arguments[0].focus({ preventScroll: true })", table.native)
+
+    expect(page.evaluate_script("document.activeElement?.tagName")).to eq("TABLE")
   end
 
   def active_descendant_id
@@ -302,11 +305,14 @@ RSpec.describe "Keyboard shortcuts", type: :system do
     end
 
     it "sets aria-activedescendant to the focused row id" do
+      create(:project)
+
       visit "/admin/resources/projects"
 
       focus_resource_table
       dispatch_keydown("ArrowDown")
 
+      expect(page).to have_css("tr.table-row.is-keyboard-focused")
       focused_row = find("tr.table-row.is-keyboard-focused")
       expect(active_descendant_id).to eq(focused_row["id"])
     end
@@ -336,6 +342,23 @@ RSpec.describe "Keyboard shortcuts", type: :system do
       search_input.send_keys("j")
 
       expect(search_input.value).to include("j")
+      expect(page).to have_no_css("tr.table-row.is-keyboard-focused")
+    end
+
+    it "does not expose the table as a grid on a show view's has-many table" do
+      project = create(:project)
+      create(:comment, commentable: project)
+
+      visit "/admin/resources/projects/#{project.id}"
+
+      # The associated comments table should NOT advertise itself as a focusable grid,
+      # so global j/k/Shift+T shortcuts find nothing and do nothing.
+      expect(page).to have_no_css('table[role="grid"]')
+      expect(page).to have_no_css('[data-index-row-navigator-target="table"]')
+
+      dispatch_keydown("j")
+      dispatch_keydown("T", shift_key: true)
+
       expect(page).to have_no_css("tr.table-row.is-keyboard-focused")
     end
   end

--- a/spec/system/avo/group_1/hotkey_spec.rb
+++ b/spec/system/avo/group_1/hotkey_spec.rb
@@ -332,6 +332,29 @@ RSpec.describe "Keyboard shortcuts", type: :system do
       expect(page.evaluate_script("document.activeElement && document.activeElement.tagName")).to eq("TABLE")
     end
 
+    it "clears row focus when blurring the table after a turbo frame refresh" do
+      target_project = create(:project, name: "Blur after turbo target")
+      create_list(:project, 3)
+
+      visit "/admin/resources/projects"
+
+      focus_resource_table
+      dispatch_keydown("ArrowDown")
+      expect(page).to have_css("tr.table-row.is-keyboard-focused")
+
+      write_in_search(target_project.name)
+      expect(page).to have_css("tr[data-visit-path]", count: 1)
+
+      focus_resource_table
+      dispatch_keydown("ArrowDown")
+      expect(page).to have_css("tr.table-row.is-keyboard-focused")
+
+      find("[data-resource-search-target='input']").click
+
+      expect(page).to have_no_css("tr.table-row.is-keyboard-focused")
+      expect(active_descendant_id).to be_nil
+    end
+
     it "does not trigger j/k while typing in the search field" do
       create_list(:project, 3)
 

--- a/spec/system/avo/group_1/hotkey_spec.rb
+++ b/spec/system/avo/group_1/hotkey_spec.rb
@@ -42,6 +42,22 @@ RSpec.describe "Keyboard shortcuts", type: :system do
     JS
   end
 
+  def focus_resource_table
+    page.execute_script(<<~JS)
+      const table = document.querySelector('[data-index-row-navigator-target="table"]')
+      if (table) table.focus({ preventScroll: true })
+    JS
+  end
+
+  def active_descendant_id
+    page.evaluate_script(<<~JS)
+      (() => {
+        const table = document.querySelector('[data-index-row-navigator-target="table"]')
+        return table ? table.getAttribute('aria-activedescendant') : null
+      })()
+    JS
+  end
+
   def dispatch_document_keydown(key, code: nil, shift_key: false, ctrl_key: false, meta_key: false, alt_key: false)
     page.evaluate_script(<<~JS)
       (() => {
@@ -149,6 +165,7 @@ RSpec.describe "Keyboard shortcuts", type: :system do
 
     visit "/admin/resources/projects"
 
+    focus_resource_table
     3.times { dispatch_keydown("ArrowDown") }
     expect(page).to have_css("tr.table-row.is-keyboard-focused")
 
@@ -157,6 +174,9 @@ RSpec.describe "Keyboard shortcuts", type: :system do
     expect(page).to have_selector("[data-component-name='avo/index/table_row_component'][data-resource-id='#{target_project.to_param}']")
     expect(page).to have_css("tr[data-visit-path]", count: 1)
 
+    # Search replaces the table via turbo and leaves focus on the search input.
+    # Re-focus the table so arrow navigation resumes on the new rows.
+    focus_resource_table
     dispatch_keydown("ArrowUp")
 
     focused_row = find("tr.table-row.is-keyboard-focused")
@@ -236,6 +256,92 @@ RSpec.describe "Keyboard shortcuts", type: :system do
   #   expect(project.reload.name).to eq("Updated from hotkey")
   # end
 
+  describe "accessible row navigation" do
+    it "does not consume arrow keys when the table is not focused" do
+      create_list(:project, 3)
+
+      visit "/admin/resources/projects"
+
+      result = dispatch_document_keydown("ArrowDown")
+
+      expect(result["defaultPrevented"]).to be(false)
+      expect(page).to have_no_css("tr.table-row.is-keyboard-focused")
+    end
+
+    it "focuses the table with Shift+T without selecting a row" do
+      create_list(:project, 3)
+
+      visit "/admin/resources/projects"
+
+      dispatch_keydown("T", shift_key: true)
+
+      expect(page.evaluate_script("document.activeElement && document.activeElement.tagName")).to eq("TABLE")
+      expect(page).to have_no_css("tr.table-row.is-keyboard-focused")
+    end
+
+    it "focuses the table and moves to the first row when pressing j" do
+      create_list(:project, 3)
+
+      visit "/admin/resources/projects"
+
+      dispatch_keydown("j")
+
+      expect(page).to have_css("tr.table-row.is-keyboard-focused")
+      expect(active_descendant_id).to be_present
+    end
+
+    it "focuses the table and moves to the previous row when pressing k" do
+      create_list(:project, 3)
+
+      visit "/admin/resources/projects"
+
+      dispatch_keydown("k")
+
+      expect(page).to have_css("tr.table-row.is-keyboard-focused")
+      expect(active_descendant_id).to be_present
+    end
+
+    it "sets aria-activedescendant to the focused row id" do
+      project = create(:project)
+
+      visit "/admin/resources/projects"
+
+      focus_resource_table
+      dispatch_keydown("ArrowDown")
+
+      focused_row = find("tr.table-row.is-keyboard-focused")
+      expect(active_descendant_id).to eq(focused_row["id"])
+    end
+
+    it "clears row focus on Escape but keeps the table focused" do
+      create_list(:project, 3)
+
+      visit "/admin/resources/projects"
+
+      focus_resource_table
+      dispatch_keydown("ArrowDown")
+      expect(page).to have_css("tr.table-row.is-keyboard-focused")
+
+      dispatch_keydown("Escape")
+
+      expect(page).to have_no_css("tr.table-row.is-keyboard-focused")
+      expect(page.evaluate_script("document.activeElement && document.activeElement.tagName")).to eq("TABLE")
+    end
+
+    it "does not trigger j/k while typing in the search field" do
+      create_list(:project, 3)
+
+      visit "/admin/resources/projects"
+
+      search_input = find("[data-resource-search-target='input']")
+      search_input.click
+      search_input.send_keys("j")
+
+      expect(search_input.value).to include("j")
+      expect(page).to have_no_css("tr.table-row.is-keyboard-focused")
+    end
+  end
+
   context "when hotkeys are disabled via config" do
     around do |example|
       original = Avo.configuration.hotkeys
@@ -263,11 +369,12 @@ RSpec.describe "Keyboard shortcuts", type: :system do
       expect(page).to have_current_path("/admin/resources/projects")
     end
 
-    it "preserves arrow-key row navigation" do
+    it "preserves arrow-key row navigation once the table is focused" do
       create_list(:project, 3)
 
       visit "/admin/resources/projects"
 
+      focus_resource_table
       dispatch_keydown("ArrowDown")
 
       expect(page).to have_css("tr.table-row.is-keyboard-focused")

--- a/spec/system/avo/group_1/hotkey_spec.rb
+++ b/spec/system/avo/group_1/hotkey_spec.rb
@@ -302,8 +302,6 @@ RSpec.describe "Keyboard shortcuts", type: :system do
     end
 
     it "sets aria-activedescendant to the focused row id" do
-      project = create(:project)
-
       visit "/admin/resources/projects"
 
       focus_resource_table


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Previously, when you'd use the arrow keys it would cycle through the table rows but that's bad for accesibility. It should scroll the page up and down. 
Now we introduced `SHIFT+M` to focus the table and then the arrow keys work.

Alternatively, you can use the global `j`/`k` keys to do what we previously had.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global hotkey handling and focus/keyboard event logic for index tables, which may impact navigation behavior across pages and Turbo frame updates. Risk is limited to client-side accessibility/UX (no auth/data changes).
> 
> **Overview**
> **Refactors index-table keyboard navigation to be opt-in via focus for accessibility.** Tables on top-level index pages are now focusable `role="grid"` elements; arrow/enter/space handling only activates when the table is focused, preserving normal page scrolling otherwise.
> 
> Adds global shortcuts to engage navigation (`Shift+T` to focus the table; `j`/`k` to focus and move next/previous row) and updates Escape behavior to clear row focus first, then blur the table on a second press (or deselect rows if any are selected). The focused row is exposed via `aria-activedescendant`, focus styling/ring is updated to avoid clipping, and has-many tables on show pages intentionally do **not** get these grid attributes.
> 
> Updates search Escape handling to prevent default clearing of `<input type="search">`, and expands system specs to cover the new focus model, ARIA attribute, Turbo refresh cases, and typing safeguards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7706110cdf7500684b3cfa3c548df4cd5a407a16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->