### PR TITLE
UI4 - fix focus visible on grid item component

### DIFF
--- a/app/assets/stylesheets/css/components/grid.css
+++ b/app/assets/stylesheets/css/components/grid.css
@@ -38,20 +38,32 @@
   box-shadow: var(--box-shadow-grid-card);
 }
 
+.grid-card:has(:focus-visible) {
+  @apply outline-none;
+
+  box-shadow: var(--box-shadow-focus);
+}
+
 .grid-card__image {
   @apply relative w-full overflow-hidden rounded-lg h-40 bg-secondary;
 }
 
+/* Keep the checkbox in the tab order, but visually hide it until the card is
+   hovered, the checkbox is focused, the card has any focused child, or the
+   checkbox is checked. `display: none` removes the input from the a11y tree
+   and from tab order, so we use opacity + absolute positioning instead. */
 .grid-card input[type="checkbox"] {
-  @apply hidden;
+  @apply absolute top-1 start-1 z-10 opacity-0 pointer-events-none;
+
+  /* Override mx-2 from RowSelectorComponent so the checkbox aligns to the card edge */
+  margin: 0 !important;
 }
 
 .grid-card input[type="checkbox"]:checked,
-.grid-card:hover input[type="checkbox"] {
-  @apply block z-10 absolute top-1 start-1;
-
-  /* Override mx-2 from item selector so checkbox aligns to card edge */
-  margin: 0 !important;
+.grid-card input[type="checkbox"]:focus-visible,
+.grid-card:hover input[type="checkbox"],
+.grid-card:focus-within input[type="checkbox"] {
+  @apply opacity-100 pointer-events-auto;
 }
 
 .grid-card__actions-row {

--- a/app/components/avo/index/grid_item_component.rb
+++ b/app/components/avo/index/grid_item_component.rb
@@ -40,7 +40,7 @@ class Avo::Index::GridItemComponent < Avo::BaseComponent
   def render_cover
     return link_to_cover if @card[:cover_url].present?
 
-    link_to resource_view_path, title: @card[:title] do
+    link_to resource_view_path, aria: {label: cover_link_label} do
       render Avo::Index::GridCoverEmptyStateComponent.new
     end
   end
@@ -48,7 +48,11 @@ class Avo::Index::GridItemComponent < Avo::BaseComponent
   def link_to_cover
     classes = "absolute h-full w-full object-cover"
 
-    link_to image_tag(@card[:cover_url], class: classes), resource_view_path, class: classes, title: @card[:title], loading: :lazy, width: "640", height: "480"
+    link_to image_tag(@card[:cover_url], class: classes, alt: ""), resource_view_path, class: classes, aria: {label: cover_link_label}, loading: :lazy, width: "640", height: "480"
+  end
+
+  def cover_link_label
+    "Open record ##{@resource.record_param}"
   end
 
   def render_title

--- a/app/components/avo/index/grid_item_component.rb
+++ b/app/components/avo/index/grid_item_component.rb
@@ -40,7 +40,7 @@ class Avo::Index::GridItemComponent < Avo::BaseComponent
   def render_cover
     return link_to_cover if @card[:cover_url].present?
 
-    link_to resource_view_path, tabindex: "-1" do
+    link_to resource_view_path, title: @card[:title] do
       render Avo::Index::GridCoverEmptyStateComponent.new
     end
   end
@@ -48,7 +48,7 @@ class Avo::Index::GridItemComponent < Avo::BaseComponent
   def link_to_cover
     classes = "absolute h-full w-full object-cover"
 
-    link_to image_tag(@card[:cover_url], class: classes), resource_view_path, class: classes, title: @card[:title], loading: :lazy, width: "640", height: "480", tabindex: "-1"
+    link_to image_tag(@card[:cover_url], class: classes), resource_view_path, class: classes, title: @card[:title], loading: :lazy, width: "640", height: "480"
   end
 
   def render_title

--- a/app/components/avo/index/grid_item_component.rb
+++ b/app/components/avo/index/grid_item_component.rb
@@ -40,7 +40,7 @@ class Avo::Index::GridItemComponent < Avo::BaseComponent
   def render_cover
     return link_to_cover if @card[:cover_url].present?
 
-    link_to resource_view_path do
+    link_to resource_view_path, tabindex: "-1" do
       render Avo::Index::GridCoverEmptyStateComponent.new
     end
   end
@@ -48,7 +48,7 @@ class Avo::Index::GridItemComponent < Avo::BaseComponent
   def link_to_cover
     classes = "absolute h-full w-full object-cover"
 
-    link_to image_tag(@card[:cover_url], class: classes), resource_view_path, class: classes, title: @card[:title], loading: :lazy, width: "640", height: "480"
+    link_to image_tag(@card[:cover_url], class: classes), resource_view_path, class: classes, title: @card[:title], loading: :lazy, width: "640", height: "480", tabindex: "-1"
   end
 
   def render_title

--- a/app/components/avo/index/grid_item_component.rb
+++ b/app/components/avo/index/grid_item_component.rb
@@ -59,7 +59,7 @@ class Avo::Index::GridItemComponent < Avo::BaseComponent
     return if @card[:title].blank?
 
     content_tag :div, class: "grid-card__title #{html(:title, :classes)}", style: html(:title, :style) do
-      link_to @card[:title], resource_view_path
+      link_to @card[:title], resource_view_path, tabindex: -1
     end
   end
 


### PR DESCRIPTION
# Description
Fix(grid): make grid card, checkbox, and kebab keyboard-focusable with focus-visible ring

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<img width="277" height="306" alt="01-card-focused" src="https://github.com/user-attachments/assets/711d454b-60ef-4936-8171-ee0664aaf583" />
<img width="277" height="306" alt="02-checkbox-focused" src="https://github.com/user-attachments/assets/bc4225fc-f85a-4c54-a273-682f7df43428" />
<img width="277" height="306" alt="03-kebab-focused" src="https://github.com/user-attachments/assets/7680a868-9011-4c0d-99e4-234683812427" />
