### PR TITLE
feature: customizable chrome CSS variables, badge FOUC + CSP fixes

### DIFF
--- a/app/assets/stylesheets/css/components/breadcrumbs.css
+++ b/app/assets/stylesheets/css/components/breadcrumbs.css
@@ -1,5 +1,5 @@
 .breadcrumbs {
-  @apply sticky z-40 w-full bg-primary mb-4;
+  @apply sticky z-40 w-full bg-(--color-main-content-background) mb-4;
   /* top: calc(var(--top-navbar-height) + var(--spacing) * 4); */
   top: calc(var(--top-navbar-height) + var(--spacing) * 2);
   margin-top: --spacing(-2);
@@ -14,7 +14,7 @@
     right: 0;
     height: calc(0.5rem);
     transform: translateY(-100%);
-    background: var(--color-primary);
+    background: var(--color-main-content-background);
     pointer-events: none;
   }
 }
@@ -32,8 +32,8 @@
   height: --spacing(4);
   background: linear-gradient(
     to bottom,
-    var(--color-primary),
-    color-mix(in oklab, var(--color-primary), transparent 100%)
+    var(--color-main-content-background),
+    color-mix(in oklab, var(--color-main-content-background), transparent 100%)
   );
   pointer-events: none;
 }

--- a/app/assets/stylesheets/css/components/color_scheme_switcher.css
+++ b/app/assets/stylesheets/css/components/color_scheme_switcher.css
@@ -115,9 +115,9 @@
   @apply bg-primary text-content shadow-sm;
 }
 
