### PR TITLE
fix: field components react to dark/light via design tokens

### DIFF
--- a/app/assets/stylesheets/css/fields/stars.css
+++ b/app/assets/stylesheets/css/fields/stars.css
@@ -1,10 +1,10 @@
 [data-component="avo/fields/common/stars_component"] {
     .star {
-      @apply h-5 w-5 text-gray-300 transition-colors;
+      @apply h-5 w-5 text-tertiary transition-colors;
     }
-  
+
     .star.filled {
-      @apply text-yellow-400;
+      @apply text-warning-foreground;
     }
   
     .rating-group {

--- a/app/components/avo/field_wrapper_component.html.erb
+++ b/app/components/avo/field_wrapper_component.html.erb
@@ -12,7 +12,7 @@
     <% else %>
       <%= @field.name %>
     <% end %>
-    <% if on_edit? && @field.is_required? %> <span class="text-red-600 ms-1">*</span> <% end %>
+    <% if on_edit? && @field.is_required? %> <span class="text-danger-content ms-1">*</span> <% end %>
     <% if label_help.present? %>
       <div class="field-wrapper__label-help"><%== label_help %></div>
     <% end %>

--- a/app/components/avo/fields/boolean_field/edit_component.html.erb
+++ b/app/components/avo/fields/boolean_field/edit_component.html.erb
@@ -21,8 +21,8 @@
         ) %>
 
       <% if as_toggle? %>
-        <div class="block w-10 h-6 rounded-full bg-gray-300 peer-checked:bg-green-500"></div>
-        <div class="dot absolute start-1 top-1 bg-white w-4 h-4 rounded-full transition-transform duration-200 transform peer-checked:translate-x-4"></div>
+        <div class="block w-10 h-6 rounded-full bg-tertiary peer-checked:bg-success"></div>
+        <div class="dot absolute start-1 top-1 bg-primary w-4 h-4 rounded-full transition-transform duration-200 transform peer-checked:translate-x-4"></div>
       <% end %>
     <% end %>
   </div>

--- a/app/components/avo/fields/common/boolean_check_component.rb
+++ b/app/components/avo/fields/common/boolean_check_component.rb
@@ -5,17 +5,17 @@ class Avo::Fields::Common::BooleanCheckComponent < Avo::BaseComponent
     true => {
       name: "checked",
       icon: "tabler/outline/circle-check",
-      color: "text-green-600"
+      color: "text-success-content"
     },
     false => {
       name: "unchecked",
       icon: "tabler/outline/circle-x",
-      color: "text-red-600"
+      color: "text-danger-content"
     },
     nil => {
       name: "indeterminate",
       icon: "tabler/outline/circle-minus",
-      color: "text-gray-400"
+      color: "text-content-secondary"
     }
   }.freeze
 

--- a/app/components/avo/fields/common/files/view_type/grid_item_component.html.erb
+++ b/app/components/avo/fields/common/files/view_type/grid_item_component.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= dom_id file %>" class="relative min-h-full max-w-full flex-1 flex flex-col justify-between space-y-2">
   <div class="flex flex-col h-full">
     <% if file.representable? && is_image? %>
-      <%= image_tag helpers.main_app.url_for(file), class: "rounded-lg max-w-full h-auto self-start #{@extra_classes}", loading: :lazy, width: file.metadata["width"], height: file.metadata["height"] %>
+      <%= image_tag helpers.main_app.url_for(file), class: "rounded-lg max-w-full h-auto self-start object-cover #{@extra_classes}", loading: :lazy, width: file.metadata["width"], height: file.metadata["height"] %>
     <% elsif is_audio? %>
       <%= audio_tag(helpers.main_app.url_for(file), controls: true, preload: false, class: 'w-full') %>
     <% elsif is_video? %>

--- a/app/components/avo/fields/common/files/view_type/grid_item_component.html.erb
+++ b/app/components/avo/fields/common/files/view_type/grid_item_component.html.erb
@@ -9,12 +9,12 @@
     <% else %>
       <%= content_tag file.representable? ? :a : :div, **document_arguments do %>
         <div class="flex flex-col justify-center items-center w-full">
-          <%= helpers.svg "tabler/outline/file-text", class: 'h-10 text-gray-600 mb-2' %>
+          <%= helpers.svg "tabler/outline/file-text", class: 'h-10 text-content-secondary mb-2' %>
         </div>
       <% end %>
     <% end %>
     <% if @field.display_filename %>
