### PR TITLE
refactor: create belongs to in modal tweaked

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -144,6 +144,7 @@
   @import "./css/components/ui/popover_menu.css";
   @import "./css/components/ui/radio.css";
   @import "./css/components/ui/checkbox_list.css";
+  @import "./css/components/ui/count.css";
   @import "./css/components/input.css";
 
   @import "./css/components/field-wrapper.css";

--- a/app/assets/stylesheets/css/components/field-wrapper.css
+++ b/app/assets/stylesheets/css/components/field-wrapper.css
@@ -10,6 +10,12 @@
   @apply text-content-secondary mt-2 text-xs leading-4;
 }
 
+/* Boolean fields render a compact checkbox/toggle, so the help text sits
+   directly beneath it without the extra top margin other inputs need. */
+[data-field-type="boolean"] .field-wrapper__help {
+  @apply mt-0;
+}
+
 .field-wrapper__label-help {
   @apply text-content-secondary text-xs leading-none font-normal;
 }

--- a/app/assets/stylesheets/css/components/filters.css
+++ b/app/assets/stylesheets/css/components/filters.css
@@ -2,15 +2,6 @@
   @apply relative flex w-full justify-between;
 }
 
-.filters__count {
-  /* Compact pill: accent-tinted background keeps the "this filter is active"
-     hint, neutral content text guarantees contrast in both schemes.
-     (Using `text-accent` looked fine in light, but in dark mode `--color-accent`
-     resolves to a *light* value — same hue and same value as the translucent
-     bg, killing contrast. Neutral text sidesteps that.) */
-  @apply inline-flex items-center justify-center ms-1 rounded-sm bg-accent/15 dark:bg-accent/30 text-content font-medium text-xs leading-none min-w-4 py-px px-1 tabular-nums;
-}
-
 .filters__panel {
   @apply absolute top-full z-40 mt-2 w-72 inset-auto sm:end-0 flex flex-col;
 

--- a/app/assets/stylesheets/css/components/modal.css
+++ b/app/assets/stylesheets/css/components/modal.css
@@ -30,18 +30,25 @@
 }
 
 .modal__card {
-  @apply relative size-full shrink-0;
+  @apply relative w-full shrink-0 flex flex-col;
+
+  /* Never exceed the viewport — keeps a tall (e.g. :auto height) modal fully
+     on screen so its body can scroll instead of being clipped by the centered
+     overlay. */
+  max-height: calc(100dvh - 2rem);
 
   box-shadow: var(--shadow-modal);
 }
 
