### PR TITLE
refactor: visual tweaks

### DIFF
--- a/app/assets/stylesheets/css/components/button.css
+++ b/app/assets/stylesheets/css/components/button.css
@@ -176,8 +176,7 @@
 
     .button--style-text {
       &:not([class*="button--color-"]) {
-
-      --btn-text-color: var(--color-avo-neutral-50);
+        --btn-text-color: var(--color-avo-neutral-50);
       }
     }
 
@@ -190,12 +189,10 @@
 
   /* Primary style */
   .button--style-primary {
-    @apply text-(--btn-color-accent-foreground) border-(--btn-color-accent-content);
+    @apply text-(--btn-color-accent-foreground) border-(--btn-color-accent);
     background: linear-gradient(180deg, var(--btn-color-accent-content) 0%, var(--btn-color-accent) 100%);
 
     &:not([class*="button--color-"]) {
-      background: linear-gradient(180deg, var(--color-white) 0%, var(--color-white) 100%);
-
       &.button--hover,
       &:hover {
         background: linear-gradient(180deg, color-mix(in oklab, var(--btn-color-accent-content) 96%, var(--color-black)) 0%, color-mix(in oklab, var(--btn-color-accent) 96%, var(--color-black)) 100%);
@@ -203,8 +200,8 @@
     }
 
     box-shadow:
-      0 -1.4px 0 0.1px var(--btn-color-accent-content) inset,
-      0 0.8px 0 0.4px color-mix(in oklab, var(--color-white) 45%, transparent) inset;
+      inset 0px -1.4px 0px 0.1px var(--btn-color-accent-content),
+      inset 0px 0.8px 0px 0.4px color-mix(in oklch, white 45%, transparent);
 
     &.button--hover,
     &:hover {
@@ -281,6 +278,11 @@
       @apply bg-secondary text-(--btn-color-accent-content);
       box-shadow: none;
     }
+
+    /* Primary color override */
+    &.button--color-primary {
+      @apply border-(--color-avo-neutral-500);
+    }
   }
 
   /* Tertiary style (outline buttons) */
@@ -295,7 +297,8 @@
 
     &.button--hover,
     &:hover {
-      @apply bg-secondary text-(--btn-text-color);
+      background: color-mix(in oklab, var(--btn-color-accent), var(--color-primary) 85%);
+      @apply text-(--btn-text-color);
     }
 
     &.button--active,

--- a/app/assets/stylesheets/css/components/button.css
+++ b/app/assets/stylesheets/css/components/button.css
@@ -169,20 +169,20 @@
     }
 
     .button--style-outline {
-      --btn-color-accent: var(--color-avo-neutral-50);
-      --btn-color-accent-content: var(--color-avo-neutral-100);
+      --btn-color-accent: var(--color-avo-neutral-100);
+      --btn-color-accent-content: var(--color-avo-neutral-200);
       --btn-color-accent-foreground: var(--color-avo-neutral-950);
     }
 
     .button--style-text {
       &:not([class*="button--color-"]) {
-        --btn-text-color: var(--color-avo-neutral-50);
+        --btn-text-color: var(--color-avo-neutral-100);
       }
     }
 
     .button.button--color-primary {
-      --btn-color-accent: var(--color-avo-neutral-50);
-      --btn-color-accent-content: var(--color-avo-neutral-100);
+      --btn-color-accent: var(--color-avo-neutral-100);
+      --btn-color-accent-content: var(--color-avo-neutral-200);
       --btn-color-accent-foreground: var(--color-avo-neutral-950);
     }
   }

