### PR TITLE
fix: sort table on associations

### DIFF
--- a/app/views/avo/partials/_table_header.html.erb
+++ b/app/views/avo/partials/_table_header.html.erb
@@ -64,7 +64,13 @@
       <%= content_tag :div,
         class: "relative flex items-center justify-between w-full" do %>
         <% if field.sortable && resource.sorting_supported? %>
-          <%= link_to params.permit!.merge(sort_by: sort_by, sort_direction: sort_direction),
+          <%
+            # url_for(params) picks the alphabetically-first per-resource route,
+            # which on association tables routes sort links to the wrong resource.
+            sort_query_params = request.query_parameters.merge(sort_by: sort_by, sort_direction: sort_direction).compact
+            sort_url = "#{request.path}?#{sort_query_params.to_query}"
+          %>
+          <%= link_to sort_url,
             class: class_names("flex-1 flex justify-between", text_classes),
             'data-turbo-frame': params[:turbo_frame] do %>
             <%= field.table_header_label %>

--- a/spec/features/avo/field_sorting_spec.rb
+++ b/spec/features/avo/field_sorting_spec.rb
@@ -19,4 +19,22 @@ RSpec.feature "Field Sorting", type: :feature do
       expect(page).not_to have_css 'th[data-control="resource-field-th"][data-table-header-field-id="id"][data-table-header-field-type="id"] a svg'
     end
   end
+
+  describe "sortable link on association tables" do
+    # Regression for AVO-1268: on a HABTM/has_many association table rendered
+    # inside a parent record's show page, the sort link in the column header
+    # pointed at an unrelated resource (whichever resource is first
+    # alphabetically) instead of the current parent resource. Reproduced by
+    # visiting the users frame under a project and checking that the sort
+    # link's href stays under /admin/resources/projects/<id>/users.
+    it "preserves the current parent resource path on the sort link" do
+      project.users << user
+
+      visit "/admin/resources/projects/#{project.id}/users?turbo_frame=has_and_belongs_to_many_field_show_users&view=show"
+
+      sort_link = find('th[data-control="resource-field-th"][data-table-header-field-id="is_writer"] a')
+
+      expect(sort_link[:href]).to start_with("/admin/resources/projects/#{project.id}/users")
+    end
+  end
 end


### PR DESCRIPTION
# Description
Fix sort links on association tables routing to the wrong resource. Build the sort URL from request.path + merged query params instead of
  url_for(params), which was matching the alphabetically-first per-resource route. Adds a request spec covering the HABTM users-on-project case.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
