### PR TITLE
fix: tags pill reacts to dark/light mode

### DIFF
--- a/app/components/avo/fields/tags_field/tag_component.html.erb
+++ b/app/components/avo/fields/tags_field/tag_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div class: "flex px-2 py-0.5 rounded-sm bg-gray-100 text-sm text-gray-800 font-normal shrink-0",
+<%= tag.div class: "flex px-2 py-0.5 rounded-sm bg-secondary text-sm text-content font-normal shrink-0",
   data: {
     target: "tag-component",
     tippy: (@title.present? ? "tooltip" : nil),


### PR DESCRIPTION
## Summary
- Swap hardcoded `bg-gray-100 text-gray-800` on the tags field pill (`Avo::Fields::TagsField::TagComponent`) for `bg-secondary text-content`.
- Pills used on the show, edit (preview), and index views now follow the design tokens already wired into light & dark themes, matching the Tagify input overrides in `app/assets/stylesheets/css/fields/tags.css`.

## Test plan
- [ ] Open a resource with a tags field; verify pills on **Index**, **Show**, and **Edit** views in **light mode** look unchanged.
- [ ] Toggle **dark mode**; verify the pills now use the secondary surface / content text tokens instead of staying light gray.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single presentation-class change in a shared tag pill component with no auth, data, or API impact.
> 
> **Overview**
> Tags field pills in `TagComponent` no longer use fixed `bg-gray-100` / `text-gray-800` classes. They now use **`bg-secondary`** and **`text-content`**, so the same pill markup on index, show, and edit follows light/dark theme tokens (aligned with Tagify styling in `tags.css`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8197da259e80340829814fb5c3b58dccd6585d82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->