--- a/app/assets/stylesheets/css/layout.css
+++ b/app/assets/stylesheets/css/layout.css
@@ -247,8 +247,7 @@ button[data-sidebar-toggle-icon] {
    Sidebar starts below the navbar (matching .main's padding-top), so the
    navbar is uninterrupted across the full viewport width. */
 .avo-sidebar {
-  @apply fixed z-50 start-0 flex-1 border-e border-tertiary lg:border-none bg-background lg:bg-transparent w-(--sidebar-width) dark:bg-primary;
-
+  @apply fixed z-50 start-0 flex-1 border-e border-tertiary lg:border-none bg-sidebar-background w-(--sidebar-width);
 
   top: var(--top-navbar-height);
   height: calc(100dvh - var(--top-navbar-height));

--- a/app/assets/stylesheets/css/typography.css
+++ b/app/assets/stylesheets/css/typography.css
@@ -30,7 +30,7 @@ kbd.kbd--called {
   box-shadow: none;
 }
 
-.hotkeys-hide-badges .hotkey-badge kbd {
+.hotkeys-hide-badges .hotkey-badge {
   display: none;
 }
 

--- a/app/assets/stylesheets/css/variables.css
+++ b/app/assets/stylesheets/css/variables.css
@@ -1,9 +1,9 @@
 /* TODO: rename this file to theming or something similar */
 @theme {
-  --color-avo-neutral-25: oklch(98.51% 0 89.88);
-  --color-avo-neutral-50: oklch(97.31% 0 89.88);
-  --color-avo-neutral-100: oklch(92.8% 0 89.88);
-  --color-avo-neutral-200: oklch(86.07% 0 89.88);
+  --color-avo-neutral-25: oklch(99.71% 0 89.88);
+  --color-avo-neutral-50: oklch(98.51% 0 89.88);
+  --color-avo-neutral-100: oklch(97.31% 0 89.88);
+  --color-avo-neutral-200: oklch(92.8% 0 89.88);
   --color-avo-neutral-300: oklch(75.72% 0 89.88);
   --color-avo-neutral-400: oklch(62.68% 0 89.88);
   --color-avo-neutral-500: oklch(53.48% 0 89.88);
@@ -45,11 +45,11 @@
     0 0.8px 0 0.4px var(--color-primary) inset;
 
   /* foundations - Light Mode */
-  --color-background: var(--color-avo-neutral-25);
+  --color-background: var(--color-avo-neutral-50);
   --color-foreground: var(--color-avo-neutral-800);
   --color-primary: var(--color-white);
-  --color-secondary: var(--color-avo-neutral-50);
-  --color-tertiary: var(--color-avo-neutral-100);
+  --color-secondary: var(--color-avo-neutral-100);
+  --color-tertiary: var(--color-avo-neutral-200);
   --color-content: var(--color-avo-neutral-950);
   --color-content-secondary: var(--color-avo-neutral-500);
 

--- a/app/assets/stylesheets/css/variables.css
+++ b/app/assets/stylesheets/css/variables.css
@@ -53,6 +53,9 @@
   --color-content: var(--color-avo-neutral-950);
   --color-content-secondary: var(--color-avo-neutral-500);
 
+  --color-scheme: var(--color-white);
+  --color-scheme-opposite: var(--color-black);
+
   /* themes - Neutral Light */
   --color-accent: var(--color-avo-neutral-800);
   --color-accent-content: var(--color-avo-neutral-950);
@@ -68,6 +71,9 @@
      `accent_colors:`, so a configured install shows its actual brand colors. */
   --color-brand-neutral-400: oklch(62.68% 0 89.88);
   --color-brand-accent: oklch(39.04% 0 89.88);
+
+  /* Semantic variables */
+  --color-sidebar-background: var(--color-background);
 }
 
 /* Dark mode defaults live in @layer theme — same layer as the @theme block
@@ -85,6 +91,9 @@
     --color-content: var(--color-white);
     --color-content-secondary: var(--color-avo-neutral-300);
 
+    --color-scheme: var(--color-black);
+    --color-scheme-opposite: var(--color-white);
+
     /* themes - Neutral Dark */
     --color-accent: var(--color-avo-neutral-50);
     --color-accent-content: var(--color-avo-neutral-100);
@@ -94,6 +103,10 @@
        :root, but using the dark default accent (neutral-50) so the swatch reads
        correctly under the dark scheme. */
     --color-brand-accent: oklch(97.31% 0 89.88);
+
+    /* Semantic variables */
+    --color-sidebar-background: color-mix(in oklab, var(--color-background), var(--color-scheme) 14%);
+
   }
 }
 

--- a/app/components/avo/button_component.rb
+++ b/app/components/avo/button_component.rb
@@ -13,6 +13,9 @@ class Avo::ButtonComponent < Avo::BaseComponent
   prop :icon do |value|
     value&.to_sym
   end
+  prop :end_icon do |value|
+    value&.to_sym
+  end
   prop :icon_class, default: ""
   prop :is_link, default: false
   prop :aria, default: {}.freeze
@@ -79,6 +82,7 @@ class Avo::ButtonComponent < Avo::BaseComponent
   def render_content
     concat helpers.svg(@icon, class: class_names("button__icon", @icon_class)) if @icon.present?
     concat content if content.present? && @style != :icon
+    concat helpers.svg(@end_icon, class: class_names("button__icon", @icon_class)) if @end_icon.present?
     concat hotkey_badge(@args.dig(:data, :hotkey)) if @args.dig(:data, :hotkey) && @args.dig(:data, :show_hotkey_badge) != false
   end
 end

--- a/app/controllers/avo/private_controller.rb
+++ b/app/controllers/avo/private_controller.rb
@@ -11,51 +11,24 @@ module Avo
     def appearance
       @page_title = "Color Tokens [Private]"
 
-      @light_foundations = [
-        {name: "--color-background", value: "var(--color-avo-neutral-25)", desc: "Page background"},
-        {name: "--color-foreground", value: "var(--color-avo-neutral-800)", desc: "Text foreground"},
-        {name: "--color-primary", value: "var(--color-white)", desc: "Primary surface"},
-        {name: "--color-secondary", value: "var(--color-avo-neutral-50)", desc: "Secondary surface"},
-        {name: "--color-tertiary", value: "var(--color-avo-neutral-100)", desc: "Tertiary surface"},
-        {name: "--color-content", value: "var(--color-avo-neutral-950)", desc: "Text content"},
-        {name: "--color-content-secondary", value: "var(--color-avo-neutral-500)", desc: "Secondary text"}
+      @foundation_tokens = [
+        {name: "--color-background", desc: "Page background"},
+        {name: "--color-foreground", desc: "Text foreground"},
+        {name: "--color-primary", desc: "Primary surface"},
+        {name: "--color-secondary", desc: "Secondary surface"},
+        {name: "--color-tertiary", desc: "Tertiary surface"},
+        {name: "--color-content", desc: "Text content"},
+        {name: "--color-content-secondary", desc: "Secondary text"}
       ]
 
-      @dark_foundations = [
-        {name: "--color-background", value: "var(--color-avo-neutral-900)", desc: "Page background"},
-        {name: "--color-foreground", value: "var(--color-avo-neutral-50)", desc: "Text foreground"},
-        {name: "--color-primary", value: "var(--color-avo-neutral-950)", desc: "Primary surface"},
-        {name: "--color-secondary", value: "var(--color-avo-neutral-800)", desc: "Secondary surface"},
-        {name: "--color-tertiary", value: "var(--color-avo-neutral-700)", desc: "Tertiary surface"},
-        {name: "--color-content", value: "var(--color-white)", desc: "Text content"},
-        {name: "--color-content-secondary", value: "var(--color-avo-neutral-300)", desc: "Secondary text"}
-      ]
+      @neutral_scale = Avo::Configuration::Appearance::NEUTRAL_SHADES.map do |shade|
+        {name: shade.to_s, css_var: "--color-avo-neutral-#{shade}"}
+      end
 
-      @neutral_scale = [
-        {name: "25", oklch: "oklch(98.51% 0.0000 89.88)"},
-        {name: "50", oklch: "oklch(97.31% 0.0000 89.88)"},
-        {name: "100", oklch: "oklch(92.80% 0.0000 89.88)"},
-        {name: "200", oklch: "oklch(86.07% 0.0000 89.88)"},
-        {name: "300", oklch: "oklch(75.72% 0.0000 89.88)"},
-        {name: "400", oklch: "oklch(62.68% 0.0000 89.88)"},
-        {name: "500", oklch: "oklch(53.48% 0.0000 89.88)"},
-        {name: "600", oklch: "oklch(47.84% 0.0000 89.88)"},
-        {name: "700", oklch: "oklch(42.76% 0.0000 89.88)"},
-        {name: "800", oklch: "oklch(39.04% 0.0000 89.88)"},
-        {name: "900", oklch: "oklch(27.68% 0.0000 89.88)"},
-        {name: "950", oklch: "oklch(20.46% 0.0000 89.88)"}
-      ]
-
-      @light_accents = [
-        {name: "--color-accent", value: "var(--color-avo-neutral-800)", desc: "Accent"},
-        {name: "--color-accent-content", value: "var(--color-avo-neutral-950)", desc: "Accent subtle"},
-        {name: "--color-accent-foreground", value: "var(--color-white)", desc: "Accent text"}
-      ]
-
-      @dark_accents = [
-        {name: "--color-accent", value: "var(--color-avo-neutral-50)", desc: "Accent"},
-        {name: "--color-accent-content", value: "var(--color-avo-neutral-100)", desc: "Accent subtle"},
-        {name: "--color-accent-foreground", value: "var(--color-avo-neutral-950)", desc: "Accent text"}
+      @accent_tokens = [
+        {name: "--color-accent", value: "var(--color-accent)", desc: "Accent"},
+        {name: "--color-accent-content", value: "var(--color-accent-content)", desc: "Accent subtle"},
+        {name: "--color-accent-foreground", value: "var(--color-accent-foreground)", desc: "Accent text"}
       ]
 
       @accent_options = [

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -52,13 +52,16 @@
       <% c.with_controls do %>
         <%= a_button type: :button,
           data: { action: 'click->modal#close', **(@action.close_modal_on_backdrop_click ? { hotkey: "Escape" } : {}) },
+          style: :text,
+          color: :primary,
           size: :md do %>
           <%= @action.cancel_button_label %>
         <% end %>
         <%= a_button type: :submit,
             color: :primary,
-            style: :primary,
+            style: :outline,
             size: :md,
+            end_icon: "tabler/outline/arrow-right",
             data: {
               target: :submit_action,
               hotkey: "Mod+Enter",

--- a/app/views/avo/private/_links_and_buttons.html.erb
+++ b/app/views/avo/private/_links_and_buttons.html.erb
@@ -1,9 +1,17 @@
 <%
   entities = [:link, :button]
-  sizes = [:lg, :md, :sm]
+  sizes = [:md, :lg, :sm, :xs]
   styles = [:primary, :outline, :text]
   colors = [nil, :primary, :accent, :blue, :gray, :red, :orange, :green, :teal, :cyan, :sky, :indigo, :violet, :purple, :fuchsia, :pink, :rose]
   states = [:regular, :hover, :disabled, :active]
+
+  def design_button_label(entity, size, style, color, state, extra_classes)
+    return "#{entity.to_s.humanize.capitalize} #{state}"
+  end
+
+  def design_button_args(entity, size, style, color, state, extra_classes)
+    return {icon: "tabler/outline/arrow-left", style: style, color: color, size: size, class: extra_classes, disabled: state == :disabled}
+  end
 %>
 <div class="px-6 space-y-4">
   <% entities.each do |entity| %>
@@ -28,18 +36,17 @@
                   %>
                   <%
                     a_button_or_link = "a_#{entity}"
-                    args = {icon: "tabler/outline/arrow-left", style: style, color: color, size: size, class: extra_classes, disabled: state == :disabled}
                   %>
                   <% if entity == :link %>
                     <div>
-                      <%= send a_button_or_link, 'javascript:void(0);', **args do %>
-                        <%= entity.to_s.humanize.capitalize %> <%= state %>
+                      <%= send a_button_or_link, 'javascript:void(0);', **design_button_args(entity, size, style, color, state, extra_classes) do %>
+                        <%= design_button_label(entity, size, style, color, state, extra_classes) %>
                       <% end %>
                     </div>
                   <% else %>
                     <div>
-                      <%= send a_button_or_link, **args do %>
-                        <%= entity.to_s.humanize.capitalize %> <%= state %>
+                      <%= send a_button_or_link, **design_button_args(entity, size, style, color, state, extra_classes) do %>
+                        <%= design_button_label(entity, size, style, color, state, extra_classes) %>
                       <% end %>
                     </div>
                     <div>

--- a/app/views/avo/private/appearance.html.erb
+++ b/app/views/avo/private/appearance.html.erb
@@ -105,13 +105,13 @@
 
   .accent-cards {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
-    gap: 1rem;
-    margin-bottom: 2rem;
+    grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+    gap: 0.5rem;
+    margin-bottom: 1rem;
   }
 
   .accent-card {
-    border-radius: 6px;
+    border-radius: 4px;
     overflow: hidden;
     cursor: pointer;
     transition: transform 0.2s;
@@ -119,34 +119,60 @@
   }
 
   .accent-card:hover {
-    transform: translateY(-2px);
+    transform: translateY(-1px);
   }
 
   .accent-swatch-color {
-    height: 80px;
+    height: 40px;
     width: 100%;
     display: flex;
-    align-items: flex-end;
+    align-items: center;
     justify-content: center;
-    padding-bottom: 0.5rem;
     color: white;
     font-weight: 600;
-    text-shadow: 0 1px 2px rgba(0,0,0,0.2);
-    font-size: 0.75rem;
-    border: 1px solid rgba(0,0,0,0.1);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+    font-size: 0.625rem;
+    border: 1px solid rgba(0, 0, 0, 0.1);
   }
 
   .accent-swatch-info {
-    padding: 0.75rem;
+    padding: 0.375rem 0.5rem;
     background: var(--color-secondary);
-    font-size: 0.75rem;
+    font-size: 0.6875rem;
+    text-align: center;
   }
 
   .accent-name {
     font-weight: 600;
     color: var(--color-content);
     text-transform: capitalize;
-    margin-bottom: 0.25rem;
+    margin-bottom: 0;
+    line-height: 1.2;
+    word-break: break-word;
+  }
+
+  .accent-card .swatch-value {
+    display: none;
+  }
+
+  .accent-card--detailed .swatch-value {
+    display: block;
+    margin-top: 0.125rem;
+    font-size: 0.625rem;
+  }
+
+  .accent-card--detailed .accent-swatch-color {
+    height: 48px;
+  }
+
+  .accent-card--detailed .accent-swatch-info {
+    padding: 0.5rem;
+    text-align: start;
+  }
+
+  .accent-cards--detailed {
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+    max-width: 24rem;
   }
 
   .section-subtitle {
@@ -220,7 +246,7 @@
   .accent-group {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.375rem;
   }
 
   .accent-group-label {
@@ -229,10 +255,34 @@
     color: var(--color-content-secondary);
   }
 
+  .accent-options-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(108px, 1fr));
+    gap: 0.75rem;
+  }
+
   .accent-group-swatches {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
-    gap: 1rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.25rem;
+  }
+
+  .accent-group-swatches .neutral-color {
+    height: 28px;
+    border-radius: 3px 3px 0 0;
+  }
+
+  .accent-group-swatches .neutral-info {
+    padding: 0.25rem;
+  }
+
+  .accent-group-swatches .neutral-label {
+    font-size: 0.6875rem;
+    margin-bottom: 0;
+  }
+
+  .accent-group-swatches .neutral-value {
+    display: none;
   }
 </style>
 
@@ -252,12 +302,12 @@
 
           <div id="foundations-light" class="tab-content active">
             <div class="color-group">
-              <% @light_foundations.each do |color| %>
+              <% @foundation_tokens.each do |color| %>
                 <div class="color-swatch" onclick="copyToClipboard('<%= color[:name] %>')">
-                  <div class="swatch-color" style="background-color: <%= color[:value] %>"></div>
+                  <div class="swatch-color" style="background-color: var(<%= color[:name] %>)"></div>
                   <div class="swatch-info">
                     <div class="swatch-label"><%= color[:name] %></div>
-                    <div class="swatch-value"><%= color[:value] %></div>
+                    <div class="swatch-value">var(<%= color[:name] %>)</div>
                     <% if color[:desc] %>
                       <div class="swatch-desc"><%= color[:desc] %></div>
                     <% end %>
@@ -268,19 +318,21 @@
           </div>
 
           <div id="foundations-dark" class="tab-content">
-            <div class="color-group">
-              <% @dark_foundations.each do |color| %>
-                <div class="color-swatch" onclick="copyToClipboard('<%= color[:name] %>')">
-                  <div class="swatch-color" style="background-color: <%= color[:value] %>"></div>
-                  <div class="swatch-info">
-                    <div class="swatch-label"><%= color[:name] %></div>
-                    <div class="swatch-value"><%= color[:value] %></div>
-                    <% if color[:desc] %>
-                      <div class="swatch-desc"><%= color[:desc] %></div>
-                    <% end %>
+            <div class="dark">
+              <div class="color-group">
+                <% @foundation_tokens.each do |color| %>
+                  <div class="color-swatch" onclick="copyToClipboard('<%= color[:name] %>')">
+                    <div class="swatch-color" style="background-color: var(<%= color[:name] %>)"></div>
+                    <div class="swatch-info">
+                      <div class="swatch-label"><%= color[:name] %></div>
+                      <div class="swatch-value">var(<%= color[:name] %>)</div>
+                      <% if color[:desc] %>
+                        <div class="swatch-desc"><%= color[:desc] %></div>
+                      <% end %>
+                    </div>
                   </div>
-                </div>
-              <% end %>
+                <% end %>
+              </div>
             </div>
           </div>
 
@@ -288,7 +340,7 @@
           <div class="neutral-scale">
             <% @neutral_scale.each do |item| %>
               <div class="neutral-swatch" onclick="copyToClipboard('--color-avo-neutral-<%= item[:name] %>')">
-                <div class="neutral-color" style="background-color: <%= item[:oklch] %>"></div>
+                <div class="neutral-color" style="background-color: var(<%= item[:css_var] %>)"></div>
                 <div class="neutral-info">
                   <div class="neutral-label"><%= item[:name] %></div>
                   <div class="neutral-value">--color-avo-neutral-<%= item[:name] %></div>
@@ -299,12 +351,10 @@
 
           <h4 class="section-header" style="font-size: 0.95rem;">Accent Variables by Color</h4>
           <p class="section-subtitle">Each accent shows its three variables: 500 (main), 600 (content), and foreground (text)</p>
-          <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 2rem;">
+          <div class="accent-options-grid">
             <% @accent_options.each do |color| %>
               <div class="accent-group">
-                <div style="font-size: 0.9rem; font-weight: 600; color: var(--color-content); text-transform: capitalize;">
-                  <%= color[:name] %>
-                </div>
+                <div class="accent-group-label" style="text-transform: capitalize;"><%= color[:name] %></div>
                 <div class="accent-group-swatches">
                   <div class="neutral-swatch" onclick="copyToClipboard('--color-<%= color[:name] %>-500')">
                     <div class="neutral-color" style="background-color: var(--color-<%= color[:name] %>-500)"></div>
@@ -350,9 +400,9 @@
           <div id="accents-default" class="tab-content active">
             <div class="accent-group">
               <div class="accent-group-label">Light Mode</div>
-              <div class="accent-cards">
-                <% @light_accents.each do |color| %>
-                  <div class="accent-card" onclick="copyToClipboard('<%= color[:name] %>')">
+              <div class="accent-cards accent-cards--detailed">
+                <% @accent_tokens.each do |color| %>
+                  <div class="accent-card accent-card--detailed" onclick="copyToClipboard('<%= color[:name] %>')">
                     <div class="accent-swatch-color" style="background-color: <%= color[:value] %>">
                       <%= color[:name].sub('--color-', '') %>
                     </div>
@@ -367,28 +417,30 @@
               </div>
 
               <div class="accent-group-label" style="margin-top: 1rem;">Dark Mode</div>
-              <div class="accent-cards">
-                <% @dark_accents.each do |color| %>
-                  <div class="accent-card" onclick="copyToClipboard('<%= color[:name] %>')">
-                    <div class="accent-swatch-color" style="background-color: <%= color[:value] %>">
-                      <%= color[:name].sub('--color-', '') %>
+              <div class="dark">
+                <div class="accent-cards accent-cards--detailed">
+                  <% @accent_tokens.each do |color| %>
+                    <div class="accent-card accent-card--detailed" onclick="copyToClipboard('<%= color[:name] %>')">
+                      <div class="accent-swatch-color" style="background-color: <%= color[:value] %>">
+                        <%= color[:name].sub('--color-', '') %>
+                      </div>
+                      <div class="accent-swatch-info">
+                        <div class="accent-name"><%= color[:name] %></div>
+                        <% if color[:desc] %>
+                          <div class="swatch-value" style="font-size: 0.75rem;"><%= color[:desc] %></div>
+                        <% end %>
+                      </div>
                     </div>
-                    <div class="accent-swatch-info">
-                      <div class="accent-name"><%= color[:name] %></div>
-                      <% if color[:desc] %>
-                        <div class="swatch-value" style="font-size: 0.75rem;"><%= color[:desc] %></div>
-                      <% end %>
-                    </div>
-                  </div>
-                <% end %>
+                  <% end %>
+                </div>
               </div>
             </div>
           </div>
 
           <div id="accents-light" class="tab-content">
-            <div class="accent-cards">
-              <% @light_accents.each do |color| %>
-                <div class="accent-card" onclick="copyToClipboard('<%= color[:name] %>')">
+            <div class="accent-cards accent-cards--detailed">
+              <% @accent_tokens.each do |color| %>
+                <div class="accent-card accent-card--detailed" onclick="copyToClipboard('<%= color[:name] %>')">
                   <div class="accent-swatch-color" style="background-color: <%= color[:value] %>">
                     <%= color[:name].sub('--color-', '') %>
                   </div>
@@ -404,20 +456,22 @@
           </div>
 
           <div id="accents-dark" class="tab-content">
-            <div class="accent-cards">
-              <% @dark_accents.each do |color| %>
-                <div class="accent-card" onclick="copyToClipboard('<%= color[:name] %>')">
-                  <div class="accent-swatch-color" style="background-color: <%= color[:value] %>">
-                    <%= color[:name].sub('--color-', '') %>
+            <div class="dark">
+              <div class="accent-cards accent-cards--detailed">
+                <% @accent_tokens.each do |color| %>
+                  <div class="accent-card accent-card--detailed" onclick="copyToClipboard('<%= color[:name] %>')">
+                    <div class="accent-swatch-color" style="background-color: <%= color[:value] %>">
+                      <%= color[:name].sub('--color-', '') %>
+                    </div>
+                    <div class="accent-swatch-info">
+                      <div class="accent-name"><%= color[:name] %></div>
+                      <% if color[:desc] %>
+                        <div class="swatch-value" style="font-size: 0.75rem;"><%= color[:desc] %></div>
+                      <% end %>
+                    </div>
                   </div>
-                  <div class="accent-swatch-info">
-                    <div class="accent-name"><%= color[:name] %></div>
-                    <% if color[:desc] %>
-                      <div class="swatch-value" style="font-size: 0.75rem;"><%= color[:desc] %></div>
-                    <% end %>
-                  </div>
-                </div>
-              <% end %>
+                <% end %>
+              </div>
             </div>
           </div>
 
@@ -425,9 +479,7 @@
             <div class="accent-cards">
               <% @accent_options.each do |color| %>
                 <div class="accent-card" onclick="copyToClipboard('--color-<%= color[:name] %>-500')">
-                  <div class="accent-swatch-color" style="background-color: var(--color-<%= color[:name] %>-500)">
-                    <%= color[:name] %>
-                  </div>
+                  <div class="accent-swatch-color" style="background-color: var(--color-<%= color[:name] %>-500)"></div>
                   <div class="accent-swatch-info">
                     <div class="accent-name"><%= color[:name] %></div>
                   </div>

--- a/lib/avo/test_helpers.rb
+++ b/lib/avo/test_helpers.rb
@@ -348,11 +348,13 @@ module Avo
     def click_row_action(record, control:)
       row = find("[data-record-id='#{record.to_param}']")
 
-      if row.has_css?(".grid-card__actions-row .button--bare", wait: 0)
-        row.find(".grid-card__actions-row .button--bare").click
+      if row.has_css?(".grid-card__actions-row button[popovertarget]", wait: 0)
+        row.find(".grid-card__actions-row button[popovertarget]").click
       end
 
-      find("a[data-control='#{control}'][data-resource-id='#{record.to_param}']").click
+      within(row) do
+        find("a[data-control='#{control}'][data-resource-id='#{record.to_param}']").click
+      end
     end
 
     private


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixed a few visual bugs around buttons, brand color scale, and contrast.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly visual/theme token adjustments, but it also changes the `Avo::ButtonComponent` API (new `end_icon`) and updates button CSS behaviors, which may subtly affect layouts and existing button usage across the UI.
> 
> **Overview**
> Improves the design system’s *button and theme contrast* by retuning neutral foundation tokens (light background/secondary/tertiary), introducing semantic scheme vars (`--color-scheme`, `--color-sidebar-background`), and updating sidebar background usage to rely on the new token.
> 
> Refines `button` styling across variants (notably dark-mode outline/text and primary borders/box-shadows), adds an `end_icon` option to `Avo::ButtonComponent`, and updates the action modal buttons to use the new styling/icon pattern.
> 
> Cleans up internal/private design tooling: the appearance preview now renders tokens via `var(...)` (including dark-mode preview via a `.dark` wrapper), and the links/buttons preview adds `:xs` size and refactors helper methods. Test helpers are adjusted to click row actions via the new popover trigger selector and to scope control clicks within the row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc2e2c0a7fdfc90c54f1814e297d9fdf97aa259d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->