-/* Modal-specific card overrides */
+/* Modal-specific card overrides. The flex-1 + min-h-0 chain lets the card and
+   its wrapper fill the (capped) modal height and shrink, so the body's
+   overflow-auto kicks in while the header and footer stay pinned. */
 .modal__card > .card {
-  @apply size-full;
+  @apply w-full flex-1 min-h-0;
 }
 
 .modal__card > .card > .card__wrapper {
-  @apply size-full flex flex-col;
+  @apply w-full flex flex-col flex-1 min-h-0;
 }
 
 .modal__card .card__header {
@@ -70,6 +77,13 @@
 
 .modal__body-content {
   @apply size-full;
+}
+
+/* Belongs-to "Create new" embeds an edit form in the modal. Drop the nested
+   panel chrome (background + border) and pad the body so the form breathes.
+   Scoped to match the `.card__body` selector above so the padding wins. */
+.card__body.modal-form-body {
+  @apply !p-4;
 }
 
 .modal__controls {

--- a/app/assets/stylesheets/css/components/ui/count.css
+++ b/app/assets/stylesheets/css/components/ui/count.css
@@ -1,0 +1,10 @@
+.count {
+  /* Compact pill: accent-tinted background keeps the "this is active" hint,
+     neutral content text guarantees contrast in both schemes.
+     (Using `text-accent` looked fine in light, but in dark mode `--color-accent`
+     resolves to a *light* value — same hue and same value as the translucent
+     bg, killing contrast. Neutral text sidesteps that.)
+     Margin is intentionally omitted — callers add spacing (e.g. `ms-1`) for
+     their own layout. */
+  @apply inline-flex items-center justify-center rounded-sm bg-accent/15 dark:bg-accent/30 text-content font-medium text-xs leading-none min-w-4 py-px px-1 tabular-nums;
+}

--- a/app/assets/stylesheets/css/layout.css
+++ b/app/assets/stylesheets/css/layout.css
@@ -209,7 +209,7 @@
 /* Links inside the always-dark navbar use primitive neutral tokens so they
    stay readable in both light and dark mode — matching the search input and
    sidebar toggle treatment. */
-.top-navbar a {
+.top-navbar .header-menu a {
   color: var(--color-avo-neutral-300);
 
   &:hover {

--- a/app/components/avo/fields/belongs_to_field/edit_component.rb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.rb
@@ -71,11 +71,11 @@ class Avo::Fields::BelongsToField::EditComponent < Avo::Fields::EditComponent
   end
 
   def modal_args
+    # `modal_layout: true` is what routes the `new` action through the `avo/modal`
+    # layout. The modal's title, size and footer controls are rendered by
+    # `Avo::Views::ResourceEditComponent` when it detects this embedded context.
     {
-      modal_layout: true,
-      modal_width: :full,
-      modal_height: :full,
-      wrapper_class: "container mx-auto py-4"
+      modal_layout: true
     }
   end
 

--- a/app/components/avo/filters_component.html.erb
+++ b/app/components/avo/filters_component.html.erb
@@ -9,7 +9,7 @@
       'data-tippy': 'tooltip' do %>
       <%= t 'avo.filters' %>
       <% if applied_filters_count.positive? %>
-        <span class="filters__count"><%= applied_filters_count %></span>
+        <%= render Avo::UI::CountComponent.new(count: applied_filters_count, classes: "ms-1") %>
       <% end %>
     <% end %>
     <%= tag.div class: 'filters__panel css-animate-slide-down',

--- a/app/components/avo/u_i/count_component.html.erb
+++ b/app/components/avo/u_i/count_component.html.erb
@@ -1,0 +1,1 @@
+<span class="<%= class_names("count", @classes) %>"><%= @count %></span>

--- a/app/components/avo/u_i/count_component.rb
+++ b/app/components/avo/u_i/count_component.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Compact numeric pill used next to a label or title — e.g. the active-filter
+# count on the filters bar or an unread-notification count. Extracted from the
+# filters bar so the same accent-tinted style can be reused anywhere a small
+# count needs to sit alongside text.
+class Avo::UI::CountComponent < Avo::BaseComponent
+  prop :count
+  prop :classes, default: nil
+end

--- a/app/components/avo/views/resource_edit_component.html.erb
+++ b/app/components/avo/views/resource_edit_component.html.erb
@@ -13,29 +13,29 @@
   <%= build_form do |form| %>
     <%= render Avo::ReferrerParamsComponent.new back_path: back_path %>
 
-    <%= content_tag :div, class: "panel-spacer" do %>
-      <% @resource.get_items.each_with_index do |item, index| %>
-        <%= render Avo::Items::SwitcherComponent.new(
-          resource: @resource,
-          reflection: @reflection,
-          item: item,
-          index: index + 1,
-          view: @view,
-          parent_resource: @parent_resource,
-          parent_record: @parent_record,
-          form: form,
-          parent_component: self,
-          actions: @actions
-        ) %>
-      <% end %>
+    <% if embedded_in_modal? %>
+      <%# The form wraps the modal so the footer submit button posts natively. %>
+      <%= render Avo::ModalComponent.new(title: title, width: :"4xl", body_class: "modal-form-body") do |c| %>
+        <% c.with_controls do %>
+          <% @resource.render_edit_controls.each do |control| %>
+            <%= render_control control %>
+          <% end %>
+        <% end %>
 
-      <% if Avo.configuration.buttons_on_form_footers %>
-        <%= render ui.panel do |panel| %>
-          <% panel.with_footer do %>
-            <%= render ui.panel_header do |header| %>
-              <% header.with_controls do %>
-                <% @resource.render_edit_controls.each do |control| %>
-                  <%= render_control control %>
+        <%= content_tag :div, render_form_items(form), class: "panel-spacer" %>
+      <% end %>
+    <% else %>
+      <%= content_tag :div, class: "panel-spacer" do %>
+        <%= render_form_items(form) %>
+
+        <% if Avo.configuration.buttons_on_form_footers %>
+          <%= render ui.panel do |panel| %>
+            <% panel.with_footer do %>
+              <%= render ui.panel_header do |header| %>
+                <% header.with_controls do %>
+                  <% @resource.render_edit_controls.each do |control| %>
+                    <%= render_control control %>
+                  <% end %>
                 <% end %>
               <% end %>
             <% end %>

--- a/app/components/avo/views/resource_edit_component.rb
+++ b/app/components/avo/views/resource_edit_component.rb
@@ -51,6 +51,35 @@ class Avo::Views::ResourceEditComponent < Avo::ResourceComponent
     @resource.render_edit_controls
   end
 
+  # True when the form is shown inside a modal opened from a belongs_to
+  # "Create new" link. In that case the title moves to the modal header and the
+  # controls move to the modal footer, so the in-form panel header is skipped.
+  def embedded_in_modal?
+    params[:via_belongs_to_resource_class].present?
+  end
+
+  # Renders the form panels. When embedded in a modal the panel header is
+  # dropped — its title and controls live in the modal chrome instead.
+  def render_form_items(form)
+    items = @resource.get_items
+    items = items.reject(&:is_header?) if embedded_in_modal?
+
+    safe_join(items.each_with_index.map do |item, index|
+      render Avo::Items::SwitcherComponent.new(
+        resource: @resource,
+        reflection: @reflection,
+        item: item,
+        index: index + 1,
+        view: @view,
+        parent_resource: @parent_resource,
+        parent_record: @parent_record,
+        form: form,
+        parent_component: self,
+        actions: @actions
+      )
+    end)
+  end
+
   private
 
   def via_index?

--- a/app/views/avo/partials/_navbar.html.erb
+++ b/app/views/avo/partials/_navbar.html.erb
@@ -37,6 +37,7 @@
 
   <div class="top-navbar__end">
     <%= render partial: "avo/partials/header" %>
+    <%= render Avo::Notifications::BellComponent.new if Avo.plugin_manager.installed?("avo-notifications") %>
     <%= render partial: "avo/partials/color_scheme_switcher" %>
   </div>
 <% end %>

--- a/app/views/layouts/avo/modal.html.erb
+++ b/app/views/layouts/avo/modal.html.erb
@@ -1,7 +1,13 @@
 <%= turbo_frame_tag Avo::MODAL_FRAME_ID do %>
-  <%= render(Avo::ModalComponent.new(width: @modal_width, height: @modal_height, body_class: "bg-backgrund")) do |c| %>
-    <%= tag.div class: @wrapper_class do %>
-      <%= yield %>
+  <% if params[:via_belongs_to_resource_class].present? %>
+    <%# Belongs-to "Create new" flow: the edit component renders its own modal
+        (title + footer controls) so the form can wrap the modal natively. %>
+    <%= yield %>
+  <% else %>
+    <%= render(Avo::ModalComponent.new(width: @modal_width, height: @modal_height, body_class: "bg-background")) do |c| %>
+      <%= tag.div class: @wrapper_class do %>
+        <%= yield %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/spec/dummy/test/components/previews/u_i/count_component_preview.rb
+++ b/spec/dummy/test/components/previews/u_i/count_component_preview.rb
@@ -1,0 +1,16 @@
+module UI
+  class CountComponentPreview < ViewComponent::Preview
+    # Count
+    # -----
+    # A compact numeric pill that sits next to a label or title — used for the
+    # active-filter count on the filters bar, unread-notification counts, etc.
+    #
+    # @param count number 3
+    def default(count: 3)
+      render_with_template(
+        template: "u_i/count_component_preview/default",
+        locals: { count: count }
+      )
+    end
+  end
+end

--- a/spec/dummy/test/components/previews/u_i/count_component_preview/default.html.erb
+++ b/spec/dummy/test/components/previews/u_i/count_component_preview/default.html.erb
@@ -1,0 +1,21 @@
+<div class="flex items-center gap-6 p-6">
+  <span class="text-sm text-content">
+    Dynamic
+    <%= render Avo::UI::CountComponent.new(count: count, classes: "ms-1") %>
+  </span>
+
+  <span class="text-sm text-content">
+    Single digit
+    <%= render Avo::UI::CountComponent.new(count: 3, classes: "ms-1") %>
+  </span>
+
+  <span class="text-sm text-content">
+    Double digit
+    <%= render Avo::UI::CountComponent.new(count: 12, classes: "ms-1") %>
+  </span>
+
+  <span class="text-sm text-content">
+    Large
+    <%= render Avo::UI::CountComponent.new(count: 99, classes: "ms-1") %>
+  </span>
+</div>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes the create belongs to in modal displays issue and a few other things.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core resource edit/modal rendering and form submission paths for belongs-to creation; layout/CSS changes are localized but user-facing across modals and filters.
> 
> **Overview**
> **Belongs-to “Create new”** now renders the related record form inside a modal owned by `ResourceEditComponent` (title, `4xl` width, footer controls) with the **form wrapping the modal** so submit works natively. The modal layout **yields without an outer** `ModalComponent` when `via_belongs_to_resource_class` is set; belongs-to links only pass `modal_layout: true` (no full-screen modal args). Panel headers are omitted in that flow, and **`modal-form-body`** padding styles the embedded form.
> 
> **Modal CSS** caps height to the viewport and uses a flex/`min-h-0` chain so tall modals scroll in the body while header/footer stay fixed. **Filter active counts** move to reusable **`Avo::UI::CountComponent`** (`.count` styles). Minor UI fixes: boolean field help margin, navbar link selector scoped to `.header-menu`, optional notifications bell, and typo fix `bg-backgrund` → `bg-background` for non–belongs-to modals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b91cbcdc6f2f4351da1acd208741313f6dd05153. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->