### PR TITLE
refactor: progressbar color and tweaks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,8 +28,6 @@ end
 APP_RAKEFILE = File.expand_path("spec/dummy/Rakefile", __dir__)
 load "rails/tasks/engine.rake"
 
-load "rails/tasks/statistics.rake"
-
 load "lib/tasks/avo_tasks.rake"
 
 require "bundler/gem_tasks"

--- a/agents.md
+++ b/agents.md
@@ -65,3 +65,29 @@ When toggling the visibility of some html elements, use the `hidden` HTML attrib
 ## Ruby on Rails
 
 Whenever possible use the `partial:` keyword when rendering partials unless needed otherwise.
+
+## Logging in (development & testing)
+
+The dummy app at `spec/dummy` uses Devise for authentication. Avo is mounted at `/admin` and is wrapped in an `authenticate :user, ->(user) { user.is_admin? }` block, so you need an admin user to reach it.
+
+#### Development (browser / `bin/dev`)
+
+1. Seed the database to create the admin user:
+
+   ```sh
+   cd spec/dummy && rails db:seed
+   ```
+
+2. Visit `/users/sign_in` and log in with:
+   - Email: `hi@avohq.io`
+   - Password: `secreto` (override with the `AVO_ADMIN_PASSWORD` env var)
+
+3. The admin panel lives at `/admin`.
+
+#### Testing (RSpec + Capybara/Cuprite)
+
+Do not drive the sign-in form in tests. Use the Devise/Warden test helpers instead:
+
+- System & feature specs: `login_as(admin, scope: :user)` (Warden test mode is enabled in `spec/support/devise.rb`).
+- Controller specs: `sign_in admin` (Devise's `ControllerHelpers`).
+- Get an admin user from the shared context: `include_context "has_admin_user"`, which exposes `admin` via `create(:user, roles: {admin: true})`. The mix-in `TestHelpers::DisableAuthentication` (`spec/support/controller_routes.rb`) wires this up automatically.

--- a/app/assets/stylesheets/css/fields/progress.css
+++ b/app/assets/stylesheets/css/fields/progress.css
@@ -1,15 +1,47 @@
 [data-component="avo/fields/common/progress_bar_component"] {
+  /* Track — a recessed groove. The base element is the track in Firefox; the
+     ::-webkit-progress-bar mirrors it for Chrome/Safari. The inset shadow is a
+     fixed dark occlusion so the groove reads the same in light and dark. */
   & progress {
-    @apply h-2 bg-white border border-slate-400 rounded-sm shadow-inner;
-  }
-  & progress[value]::-webkit-progress-bar {
-    @apply bg-white border border-gray-500 rounded-sm shadow-inner;
-  }
-  & progress[value]::-webkit-progress-value{
-    @apply bg-primary-500 rounded-sm;
+    @apply h-2 rounded-sm border border-content-secondary/15 overflow-hidden;
 
+    background-color: var(--color-tertiary);
+    box-shadow: inset 0 1px 2px 0 color-mix(in oklab, var(--color-black) 14%, transparent);
   }
+
+  & progress[value]::-webkit-progress-bar {
+    @apply rounded-sm;
+
+    background-color: var(--color-tertiary);
+    box-shadow: inset 0 1px 2px 0 color-mix(in oklab, var(--color-black) 14%, transparent);
+  }
+
+  /* Fill — a slightly raised, glossy bar sitting in the groove. The vertical
+     gradient lightens the top and darkens the foot (baked-in highlight so the
+     depth survives even where pseudo-element box-shadows are ignored), keyed off
+     the accent token so it tracks the theme. */
+  & progress[value]::-webkit-progress-value {
+    @apply rounded-sm;
+
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--color-accent), var(--color-white) 22%) 0%,
+      var(--color-accent) 55%,
+      color-mix(in oklab, var(--color-accent), var(--color-black) 12%) 100%
+    );
+    box-shadow:
+      inset 0 1px 0 0 color-mix(in oklab, var(--color-white) 35%, transparent),
+      inset 0 -1px 1px 0 color-mix(in oklab, var(--color-black) 18%, transparent);
+  }
+
   & progress[value]::-moz-progress-bar {
-    @apply bg-primary-500 rounded-sm appearance-none;
+    @apply rounded-sm appearance-none;
+
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--color-accent), var(--color-white) 22%) 0%,
+      var(--color-accent) 55%,
+      color-mix(in oklab, var(--color-accent), var(--color-black) 12%) 100%
+    );
   }
 }

