### PR TITLE
feat: add parent_resource prop to FiltersComponent and update related paths

### DIFF
--- a/app/components/avo/filters_component.rb
+++ b/app/components/avo/filters_component.rb
@@ -7,6 +7,7 @@ class Avo::FiltersComponent < Avo::BaseComponent
   prop :resource
   prop :applied_filters, default: {}.freeze
   prop :parent_record
+  prop :parent_resource
 
   def render?
     @filters.present?
@@ -15,7 +16,7 @@ class Avo::FiltersComponent < Avo::BaseComponent
   def reset_path
     # If come from a association page
     if @parent_record.present?
-      helpers.related_resources_path(@parent_record, @parent_record, encoded_filters: nil, reset_filter: true, keep_query_params: true)
+      helpers.related_resources_path(@parent_record, @parent_record, parent_resource: @parent_resource, encoded_filters: nil, reset_filter: true, keep_query_params: true)
     else
       helpers.resources_path(resource: @resource, encoded_filters: nil, reset_filter: true, keep_query_params: true)
     end

--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -102,7 +102,7 @@
                   <% end %>
 
                   <% unless field&.hide_filter_button %>
-                    <%= render Avo::FiltersComponent.new filters: @filters, resource: @resource, applied_filters: @applied_filters, parent_record: @parent_record %>
+                    <%= render Avo::FiltersComponent.new filters: @filters, resource: @resource, applied_filters: @applied_filters, parent_record: @parent_record, parent_resource: @parent_resource %>
                   <% end %>
 
                   <%= render partial: "avo/partials/view_toggle_button", locals: { available_view_types: @resource.available_view_types, view_type: @resource.view_type, turbo_frame: @turbo_frame } %>

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -148,6 +148,7 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
       resource: @resource,
       turbo_frame: @turbo_frame,
       parent_record: @parent_record,
+      parent_resource: @parent_resource,
       query: @query,
       loader: @resource.entity_loader(:scope)
     )

--- a/app/helpers/avo/url_helpers.rb
+++ b/app/helpers/avo/url_helpers.rb
@@ -77,7 +77,12 @@ module Avo
       rescue
       end
 
-      route_key = parent_resource&.route_key || parent_record.model_name.route_key
+      route_key = if parent_resource.present?
+        parent_resource.route_key
+      else
+        Avo.resource_manager.get_resource_by_model_class(parent_record.class)&.route_key ||
+          parent_record.model_name.route_key
+      end
 
       avo.send(:"resources_#{route_key}_associations_index_path", record.to_param, **existing_params, **args)
     end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #4477

- Fix association URLs for scoped has_many indexes when the parent is an STI child mapped via `model_resource_mapping`—URLs were built using the concrete model’s route key instead of the mapped Avo resource’s key.
- `related_resources_path` resolves the route key through `Avo.resource_manager.get_resource_by_model_class` when `parent_resource` is omitted; scopes (`ListComponent`) and filter reset (`FiltersComponent`) now pass `parent_resource` through (same pattern as pagination).
Related: https://github.com/avo-hq/avo/issues/4477

Related: https://github.com/avo-hq/avo-advanced/pull/91