### PR TITLE
fix: bind index row navigator handlers in initialize()

### DIFF
--- a/app/javascript/js/controllers/index_row_navigator_controller.js
+++ b/app/javascript/js/controllers/index_row_navigator_controller.js
@@ -38,13 +38,19 @@ const TYPING_SELECTOR = 'input, textarea, select, [contenteditable]'
 export default class extends Controller {
   static targets = ['table']
 
-  connect() {
-    this.currentIndex = -1
-    this.hotkeysEnabled = window.Avo?.configuration?.hotkeys?.enabled !== false
+  initialize() {
+    // Bind here, not in connect(). Stimulus fires tableTargetConnected() BEFORE
+    // connect(), so binding in connect() would register the unbound prototype
+    // method as the blur listener.
     this.handleKeydown = this.handleKeydown.bind(this)
     this.handleDropdownOpen = this.handleDropdownOpen.bind(this)
     this.handleAdvanceRequest = this.handleAdvanceRequest.bind(this)
     this.handleTableBlur = this.handleTableBlur.bind(this)
+  }
+
+  connect() {
+    this.currentIndex = -1
+    this.hotkeysEnabled = window.Avo?.configuration?.hotkeys?.enabled !== false
 
     document.addEventListener('keydown', this.handleKeydown)
     document.addEventListener('dropdown-menu:open', this.handleDropdownOpen)


### PR DESCRIPTION

## Summary

- Fixes `Uncaught TypeError: this.rows is not a function` thrown from `index_row_navigator_controller.js` on resource index pages when the table loses focus.

<img width="1294" height="260" alt="CleanShot 2026-05-22 at 12 41 48@2x" src="https://github.com/user-attachments/assets/b7709d9a-8259-49bd-b392-6afaa19cc4b8" />



## Root cause

Stimulus's `Context#connect()` starts the `targetObserver` **before** invoking `controller.connect()` (see `@hotwired/stimulus/dist/stimulus.js:1492-1503`). That means `tableTargetConnected()` fires first and registers `this.handleTableBlur` as the blur listener — but at that moment the bind in `connect()` hasn't run yet, so the unbound prototype method gets registered. Later, when the table blurs, `this` is the `HTMLTableElement` and `this.rows()` blows up.

The other listeners (`keydown`, `dropdown-menu:open`, `avo:advance-resource-table`) were added inside `connect()` itself, so they were bound before being registered. Only the blur listener wired up via `tableTargetConnected` was affected.

## Fix

Move the four `bind(this)` calls into `initialize()`, which is guaranteed to run before any target callback. `connect()` keeps the event-listener registrations and per-connect state (`currentIndex`, `hotkeysEnabled`).

## Test plan

- [ ] Open a resource index page, focus the table (Tab or Shift+T), then blur it (Tab away / click elsewhere) — no console error.
- [ ] Verify keyboard navigation still works: ↑/↓, Enter, Space, Escape, j/k.
- [ ] Verify dropdown-menu open still clears row focus.
- [ ] Verify row hotkeys still work when a row is focused.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix that only changes when event handlers are bound to ensure correct `this` context; impact is limited to keyboard/table focus behavior on index pages.
> 
> **Overview**
> Fixes a focus/blur crash in `index_row_navigator_controller` by moving `bind(this)` for key and blur/dropdown/advance handlers from `connect()` to `initialize()`, ensuring target callbacks (like `tableTargetConnected`) register bound methods.
> 
> `connect()` now only initializes per-connection state and registers the document-level listeners, preventing `this` from being the table element when the blur handler runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0750555a0e7070e3e4bcf0512c45c99312158433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->