### PR TITLE
AVO-1271: Add avo_engine DSL (Avo::EngineDSL)

### DIFF
--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -4,6 +4,7 @@ require "active_support/inflector"
 require_relative "avo/version"
 require_relative "avo/tailwind_builder"
 require_relative "avo/configuration"
+require_relative "avo/engine_dsl"
 require_relative "avo/engine" if defined?(Rails)
 
 loader = Zeitwerk::Loader.for_gem

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -11,7 +11,8 @@ loader = Zeitwerk::Loader.for_gem
 loader.inflector.inflect(
   "html" => "HTML",
   "uri_service" => "URIService",
-  "has_html_attributes" => "HasHTMLAttributes"
+  "has_html_attributes" => "HasHTMLAttributes",
+  "engine_dsl" => "EngineDSL"
 )
 loader.ignore("#{__dir__}/generators")
 loader.setup

--- a/lib/avo/engine_dsl.rb
+++ b/lib/avo/engine_dsl.rb
@@ -1,0 +1,8 @@
+module Avo
+  module EngineDSL
+    def avo_engine(handler_class = nil)
+      handler_class ||= "#{name.deconstantize}::EngineHandler".constantize
+      instance_exec(&handler_class.handle)
+    end
+  end
+end

--- a/spec/lib/avo/engine_dsl_spec.rb
+++ b/spec/lib/avo/engine_dsl_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe Avo::EngineDSL do
+  before do
+    stub_const("Avo::EngineDSLSpec", Module.new)
+
+    stub_const("Avo::EngineDSLSpec::EngineHandler", Class.new do
+      def self.handle
+        -> {
+          isolate_namespace Avo::EngineDSLSpec
+
+          initializer "avo-engine-dsl-spec.init" do
+          end
+        }
+      end
+    end)
+
+    stub_const("Avo::EngineDSLSpec::Engine", Class.new(Rails::Engine) do
+      extend Avo::EngineDSL
+      avo_engine
+    end)
+  end
+
+  let(:engine) { Avo::EngineDSLSpec::Engine }
+
+  it "registers initializers from the handler proc" do
+    expect(engine.initializers.map(&:name)).to include("avo-engine-dsl-spec.init")
+  end
+
+  it "isolates the engine namespace" do
+    expect(engine).to be_isolated
+    expect(engine.isolated_namespace).to eq(Avo::EngineDSLSpec)
+  end
+
+  it "accepts an explicit handler class" do
+    stub_const("Avo::EngineDSLSpec::CustomHandler", Class.new do
+      def self.handle
+        -> {
+          initializer "avo-engine-dsl-spec.custom" do
+          end
+        }
+      end
+    end)
+
+    engine_class = Class.new(Rails::Engine) do
+      def self.name
+        "Avo::EngineDSLSpec::CustomEngine"
+      end
+
+      extend Avo::EngineDSL
+      avo_engine Avo::EngineDSLSpec::CustomHandler
+    end
+
+    expect(engine_class.initializers.map(&:name)).to include("avo-engine-dsl-spec.custom")
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `Avo::EngineDSL#avo_engine` in core avo (replaces `instance_exec &EngineContent.write_content`).
- Renames `EngineContent` → `EngineHandler`, `write_content` → `handle`, `engine_content.rb` → `engine_handler.rb`.
- Plugin engines use `extend Avo::EngineDSL` and `avo_engine`.

Part of [AVO-1271](https://linear.app/avo-hq/issue/AVO-1271).

## Test plan
- [ ] Point app Gemfile at path deps for `avo` + addon branches
- [ ] Boot app and open Avo admin
- [ ] Confirm plugin registers on `avo_boot` / `avo_plugin_include`

**Note:** Merge `avo` first; addons depend on `Avo::EngineDSL` in core.

Made with [Cursor](https://cursor.com)