### PR TITLE
fix: horizontal fields layout

### DIFF
--- a/app/assets/stylesheets/css/components/ui/description_list.css
+++ b/app/assets/stylesheets/css/components/ui/description_list.css
@@ -1,3 +1,3 @@
 .description-list {
-  @apply w-full flex flex-wrap overflow-auto flex-1 divide-y divide-tertiary flex-col;
+  @apply w-full flex flex-wrap overflow-auto flex-1 divide-y divide-tertiary;
 }

--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -5,7 +5,7 @@
       data-association="<%= @field.id %>"
       data-association-class="<%= @field&.target_resource&.model_class || nil %>"
     >
-    <div class="description-list">
+    <div class="w-full flex flex-wrap">
       <%= field_wrapper(**field_wrapper_args, label_for: @field.polymorphic_form_field_label, help: @field.polymorphic_help || '') do %>
         <%= @form.select @field.type_input_foreign_key, @field.types.map { |type| [Avo.resource_manager.get_resource_by_model_class(type.to_s).name, type.to_s] },
         {
@@ -29,11 +29,11 @@
           <%= @form.hidden_field @field.type_input_foreign_key %>
         <% end %>
       <% end %>
-      <div data-belongs-to-field-target="container" class="hidden border-0"></div>
+      <div data-belongs-to-field-target="container" class="hidden <%= @field.width_class %>"></div>
       <% @field.types.each do |type| %>
         <template data-belongs-to-field-target="type" data-type="<%= type %>">
           <div data-polymorphic-type="<%= type %>">
-            <%= field_wrapper(**field_wrapper_args.merge!(data: reload_data), label: Avo.resource_manager.get_resource_by_model_class(type.to_s).name) do %>
+            <%= field_wrapper(**field_wrapper_args.merge!(data: reload_data), label: Avo.resource_manager.get_resource_by_model_class(type.to_s).name, class: "!w-full") do %>
               <% if @field.is_searchable? %>
                 <%= render Avo::Pro::SearchableAssociations::AutocompleteComponent.new form: @form,
                   disabled: disabled,

--- a/spec/dummy/app/avo/resources/comment.rb
+++ b/spec/dummy/app/avo/resources/comment.rb
@@ -23,14 +23,14 @@ class Avo::Resources::Comment < Avo::BaseResource
       with_options width: 50 do
         field :user, as: :belongs_to, use_resource: Avo::Resources::CompactUser, link_to_record: true
       end
-      field :commentable, as: :belongs_to, polymorphic_as: :commentable, types: [::Post, ::Project]
-      field :test, stacked: true, width: 33 do
+      field :commentable, width: 50, as: :belongs_to, polymorphic_as: :commentable, types: [::Post, ::Project]
+      field :test, stacked: true, width: 50 do
         "test1"
       end
-      field :test2, stacked: true, width: 33 do
+      field :test2, stacked: true, width: 50 do
         "test2"
       end
-      field :test2, stacked: true, width: 33 do
+      field :test2, stacked: true, width: 50 do
         "test3"
       end
       # field :test3 do

--- a/spec/system/avo/group_1/belongs_to_polymorphic_spec.rb
+++ b/spec/system/avo/group_1/belongs_to_polymorphic_spec.rb
@@ -124,6 +124,18 @@ RSpec.feature "belongs_to", type: :system do
       end
     end
 
+    describe "edit form rendering" do
+      it "does not nest a description-list inside the polymorphic wrapper" do
+        visit "/admin/resources/comments/new"
+
+        polymorphic_outer = find('[data-controller="belongs-to-field"]')
+        expect(polymorphic_outer[:class].split).to include("w-full", "flex-col")
+
+        inner_wrapper = polymorphic_outer.find(:xpath, "./div[1]")
+        expect(inner_wrapper[:class].split).not_to include("description-list")
+      end
+    end
+
     describe "within a parent model" do
       let!(:project) { create :project }
       let!(:comment) { create :comment, body: "hey there", user: user, commentable: project }


### PR DESCRIPTION
# Description
  Fix doubled border on polymorphic belongs_to and restore width pairing.
  Fields with a width option (e.g. width 50, 33) were stacked vertically instead of pairing side by side because of a stray flex-col on the description-list class.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<img width="945" height="109" alt="Screenshot 2026-05-21 at 00 42 55" src="https://github.com/user-attachments/assets/bee69d22-40e9-4009-b4c7-0194aea89d72" />
</br>
<img width="945" height="109" alt="Screenshot 2026-05-21 at 00 43 07" src="https://github.com/user-attachments/assets/930c904a-aa18-414a-8285-b0cfd1b1ecc1" />
</br>
<img width="945" height="132" alt="Screenshot 2026-05-21 at 00 43 52" src="https://github.com/user-attachments/assets/82724f9e-f815-42de-a315-adc0628b634c" />
