### PR TITLE
expand always true for dynamic filter

### DIFF
--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -95,12 +95,6 @@
                 </div>
 
                 <div class="flex items-center justify-between space-x-3 rtl:space-x-reverse justify-self-end xs:justify-end">
-                  <% if show_dynamic_filters_button? %>
-                    <div class="index-missing-resources:hidden">
-                      <%= render_dynamic_filters_button %>
-                    </div>
-                  <% end %>
-
                   <% unless field&.hide_filter_button %>
                     <%= render Avo::FiltersComponent.new filters: @filters, resource: @resource, applied_filters: @applied_filters, parent_record: @parent_record, parent_resource: @parent_resource %>
                   <% end %>
@@ -110,7 +104,7 @@
               </div>
 
               <% if has_dynamic_filters? %>
-                <%= render Avo::DynamicFilters::FiltersComponent.new resource: resource, turbo_frame: @turbo_frame, dynamic_filters_component_id: dynamic_filters_component_id, parent_record: @parent_record, parent_resource: @parent_resource %>
+                <%= render Avo::DynamicFilters::FiltersComponent.new resource: resource, turbo_frame: @turbo_frame, parent_record: @parent_record, parent_resource: @parent_resource %>
               <% end %>
             </div>
           </div>

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -127,21 +127,6 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
     @resource.authorization.authorize_action("search", raise_exception: false)
   end
 
-  def render_dynamic_filters_button
-    return unless show_dynamic_filters_button?
-
-    a_button size: :md,
-      color: :primary,
-      icon: "tabler/outline/filter",
-      data: {
-        controller: "avo-filters",
-        action: "click->avo-filters#toggleFiltersArea",
-        avo_filters_dynamic_filters_component_id_value: dynamic_filters_component_id
-      } do
-      Avo::DynamicFilters.configuration.button_label
-    end
-  end
-
   def scopes_list
     Avo::Advanced::Scopes::ListComponent.new(
       scopes: @scopes,
@@ -211,12 +196,6 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
     @resource.available_view_types.count > 1
   end
 
-  # Generate a unique component id for the current component.
-  # This is used to identify the component in the DOM.
-  def dynamic_filters_component_id
-    @dynamic_filters_component_id ||= "dynamic_filters_component_id_#{SecureRandom.hex(3)}"
-  end
-
   def reloadable?
     field&.reloadable?
   end
@@ -242,13 +221,5 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
 
   def has_resources?
     @resources.present?
-  end
-
-  def show_dynamic_filters_button?
-    Avo.avo_dynamic_filters_installed? &&
-      @resource.has_filters? &&
-      has_resources? &&
-      !field&.hide_filter_button &&
-      !Avo::DynamicFilters.configuration.always_expanded
   end
 end

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -185,13 +185,6 @@ Avo.configure do |config|
   }
 end
 
-if defined?(Avo::DynamicFilters)
-  Avo::DynamicFilters.configure do |config|
-    config.button_label = "Advanced filters"
-    config.always_expanded = true
-  end
-end
-
 if defined?(Avo::MediaLibrary)
   Avo::MediaLibrary.configure do |config|
     config.visible = -> { Avo::Current.user.is_developer? }


### PR DESCRIPTION
# Description
  Removes the toggle button that showed/hid the dynamic filters bar. The bar is now always visible on resource index pages. With it goes the button_label and always_expanded config attributes, the toggle button rendering in avo core, the toggleFilter / toggleFiltersArea Stimulus actions, the dynamic_filters_component_id plumbing, and the el-transition npm dep.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<img width="897" height="59" alt="Screenshot 2026-05-22 at 07 05 12" src="https://github.com/user-attachments/assets/ce65d9c6-1d4e-4b80-a2aa-d138d7f1c258" />
