### PR TITLE
refactor: various tweaks

### DIFF
--- a/app/assets/stylesheets/css/components/breadcrumbs.css
+++ b/app/assets/stylesheets/css/components/breadcrumbs.css
@@ -2,7 +2,7 @@
   @apply sticky z-40 w-full bg-primary mb-4;
   /* top: calc(var(--top-navbar-height) + var(--spacing) * 4); */
   top: calc(var(--top-navbar-height) + var(--spacing) * 2);
-  margin-top: calc(var(--spacing) * -2 + 1px);
+  margin-top: --spacing(-2);
 
   /* Fake background so the content scrolling underneath the breadcrumbs doesn't look like it's bleeding through */
   &::before {

--- a/app/assets/stylesheets/css/components/button.css
+++ b/app/assets/stylesheets/css/components/button.css
@@ -15,7 +15,7 @@
     --btn-text-color: color-mix(in oklab, var(--btn-color-accent), var(--color-content) 20%);
 
     /* Base styles for all button types */
-    &:active:not(:disabled) {
+    &:where(:not(:disabled, [disabled], [data-disabled='true'], .button--disabled)):active {
       @apply translate-y-px;
     }
 
@@ -30,7 +30,7 @@
     &:disabled,
     &[disabled],
     &[data-disabled='true'] {
-      @apply opacity-60;
+      @apply opacity-60 pointer-events-none;
     }
 
     /* Default colors */
@@ -320,9 +320,11 @@
       }
     }
 
-    &.button--active,
-    &:active {
-      @apply bg-secondary;
+    &:where(:not(:disabled, [disabled], [data-disabled='true'], .button--disabled)) {
+      &.button--active,
+      &:active {
+        @apply bg-secondary;
+      }
     }
 
     &.button--disabled,

--- a/app/assets/stylesheets/css/components/button.css
+++ b/app/assets/stylesheets/css/components/button.css
@@ -26,6 +26,12 @@
       box-shadow: var(--box-shadow-focus);
     }
 
+    &.button--disabled,
+    &:disabled,
+    &[disabled],
+    &[data-disabled='true'] {
+      @apply opacity-60;
+    }
 
     /* Default colors */
     --btn-color-accent: var(--color-avo-neutral-50);
