### PR TITLE
Fix tags input text color

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -97,6 +97,7 @@
 
 @import "./css/components/ui/checkbox.css";
 @import "./css/components/tooltip.css";
+@import "./css/fields/tags.css";
 
 /* variables.css uses explicit @layer theme { .dark } and @layer components
    { .neutral-theme-*, .accent-theme-* } blocks internally. Importing it OUTSIDE
@@ -125,7 +126,6 @@
   @import "./css/fields/progress.css";
   @import "./css/fields/key_value.css";
   @import "./css/fields/trix.css";
-  @import "./css/fields/tags.css";
   @import "./css/fields/tiptap.css";
   @import "./css/fields/stars.css";
 

--- a/app/assets/stylesheets/css/fields/tags.css
+++ b/app/assets/stylesheets/css/fields/tags.css
@@ -8,6 +8,11 @@ tags.tagify {
   --tags-focus-border-color: var(--color-primary);
   --placeholder-color: var(--color-content-secondary);
   --placeholder-color-focus: var(--color-content-secondary);
+  --tag-text-color: var(--color-content);
+  --tag-text-color--edit: var(--color-content);
+  --tag-remove-btn-color: var(--color-content);
+  --tag-bg: var(--color-secondary);
+  --tag-hover: var(--color-tertiary);
 
   padding-block: var(--input-py);
   align-items: center;

--- a/spec/system/avo/group_2/tags_spec.rb
+++ b/spec/system/avo/group_2/tags_spec.rb
@@ -152,6 +152,37 @@ RSpec.describe "Tags", type: :system do
     end
   end
 
+  describe "placeholder color (AVO-1272)" do
+    let(:field_value_slot) { tags_element(find_field_value_element("user_id")) }
+
+    it "uses the design-system token instead of tagify's hardcoded default" do
+      visit "/admin/resources/users/#{admin.slug}"
+      open_panel_action(action_name: "Toggle inactive")
+
+      # Ensure the tagify element is in the DOM before reading computed styles.
+      expect(field_value_slot).to have_selector("span[contenteditable]")
+
+      tagify_default = "rgba(0, 0, 0, 0.4)"
+
+      expected_color = page.evaluate_script(<<~JS)
+        getComputedStyle(document.documentElement).getPropertyValue('--color-content-secondary').trim()
+      JS
+
+      placeholder_var = page.evaluate_script(<<~JS)
+        getComputedStyle(document.querySelector('[role="dialog"] tags.tagify')).getPropertyValue('--placeholder-color').trim()
+      JS
+
+      pseudo_color = page.evaluate_script(<<~JS)
+        getComputedStyle(document.querySelector('[role="dialog"] tags.tagify .tagify__input'), '::before').getPropertyValue('color').trim()
+      JS
+
+      expect(expected_color).not_to be_empty
+      expect(placeholder_var).not_to eq(tagify_default)
+      expect(pseudo_color).not_to eq(tagify_default)
+      expect(placeholder_var).to eq(expected_color)
+    end
+  end
+
   describe "fetch labels" do
     let!(:users) { create_list :user, 2 }
     let!(:courses) { create_list :course, 2, skills: users.pluck(:id) }


### PR DESCRIPTION
# Description
 Tagify ships unlayered, so our @layer components overrides on tags.tagify lost the cascade and the placeholder was invisible on dark. Moved tags.css out of the layer (specificity now wins) and added the missing variable overrides (--tag-text-color, --tag-bg, --tag-hover, --tag-remove-btn-color) so selected tags and the × button also use design tokens. Spec asserts the resolved --placeholder-color matches --color-content-secondary.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<img width="627" height="89" alt="Screenshot 2026-05-27 at 20 14 37" src="https://github.com/user-attachments/assets/c341dac7-f569-4765-99df-11751cc241d0" />
<img width="626" height="231" alt="Screenshot 2026-05-27 at 20 15 12" src="https://github.com/user-attachments/assets/47ddf58d-1150-47ab-a9a9-49754e025aff" />