-/* Shortcut badge buttons - active state mirrors body.hotkeys-hide-badges. */
-body:not(.hotkeys-hide-badges) .color-scheme-switcher__scheme-button[data-key-badges="show"],
-body.hotkeys-hide-badges .color-scheme-switcher__scheme-button[data-key-badges="hide"] {
+/* Shortcut badge buttons - active state mirrors :root.hotkeys-hide-badges. */
+:root:not(.hotkeys-hide-badges) .color-scheme-switcher__scheme-button[data-key-badges="show"],
+:root.hotkeys-hide-badges .color-scheme-switcher__scheme-button[data-key-badges="hide"] {
   @apply bg-primary text-content shadow-sm;
 }
 

--- a/app/assets/stylesheets/css/layout.css
+++ b/app/assets/stylesheets/css/layout.css
@@ -1,9 +1,7 @@
 @theme {
   --top-navbar-height: 3rem;
 
-  --navbar-bg: var(--color-avo-neutral-900);
-  --navbar-notch-radius: 1rem;
-  --navbar-notch-color: var(--navbar-bg);
+  --navbar-notch-color: var(--color-navbar-background);
 
   --border-color: var(--color-tertiary);
 }
@@ -66,7 +64,7 @@
 }
 
 .main-content {
-  @apply w-(--content-width) flex flex-col bg-primary py-2 lg:py-4 px-2 lg:px-4 border-s border-(--border-color) ms-1 rounded-se-(--navbar-notch-radius) rounded-ss-(--navbar-notch-radius);
+  @apply w-(--content-width) flex flex-col bg-(--color-main-content-background) py-2 lg:py-4 px-2 lg:px-4 border-s border-(--color-main-content-border) ms-1 rounded-se-(--navbar-notch-radius) rounded-ss-(--navbar-notch-radius);
 
   transition: margin 0.1s ease-in-out, width 0.1s ease-in-out;
   min-height: calc(100dvh - var(--top-navbar-height) - var(--spacing));
@@ -101,7 +99,7 @@
   gap: 0.75rem;
   padding-inline: 0.5rem;
 
-  background-color: var(--navbar-bg);
+  background-color: var(--color-navbar-background);
 
   > * {
     @apply pointer-events-auto;
@@ -125,6 +123,17 @@
     height: var(--navbar-notch-radius);
     pointer-events: none;
     /* border: 1px solid red; */
+  }
+
+  /* Hide the arches when --navbar-notch-enabled is false. A style query lets the
+     variable read like a boolean (true/false) instead of exposing raw CSS
+     display keywords. The pseudo-elements query their originating element
+     (.top-navbar), which inherits --navbar-notch-enabled from :root. */
+  @container style(--navbar-notch-enabled: false) {
+    &::before,
+    &::after {
+      display: none;
+    }
   }
 
   &::before {

--- a/app/assets/stylesheets/css/variables.css
+++ b/app/assets/stylesheets/css/variables.css
@@ -73,7 +73,44 @@
   --color-brand-accent: oklch(39.04% 0 89.88);
 
   /* Semantic variables */
+
+  /* Sidebar background. Dedicated knob so installs can recolor the sidebar
+     independently of the neutral palette. Defaults to the page background in
+     light mode and a subtly tinted surface in dark (see the .dark override). */
   --color-sidebar-background: var(--color-background);
+
+  /* Top navbar background. Dedicated knob so installs can recolor the navbar
+     without touching the neutral palette. Defaults to the page background so
+     the navbar blends with the canvas; resolves per-scheme automatically since
+     --color-background is itself redefined in .dark. Override it (here or in
+     `.dark`) to give the navbar its own color. */
+  --color-navbar-background: var(--color-avo-neutral-900);
+
+  /* Background of the main content panel. Dedicated knob so installs can recolor
+     the content surface independently of the primary surface token. Defaults to
+     --color-primary; resolves per-scheme since --color-primary is redefined in
+     .dark. */
+  --color-main-content-background: var(--color-primary);
+
+  /* Border between the sidebar and the main content panel. Dedicated knob so
+     installs can restyle just this seam without touching the shared
+     --border-color (which also draws the sidebar-status borders). Tracks
+     --border-color by default, so it resolves per-scheme automatically. */
+  --color-main-content-border: var(--border-color);
+}
+
+/* Navbar notch knobs live in a plain :root block, not in @theme:
+   --navbar-notch-enabled is read by a style query (Tailwind tree-shakes @theme
+   vars not referenced via var(), so it would be stripped), and we keep
+   --navbar-notch-radius alongside it so both notch knobs sit together. */
+:root {
+  /* Set to `false` to hide the navbar's inverted corner arches (e.g. when the
+     navbar and content share a background). */
+  --navbar-notch-enabled: true;
+
+  /* Radius of the content panel's rounded top corners (and the matching navbar
+     arches that fill them). Set to `0` to flatten the corners entirely. */
+  --navbar-notch-radius: 1rem;
 }
 
 /* Dark mode defaults live in @layer theme — same layer as the @theme block

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -80,19 +80,8 @@ document.addEventListener('turbo:frame-render', (e) => {
 })
 
 document.addEventListener('turbo:load', () => {
-  // Restore badge visibility preference from localStorage before installing hotkeys
-  if (window.Avo?.configuration?.hotkeys?.showKeyBadges !== false) {
-    try {
-      if (localStorage.getItem('avo:hotkeys:hide_badges') === '1') {
-        document.body.classList.add('hotkeys-hide-badges')
-      } else {
-        document.body.classList.remove('hotkeys-hide-badges')
-      }
-    } catch (e) {
-      // localStorage unavailable
-    }
-  }
-
+  // Badge visibility preference is restored pre-paint on <html> in
+  // _color_theme_override.html.erb; the class persists across Turbo navigations.
   if (window.Avo?.configuration?.hotkeys?.enabled !== false) installHotkeys()
   initTippy()
 

--- a/app/javascript/js/controllers.js
+++ b/app/javascript/js/controllers.js
@@ -11,6 +11,7 @@ import CheckboxListFieldController from './controllers/fields/checkbox_list_fiel
 import ClearInputController from './controllers/fields/clear_input_controller'
 import CodeFieldController from './controllers/fields/code_field_controller'
 import AppearanceController from './controllers/appearance_controller'
+import AppearancePreviewController from './controllers/appearance_preview_controller'
 import ConfirmDialogController from './controllers/confirm_dialog_controller'
 import CopyToClipboardController from './controllers/copy_to_clipboard_controller'
 import DashboardCardController from './controllers/dashboard_card_controller'
@@ -77,6 +78,7 @@ application.register('boolean-filter', BooleanFilterController)
 application.register('card-filters', CardFiltersController)
 application.register('clear-input', ClearInputController)
 application.register('appearance', AppearanceController)
+application.register('appearance-preview', AppearancePreviewController)
 application.register('copy-to-clipboard', CopyToClipboardController)
 application.register('dashboard-card', DashboardCardController)
 application.register('date-time-filter', DateTimeFilterController)

--- a/app/javascript/js/controllers/appearance_controller.js
+++ b/app/javascript/js/controllers/appearance_controller.js
@@ -327,14 +327,14 @@ export default class extends Controller {
   }
 
   // Mirrors the Shift+K hotkey in global_hotkeys.js. CSS handles the active
-  // state via [data-key-badges] selectors against `body.hotkeys-hide-badges`.
+  // state via [data-key-badges] selectors against `:root.hotkeys-hide-badges`.
   setKeyBadges(event) {
     event.preventDefault()
     const { keyBadges } = event.currentTarget.dataset
     if (keyBadges !== 'show' && keyBadges !== 'hide') return
 
     const hide = keyBadges === 'hide'
-    document.body.classList.toggle('hotkeys-hide-badges', hide)
+    document.documentElement.classList.toggle('hotkeys-hide-badges', hide)
     try {
       if (hide) {
         localStorage.setItem('avo:hotkeys:hide_badges', '1')

--- a/app/javascript/js/controllers/appearance_preview_controller.js
+++ b/app/javascript/js/controllers/appearance_preview_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Powers the internal color-token reference page (private#appearance): tab
+// switching between token panels and click-to-copy on swatches, with a shared
+// "Copied!" toast. Replaces the page's former inline <script> + onclick handlers
+// so the page stays CSP-safe (no inline script execution).
+export default class extends Controller {
+  static targets = ['indicator']
+
+  switchTab(event) {
+    event.preventDefault()
+    const button = event.currentTarget
+    const group = button.closest('.tabs')
+    const container = group.parentElement
+
+    container.querySelectorAll('.tab-content').forEach((tab) => tab.classList.remove('active'))
+    group.querySelectorAll('.tab-button').forEach((btn) => btn.classList.remove('active'))
+
+    document.getElementById(button.dataset.tab)?.classList.add('active')
+    button.classList.add('active')
+  }
+
+  copy(event) {
+    const { copyText } = event.currentTarget.dataset
+    if (!copyText) return
+
+    navigator.clipboard.writeText(copyText).then(() => {
+      if (!this.hasIndicatorTarget) return
+
+      this.indicatorTarget.classList.add('show')
+      setTimeout(() => this.indicatorTarget.classList.remove('show'), 2000)
+    })
+  }
+}

--- a/app/javascript/js/global_hotkeys.js
+++ b/app/javascript/js/global_hotkeys.js
@@ -97,8 +97,8 @@ const DIRECT_HOTKEYS = [
     match: (e) => e.shiftKey && e.key === 'K'
       && window.Avo?.configuration?.hotkeys?.showKeyBadges !== false,
     handle: () => {
-      document.body.classList.toggle('hotkeys-hide-badges')
-      const hidden = document.body.classList.contains('hotkeys-hide-badges')
+      document.documentElement.classList.toggle('hotkeys-hide-badges')
+      const hidden = document.documentElement.classList.contains('hotkeys-hide-badges')
       try {
         if (hidden) {
           localStorage.setItem('avo:hotkeys:hide_badges', '1')

--- a/app/views/avo/partials/_color_theme_override.html.erb
+++ b/app/views/avo/partials/_color_theme_override.html.erb
@@ -6,6 +6,19 @@
     var root = document.documentElement;
     var appearance = window.Avo && window.Avo.configuration && window.Avo.configuration.appearance || {};
 
+    // Restore the kbd-badge visibility preference (Shift+K) before paint so a
+    // hidden set of badges never flashes in. It's a per-client preference, so it
+    // lives in localStorage rather than a cookie; the class sits on <html> next
+    // to the theme classes, which also lets it persist across Turbo navigations.
+    var hotkeys = window.Avo && window.Avo.configuration && window.Avo.configuration.hotkeys || {};
+    if (hotkeys.showKeyBadges !== false) {
+      try {
+        if (localStorage.getItem('avo:hotkeys:hide_badges') === '1') {
+          root.classList.add('hotkeys-hide-badges');
+        }
+      } catch (e) {}
+    }
+
     if (appearance.persistence !== 'database') {
       function getCookie(name) {
         var value = '; ' + document.cookie;

--- a/app/views/avo/private/appearance.html.erb
+++ b/app/views/avo/private/appearance.html.erb
@@ -286,7 +286,7 @@
   }
 </style>
 
-<div class="flex flex-col">
+<div class="flex flex-col" data-controller="appearance-preview">
   <%= render ui.panel(title: 'Color Tokens', description: 'Avo design system color variables for Light and Dark modes. Click any swatch to copy the CSS variable name.') do |panel| %>
     <% panel.with_body do %>
       <div class="flex flex-col gap-6">
@@ -296,14 +296,14 @@
           <p class="section-subtitle">Base colors used for layout and structure</p>
 
           <div class="tabs" id="foundations-tabs">
-            <button class="tab-button active" data-tab="foundations-light">☀️ Light Mode</button>
-            <button class="tab-button" data-tab="foundations-dark">🌙 Dark Mode</button>
+            <button data-action="click->appearance-preview#switchTab" class="tab-button active" data-tab="foundations-light">☀️ Light Mode</button>
+            <button data-action="click->appearance-preview#switchTab" class="tab-button" data-tab="foundations-dark">🌙 Dark Mode</button>
           </div>
 
           <div id="foundations-light" class="tab-content active">
             <div class="color-group">
               <% @foundation_tokens.each do |color| %>
-                <div class="color-swatch" onclick="copyToClipboard('<%= color[:name] %>')">
+                <div class="color-swatch" data-action="click->appearance-preview#copy" data-copy-text="<%= color[:name] %>">
                   <div class="swatch-color" style="background-color: var(<%= color[:name] %>)"></div>
                   <div class="swatch-info">
                     <div class="swatch-label"><%= color[:name] %></div>
@@ -321,7 +321,7 @@
             <div class="dark">
               <div class="color-group">
                 <% @foundation_tokens.each do |color| %>
-                  <div class="color-swatch" onclick="copyToClipboard('<%= color[:name] %>')">
+                  <div class="color-swatch" data-action="click->appearance-preview#copy" data-copy-text="<%= color[:name] %>">
                     <div class="swatch-color" style="background-color: var(<%= color[:name] %>)"></div>
                     <div class="swatch-info">
                       <div class="swatch-label"><%= color[:name] %></div>
@@ -339,7 +339,7 @@
           <h4 class="section-header" style="font-size: 0.95rem;">Neutral Scale</h4>
           <div class="neutral-scale">
             <% @neutral_scale.each do |item| %>
-              <div class="neutral-swatch" onclick="copyToClipboard('--color-avo-neutral-<%= item[:name] %>')">
+              <div class="neutral-swatch" data-action="click->appearance-preview#copy" data-copy-text="--color-avo-neutral-<%= item[:name] %>">
                 <div class="neutral-color" style="background-color: var(<%= item[:css_var] %>)"></div>
                 <div class="neutral-info">
                   <div class="neutral-label"><%= item[:name] %></div>
@@ -356,7 +356,7 @@
               <div class="accent-group">
                 <div class="accent-group-label" style="text-transform: capitalize;"><%= color[:name] %></div>
                 <div class="accent-group-swatches">
-                  <div class="neutral-swatch" onclick="copyToClipboard('--color-<%= color[:name] %>-500')">
+                  <div class="neutral-swatch" data-action="click->appearance-preview#copy" data-copy-text="--color-<%= color[:name] %>-500">
                     <div class="neutral-color" style="background-color: var(--color-<%= color[:name] %>-500)"></div>
                     <div class="neutral-info">
                       <div class="neutral-label">500</div>
@@ -364,7 +364,7 @@
                     </div>
                   </div>
 
-                  <div class="neutral-swatch" onclick="copyToClipboard('--color-<%= color[:name] %>-600')">
+                  <div class="neutral-swatch" data-action="click->appearance-preview#copy" data-copy-text="--color-<%= color[:name] %>-600">
                     <div class="neutral-color" style="background-color: var(--color-<%= color[:name] %>-600)"></div>
                     <div class="neutral-info">
                       <div class="neutral-label">600</div>
@@ -372,7 +372,7 @@
                     </div>
                   </div>
 
-                  <div class="neutral-swatch" onclick="copyToClipboard('--color-white')">
+                  <div class="neutral-swatch" data-action="click->appearance-preview#copy" data-copy-text="--color-white">
                     <div class="neutral-color" style="background-color: var(--color-white)"></div>
                     <div class="neutral-info">
                       <div class="neutral-label">fg</div>
@@ -391,10 +391,10 @@
           <p class="section-subtitle">Brand colors used for emphasis and accent elements</p>
 
           <div class="tabs" id="accents-tabs">
-            <button class="tab-button active" data-tab="accents-default">◼️ Default</button>
-            <button class="tab-button" data-tab="accents-light">☀️ Light Mode</button>
-            <button class="tab-button" data-tab="accents-dark">🌙 Dark Mode</button>
-            <button class="tab-button" data-tab="accents-options">🎨 All Colors</button>
+            <button data-action="click->appearance-preview#switchTab" class="tab-button active" data-tab="accents-default">◼️ Default</button>
+            <button data-action="click->appearance-preview#switchTab" class="tab-button" data-tab="accents-light">☀️ Light Mode</button>
+            <button data-action="click->appearance-preview#switchTab" class="tab-button" data-tab="accents-dark">🌙 Dark Mode</button>
+            <button data-action="click->appearance-preview#switchTab" class="tab-button" data-tab="accents-options">🎨 All Colors</button>
           </div>
 
           <div id="accents-default" class="tab-content active">
@@ -402,7 +402,7 @@
               <div class="accent-group-label">Light Mode</div>
               <div class="accent-cards accent-cards--detailed">
                 <% @accent_tokens.each do |color| %>
-                  <div class="accent-card accent-card--detailed" onclick="copyToClipboard('<%= color[:name] %>')">
+                  <div class="accent-card accent-card--detailed" data-action="click->appearance-preview#copy" data-copy-text="<%= color[:name] %>">
                     <div class="accent-swatch-color" style="background-color: <%= color[:value] %>">
                       <%= color[:name].sub('--color-', '') %>
                     </div>
@@ -420,7 +420,7 @@
               <div class="dark">
                 <div class="accent-cards accent-cards--detailed">
                   <% @accent_tokens.each do |color| %>
-                    <div class="accent-card accent-card--detailed" onclick="copyToClipboard('<%= color[:name] %>')">
+                    <div class="accent-card accent-card--detailed" data-action="click->appearance-preview#copy" data-copy-text="<%= color[:name] %>">
                       <div class="accent-swatch-color" style="background-color: <%= color[:value] %>">
                         <%= color[:name].sub('--color-', '') %>
                       </div>
@@ -440,7 +440,7 @@
           <div id="accents-light" class="tab-content">
             <div class="accent-cards accent-cards--detailed">
               <% @accent_tokens.each do |color| %>
-                <div class="accent-card accent-card--detailed" onclick="copyToClipboard('<%= color[:name] %>')">
+                <div class="accent-card accent-card--detailed" data-action="click->appearance-preview#copy" data-copy-text="<%= color[:name] %>">
                   <div class="accent-swatch-color" style="background-color: <%= color[:value] %>">
                     <%= color[:name].sub('--color-', '') %>
                   </div>
@@ -459,7 +459,7 @@
             <div class="dark">
               <div class="accent-cards accent-cards--detailed">
                 <% @accent_tokens.each do |color| %>
-                  <div class="accent-card accent-card--detailed" onclick="copyToClipboard('<%= color[:name] %>')">
+                  <div class="accent-card accent-card--detailed" data-action="click->appearance-preview#copy" data-copy-text="<%= color[:name] %>">
                     <div class="accent-swatch-color" style="background-color: <%= color[:value] %>">
                       <%= color[:name].sub('--color-', '') %>
                     </div>
@@ -478,7 +478,7 @@
           <div id="accents-options" class="tab-content">
             <div class="accent-cards">
               <% @accent_options.each do |color| %>
-                <div class="accent-card" onclick="copyToClipboard('--color-<%= color[:name] %>-500')">
+                <div class="accent-card" data-action="click->appearance-preview#copy" data-copy-text="--color-<%= color[:name] %>-500">
                   <div class="accent-swatch-color" style="background-color: var(--color-<%= color[:name] %>-500)"></div>
                   <div class="accent-swatch-info">
                     <div class="accent-name"><%= color[:name] %></div>
@@ -491,41 +491,6 @@
       </div>
     <% end %>
   <% end %>
+
+  <div class="copy-indicator" data-appearance-preview-target="indicator">Copied to clipboard!</div>
 </div>
-
-<div class="copy-indicator" id="copyIndicator">Copied to clipboard!</div>
-
-<script>
-  // Tab switching
-  document.querySelectorAll('.tab-button').forEach(button => {
-    button.addEventListener('click', function(event) {
-      event.preventDefault();
-      const tabId = this.dataset.tab;
-      const tabGroup = this.closest('.tabs');
-      const tabContainer = tabGroup.parentElement;
-
-      // Hide all tabs in this group
-      tabContainer.querySelectorAll('.tab-content').forEach(tab => {
-        tab.classList.remove('active');
-      });
-
-      // Deactivate all buttons in this group
-      tabGroup.querySelectorAll('.tab-button').forEach(btn => {
-        btn.classList.remove('active');
-      });
-
-      // Show selected tab and activate button
-      document.getElementById(tabId).classList.add('active');
-      this.classList.add('active');
-    });
-  });
-
-  // Copy to clipboard
-  function copyToClipboard(text) {
-    navigator.clipboard.writeText(text).then(() => {
-      const indicator = document.getElementById('copyIndicator');
-      indicator.classList.add('show');
-      setTimeout(() => indicator.classList.remove('show'), 2000);
-    });
-  }
-</script>

--- a/spec/system/avo/group_1/hotkey_spec.rb
+++ b/spec/system/avo/group_1/hotkey_spec.rb
@@ -112,18 +112,18 @@ RSpec.describe "Keyboard shortcuts", type: :system do
     expect(page).to have_css(".hotkey[hidden]", visible: false)
   end
 
-  it "toggles the hotkeys-hide-badges body class when pressing Shift+K" do
+  it "toggles the hotkeys-hide-badges class on the html element when pressing Shift+K" do
     visit "/admin/resources/projects"
 
     expect(page).to have_css('[data-hotkey="r u"] .hotkey-badge kbd', visible: :all)
     expect(page).to have_css(".search-input__suffix kbd", visible: :all, count: 1)
-    expect(page).to have_no_css("body.hotkeys-hide-badges")
+    expect(page).to have_no_css("html.hotkeys-hide-badges")
 
     dispatch_keydown("K", shift_key: true)
-    expect(page).to have_css("body.hotkeys-hide-badges")
+    expect(page).to have_css("html.hotkeys-hide-badges")
 
     dispatch_keydown("K", shift_key: true)
-    expect(page).to have_no_css("body.hotkeys-hide-badges")
+    expect(page).to have_no_css("html.hotkeys-hide-badges")
   end
 
   it "applies kbd--called animation feedback when a hotkey fires" do


### PR DESCRIPTION
## Summary

Makes Avo's chrome — top navbar, sidebar, main content panel, breadcrumbs — recolorable through dedicated CSS custom properties, and fixes two latent issues in the same surface area: a flash of the keyboard-badge state on load, and a CSP-unsafe inline script on the internal appearance page. Each piece is an independent commit.

## Customizable chrome CSS variables

New overridable custom properties, defined in `variables.css` alongside the existing theme tokens, so installs can recolor the chrome without ejecting from Avo's theming:

| Variable | Default | Controls |
|----------|---------|----------|
| `--color-navbar-background` | `var(--color-avo-neutral-900)` | Top navbar background |
| `--color-sidebar-background` | `var(--color-background)` | Sidebar background |
| `--color-main-content-background` | `var(--color-primary)` | Main content panel (and breadcrumb bar) |
| `--color-main-content-border` | `var(--border-color)` | Sidebar / content seam |
| `--navbar-notch-enabled` | `true` | Whether the navbar corner arches render |
| `--navbar-notch-radius` | `1rem` | Content panel rounded-corner radius (`0` flattens) |

Each defaults to an existing token, so the rendered appearance is unchanged, and resolves per-scheme automatically (the underlying tokens are themselves redefined in `.dark`). The breadcrumb bar and its fade pseudo-elements now track `--color-main-content-background` so they stay seamless when it's overridden. `--navbar-notch-enabled` is read via a CSS style query, giving it a readable `true`/`false` API rather than raw `display` values.

## Hotkey badge visibility: no FOUC

The Shift+K "hide badges" preference is per-client (`localStorage`) but was re-applied on `turbo:load` — after paint — so anyone who'd hidden their badges saw them flash in on every load. The `hotkeys-hide-badges` class moves from `<body>` to `<html>` and is restored pre-paint in `_color_theme_override`, next to the existing theme/scheme restore. As a bonus, the class now persists across Turbo navigations like the theme classes, so the post-paint restore is removed entirely.

## Appearance page CSP fix

The internal `private#appearance` reference page used an inline `<script>` plus inline `onclick` handlers — both blocked under a strict `script-src`. Tab switching and click-to-copy now live in a new `appearance-preview` Stimulus controller, removing all inline script execution from the page.

## Test plan

- `spec/system/avo/group_1/hotkey_spec.rb` updated to assert the badge class on `<html>`; passing.
- Appearance preview page (developer/admin-only, no spec coverage): tabs switch and swatches copy via the new controller.

---

[![Compound Engineering v2.59.0](https://img.shields.io/badge/Compound_Engineering-v2.59.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual/theming and client-preference behavior only; defaults preserve current look and hotkey specs were updated.
> 
> **Overview**
> Adds **overridable chrome CSS variables** (`--color-navbar-background`, `--color-main-content-background`, `--color-main-content-border`, `--navbar-notch-enabled`, `--navbar-notch-radius`, etc.) and wires navbar, main panel, and breadcrumbs to them. Navbar corner arches can be turned off via a **style query** on `--navbar-notch-enabled`.
> 
> **Shift+K badge hiding** moves from `body` to `<html>` (`:root.hotkeys-hide-badges`), restored **pre-paint** in `_color_theme_override.html.erb` from `localStorage`, with the redundant `turbo:load` restore removed from `application.js`.
> 
> The internal **appearance** token page drops inline scripts/`onclick` in favor of an **`appearance-preview`** Stimulus controller (tabs + copy-to-clipboard). System spec asserts the badge class on `html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ad31873decf21a75e72ebd2d0b402b1f4231ac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->