@@ -193,9 +199,14 @@
     background: linear-gradient(180deg, var(--btn-color-accent-content) 0%, var(--btn-color-accent) 100%);
 
     &:not([class*="button--color-"]) {
-      &.button--hover,
-      &:hover {
-        background: linear-gradient(180deg, color-mix(in oklab, var(--btn-color-accent-content) 96%, var(--color-black)) 0%, color-mix(in oklab, var(--btn-color-accent) 96%, var(--color-black)) 100%);
+      /* :where(:not(…)) filters disabled states out of hover without adding
+         specificity, so disabled buttons show no hover feedback while :active
+         and :disabled keep winning as before. */
+      &:where(:not(:disabled, [disabled], [data-disabled='true'], .button--disabled)) {
+        &.button--hover,
+        &:hover {
+          background: linear-gradient(180deg, color-mix(in oklab, var(--btn-color-accent-content) 96%, var(--color-black)) 0%, color-mix(in oklab, var(--btn-color-accent) 96%, var(--color-black)) 100%);
+        }
       }
     }
 
@@ -203,12 +214,14 @@
       inset 0px -1.4px 0px 0.1px var(--btn-color-accent-content),
       inset 0px 0.8px 0px 0.4px color-mix(in oklch, white 45%, transparent);
 
-    &.button--hover,
-    &:hover {
-      @apply text-(--btn-color-accent-foreground);
+    &:where(:not(:disabled, [disabled], [data-disabled='true'], .button--disabled)) {
+      &.button--hover,
+      &:hover {
+        @apply text-(--btn-color-accent-foreground);
 
-      background: linear-gradient(180deg, color-mix(in oklab, var(--btn-color-accent-content) 90%, var(--color-black)) 0%, color-mix(in oklab, var(--btn-color-accent) 90%, var(--color-black)) 100%), var(--color-primary);
-      box-shadow: 0 -1.4px 0 0.1px var(--btn-color-accent-content) inset, 0 0.8px 0 0.4px color-mix(in oklab, var(--color-white) 45%, transparent) inset;
+        background: linear-gradient(180deg, color-mix(in oklab, var(--btn-color-accent-content) 90%, var(--color-black)) 0%, color-mix(in oklab, var(--btn-color-accent) 90%, var(--color-black)) 100%), var(--color-primary);
+        box-shadow: 0 -1.4px 0 0.1px var(--btn-color-accent-content) inset, 0 0.8px 0 0.4px color-mix(in oklab, var(--color-white) 45%, transparent) inset;
+      }
     }
 
     &.button--active,
@@ -221,7 +234,7 @@
     &:disabled,
     &[disabled],
     &[data-disabled='true'] {
-      @apply text-(--btn-color-accent-foreground) border-transparent;
+      @apply text-(--btn-color-accent-foreground) border-transparent ;
       box-shadow: none;
     }
   }
@@ -236,10 +249,12 @@
 
       --btn-box-shadow-color: color-mix(in oklab, var(--color-content), transparent 65%);
 
-      &.button--hover,
-      &:hover {
-        --btn-box-shadow-color: color-mix(in oklab, var(--color-content), transparent 55%);
-        @apply text-content bg-tertiary;
+      &:where(:not(:disabled, [disabled], [data-disabled='true'], .button--disabled)) {
+        &.button--hover,
+        &:hover {
+          --btn-box-shadow-color: color-mix(in oklab, var(--color-content), transparent 55%);
+          @apply text-content bg-tertiary;
+        }
       }
 
       &.button--disabled,
@@ -256,12 +271,14 @@
     background: var(--color-primary);
     box-shadow: 0 -1.4px 0 0.1px var(--btn-box-shadow-color) inset, 0 0.8px 0 0.4px var(--color-primary) inset;
 
-    &.button--hover,
-    &:hover {
-      @apply text-(--btn-text-color);
+    &:where(:not(:disabled, [disabled], [data-disabled='true'], .button--disabled)) {
+      &.button--hover,
+      &:hover {
+        @apply text-(--btn-text-color);
 
-      --btn-box-shadow-color: color-mix(in oklab, var(--btn-color-accent), transparent 55%);
-      background: color-mix(in oklab, var(--btn-color-accent), var(--color-primary) 85%);
+        --btn-box-shadow-color: color-mix(in oklab, var(--btn-color-accent), transparent 55%);
+        background: color-mix(in oklab, var(--btn-color-accent), var(--color-primary) 85%);
+      }
     }
 
     &.button--active:not(:disabled),
@@ -295,10 +312,12 @@
       --btn-color-accent-foreground: var(--color-white);
     }
 
-    &.button--hover,
-    &:hover {
-      background: color-mix(in oklab, var(--btn-color-accent), var(--color-primary) 85%);
-      @apply text-(--btn-text-color);
+    &:where(:not(:disabled, [disabled], [data-disabled='true'], .button--disabled)) {
+      &.button--hover,
+      &:hover {
+        background: color-mix(in oklab, var(--btn-color-accent), var(--color-primary) 85%);
+        @apply text-(--btn-text-color);
+      }
     }
 
     &.button--active,

--- a/app/assets/stylesheets/css/components/color_scheme_switcher.css
+++ b/app/assets/stylesheets/css/components/color_scheme_switcher.css
@@ -115,6 +115,12 @@
   @apply bg-primary text-content shadow-sm;
 }
 
+/* Shortcut badge buttons - active state mirrors body.hotkeys-hide-badges. */
+body:not(.hotkeys-hide-badges) .color-scheme-switcher__scheme-button[data-key-badges="show"],
+body.hotkeys-hide-badges .color-scheme-switcher__scheme-button[data-key-badges="hide"] {
+  @apply bg-primary text-content shadow-sm;
+}
+
 .color-scheme-switcher__scheme-label {
   @apply text-xs font-medium leading-none;
 }

--- a/app/assets/stylesheets/css/components/filters.css
+++ b/app/assets/stylesheets/css/components/filters.css
@@ -23,29 +23,6 @@
   }
 }
 
-.filters-card__header {
-  @apply flex w-full items-center justify-between px-3 py-1.5 font-medium;
-}
-
-.filters-card__title {
-  @apply text-sm text-content;
-}
-
-.filters-card__reset {
-  @apply text-[10px] leading-3.5 font-medium transition-colors text-content-secondary;
-
-  &:hover {
-    @apply text-content;
-  }
-}
-
-.filters-card__reset--disabled {
-  @apply text-content-secondary cursor-not-allowed;
-  &:hover {
-    @apply text-content-secondary;
-  }
-}
-
 .filters-card__content {
   @apply p-1 overflow-hidden;
 }

