### PR TITLE
fix: generate all_resources only for ActiveRecord models

### DIFF
--- a/lib/generators/avo/all_resources_generator.rb
+++ b/lib/generators/avo/all_resources_generator.rb
@@ -22,13 +22,18 @@ module Generators
       no_tasks do
         def fetch_models
           model_files = Dir[Rails.root.join("app/models/**/*.rb")]
-          model_files.map do |file|
+          model_files.filter_map do |file|
             model_name = file.sub(Rails.root.join("app/models/").to_s, "").sub(".rb", "")
-            model_name.camelize.constantize
+            klass = model_name.camelize.constantize
+
+            next unless klass.is_a?(Class)
+            next unless klass < ActiveRecord::Base
+            next if klass.abstract_class?
+
             model_name.camelize
           rescue NameError
             nil
-          end.compact
+          end
         end
       end
     end

--- a/spec/features/avo/generators/all_resources_generator_spec.rb
+++ b/spec/features/avo/generators/all_resources_generator_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+require "rails/generators"
+require "generators/avo/all_resources_generator"
+
+RSpec.feature "all_resources generator", type: :feature do
+  it "only discovers ActiveRecord models" do
+    generator = Generators::Avo::AllResourcesGenerator.new
+    models = generator.send(:fetch_models)
+
+    expect(models).not_to include("Current")
+    expect(models).not_to include("ApplicationRecord")
+    expect(models).to include("Location")
+    expect(models).to include("Course::Link")
+  end
+end


### PR DESCRIPTION
## Summary

- Filter `avo:all_resources` to only discover classes that inherit from `ActiveRecord::Base`
- Skip abstract classes, modules/concerns, POROs, `Current` (`ActiveSupport::CurrentAttributes`), and form objects
- Add generator spec verifying `Current` is excluded and AR models like `Location` and `Course::Link` are included

Fixes #3518

## Context

Running `rails g avo:all_resources` previously scanned every file under `app/models` and generated resources for non-database models. This produced empty/broken resource files (e.g. for `Current` from the Rails auth generator) that could crash Zeitwerk on boot.

## Test plan

- [x] `bundle exec rspec spec/features/avo/generators/all_resources_generator_spec.rb`
- [ ] Run `rails g avo:all_resources` in an app with `Current` in `app/models` and verify no `current` resource is generated
- [ ] Verify AR models still get resources generated


Made with [Cursor](https://cursor.com)