### PR TITLE
refactor: rename appearance.layout to appearance.picker_layout

### DIFF
--- a/app/views/avo/partials/_color_scheme_switcher.html.erb
+++ b/app/views/avo/partials/_color_scheme_switcher.html.erb
@@ -14,7 +14,7 @@
 
 <%# :inline renders BOTH the desktop pill (lg:+) and the compact dropdown trigger (mobile fallback). %>
 <%# :dropdown renders ONLY the compact dropdown trigger at every breakpoint. %>
-<% if appearance.layout == :inline %>
+<% if appearance.picker_layout == :inline %>
   <%= render partial: "avo/partials/switcher_inline", locals: locals %>
 <% end %>
 <%= render partial: "avo/partials/switcher_dropdown", locals: locals %>

--- a/app/views/avo/partials/_switcher_dropdown.html.erb
+++ b/app/views/avo/partials/_switcher_dropdown.html.erb
@@ -1,4 +1,4 @@
-<div class="<%= class_names("color-scheme-switcher color-scheme-switcher--compact", "lg:hidden": appearance.layout == :inline) %>"
+<div class="<%= class_names("color-scheme-switcher color-scheme-switcher--compact", "lg:hidden": appearance.picker_layout == :inline) %>"
      data-controller="appearance">
   <%= render Avo::UI::DropdownComponent.new do |component| %>
     <% component.with_trigger do %>

--- a/lib/avo/configuration/appearance.rb
+++ b/lib/avo/configuration/appearance.rb
@@ -16,15 +16,15 @@ class Avo::Configuration::Appearance
     :favicon_dark,
     :chart_colors,
     :placeholder,
-    :layout, # :inline | :dropdown — navbar switcher layout (auto-collapses to dropdown below lg:)
+    :picker_layout, # :inline | :dropdown — navbar switcher layout (auto-collapses to dropdown below lg:)
     :load_settings_block,
     :save_settings_block
 
   # Guarded so the file is safe to be loaded more than once (Zeitwerk + the
   # gem's own require_relative chain can both touch this file). Re-assigning
   # frozen constants would otherwise emit "already initialized" warnings.
-  unless defined?(LAYOUTS)
-    LAYOUTS = [:inline, :dropdown].freeze
+  unless defined?(PICKER_LAYOUTS)
+    PICKER_LAYOUTS = [:inline, :dropdown].freeze
 
     DEFAULT_NEUTRALS = %w[brand slate stone gray zinc neutral taupe mauve mist olive].freeze
     DEFAULT_ACCENTS = %w[brand red orange amber yellow lime green emerald teal cyan sky blue indigo violet purple fuchsia pink rose].freeze
@@ -50,7 +50,7 @@ class Avo::Configuration::Appearance
       neutrals: DEFAULT_NEUTRALS,
       accents: DEFAULT_ACCENTS,
       lock: [],
-      layout: :inline
+      picker_layout: :inline
     }.freeze
   end
 
@@ -74,11 +74,11 @@ class Avo::Configuration::Appearance
     @favicon_dark = config[:favicon_dark]
     @chart_colors = config[:chart_colors]
     @placeholder = config[:placeholder]
-    @layout = config[:layout]
+    @picker_layout = config[:picker_layout]
     @load_settings_block = config[:load_settings]
     @save_settings_block = config[:save_settings]
 
-    validate_layout!(@layout)
+    validate_picker_layout!(@picker_layout)
     validate_selection!("neutral", @neutral)
     validate_selection!("accent", @accent)
     validate_color_palette!("neutral_colors", @neutral_colors, NEUTRAL_SHADES, "shades") if @neutral_colors
@@ -160,10 +160,10 @@ class Avo::Configuration::Appearance
     declarations
   end
 
-  def validate_layout!(value)
-    return if LAYOUTS.include?(value)
+  def validate_picker_layout!(value)
+    return if PICKER_LAYOUTS.include?(value)
 
