### PR TITLE
refactor: neutral and accent colors same for both color schemes

### DIFF
--- a/lib/avo/configuration/appearance.rb
+++ b/lib/avo/configuration/appearance.rb
@@ -2,8 +2,8 @@ class Avo::Configuration::Appearance
   attr_reader :scheme, # :auto | :light | :dark
     :neutral, # Symbol — default theme selection (e.g. :slate, :brand)
     :accent,  # Symbol — default accent selection (e.g. :blue, :brand)
-    :neutral_colors, # Hash{ light:, dark: } — full 12-shade brand override
-    :accent_colors,  # Hash{ light:, dark: } — three-token brand override
+    :neutral_colors, # Hash{ 25 => ..., 50 => ..., ..., 950 => ... } — full 12-shade brand override (single palette, applied in both light and dark mode)
+    :accent_colors,  # Hash{ color:, content:, foreground: } — three-token brand override (single palette, applied in both light and dark mode)
     :neutrals, # Array[String] — available neutral theme names
     :accents, # Array[String] — available accent color names
     :lock, # Array[Symbol] — subset of [:scheme, :neutral, :accent]
@@ -37,7 +37,6 @@ class Avo::Configuration::Appearance
       content: "--color-accent-content",
       foreground: "--color-accent-foreground"
     }.freeze
