### PR TITLE
refactor: discreet information tweaks

### DIFF
--- a/app/assets/stylesheets/css/components/discreet_information.css
+++ b/app/assets/stylesheets/css/components/discreet_information.css
@@ -7,14 +7,14 @@
 }
 
 .discreet-information__text {
-  @apply inline-flex items-center space-x-1;
+  @apply inline-flex items-center gap-1;
 }
 
 .discreet-information__badge {
   @apply inline-flex rounded-md items-center font-semibold gap-1 py-1 px-1 bg-linear-to-b from-primary/85 to-primary/85 bg-foreground text-foreground;
 
   .discreet-information__icon {
-    @apply text-foreground me-1 size-3;
+    @apply text-foreground size-3;
   }
 }
 
@@ -43,7 +43,7 @@
   @apply rounded-md;
 
   .discreet-information__text {
-    @apply px-1;
+    @apply px-2;
   }
 }
 

--- a/app/assets/stylesheets/css/components/discreet_information.css
+++ b/app/assets/stylesheets/css/components/discreet_information.css
@@ -7,7 +7,7 @@
 }
 
 .discreet-information__text {
-  @apply inline px-2;
+  @apply inline-flex items-center space-x-1;
 }
 
 .discreet-information__badge {
@@ -23,7 +23,11 @@
 }
 
 .discreet-information__key {
-  @apply rounded-sm py-0.5 px-2 font-normal bg-linear-to-b  to-avo-neutral-200 from-foreground/6 to-black/4 bg-secondary;
+  @apply rounded-sm py-0.5 px-1 font-normal bg-linear-to-b  to-avo-neutral-200 from-foreground/6 to-black/4 bg-secondary;
+}
+
+.discreet-information__value {
+  @apply inline-flex items-center px-1;
 }
 
 .discreet-information--as-key-value,

--- a/app/assets/stylesheets/css/components/ui/panel_header.css
+++ b/app/assets/stylesheets/css/components/ui/panel_header.css
@@ -33,7 +33,7 @@
 }
 
 .header__discreet-information {
-  @apply flex justify-center sm:justify-start gap-2 items-start w-full flex-wrap;
+  @apply flex justify-center sm:justify-start gap-x-2.5 gap-y-1 items-start w-full flex-wrap;
 }
 
 /* Size variants */

--- a/app/components/avo/discreet_information_component.html.erb
+++ b/app/components/avo/discreet_information_component.html.erb
@@ -11,7 +11,7 @@
   <% elsif as_text? %>
     <div class="discreet-information__text">
       <%= helpers.svg @icon, class: "discreet-information__icon" if @icon.present? %>
-      <%= @text %>
+      <span><%= @text %></span>
     </div>
   <% elsif as_badge? %>
     <div class="discreet-information__badge">
@@ -24,7 +24,7 @@
     <div class="discreet-information__key-value">
       <div class="discreet-information__key"><%= @key %></div>
 
-      <div class="discreet-information__text">
+      <div class="discreet-information__value">
         <%= @value %>
       </div>
     </div>

--- a/spec/dummy/app/avo/resources/project.rb
+++ b/spec/dummy/app/avo/resources/project.rb
@@ -47,6 +47,22 @@ class Avo::Resources::Project < Avo::BaseResource
       visible: true
     },
     {
+      text: -> { "Simple text (2) #{record.id}" },
+      as: :text,
+      title: -> { sanitize("View <strong>#{record.name}</strong> on site", tags: %w[strong]) },
+      icon: -> { "tabler/outline/external-link" },
+      url: -> { main_app.root_url },
+      visible: true
+    },
+    {
+      text: -> { "Simple text (3) #{record.id}" },
+      as: :text,
+      title: -> { sanitize("View <strong>#{record.name}</strong> on site", tags: %w[strong]) },
+      icon: -> { "tabler/outline/external-link" },
+      url: -> { main_app.root_url },
+      visible: true
+    },
+    {
       text: "Test",
       as: :badge,
       visible: false


### PR DESCRIPTION
## Summary

- Vertically center the icon + text inside `.discreet-information__text` by switching it from `display: inline` to `inline-flex items-center` (with `space-x-1` for icon/text spacing).
- Decouple the key-value variant from `__text`: introduce a dedicated `.discreet-information__value` class so the badge/text variants and the key-value variant can evolve independently without stepping on each other.
- Tighten `.discreet-information__key` padding from `px-2` to `px-1`.
- Wrap the `as: :text` content in a `<span>` so the icon and text are clean siblings of the flex container.

## Test plan

- [ ] Open the `DiscreetInformationComponent` Lookbook preview and verify all four variants (`:icon`, `:text`, `:badge`, `:key_value`) render with vertically centered content
- [ ] Verify the `:badge` variant with and without an icon still spaces correctly
- [ ] Verify the `:key_value` variant looks right with the new `__value` class and `px-1` key padding

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling/layout tweaks plus dummy resource data changes; main risk is minor visual regressions in `DiscreetInformationComponent`/header spacing across breakpoints.
> 
> **Overview**
> Tightens and standardizes spacing in `DiscreetInformationComponent` by switching to `gap`-based flex spacing, removing badge icon margin hacks, increasing badge text padding, and adding a dedicated `.discreet-information__value` wrapper for the key/value variant (with `:text` content wrapped in a `<span>`).
> 
> Updates `PanelHeader` discreet-information layout to use separate horizontal/vertical gaps for better wrapping, and expands the dummy `Project` resource with additional `as: :text` discreet-information entries to exercise the updated styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d92137dc35d4114f5c562f3b81e2ebe6aee11c32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->