-    raise ArgumentError, "appearance.layout must be one of #{LAYOUTS.inspect}, got #{value.inspect}"
+    raise ArgumentError, "appearance.picker_layout must be one of #{PICKER_LAYOUTS.inspect}, got #{value.inspect}"
   end
 
   def validate_selection!(name, value)

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -64,7 +64,7 @@ Avo.configure do |config|
 
   ## == Appearance ==
   config.appearance = {
-    layout: :inline, # :inline (default, with mobile auto-collapse) or :dropdown (always compact)
+    picker_layout: :inline, # :inline (default, with mobile auto-collapse) or :dropdown (always compact)
     logo: "avo/logo.png",
     logo_dark: "avo/logo-dark.png",
     logomark: "avo/logomark.png",

--- a/spec/lib/avo/configuration/appearance_spec.rb
+++ b/spec/lib/avo/configuration/appearance_spec.rb
@@ -43,24 +43,24 @@ RSpec.describe Avo::Configuration::Appearance do
       expect(appearance.save_settings_block).to be_nil
     end
 
-    it "defaults layout to :inline" do
-      expect(appearance.layout).to eq(:inline)
+    it "defaults picker_layout to :inline" do
+      expect(appearance.picker_layout).to eq(:inline)
     end
   end
 
-  describe "layout" do
+  describe "picker_layout" do
     it "accepts :dropdown" do
-      expect(described_class.new(layout: :dropdown).layout).to eq(:dropdown)
+      expect(described_class.new(picker_layout: :dropdown).picker_layout).to eq(:dropdown)
     end
 
-    it "raises when layout is not :inline or :dropdown" do
-      expect { described_class.new(layout: :sidebar) }
-        .to raise_error(ArgumentError, /appearance\.layout must be one of \[:inline, :dropdown\]/)
+    it "raises when picker_layout is not :inline or :dropdown" do
+      expect { described_class.new(picker_layout: :sidebar) }
+        .to raise_error(ArgumentError, /appearance\.picker_layout must be one of \[:inline, :dropdown\]/)
     end
 
-    it "raises when layout is a String (Symbol-only contract)" do
-      expect { described_class.new(layout: "inline") }
-        .to raise_error(ArgumentError, /appearance\.layout must be one of/)
+    it "raises when picker_layout is a String (Symbol-only contract)" do
+      expect { described_class.new(picker_layout: "inline") }
+        .to raise_error(ArgumentError, /appearance\.picker_layout must be one of/)
     end
   end
 


### PR DESCRIPTION
## Summary

- Renames the `appearance.layout` config option to `appearance.picker_layout` to clarify that it controls the appearance switcher (picker) layout in the navbar, not the overall application layout.
- Updates the matching validator name and `LAYOUTS` → `PICKER_LAYOUTS` constant.
- Updates the dummy initializer, partials (`_color_scheme_switcher`, `_switcher_dropdown`), spec, and the corresponding docs in the `/docs` repo (companion PR).

## Test plan

- [x] `bundle exec rspec spec/lib/avo/configuration/appearance_spec.rb` — 43 examples, 0 failures
- [ ] Verify the appearance picker still renders inline on `lg+` and collapses to dropdown on small screens
- [ ] Verify `picker_layout: :dropdown` always renders the compact dropdown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this is a breaking rename of a public configuration key; existing apps using `appearance.layout` will misconfigure the picker until updated, though runtime behavior is otherwise unchanged.
> 
> **Overview**
> Renames the appearance config option controlling the navbar color-scheme switcher from `appearance.layout` to `appearance.picker_layout`, including updating the default value, validation method, and the `LAYOUTS` constant to `PICKER_LAYOUTS`.
> 
> Updates the switcher partials, dummy initializer, and specs to reference `picker_layout` so the inline-vs-dropdown rendering behavior continues to work under the new option name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d5c206251ba32c97712e093fe54549636597712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->