--- a/app/assets/stylesheets/css/components/ui/card.css
+++ b/app/assets/stylesheets/css/components/ui/card.css
@@ -48,7 +48,7 @@
 
 /* Card header */
 .card__header {
-  @apply flex flex-col items-start self-stretch py-3 px-4;
+  @apply flex flex-col items-start self-stretch py-2 px-4 leading-tight;
 
   &:has(select),
   &:has(.button) {

--- a/app/assets/stylesheets/css/components/ui/dropdown_card.css
+++ b/app/assets/stylesheets/css/components/ui/dropdown_card.css
@@ -8,3 +8,12 @@
 .dropdown-card__body {
   @apply overflow-hidden rounded-lg border border-tertiary bg-primary;
 }
+
+.dropdown-card__footer,
+.dropdown-card__header {
+  @apply flex w-full items-center px-2 py-1.5;
+}
+
+.dropdown-card__title {
+  @apply text-sm text-content font-medium text-content-secondary;
+}

--- a/app/assets/stylesheets/css/components/ui/panel_header.css
+++ b/app/assets/stylesheets/css/components/ui/panel_header.css
@@ -33,7 +33,7 @@
 }
 
 .header__discreet-information {
-  @apply flex justify-center sm:justify-start gap-x-2.5 gap-y-1 items-start w-full flex-wrap;
+  @apply flex justify-start gap-x-2.5 gap-y-1 items-start w-full flex-wrap;
 }
 
 /* Size variants */

--- a/app/assets/stylesheets/css/layout.css
+++ b/app/assets/stylesheets/css/layout.css
@@ -155,7 +155,7 @@
 }
 
 .top-navbar__center {
-  @apply flex items-center justify-center min-w-0;
+  @apply flex items-center justify-center min-w-0 sm:w-80 lg:w-96 xl:w-120;
 
   /* Search input is rendered against the dark navbar in both light/dark
      themes, so it uses primitive neutral tokens that are stable across modes

--- a/app/components/avo/filters_component.html.erb
+++ b/app/components/avo/filters_component.html.erb
@@ -29,15 +29,18 @@
           </div>
         <% end %>
         <% card.with_footer do %>
-          <% path = @applied_filters.present? ? reset_path : "javascript:void(0);" %>
-          <%= a_link path,
+          <% reset_disabled = @applied_filters.blank? %>
+          <%= a_link(reset_disabled ? "#" : reset_path,
             style: :text,
             size: :sm,
             title: t('avo.reset_filters'),
-            data: {turbo_frame: params[:turbo_frame]},
-            class: class_names(
-              "w-full",
-              "button--disabled": !@applied_filters.present?) do %>
+            aria: {disabled: reset_disabled},
+            tabindex: (reset_disabled ? -1 : nil),
+            data: {
+              turbo_frame: params[:turbo_frame],
+              **(reset_disabled ? {disabled: true} : {})
+            },
+            class: class_names("w-full", "button--disabled": reset_disabled)) do %>
             <%= t('avo.reset_filters') %>
           <% end %>
         <% end %>

--- a/app/components/avo/filters_component.html.erb
+++ b/app/components/avo/filters_component.html.erb
@@ -1,7 +1,7 @@
 <div data-controller="toggle" data-toggle-exemption-containers-value='[".flatpickr-calendar"]' data-component-name="<%= self.class.to_s.underscore %>">
   <div class="filters__bar">
     <%= a_button class: 'focus:outline-hidden',
-      style: :primary,
+      style: :outline,
       icon: "tabler/outline/filter",
       title: t('avo.click_to_reveal_filters'),
       'data-button': 'resource-filters',
@@ -17,16 +17,7 @@
       hidden: params[:keep_filters_panel_open] != '1' do %>
       <%= render Avo::UI::DropdownCardComponent.new do |card| %>
         <% card.with_header do %>
-          <div class="filters-card__header">
-            <span class="filters-card__title"><%= t('avo.filters') %></span>
-            <% if @applied_filters.present? %>
-              <%= link_to t('avo.reset_filters'), reset_path, data: {turbo_frame: params[:turbo_frame]}, class: 'filters-card__reset filters-card__reset--active' %>
-            <% else %>
-              <span class="filters-card__reset filters-card__reset--disabled">
-                <%= t('avo.reset_filters') %>
-              </span>
-            <% end %>
-          </div>
+          <span class="dropdown-card__title"><%= t('avo.filters') %></span>
         <% end %>
         <% card.with_body do %>
           <div class="filters-card__content">
@@ -36,6 +27,19 @@
               <% end %>
             </div>
           </div>
+        <% end %>
+        <% card.with_footer do %>
+          <% path = @applied_filters.present? ? reset_path : "javascript:void(0);" %>
+          <%= a_link path,
+            style: :text,
+            size: :sm,
+            title: t('avo.reset_filters'),
+            data: {turbo_frame: params[:turbo_frame]},
+            class: class_names(
+              "w-full",
+              "button--disabled": !@applied_filters.present?) do %>
+            <%= t('avo.reset_filters') %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/avo/keyboard_shortcuts_component.rb
+++ b/app/components/avo/keyboard_shortcuts_component.rb
@@ -7,8 +7,8 @@ class Avo::KeyboardShortcutsComponent < Avo::BaseComponent
         "Navigation",
         [
           shortcut(action: "Show keyboard shortcuts", keys: ["?"]),
-          shortcut(action: "Focus resource search", keys: {mac: ["Cmd", "K"], other: ["Ctrl", "K"]}),
-          shortcut(action: "Toggle sidebar", keys: {mac: ["Cmd", "\\"], other: ["Ctrl", "\\"]}),
+          shortcut(action: "Focus Global Search", keys: {mac: ["Cmd", "K"], other: ["Ctrl", "K"]}),
+          shortcut(action: "Toggle sidebar", keys: ["Shift", "\\"]),
           shortcut(action: "Close modal", keys: ["Esc"]),
           shortcut(
             action: "Navigate options in the modal",

--- a/app/components/avo/u_i/dropdown_card_component.html.erb
+++ b/app/components/avo/u_i/dropdown_card_component.html.erb
@@ -1,9 +1,17 @@
 <%= content_tag :div, class: class_names("dropdown-card", @classes) do %>
-  <%= header %>
+  <% if header? %>
+  <div class="dropdown-card__header">
+      <%= header %>
+    </div>
+  <% end %>
 
   <div class="dropdown-card__body">
     <%= body %>
   </div>
 
-  <%= footer %>
+  <% if footer? %>
+    <div class="dropdown-card__footer">
+      <%= footer %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/javascript/js/controllers/appearance_controller.js
+++ b/app/javascript/js/controllers/appearance_controller.js
@@ -325,4 +325,24 @@ export default class extends Controller {
 
     this.themeLabelTarget.textContent = theme.charAt(0).toUpperCase() + theme.slice(1)
   }
+
+  // Mirrors the Shift+K hotkey in global_hotkeys.js. CSS handles the active
+  // state via [data-key-badges] selectors against `body.hotkeys-hide-badges`.
+  setKeyBadges(event) {
+    event.preventDefault()
+    const { keyBadges } = event.currentTarget.dataset
+    if (keyBadges !== 'show' && keyBadges !== 'hide') return
+
+    const hide = keyBadges === 'hide'
+    document.body.classList.toggle('hotkeys-hide-badges', hide)
+    try {
+      if (hide) {
+        localStorage.setItem('avo:hotkeys:hide_badges', '1')
+      } else {
+        localStorage.removeItem('avo:hotkeys:hide_badges')
+      }
+    } catch (e) {
+      // localStorage unavailable (private browsing) — toggle works for the current session only
+    }
+  }
 }

--- a/app/javascript/js/controllers/sidebar_controller.js
+++ b/app/javascript/js/controllers/sidebar_controller.js
@@ -73,7 +73,9 @@ export default class extends Controller {
     this.handleToggleShortcut = (event) => {
       if (event.repeat || event.defaultPrevented) return
       if (event.target?.closest('input, textarea, select, [contenteditable]')) return
-      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.key !== '\\') return
+      // Shift+\ — use event.code so layout differences (Shift+\ → "|" on US) don't matter.
+      if (!event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return
+      if (event.code !== 'Backslash') return
 
       event.preventDefault()
       this.toggleSidebarForViewport()

--- a/app/views/avo/partials/_color_scheme_switcher.html.erb
+++ b/app/views/avo/partials/_color_scheme_switcher.html.erb
@@ -2,12 +2,14 @@
 <% show_neutral_picker = !appearance.neutral_locked? %>
 <% show_accent_picker = !appearance.accent_locked? %>
 <% show_scheme_picker = !appearance.scheme_locked? %>
-<% return unless show_neutral_picker || show_accent_picker || show_scheme_picker %>
+<% show_key_badges_toggle = Avo.configuration.hotkeys[:enabled] && Avo.configuration.hotkeys[:show_key_badges] %>
+<% return unless show_neutral_picker || show_accent_picker || show_scheme_picker || show_key_badges_toggle %>
 <% locals = {
      appearance: appearance,
      show_neutral_picker: show_neutral_picker,
      show_accent_picker: show_accent_picker,
      show_scheme_picker: show_scheme_picker,
+     show_key_badges_toggle: show_key_badges_toggle,
      active_neutral: current_neutral,
      active_accent: current_accent
    } %>

--- a/app/views/avo/partials/_switcher_dropdown.html.erb
+++ b/app/views/avo/partials/_switcher_dropdown.html.erb
@@ -98,6 +98,32 @@
               </div>
             </div>
           <% end %>
+
+          <% if show_key_badges_toggle %>
+            <div class="color-scheme-switcher__section">
+              <div class="color-scheme-switcher__section-label"><%= t("avo.appearance.shortcut_badges") %></div>
+              <div class="color-scheme-switcher__scheme-row">
+                <button type="button"
+                        data-action="click->appearance#setKeyBadges"
+                        data-key-badges="show"
+                        data-tippy="tooltip"
+                        class="color-scheme-switcher__scheme-button"
+                        title="<%= t("avo.appearance.shortcut_badges_show_tooltip") %>">
+                  <%= svg "tabler/outline/eye", class: "color-scheme-switcher__icon" %>
+                  <span class="color-scheme-switcher__scheme-label"><%= t("avo.appearance.show") %></span>
+                </button>
+                <button type="button"
+                        data-action="click->appearance#setKeyBadges"
+                        data-key-badges="hide"
+                        data-tippy="tooltip"
+                        class="color-scheme-switcher__scheme-button"
+                        title="<%= t("avo.appearance.shortcut_badges_hide_tooltip") %>">
+                  <%= svg "tabler/outline/eye-off", class: "color-scheme-switcher__icon" %>
+                  <span class="color-scheme-switcher__scheme-label"><%= t("avo.appearance.hide") %></span>
+                </button>
+              </div>
+            </div>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/avo/partials/distribution_chart.html.erb
+++ b/app/views/avo/partials/distribution_chart.html.erb
@@ -25,18 +25,18 @@
     <% end %>
 
     <% card.with_footer do %>
-      <div class="distribution-chart__footer">
-        <%= a_link distribution_chart_full_path(
-          resource_name: params[:resource_name],
-          field_id: params[:field_id],
-          **request.query_parameters.except(:resource_name, :field_id)
-        ),
-          style: :text,
-          icon: "tabler/outline/external-link",
-          data: { turbo_frame: "_top" } do %>
-          View full summary
-        <% end %>
-      </div>
+      <%= a_link distribution_chart_full_path(
+        resource_name: params[:resource_name],
+        field_id: params[:field_id],
+        **request.query_parameters.except(:resource_name, :field_id)
+      ),
+        style: :text,
+        size: :sm,
+        class: "w-full",
+        icon: "tabler/outline/external-link",
+        data: { turbo_frame: "_top" } do %>
+        View full summary
+      <% end %>
     <% end %>
   <% end %>
 </turbo-frame>

--- a/lib/generators/avo/templates/locales/avo.ar.yml
+++ b/lib/generators/avo/templates/locales/avo.ar.yml
@@ -12,11 +12,16 @@ ar:
       auto_tooltip: تلقائي (تفضيل النظام)
       dark: داكن
       dark_tooltip: وضع الداكن
+      hide: إخفاء
       light: فاتح
       light_tooltip: وضع الفاتح
       neutrals: السمة
       neutrals_picker: سمة الألوان المحايدة
       schemes: المظهر
+      shortcut_badges: شارات الاختصار
+      shortcut_badges_hide_tooltip: إخفاء شارات اختصارات لوحة المفاتيح
+      shortcut_badges_show_tooltip: عرض شارات اختصارات لوحة المفاتيح
+      show: عرض
       title: المظهر
     applied:
       few: applied

--- a/lib/generators/avo/templates/locales/avo.de.yml
+++ b/lib/generators/avo/templates/locales/avo.de.yml
@@ -12,11 +12,16 @@ de:
       auto_tooltip: Automatisch (Systemeinstellung)
       dark: Dunkel
       dark_tooltip: Dunkler Modus
+      hide: Ausblenden
       light: Hell
       light_tooltip: Heller Modus
       neutrals: Thema
       neutrals_picker: Neutrale Themen
       schemes: Erscheinungsbild
+      shortcut_badges: Verknüpfungssymbole
+      shortcut_badges_hide_tooltip: Tastenkombinationssymbole ausblenden
+      shortcut_badges_show_tooltip: Tastenkombinationssymbole anzeigen
+      show: Anzeigen
       title: Erscheinungsbild
     applied: angewendet
     are_you_sure: Sind Sie sicher?

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -12,11 +12,16 @@ en:
       auto_tooltip: Auto (system preference)
       dark: Dark
       dark_tooltip: Dark mode
+      hide: Hide
       light: Light
       light_tooltip: Light mode
       neutrals: Theme
       neutrals_picker: Select neutral color
       schemes: Appearance
+      shortcut_badges: Shortcut badges
+      shortcut_badges_hide_tooltip: Hide keyboard shortcut badges
+      shortcut_badges_show_tooltip: Show keyboard shortcut badges
+      show: Show
       title: Appearance
     applied: applied
     are_you_sure: Are you sure?

--- a/lib/generators/avo/templates/locales/avo.es.yml
+++ b/lib/generators/avo/templates/locales/avo.es.yml
@@ -12,11 +12,16 @@ es:
       auto_tooltip: Automático (preferencia del sistema)
       dark: Oscuro
       dark_tooltip: Modo oscuro
+      hide: Ocultar
       light: Claro
       light_tooltip: Modo claro
       neutrals: Tema
       neutrals_picker: Tema neutro
       schemes: Apariencia
+      shortcut_badges: Insignias de atajo
+      shortcut_badges_hide_tooltip: Ocultar insignias de atajo de teclado
+      shortcut_badges_show_tooltip: Mostrar insignias de atajo de teclado
+      show: Mostrar
       title: Apariencia
     applied:
       one: aplicado

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -12,11 +12,16 @@ fr:
       auto_tooltip: Automatique (préférence système)
       dark: Sombre
       dark_tooltip: Mode sombre
+      hide: Cacher
       light: Clair
       light_tooltip: Mode clair
       neutrals: Thème
       neutrals_picker: Thème neutre
       schemes: Apparence
+      shortcut_badges: Badges de raccourci
+      shortcut_badges_hide_tooltip: Cacher les badges de raccourci clavier
+      shortcut_badges_show_tooltip: Afficher les badges de raccourci clavier
+      show: Afficher
       title: Apparence
     applied:
       one: appliqué

--- a/lib/generators/avo/templates/locales/avo.it.yml
+++ b/lib/generators/avo/templates/locales/avo.it.yml
@@ -12,11 +12,16 @@ it:
       auto_tooltip: Automatico (preferenza di sistema)
       dark: Scuro
       dark_tooltip: Modalità scura
+      hide: Nascondi
       light: Chiaro
       light_tooltip: Modalità chiara
       neutrals: Tema
       neutrals_picker: Tema neutro
       schemes: Aspetto
+      shortcut_badges: Badge di scorciatoia
+      shortcut_badges_hide_tooltip: Nascondi i badge delle scorciatoie da tastiera
+      shortcut_badges_show_tooltip: Mostra i badge delle scorciatoie da tastiera
+      show: Mostra
       title: Aspetto
     applied: applicato
     are_you_sure: Sei sicuro?

--- a/lib/generators/avo/templates/locales/avo.ja.yml
+++ b/lib/generators/avo/templates/locales/avo.ja.yml
@@ -12,11 +12,16 @@ ja:
       auto_tooltip: 自動（システム設定）
       dark: ダーク
       dark_tooltip: ダークモード
+      hide: 非表示
       light: ライト
       light_tooltip: ライトモード
       neutrals: テーマ
       neutrals_picker: ニュートラルテーマ
       schemes: 外観
+      shortcut_badges: ショートカットバッジ
+      shortcut_badges_hide_tooltip: キーボードショートカットバッジを非表示
+      shortcut_badges_show_tooltip: キーボードショートカットバッジを表示
+      show: 表示
       title: 外観
     applied:
       one: applied

--- a/lib/generators/avo/templates/locales/avo.nb.yml
+++ b/lib/generators/avo/templates/locales/avo.nb.yml
@@ -12,11 +12,16 @@ nb:
       auto_tooltip: Auto (systempreferanse)
       dark: Mørk
       dark_tooltip: Mørk modus
+      hide: Skjul
       light: Lys
       light_tooltip: Lys modus
       neutrals: Tema
       neutrals_picker: Nøytralt tema
       schemes: Utseende
+      shortcut_badges: Snarveisknapper
+      shortcut_badges_hide_tooltip: Skjul snarveisknapper
+      shortcut_badges_show_tooltip: Vis snarveisknapper
+      show: Vis
       title: Utseende
     applied:
       one: applied

--- a/lib/generators/avo/templates/locales/avo.nl.yml
+++ b/lib/generators/avo/templates/locales/avo.nl.yml
@@ -12,11 +12,16 @@ nl:
       auto_tooltip: Automatisch (systeemvoorkeur)
       dark: Donker
       dark_tooltip: Donkermodus
+      hide: Verbergen
       light: Licht
       light_tooltip: Lichtmodus
       neutrals: Thema
       neutrals_picker: Neutrale thema
       schemes: Uiterlijk
+      shortcut_badges: Sneltoets badges
+      shortcut_badges_hide_tooltip: Verberg sneltoets badges
+      shortcut_badges_show_tooltip: Toon sneltoets badges
+      show: Toon
       title: Uiterlijk
     applied: toegepast
     are_you_sure: Weet u het zeker?

--- a/lib/generators/avo/templates/locales/avo.nn.yml
+++ b/lib/generators/avo/templates/locales/avo.nn.yml
@@ -12,11 +12,16 @@ nn:
       auto_tooltip: Auto (systempreferanse)
       dark: Mørk
       dark_tooltip: Mørkmodus
+      hide: Skjul
       light: Lys
       light_tooltip: Lysmodus
       neutrals: Tema
       neutrals_picker: Nøytrale tema
       schemes: Utseende
+      shortcut_badges: Snarveiknappar
+      shortcut_badges_hide_tooltip: Skjul snarveiknappar
+      shortcut_badges_show_tooltip: Vis snarveiknappar
+      show: Vis
       title: Utseende
     applied:
       one: applied

--- a/lib/generators/avo/templates/locales/avo.pl.yml
+++ b/lib/generators/avo/templates/locales/avo.pl.yml
@@ -12,11 +12,16 @@ pl:
       auto_tooltip: Automatycznie (preferencje systemowe)
       dark: Ciemny
       dark_tooltip: Tryb ciemny
+      hide: Ukryj
       light: Jasny
       light_tooltip: Tryb jasny
       neutrals: Motyw
       neutrals_picker: Motyw neutralny
       schemes: Wygląd
+      shortcut_badges: Ikony skrótów
+      shortcut_badges_hide_tooltip: Ukryj ikony skrótów klawiaturowych
+      shortcut_badges_show_tooltip: Pokaż ikony skrótów klawiaturowych
+      show: Pokaż
       title: Wygląd
     applied: zastosowane
     are_you_sure: Czy na pewno?

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -12,11 +12,16 @@ pt-BR:
       auto_tooltip: Automático (preferência do sistema)
       dark: Escuro
       dark_tooltip: Modo Escuro
+      hide: Ocultar
       light: Claro
       light_tooltip: Modo Claro
       neutrals: Tema
       neutrals_picker: Tema Neutro
       schemes: Aparência
+      shortcut_badges: Badges de atalho
+      shortcut_badges_hide_tooltip: Ocultar badges de atalho do teclado
+      shortcut_badges_show_tooltip: Mostrar badges de atalho do teclado
+      show: Mostrar
       title: Aparência
     applied:
       one: aplicado

--- a/lib/generators/avo/templates/locales/avo.pt.yml
+++ b/lib/generators/avo/templates/locales/avo.pt.yml
@@ -12,11 +12,16 @@ pt:
       auto_tooltip: Automático (preferência do sistema)
       dark: Escuro
       dark_tooltip: Modo Escuro
+      hide: Ocultar
       light: Claro
       light_tooltip: Modo Claro
       neutrals: Tema
       neutrals_picker: Tema Neutro
       schemes: Aparência
+      shortcut_badges: Insígnias de atalho
+      shortcut_badges_hide_tooltip: Ocultar insígnias de atalho do teclado
+      shortcut_badges_show_tooltip: Mostrar insígnias de atalho do teclado
+      show: Mostrar
       title: Aparência
     applied:
       one: aplicado

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -12,11 +12,16 @@ ro:
       auto_tooltip: Automat (preferința sistemului)
       dark: Întunecat
       dark_tooltip: Mod întunecat
+      hide: Ascunde
       light: Deschis
       light_tooltip: Mod deschis
       neutrals: Temă
       neutrals_picker: Temă neutre
       schemes: Aspect
+      shortcut_badges: Insignele scurtăturilor
+      shortcut_badges_hide_tooltip: Ascunde insignele scurtăturilor de tastatură
+      shortcut_badges_show_tooltip: Afișează insignele scurtăturilor de tastatură
+      show: Afișează
       title: Aspect
     applied:
       few: aplicate

--- a/lib/generators/avo/templates/locales/avo.ru.yml
+++ b/lib/generators/avo/templates/locales/avo.ru.yml
@@ -12,11 +12,16 @@ ru:
       auto_tooltip: Авто (системные предпочтения)
       dark: Темный
       dark_tooltip: Темный режим
+      hide: Скрыть
       light: Светлый
       light_tooltip: Светлый режим
       neutrals: Тема
       neutrals_picker: Нейтральная тема
       schemes: Внешний вид
+      shortcut_badges: Значки ярлыков
+      shortcut_badges_hide_tooltip: Скрыть значки клавиатурных ярлыков
+      shortcut_badges_show_tooltip: Показать значки клавиатурных ярлыков
+      show: Показать
       title: Внешний вид
     applied: применено
     are_you_sure: Вы уверены?

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -12,11 +12,16 @@ tr:
       auto_tooltip: Otomatik (sistem tercihi)
       dark: Koyu
       dark_tooltip: Koyu mod
+      hide: Gizle
       light: Açık
       light_tooltip: Açık mod
       neutrals: Tema
       neutrals_picker: Nötr tema
       schemes: Görünüm
+      shortcut_badges: Kısayol rozetleri
+      shortcut_badges_hide_tooltip: Klavye kısayolu rozetlerini gizle
+      shortcut_badges_show_tooltip: Klavye kısayolu rozetlerini göster
+      show: Göster
       title: Görünüm
     applied:
       one: uygulandı

--- a/lib/generators/avo/templates/locales/avo.ua.yml
+++ b/lib/generators/avo/templates/locales/avo.ua.yml
@@ -12,11 +12,16 @@ ua:
       auto_tooltip: Авто (системні налаштування)
       dark: Темний
       dark_tooltip: Темний режим
+      hide: Сховати
       light: Світлий
       light_tooltip: Світлий режим
       neutrals: Тема
       neutrals_picker: Нейтральна тема
       schemes: Зовнішній вигляд
+      shortcut_badges: Значки ярликів
+      shortcut_badges_hide_tooltip: Сховати значки клавіатурних ярликів
+      shortcut_badges_show_tooltip: Показати значки клавіатурних ярликів
+      show: Показати
       title: Зовнішній вигляд
     applied: застосовано
     are_you_sure: Ви впевнені?

--- a/lib/generators/avo/templates/locales/avo.zh-TW.yml
+++ b/lib/generators/avo/templates/locales/avo.zh-TW.yml
@@ -12,11 +12,16 @@ zh-TW:
       auto_tooltip: 自動（系統偏好）
       dark: 深色
       dark_tooltip: 深色模式
+      hide: 隱藏
       light: 淺色
       light_tooltip: 淺色模式
       neutrals: 主題
       neutrals_picker: 中性色主題
       schemes: 外觀
+      shortcut_badges: 快捷鍵徽章
+      shortcut_badges_hide_tooltip: 隱藏鍵盤快捷鍵徽章
+      shortcut_badges_show_tooltip: 顯示鍵盤快捷鍵徽章
+      show: 顯示
       title: 外觀
     applied: 已應用
     are_you_sure: 您確定嗎？

--- a/lib/generators/avo/templates/locales/avo.zh.yml
+++ b/lib/generators/avo/templates/locales/avo.zh.yml
@@ -12,11 +12,16 @@ zh:
       auto_tooltip: 自动（系统偏好）
       dark: 深色
       dark_tooltip: 深色模式
+      hide: 隐藏
       light: 浅色
       light_tooltip: 浅色模式
       neutrals: 主题
       neutrals_picker: 中性色主题
       schemes: 外观
+      shortcut_badges: 快捷键徽章
+      shortcut_badges_hide_tooltip: 隐藏键盘快捷键徽章
+      shortcut_badges_show_tooltip: 显示键盘快捷键徽章
+      show: 显示
       title: 外观
     applied: 已应用
     are_you_sure: 您确定吗？

--- a/spec/system/avo/group_2/filters/filters_spec.rb
+++ b/spec/system/avo/group_2/filters/filters_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe "Filters", type: :system do
       expect(page).to have_css(".button--disabled", text: "Reset filters")
     end
 
+    it "marks reset filters as disabled when no filters are applied" do
+      visit url
+      open_filters_menu
+
+      reset_link = find("a.button--disabled", text: "Reset filters")
+
+      expect(reset_link["aria-disabled"]).to eq("true")
+      expect(reset_link["tabindex"]).to eq("-1")
+      expect(reset_link["data-disabled"]).to eq("true")
+      expect(reset_link[:href]).to end_with("#")
+    end
+
     it "changes the query" do
       visit url
       open_filters_menu

--- a/spec/system/avo/group_2/filters/filters_spec.rb
+++ b/spec/system/avo/group_2/filters/filters_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Filters", type: :system do
       expect(page).to have_unchecked_field "Unfeatured"
       expect(page).to have_text "Featured post"
       expect(page).to have_text "Unfeatured post"
-      expect(page).to have_css(".filters-card__reset.filters-card__reset--disabled", text: "Reset filters")
+      expect(page).to have_css(".button--disabled", text: "Reset filters")
     end
 
     it "changes the query" do
@@ -87,7 +87,7 @@ RSpec.describe "Filters", type: :system do
       expect(page).to have_unchecked_field "Featured"
       expect(page).to have_unchecked_field "Unfeatured"
       expect(current_url).not_to include "encoded_filters="
-      expect(page).to have_css(".filters-card__reset.filters-card__reset--disabled", text: "Reset filters")
+      expect(page).to have_css(".button--disabled", text: "Reset filters")
     end
   end
 
@@ -111,7 +111,7 @@ RSpec.describe "Filters", type: :system do
       expect(page).to have_checked_field "Has Members"
       expect(page).not_to have_text "Without Members"
       expect(page).to have_text "With Members"
-      expect(page).to have_css(".filters-card__reset.filters-card__reset--disabled", text: "Reset filters")
+      expect(page).to have_css(".button--disabled", text: "Reset filters")
     end
 
     it "changes the query and reset" do
@@ -137,7 +137,7 @@ RSpec.describe "Filters", type: :system do
       expect(page).to have_checked_field "Has Members"
       expect(page).not_to have_text "Without Members"
       expect(page).to have_text "With Members"
-      expect(page).to have_css(".filters-card__reset.filters-card__reset--disabled", text: "Reset filters")
+      expect(page).to have_css(".button--disabled", text: "Reset filters")
     end
   end
 
@@ -156,7 +156,7 @@ RSpec.describe "Filters", type: :system do
         expect(page).to have_select "published status", selected: "Published or unpublished", options: ["Published or unpublished", "Published", "Unpublished"]
         expect(page).to have_text "Published post"
         expect(page).to have_text "Unpublished post"
-        expect(page).to have_css(".filters-card__reset.filters-card__reset--disabled", text: "Reset filters")
+        expect(page).to have_css(".button--disabled", text: "Reset filters")
       end
 
       it "changes the query" do
@@ -196,7 +196,7 @@ RSpec.describe "Filters", type: :system do
         expect(page).to have_text "Unpublished post"
         expect(page).to have_select "avo_filters_published_status", selected: "Published or unpublished", options: ["Published or unpublished", "Published", "Unpublished"]
         expect(current_url).not_to include "encoded_filters="
-        expect(page).to have_css(".filters-card__reset.filters-card__reset--disabled", text: "Reset filters")
+        expect(page).to have_css(".button--disabled", text: "Reset filters")
 
         select "Unpublished", from: "avo_filters_published_status"
         wait_for_loaded
@@ -216,7 +216,7 @@ RSpec.describe "Filters", type: :system do
         expect(page).to have_select "avo_filters_published_status", selected: "Published or unpublished", options: ["Published or unpublished", "Published", "Unpublished"]
         expect(page).to have_text "Published post"
         expect(page).to have_text "Unpublished post"
-        expect(page).to have_css(".filters-card__reset.filters-card__reset--disabled", text: "Reset filters")
+        expect(page).to have_css(".button--disabled", text: "Reset filters")
       end
     end
   end
@@ -235,7 +235,7 @@ RSpec.describe "Filters", type: :system do
 
         expect(page).to have_text "Status"
         expect(page).to have_select "avo_filters_status", selected: [], options: ["draft", "published", "archived"]
-        expect(page).to have_css(".filters-card__reset.filters-card__reset--disabled", text: "Reset filters")
+        expect(page).to have_css(".button--disabled", text: "Reset filters")
       end
 
       it "changes the query" do


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes various visual and functional issues.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to styling, filter/appearance UX, and documented hotkey bindings; no auth, data, or server logic changes.
> 
> **Overview**
> This PR polishes admin UI behavior and documents updated keyboard shortcuts.
> 
> **Buttons and filters:** Disabled buttons no longer show hover/active feedback; shared disabled styling uses `button--disabled` and related attributes. The filters trigger is **outline** instead of primary; **Reset filters** moves to the dropdown **footer** as a full-width text link with proper disabled state (`aria-disabled`, `tabindex`, `data-disabled`) instead of custom `.filters-card__reset` styles.
> 
> **Dropdown cards:** `DropdownCardComponent` wraps optional header/footer in `.dropdown-card__header` / `.dropdown-card__footer` only when content is present, aligning filters and distribution-chart footers with the design system.
> 
> **Hotkeys and appearance:** Sidebar toggle changes from **Cmd/Ctrl+\\** to **Shift+\\** (`event.code` **Backslash**). The shortcuts help text matches (**Focus Global Search**, **Shift+\\**, **Shift+K**). When hotkey badges are enabled in config, the appearance menu gains **Show/Hide shortcut badges** controls that toggle `body.hotkeys-hide-badges` and persist via `localStorage`, with CSS highlighting the active choice.
> 
> **Misc layout/CSS:** Breadcrumbs use `--spacing(-2)`; navbar search gets responsive widths; card header is slightly tighter; panel discreet info is left-aligned on small screens.
> 
> **i18n/tests:** Locale templates add appearance strings for shortcut badges; filter specs assert `.button--disabled` for reset instead of the removed reset link classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e552a998fe98f924f9c834d900e795c990d3f518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->