--- a/app/assets/stylesheets/css/layout.css
+++ b/app/assets/stylesheets/css/layout.css
@@ -66,7 +66,14 @@
 }
 
 .main-content {
-  @apply w-(--content-width) flex flex-col bg-primary py-2 lg:py-4 px-2 lg:px-4 border-s border-(--border-color) ms-1;
+  @apply w-(--content-width) flex flex-col bg-primary py-2 lg:py-4
+  px-2 lg:px-4
+  border-s border-(--border-color)
+  /* ms-1 */
+   rounded-se-(--navbar-notch-radius)
+  rounded-ss-(--navbar-notch-radius)
+  ;
+
   transition: margin 0.1s ease-in-out, width 0.1s ease-in-out;
   min-height: calc(100dvh - var(--top-navbar-height) - var(--spacing));
 }
@@ -123,6 +130,7 @@
     width: var(--navbar-notch-radius);
     height: var(--navbar-notch-radius);
     pointer-events: none;
+    /* border: 1px solid red; */
   }
 
   &::before {
@@ -269,6 +277,9 @@ html[dir="rtl"] .avo-sidebar {
 
   html[dir="rtl"] .sidebar-open .avo-sidebar {
     transform: translateX(0);
+  }
+  .sidebar-open .main-content {
+    @apply rounded-ss-none;
   }
 }
 

--- a/app/assets/stylesheets/css/layout.css
+++ b/app/assets/stylesheets/css/layout.css
@@ -66,13 +66,7 @@
 }
 
 .main-content {
-  @apply w-(--content-width) flex flex-col bg-primary py-2 lg:py-4
-  px-2 lg:px-4
-  border-s border-(--border-color)
-  /* ms-1 */
-   rounded-se-(--navbar-notch-radius)
-  rounded-ss-(--navbar-notch-radius)
-  ;
+  @apply w-(--content-width) flex flex-col bg-primary py-2 lg:py-4 px-2 lg:px-4 border-s border-(--border-color) ms-1 rounded-se-(--navbar-notch-radius) rounded-ss-(--navbar-notch-radius);
 
   transition: margin 0.1s ease-in-out, width 0.1s ease-in-out;
   min-height: calc(100dvh - var(--top-navbar-height) - var(--spacing));
@@ -278,8 +272,13 @@ html[dir="rtl"] .avo-sidebar {
   html[dir="rtl"] .sidebar-open .avo-sidebar {
     transform: translateX(0);
   }
+
   .sidebar-open .main-content {
     @apply rounded-ss-none;
+  }
+
+  .main:not(.sidebar-open) .main-content {
+    @apply ms-0;
   }
 }
 

--- a/spec/system/avo/group_2/progress_bar_field_spec.rb
+++ b/spec/system/avo/group_2/progress_bar_field_spec.rb
@@ -1,6 +1,49 @@
 require "rails_helper"
+require "vips"
 
 RSpec.describe "ProgressBarField", type: :system do
+  describe "renders a visible fill" do
+    let!(:project) { create :project, progress: 27 }
+
+    # The native <progress> fill is painted by a browser pseudo-element whose
+    # color is not exposed via getComputedStyle, so we screenshot the bar and
+    # compare a pixel inside the filled zone (left, within the 27% value) to one
+    # in the empty track (right). When the fill token is undefined the bar is
+    # "all white" and both pixels match.
+    def fill_and_track_pixels
+      path = Rails.root.join("tmp", "progress_#{SecureRandom.hex(4)}.png").to_s
+      page.driver.save_screenshot(path, selector: "[data-field-id='progress'] progress")
+
+      image = Vips::Image.new_from_file(path)
+      y = image.height / 2
+      filled = image.getpoint((image.width * 0.12).to_i, y).first(3)
+      track = image.getpoint((image.width * 0.88).to_i, y).first(3)
+      {filled: filled, track: track}
+    ensure
+      File.delete(path) if path && File.exist?(path)
+    end
+
+    shared_examples "a visible progress fill" do
+      it "fills with a color distinct from the track" do
+        expect(page).to have_css "[data-field-id='progress'] progress[value='27']"
+
+        pixels = fill_and_track_pixels
+        expect(pixels[:filled]).not_to eq(pixels[:track]),
+          "progress fill #{pixels[:filled]} matches the track #{pixels[:track]} — bar is invisible"
+      end
+    end
+
+    context "on index" do
+      before { visit "/admin/resources/projects/?view_type=table" }
+      it_behaves_like "a visible progress fill"
+    end
+
+    context "on show" do
+      before { visit "/admin/resources/projects/#{project.id}" }
+      it_behaves_like "a visible progress fill"
+    end
+  end
+
   describe "able to contain nil value" do
     context "create" do
       it "progress field remains blank" do

--- a/spec/system/avo/group_2/progress_bar_field_spec.rb
+++ b/spec/system/avo/group_2/progress_bar_field_spec.rb
@@ -1,49 +1,6 @@
 require "rails_helper"
-require "vips"
 
 RSpec.describe "ProgressBarField", type: :system do
-  describe "renders a visible fill" do
-    let!(:project) { create :project, progress: 27 }
-
-    # The native <progress> fill is painted by a browser pseudo-element whose
-    # color is not exposed via getComputedStyle, so we screenshot the bar and
-    # compare a pixel inside the filled zone (left, within the 27% value) to one
-    # in the empty track (right). When the fill token is undefined the bar is
-    # "all white" and both pixels match.
-    def fill_and_track_pixels
-      path = Rails.root.join("tmp", "progress_#{SecureRandom.hex(4)}.png").to_s
-      page.driver.save_screenshot(path, selector: "[data-field-id='progress'] progress")
-
-      image = Vips::Image.new_from_file(path)
-      y = image.height / 2
-      filled = image.getpoint((image.width * 0.12).to_i, y).first(3)
-      track = image.getpoint((image.width * 0.88).to_i, y).first(3)
-      {filled: filled, track: track}
-    ensure
-      File.delete(path) if path && File.exist?(path)
-    end
-
-    shared_examples "a visible progress fill" do
-      it "fills with a color distinct from the track" do
-        expect(page).to have_css "[data-field-id='progress'] progress[value='27']"
-
-        pixels = fill_and_track_pixels
-        expect(pixels[:filled]).not_to eq(pixels[:track]),
-          "progress fill #{pixels[:filled]} matches the track #{pixels[:track]} — bar is invisible"
-      end
-    end
-
-    context "on index" do
-      before { visit "/admin/resources/projects/?view_type=table" }
-      it_behaves_like "a visible progress fill"
-    end
-
-    context "on show" do
-      before { visit "/admin/resources/projects/#{project.id}" }
-      it_behaves_like "a visible progress fill"
-    end
-  end
-
   describe "able to contain nil value" do
     context "create" do
       it "progress field remains blank" do


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes an issue witht he progressbar not having a bg-color + a few other tweaks.

https://github.com/user-attachments/assets/6bef47e5-3566-40b6-baf0-336a077fd4e6



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deletion; no production code in the diff, but regressions in progress bar styling would no longer be caught on index/show.
> 
> **Overview**
> This PR **removes** the system spec coverage that asserted the progress bar shows a **visible fill** (distinct from the track) on **index** and **show**, along with the **Vips** screenshot helper and the **`require "vips"`** dependency in that spec file.
> 
> The **`ProgressBarField`** system spec now only keeps the **nil progress on create** example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7367f6d0711beb443445dd96f2fd243b044ed116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->