-    SCHEMES = [:light, :dark].freeze
 
     DEFAULTS = {
       scheme: :auto,
@@ -100,17 +99,25 @@ class Avo::Configuration::Appearance
   # Returns the accent name for the data attribute (nil when accent is unset)
   def accent_css_class = accent&.to_s
 
-  # Returns the full inline CSS string that overrides brand vars at :root and .dark
-  # when neutral_colors / accent_colors are configured. Returns nil when neither is set
-  # so the layout can skip emitting the <style> tag entirely.
+  # Returns the inline CSS string that overrides brand vars at :root when
+  # neutral_colors / accent_colors are configured. Returns nil when neither is
+  # set so the layout can skip emitting the <style> tag entirely.
+  #
+  # Brand palettes are single-toned — one set of values applied in both light
+  # and dark mode (matching how the built-in `.neutral-theme-*` /
+  # `.accent-theme-*` classes work). The override is emitted only in `:root`;
+  # layer ordering does the rest.
   #
   # The output is wrapped in `@layer base` so it sits between Avo's defaults
-  # (`@layer theme`, where the built-in `:root` colors live) and the theme classes
-  # (`@layer components`, where `.neutral-theme-*` / `.accent-theme-*` are defined).
+  # (`@layer theme`, where the built-in `:root` colors and the `.dark`
+  # overrides live) and the theme classes (`@layer components`, where
+  # `.neutral-theme-*` / `.accent-theme-*` are defined).
   # Layer ordering — `theme < base < components` — guarantees:
-  #   * Our override beats Avo's default `:root` palette (we're in a later layer)
-  #   * A user-selected `.accent-theme-orange` still wins over our `:root` (it's
-  #     in a later layer), so the picker keeps working.
+  #   * Our :root override beats Avo's default `:root` palette and `.dark`
+  #     overrides (we're in a later layer), so the brand color applies in
+  #     both light and dark mode.
+  #   * A user-selected `.accent-theme-orange` still wins over our `:root`
+  #     (it's in a later layer), so the picker keeps working.
   # Without an `@layer` wrapper, the unlayered inline style would beat every
   # layered rule regardless of specificity, silently breaking theme selection.
   def brand_css_overrides
@@ -119,10 +126,7 @@ class Avo::Configuration::Appearance
     [
       "@layer base {",
       "  :root {",
-      *brand_declarations_for(:light).map { |line| "  #{line}" },
-      "  }",
-      "  .dark {",
-      *brand_declarations_for(:dark).map { |line| "  #{line}" },
+      *brand_declarations.map { |line| "  #{line}" },
       "  }",
       "}"
     ].join("\n")
@@ -130,27 +134,27 @@ class Avo::Configuration::Appearance
 
   private
 
-  def brand_declarations_for(scheme)
+  def brand_declarations
     declarations = []
 
     if neutral_colors
       NEUTRAL_SHADES.each do |shade|
-        declarations << "  --color-avo-neutral-#{shade}: #{neutral_colors[scheme][shade]};"
+        declarations << "  --color-avo-neutral-#{shade}: #{neutral_colors[shade]};"
       end
       # Brand-scoped alias for the picker swatch. Theme classes (`.neutral-theme-*`)
       # never set this var, so the swatch keeps showing the configured brand
       # neutral even while another theme is hovered or selected.
-      declarations << "  --color-brand-neutral-400: #{neutral_colors[scheme][400]};"
+      declarations << "  --color-brand-neutral-400: #{neutral_colors[400]};"
     end
 
     if accent_colors
       ACCENT_TOKENS.each do |token|
-        declarations << "  #{ACCENT_TOKEN_VAR_NAMES[token]}: #{accent_colors[scheme][token]};"
+        declarations << "  #{ACCENT_TOKEN_VAR_NAMES[token]}: #{accent_colors[token]};"
       end
       # Brand-scoped alias for the picker swatch. Theme classes (`.accent-theme-*`)
       # never set this var, so the swatch keeps showing the configured brand
       # accent even while another accent is hovered or selected.
-      declarations << "  --color-brand-accent: #{accent_colors[scheme][:color]};"
+      declarations << "  --color-brand-accent: #{accent_colors[:color]};"
     end
 
     declarations
@@ -175,24 +179,10 @@ class Avo::Configuration::Appearance
 
   def validate_color_palette!(name, palette, required_keys, missing_label)
     unless palette.is_a?(Hash)
-      raise ArgumentError, "#{name} must be a Hash with :light and :dark keys, got #{palette.class}"
+      raise ArgumentError, "#{name} must be a Hash, got #{palette.class}"
     end
 
-    errors = []
-    SCHEMES.each do |scheme|
-      scheme_hash = palette[scheme]
-      if scheme_hash.nil?
-        errors << "missing scheme :#{scheme}"
-        next
-      end
-      unless scheme_hash.is_a?(Hash)
-        errors << ":#{scheme} must be a Hash, got #{scheme_hash.class}"
-        next
-      end
-      missing = required_keys.select { |key| scheme_hash[key].nil? }
-      errors << ":#{scheme} missing #{missing_label} #{missing.inspect}" if missing.any?
-    end
-
-    raise ArgumentError, "#{name} is invalid: #{errors.join("; ")}" if errors.any?
+    missing = required_keys.select { |key| palette[key].nil? }
+    raise ArgumentError, "#{name} is missing #{missing_label} #{missing.inspect}" if missing.any?
   end
 end

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -78,45 +78,31 @@ Avo.configure do |config|
     # neutrals: %w[brand mist olive],
     # accents: %w[brand red orange pink rose],
     # Override the brand neutral and accent palettes. Both keys are independent —
-    # set one, the other, both, or neither.
+    # set one, the other, both, or neither. A single palette is applied in both
+    # light and dark mode (matching the built-in `.neutral-theme-*` /
+    # `.accent-theme-*` classes).
     # All 12 shades are required for `neutral_colors`; all three tokens for `accent_colors`.
-    # Both `light:` and `dark:` schemes are required for either key.
     # Values are passed through verbatim — any string a CSS custom property
     # accepts works (`oklch(...)`, `#hex`, `rgb(...)`, `hsl(...)`, `var(...)`).
     # Comment this block out to see Avo's defaults instead.
     # neutral_colors: {
-    #   light: {
-    #     25 => "oklch(98.5% 0.005 60)",
-    #     50 => "oklch(97%   0.008 60)",
-    #     100 => "oklch(93%   0.012 60)",
-    #     200 => "oklch(86%   0.015 60)",
-    #     300 => "oklch(76%   0.015 60)",
-    #     400 => "oklch(63%   0.014 60)",
-    #     500 => "oklch(53%   0.013 60)",
-    #     600 => "oklch(48%   0.012 60)",
-    #     700 => "oklch(43%   0.011 60)",
-    #     800 => "oklch(39%   0.010 60)",
-    #     900 => "oklch(28%   0.008 60)",
-    #     950 => "oklch(20%   0.005 60)"
-    #   },
-    #   dark: {
-    #     25 => "oklch(98.5% 0.005 60)",
-    #     50 => "oklch(97%   0.008 60)",
-    #     100 => "oklch(93%   0.012 60)",
-    #     200 => "oklch(86%   0.015 60)",
-    #     300 => "oklch(76%   0.015 60)",
-    #     400 => "oklch(63%   0.014 60)",
-    #     500 => "oklch(53%   0.013 60)",
-    #     600 => "oklch(48%   0.012 60)",
-    #     700 => "oklch(43%   0.011 60)",
-    #     800 => "oklch(39%   0.010 60)",
-    #     900 => "oklch(28%   0.008 60)",
-    #     950 => "oklch(20%   0.005 60)"
-    #   }
+    #   25 => "oklch(98.5% 0.005 60)",
+    #   50 => "oklch(97%   0.008 60)",
+    #   100 => "oklch(93%   0.012 60)",
+    #   200 => "oklch(86%   0.015 60)",
+    #   300 => "oklch(76%   0.015 60)",
+    #   400 => "oklch(63%   0.014 60)",
+    #   500 => "oklch(53%   0.013 60)",
+    #   600 => "oklch(48%   0.012 60)",
+    #   700 => "oklch(43%   0.011 60)",
+    #   800 => "oklch(39%   0.010 60)",
+    #   900 => "oklch(28%   0.008 60)",
+    #   950 => "oklch(20%   0.005 60)"
     # },
     # accent_colors: {
-    #   light: {color: "oklch(55% 0.2 280)", content: "oklch(45% 0.2 280)", foreground: "oklch(99% 0 0)"},
-    #   dark: {color: "oklch(70% 0.2 280)", content: "oklch(80% 0.15 280)", foreground: "oklch(15% 0.05 280)"}
+    #   color: "oklch(55% 0.2 280)",
+    #   content: "oklch(45% 0.2 280)",
+    #   foreground: "oklch(99% 0 0)"
     # },
     persistence: :database, # :database or :cookie
     load_settings: -> {

--- a/spec/lib/avo/configuration/appearance_spec.rb
+++ b/spec/lib/avo/configuration/appearance_spec.rb
@@ -179,17 +179,11 @@ RSpec.describe Avo::Configuration::Appearance do
 
   describe "neutral_colors / accent_colors" do
     let(:complete_neutral) do
-      {
-        light: described_class::NEUTRAL_SHADES.each_with_object({}) { |s, h| h[s] = "oklch(0.99 0.01 240)" },
-        dark: described_class::NEUTRAL_SHADES.each_with_object({}) { |s, h| h[s] = "oklch(0.15 0.01 240)" }
-      }
+      described_class::NEUTRAL_SHADES.each_with_object({}) { |s, h| h[s] = "oklch(0.99 0.01 240)" }
     end
 
     let(:complete_accent) do
-      {
-        light: {color: "oklch(0.6 0.2 260)", content: "oklch(0.5 0.2 260)", foreground: "oklch(1 0 0)"},
-        dark: {color: "oklch(0.7 0.2 260)", content: "oklch(0.8 0.2 260)", foreground: "oklch(0.1 0 0)"}
-      }
+      {color: "oklch(0.6 0.2 260)", content: "oklch(0.5 0.2 260)", foreground: "oklch(1 0 0)"}
     end
 
     describe "accessors" do
@@ -210,45 +204,26 @@ RSpec.describe Avo::Configuration::Appearance do
           .to raise_error(ArgumentError, /neutral_colors must be a Hash/)
       end
 
-      it "raises when :dark is missing entirely" do
-        expect { described_class.new(neutral_colors: {light: complete_neutral[:light]}) }
-          .to raise_error(ArgumentError, /missing scheme :dark/)
-      end
-
       it "raises and names missing shades" do
-        partial = {light: complete_neutral[:light].except(100, 700), dark: complete_neutral[:dark]}
-
-        expect { described_class.new(neutral_colors: partial) }
-          .to raise_error(ArgumentError, /:light missing shades \[100, 700\]/)
+        expect { described_class.new(neutral_colors: complete_neutral.except(100, 700)) }
+          .to raise_error(ArgumentError, /neutral_colors is missing shades \[100, 700\]/)
       end
 
       it "treats nil shade values as missing" do
-        partial = {light: complete_neutral[:light].merge(500 => nil), dark: complete_neutral[:dark]}
-
-        expect { described_class.new(neutral_colors: partial) }
-          .to raise_error(ArgumentError, /:light missing shades \[500\]/)
-      end
-
-      it "raises when a scheme is not a Hash" do
-        expect { described_class.new(neutral_colors: {light: complete_neutral[:light], dark: "nope"}) }
-          .to raise_error(ArgumentError, /:dark must be a Hash/)
+        expect { described_class.new(neutral_colors: complete_neutral.merge(500 => nil)) }
+          .to raise_error(ArgumentError, /neutral_colors is missing shades \[500\]/)
       end
     end
 
     describe "validation of accent_colors" do
-      it "raises when :foreground is missing in :light" do
-        partial = {
-          light: complete_accent[:light].except(:foreground),
-          dark: complete_accent[:dark]
-        }
-
-        expect { described_class.new(accent_colors: partial) }
-          .to raise_error(ArgumentError, /:light missing tokens \[:foreground\]/)
+      it "raises when :foreground is missing" do
+        expect { described_class.new(accent_colors: complete_accent.except(:foreground)) }
+          .to raise_error(ArgumentError, /accent_colors is missing tokens \[:foreground\]/)
       end
 
-      it "raises when :dark is missing entirely" do
-        expect { described_class.new(accent_colors: {light: complete_accent[:light]}) }
-          .to raise_error(ArgumentError, /missing scheme :dark/)
+      it "raises when not a Hash" do
+        expect { described_class.new(accent_colors: "nope") }
+          .to raise_error(ArgumentError, /accent_colors must be a Hash/)
       end
     end
 
@@ -260,16 +235,15 @@ RSpec.describe Avo::Configuration::Appearance do
       context "when only neutral_colors is configured" do
         let(:options) { {neutral_colors: complete_neutral} }
 
-        it "emits :root and .dark blocks with all 12 neutral shades inside @layer base" do
+        it "emits a single :root block with all 12 neutral shades inside @layer base" do
           css = appearance.brand_css_overrides
 
           expect(css).to start_with("@layer base {")
           expect(css.strip).to end_with("}")
-          expect(css).to include(":root {")
-          expect(css).to include(".dark {")
+          expect(css.scan(":root {").size).to eq(1)
+          expect(css).not_to include(".dark {")
           described_class::NEUTRAL_SHADES.each do |shade|
             expect(css).to include("--color-avo-neutral-#{shade}: oklch(0.99 0.01 240);")
-            expect(css).to include("--color-avo-neutral-#{shade}: oklch(0.15 0.01 240);")
           end
         end
 
@@ -277,7 +251,6 @@ RSpec.describe Avo::Configuration::Appearance do
           css = appearance.brand_css_overrides
 
           expect(css).to include("--color-brand-neutral-400: oklch(0.99 0.01 240);")
-          expect(css).to include("--color-brand-neutral-400: oklch(0.15 0.01 240);")
         end
 
         it "does not emit accent declarations" do
@@ -291,21 +264,20 @@ RSpec.describe Avo::Configuration::Appearance do
       context "when only accent_colors is configured" do
         let(:options) { {accent_colors: complete_accent} }
 
-        it "emits all three accent tokens for both schemes" do
+        it "emits all three accent tokens once inside @layer base :root" do
           css = appearance.brand_css_overrides
 
+          expect(css.scan(":root {").size).to eq(1)
+          expect(css).not_to include(".dark {")
           expect(css).to include("--color-accent: oklch(0.6 0.2 260);")
           expect(css).to include("--color-accent-content: oklch(0.5 0.2 260);")
           expect(css).to include("--color-accent-foreground: oklch(1 0 0);")
-          expect(css).to include("--color-accent: oklch(0.7 0.2 260);")
-          expect(css).to include("--color-accent-content: oklch(0.8 0.2 260);")
         end
 
         it "emits the brand-scoped --color-brand-accent alias for the picker swatch" do
           css = appearance.brand_css_overrides
 
           expect(css).to include("--color-brand-accent: oklch(0.6 0.2 260);")
-          expect(css).to include("--color-brand-accent: oklch(0.7 0.2 260);")
         end
 
         it "does not emit neutral declarations" do
@@ -319,11 +291,11 @@ RSpec.describe Avo::Configuration::Appearance do
       context "when both keys are configured" do
         let(:options) { {neutral_colors: complete_neutral, accent_colors: complete_accent} }
 
-        it "emits both palettes inside a single :root and a single .dark block" do
+        it "emits both palettes inside a single :root block (no .dark block)" do
           css = appearance.brand_css_overrides
 
           expect(css.scan(":root {").size).to eq(1)
-          expect(css.scan(".dark {").size).to eq(1)
+          expect(css).not_to include(".dark {")
           expect(css).to include("--color-avo-neutral-25: oklch(0.99 0.01 240);")
           expect(css).to include("--color-accent-foreground: oklch(1 0 0);")
         end

--- a/spec/requests/avo/appearance_overrides_request_spec.rb
+++ b/spec/requests/avo/appearance_overrides_request_spec.rb
@@ -22,13 +22,11 @@ RSpec.describe "Appearance overrides", type: :request do
   context "when overrides are configured" do
     let(:overrides_css) do
       <<~CSS
-        :root {
-          --color-avo-neutral-25: oklch(0.99 0.01 240);
-          --color-accent: oklch(0.6 0.2 260);
-        }
-        .dark {
-          --color-avo-neutral-25: oklch(0.15 0.01 240);
-          --color-accent: oklch(0.7 0.2 260);
+        @layer base {
+          :root {
+            --color-avo-neutral-25: oklch(0.99 0.01 240);
+            --color-accent: oklch(0.6 0.2 260);
+          }
         }
       CSS
     end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Changes the way one can control the neutral and accent colors. we don't need special ones for each scheme. one is just fine.

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot ro a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public configuration shape for `appearance.neutral_colors`/`accent_colors` and alters how brand CSS overrides are generated, which may break existing integrations expecting per-scheme palettes. Risk is limited to theming/appearance behavior and related validation errors.
> 
> **Overview**
> **Brand color overrides are now single-palettes (scheme-agnostic).** `appearance.neutral_colors` and `appearance.accent_colors` no longer accept `{ light:, dark: }` hashes; they now take a single hash of 12 neutral shades or 3 accent tokens that applies to both light and dark mode.
> 
> `brand_css_overrides` now emits only a `@layer base` `:root` block (removing the separate `.dark` block), and validation/specs/examples were updated to match the new input format and output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ba87d2f7db3bc5fbdc5542c1a30be99cab3e359. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->