-      <span class="text-gray-500 mt-1 text-sm truncate" title="<%= file.filename %>"><%= file.filename %></span>
+      <span class="text-content-secondary mt-1 text-sm truncate" title="<%= file.filename %>"><%= file.filename %></span>
     <% end %>
   </div>
   <div class="flex space-x-2 rtl:space-x-reverse">

--- a/app/components/avo/fields/common/files/view_type/grid_item_component.html.erb
+++ b/app/components/avo/fields/common/files/view_type/grid_item_component.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= dom_id file %>" class="relative min-h-full max-w-full flex-1 flex flex-col justify-between space-y-2">
   <div class="flex flex-col h-full">
     <% if file.representable? && is_image? %>
-      <%= image_tag helpers.main_app.url_for(file), class: "rounded-lg max-w-full self-start #{@extra_classes}", loading: :lazy, width: file.metadata["width"], height: file.metadata["height"] %>
+      <%= image_tag helpers.main_app.url_for(file), class: "rounded-lg max-w-full h-auto self-start #{@extra_classes}", loading: :lazy, width: file.metadata["width"], height: file.metadata["height"] %>
     <% elsif is_audio? %>
       <%= audio_tag(helpers.main_app.url_for(file), controls: true, preload: false, class: 'w-full') %>
     <% elsif is_video? %>

--- a/app/components/avo/fields/common/files/view_type/grid_item_component.rb
+++ b/app/components/avo/fields/common/files/view_type/grid_item_component.rb
@@ -51,9 +51,9 @@ class Avo::Fields::Common::Files::ViewType::GridItemComponent < Avo::BaseCompone
   def document_arguments
     args = {
       class: class_names(
-        "relative flex flex-col justify-evenly items-center px-2 rounded-lg border bg-white border-gray-500 min-h-24",
+        "relative flex flex-col justify-evenly items-center px-2 rounded-lg border bg-primary border-tertiary min-h-24",
         {
-          "hover:bg-gray-100 transition": file.representable?
+          "hover:bg-secondary transition": file.representable?
         }
       )
     }

--- a/app/components/avo/fields/common/status_viewer_component.html.erb
+++ b/app/components/avo/fields/common/status_viewer_component.html.erb
@@ -1,4 +1,4 @@
-<div class=" <%= class_names("flex shrink-0 items-center", "text-red-600": @status == 'failed', "text-green-600": @status == 'success', "text-gray-600": @status == 'neutral') %>">
+<div class=" <%= class_names("flex shrink-0 items-center", "text-danger-content": @status == 'failed', "text-success-content": @status == 'success', "text-content-secondary": @status == 'neutral') %>">
   <% if @status == 'success' %>
     <%= helpers.svg 'tabler/filled/circle-check', class: 'h-4' %>
   <% elsif @status == 'failed' %>

--- a/app/components/avo/fields/file_field/edit_component.html.erb
+++ b/app/components/avo/fields/file_field/edit_component.html.erb
@@ -31,7 +31,7 @@
         %>
       <% end %>
       <%= content_tag :button,
