### PR TITLE
fix: association search design

### DIFF
--- a/app/assets/stylesheets/css/components/filters.css
+++ b/app/assets/stylesheets/css/components/filters.css
@@ -23,14 +23,6 @@
   }
 }
 
-.filters-card__header {
-  @apply flex w-full items-center justify-between px-3 py-1.5 font-medium;
-}
-
-.filters-card__title {
-  @apply text-sm text-content;
-}
-
 .filters-card__reset {
   @apply text-[10px] leading-3.5 font-medium transition-colors text-content-secondary;
 

--- a/app/assets/stylesheets/css/components/ui/dropdown_card.css
+++ b/app/assets/stylesheets/css/components/ui/dropdown_card.css
@@ -8,3 +8,11 @@
 .dropdown-card__body {
   @apply overflow-hidden rounded-lg border border-tertiary bg-primary;
 }
+
+.dropdown-card__header {
+  @apply flex w-full items-center justify-between px-2 py-1.5;
+}
+
+.dropdown-card__title {
+  @apply text-sm text-content;
+}

--- a/app/components/avo/filters_component.html.erb
+++ b/app/components/avo/filters_component.html.erb
@@ -17,8 +17,8 @@
       hidden: params[:keep_filters_panel_open] != '1' do %>
       <%= render Avo::UI::DropdownCardComponent.new do |card| %>
         <% card.with_header do %>
-          <div class="filters-card__header">
-            <span class="filters-card__title"><%= t('avo.filters') %></span>
+          <div class="dropdown-card__header">
+            <span class="dropdown-card__title"><%= t('avo.filters') %></span>
             <% if @applied_filters.present? %>
               <%= link_to t('avo.reset_filters'), reset_path, data: {turbo_frame: params[:turbo_frame]}, class: 'filters-card__reset filters-card__reset--active' %>
             <% else %>


### PR DESCRIPTION
# Description
Design — The dropdown header used by the picker now looks the same as the one on the filters dropdown. We moved the shared styles into one place so any future dropdown card gets the same header for free. Visually, "Fish (3)" now uses the same font and spacing as the "Filters" card title.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<img width="499" height="221" alt="Screenshot 2026-05-25 at 12 15 01" src="https://github.com/user-attachments/assets/bc8d9773-16bd-4077-b15f-52149c9930f0" />
<img width="384" height="180" alt="Screenshot 2026-05-25 at 12 19 42" src="https://github.com/user-attachments/assets/14011f22-e6c8-46a6-bfac-29a879515f9a" />