-          class: "self-center hidden font-semibold text-xs text-red-600 p-1 cursor-pointer mt-2",
+          class: "self-center hidden font-semibold text-xs text-danger-content p-1 cursor-pointer mt-2",
           id: :reset,
           type: :button,
           data: {

--- a/app/components/avo/fields/files_field/edit_component.html.erb
+++ b/app/components/avo/fields/files_field/edit_component.html.erb
@@ -26,7 +26,7 @@
         %>
       <% end %>
       <%= content_tag :button,
-          class: "self-center hidden font-semibold text-xs text-red-600 p-1 cursor-pointer",
+          class: "self-center hidden font-semibold text-xs text-danger-content p-1 cursor-pointer",
           id: :reset,
           type: :button,
           data: {

--- a/app/components/avo/fields/preview_field/index_component.rb
+++ b/app/components/avo/fields/preview_field/index_component.rb
@@ -5,7 +5,7 @@ class Avo::Fields::PreviewField::IndexComponent < Avo::Fields::IndexComponent
     link_to resource_view_path, title: t("avo.view_item", item: @resource.name).humanize do
       helpers.svg(
         "tabler/outline/zoom-scan",
-        class: "block h-6 text-gray-600",
+        class: "block h-6 text-content-secondary",
         data: {
           controller: "preview",
           preview_url_value: helpers.preview_resource_path(resource: @resource, turbo_frame: :preview_modal),

--- a/spec/features/avo/required_takes_a_block_spec.rb
+++ b/spec/features/avo/required_takes_a_block_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "RequiredTakesABlock", type: :feature do
       visit "/admin/resources/fish/new"
 
       within '[data-resource-edit-target="nameTextWrapper"][data-field-id="name"]' do
-        expect(page).to have_selector ".text-red-600.ms-1"
+        expect(page).to have_selector ".text-danger-content.ms-1"
       end
     end
   end
@@ -18,7 +18,7 @@ RSpec.feature "RequiredTakesABlock", type: :feature do
       visit "/admin/resources/fish/#{fish.id}/edit"
 
       within '[data-resource-edit-target="nameTextWrapper"][data-field-id="name"]' do
-        expect(page).not_to have_selector ".text-red-600.ms-1"
+        expect(page).not_to have_selector ".text-danger-content.ms-1"
       end
     end
   end

--- a/spec/features/avo/status_field_spec.rb
+++ b/spec/features/avo/status_field_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "StatusField", type: :feature do
 
       it {
         is_expected.to have_text status
-        is_expected.to have_css ".text-red-600"
+        is_expected.to have_css ".text-danger-content"
       }
     end
 
@@ -64,7 +64,7 @@ RSpec.describe "StatusField", type: :feature do
 
       it {
         is_expected.to have_text status
-        is_expected.to have_css ".text-red-600"
+        is_expected.to have_css ".text-danger-content"
       }
     end
 
@@ -106,7 +106,7 @@ RSpec.describe "StatusField", type: :feature do
 
         expect(current_path).to eql "/admin/resources/projects/#{project.id}"
         expect(find_field_value_element("status")).to have_text fail_status
-        expect(find_field_value_element("status")).to have_css ".text-red-600"
+        expect(find_field_value_element("status")).to have_css ".text-danger-content"
       end
 
       it "changes the status to load value" do
@@ -228,7 +228,7 @@ RSpec.describe "StatusField", type: :feature do
         expect(current_path).to eql "/admin/resources/projects/#{project.id}"
 
         expect(find_field_element("status")).to have_text "normal"
-        expect(find_field_element("status")).not_to have_css ".text-red-600"
+        expect(find_field_element("status")).not_to have_css ".text-danger-content"
         expect(find_field_element("status")).not_to have_css ".spinner"
       end
 
@@ -241,7 +241,7 @@ RSpec.describe "StatusField", type: :feature do
 
         expect(current_path).to eql "/admin/resources/projects/#{project.id}"
         expect(find_field_value_element("status")).to have_text "failed"
-        expect(find_field_element("status")).to have_css ".text-red-600"
+        expect(find_field_element("status")).to have_css ".text-danger-content"
         expect(find_field_element("status")).not_to have_css ".spinner"
       end
 
@@ -256,7 +256,7 @@ RSpec.describe "StatusField", type: :feature do
 
         expect(find_field_element("status")).to have_text "waiting"
         expect(find_field_element("status")).to have_css ".spinner"
-        expect(find_field_element("status")).not_to have_css ".text-red-600"
+        expect(find_field_element("status")).not_to have_css ".text-danger-content"
       end
     end
   end
@@ -282,7 +282,7 @@ RSpec.describe "StatusField", type: :feature do
         visit "/admin/resources/projects"
 
         expect(find_field_element("status")).to have_text "user_reject"
-        expect(find_field_element("status")).to have_css ".text-red-600"
+        expect(find_field_element("status")).to have_css ".text-danger-content"
       end
     end
   end

--- a/spec/system/avo/group_1/avo_record_previews_spec.rb
+++ b/spec/system/avo/group_1/avo_record_previews_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Record previews", type: :system do
   it "opens the preview" do
     visit "/admin/resources/teams"
     within find("[data-resource-id='#{team.id}'] [data-field-id='preview'][data-field-type='preview']") do
-      expect(page).to have_css("svg.block.h-6.text-gray-600")
+      expect(page).to have_css("svg.block.h-6.text-content-secondary")
       find('a[title="View team"]').hover
     end
 

--- a/spec/system/avo/group_1/boolean_field_spec.rb
+++ b/spec/system/avo/group_1/boolean_field_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "BooleanField", type: :system do
         field_value = find_field_value_element("is_featured")
 
         expect(field_value).not_to have_text empty_dash
-        expect(field_value).to have_css("svg[data-checked-state='indeterminate'].text-gray-400")
+        expect(field_value).to have_css("svg[data-checked-state='indeterminate'].text-content-secondary")
       end
 
       it "shows indeterminate icon on index view" do
@@ -40,7 +40,7 @@ RSpec.describe "BooleanField", type: :system do
         field_value = index_field_wrapper(id: "is_featured", record_id: post.to_param)
 
         expect(field_value).not_to have_text empty_dash
-        expect(field_value).to have_css("svg[data-checked-state='indeterminate'].text-gray-400")
+        expect(field_value).to have_css("svg[data-checked-state='indeterminate'].text-content-secondary")
       end
     end
   end

--- a/spec/system/avo/group_2/boolean_group_field_spec.rb
+++ b/spec/system/avo/group_2/boolean_group_field_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "BooleanGroupField", type: :system do
           sleep 0.1
 
           assert_popup_texts %w[Administrator Manager Writer]
-          assert_svg_classes %w[text-red-600 text-red-600 text-red-600]
+          assert_svg_classes %w[text-danger-content text-danger-content text-danger-content]
         end
       end
 
@@ -54,7 +54,7 @@ RSpec.describe "BooleanGroupField", type: :system do
           sleep 0.1
 
           assert_popup_texts %w[Administrator Manager Writer]
-          assert_svg_classes %w[text-green-600 text-red-600 text-red-600]
+          assert_svg_classes %w[text-success-content text-danger-content text-danger-content]
         end
 
         it "doesn't affect unspecified options" do
@@ -101,7 +101,7 @@ RSpec.describe "BooleanGroupField", type: :system do
         sleep 0.1
 
         assert_popup_texts %w[Create Read Update Delete]
-        assert_svg_classes %w[text-green-600 text-green-600 text-red-600 text-green-600]
+        assert_svg_classes %w[text-success-content text-success-content text-danger-content text-success-content]
       end
     end
 
@@ -128,7 +128,7 @@ RSpec.describe "BooleanGroupField", type: :system do
         sleep 0.1
 
         assert_popup_texts %w[Create Read Update Delete]
-        assert_svg_classes %w[text-green-600 text-green-600 text-red-600 text-green-600]
+        assert_svg_classes %w[text-success-content text-success-content text-danger-content text-success-content]
       end
     end
   end


### PR DESCRIPTION
## Summary
Follow-up to #4514. Field components still had hardcoded Tailwind color utilities that didn't react to dark mode. This swap replaces them with the existing foundation and semantic design tokens.

| File | Before | After |
| --- | --- | --- |
| `boolean_field/edit_component.html.erb` | `bg-gray-300`, `peer-checked:bg-green-500`, `bg-white` | `bg-tertiary`, `peer-checked:bg-success`, `bg-primary` |
| `common/boolean_check_component.rb` | `text-green-600` / `text-red-600` / `text-gray-400` | `text-success-content` / `text-danger-content` / `text-content-secondary` |
| `common/status_viewer_component.html.erb` | `text-red-600` / `text-green-600` / `text-gray-600` | `text-danger-content` / `text-success-content` / `text-content-secondary` |
| `common/files/view_type/grid_item_component.rb` | `bg-white border-gray-500`, `hover:bg-gray-100` | `bg-primary border-tertiary`, `hover:bg-secondary` |
| `common/files/view_type/grid_item_component.html.erb` | `text-gray-600`, `text-gray-500` | `text-content-secondary` |
| `file_field/edit_component.html.erb` | `text-red-600` | `text-danger-content` |
| `files_field/edit_component.html.erb` | `text-red-600` | `text-danger-content` |
| `preview_field/index_component.rb` | `text-gray-600` | `text-content-secondary` |
| `fields/stars.css` | `text-gray-300` / `text-yellow-400` | `text-tertiary` / `text-warning-foreground` |

## Test plan
- [ ] Toggle dark mode and verify each surface looks correct:
  - [ ] **Boolean** edit toggle track + dot
  - [ ] **Boolean** check icons on Show/Index (true/false/indeterminate)
  - [ ] **Status viewer** success / failed / neutral / loading states
  - [ ] **File / Files** grid item tile, file-text icon, filename label, remove buttons
  - [ ] **Preview** index zoom icon
  - [ ] **Stars** field empty + filled states

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only class renames and matching test selectors; no logic, auth, or data changes.
> 
> **Overview**
> Replaces hardcoded Tailwind grays and reds/greens/yellows on **field UI** (boolean toggle, boolean check icons, status viewer, file grid tiles, clear buttons, preview icon, stars, required asterisk) with **semantic tokens** (`text-danger-content`, `bg-primary`, `text-success-content`, etc.) so those surfaces follow light/dark theming like the rest of the design system.
> 
> Specs are updated to assert the new utility classes instead of `text-red-600` / `text-gray-400` and similar. **File grid** images also get `h-auto` and `object-cover` for layout, separate from the color-token work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ff18c3788e0419269ac1ba6fc02602bb881ec3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->