### PR TITLE
refactor: render modal via native popover API

### DIFF
--- a/app/assets/stylesheets/css/components/modal.css
+++ b/app/assets/stylesheets/css/components/modal.css
@@ -11,30 +11,51 @@
   --modal-height-4xl: 56rem;
 }
 
+/* Rendered in the top layer via the native popover API (`popover="manual"`),
+   so it sits above everything without a z-index and gets a free `::backdrop`. */
 .modal {
-  @apply fixed inset-0 w-full z-1000 flex justify-center items-center;
+  /* size-full + m-0 + border-0/p-0/bg-transparent reset the popover UA chrome
+     (fit-content sizing, auto margins, border, padding, background) so the
+     element stays a transparent, full-viewport flex container that centers the card. */
+  @apply fixed inset-0 size-full m-0 border-0 p-0 bg-transparent justify-center items-center;
 
   /* Enter/leave transition duration, shared by the card and the backdrop.
      Keep in sync with TRANSITION_MS in base_modal_controller.js. */
   --modal-transition-duration: 90ms;
+
+  /* The popover attribute keeps the element display:none until it's shown; only
+     lay it out (flex) while open. `allow-discrete` on display/overlay keeps the
+     element in the top layer for the leave transition so the card + backdrop can
+     animate out before it's hidden. */
+  transition:
+    overlay var(--modal-transition-duration) ease-out allow-discrete,
+    display var(--modal-transition-duration) ease-out allow-discrete;
 }
 
-.modal__overlay {
-  @apply absolute w-full h-full flex justify-center items-center;
+.modal:popover-open {
+  @apply flex;
+}
 
+.modal::backdrop {
   background-color: color-mix(in oklch, var(--color-avo-neutral-950) 25%, transparent);
-
-  .dark & {
-    background-color: color-mix(in oklch, var(--color-avo-neutral-950) 60%, transparent);
-  }
 
   /* Fade in/out alongside the card. */
   opacity: 0;
   transition: opacity var(--modal-transition-duration) ease-out;
 }
 
-.modal--open .modal__overlay {
+.dark .modal::backdrop {
+  background-color: color-mix(in oklch, var(--color-avo-neutral-950) 60%, transparent);
+}
+
+.modal:popover-open::backdrop {
   opacity: 1;
+}
+
+@starting-style {
+  .modal:popover-open::backdrop {
+    opacity: 0;
+  }
 }
 
 .modal__card-container {
@@ -52,23 +73,52 @@
   box-shadow: var(--shadow-modal);
 
   /* Enter/leave transition: the card scales + fades from its center.
-     Closed is the default state; `.modal--open` (toggled in JS) is the
-     resting open state. */
+     Closed (default) state; `:popover-open` is the resting open state, with
+     `@starting-style` supplying the from-state for the enter animation. */
   opacity: 0;
-  transform: scale(0.95);
+  transform: scale(0.975);
   transition:
     opacity var(--modal-transition-duration) ease-out,
     transform var(--modal-transition-duration) ease-out;
 }
 
-.modal--open .modal__card {
+.modal:popover-open .modal__card {
   opacity: 1;
   transform: scale(1);
+}
+
+@starting-style {
+  .modal:popover-open .modal__card {
+    opacity: 0;
+    transform: scale(0.975);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .modal__card {
     transition: none;
+  }
+}
+
+/* Head-shake "no" — played when the modal refuses to dismiss (a backdrop click
+   or Escape while close_modal_on_backdrop_click is false). */
+@keyframes modal-nudge {
+  0%, 100% { transform: translateX(0); }
+  15% { transform: translateX(-0.5rem); }
+  30% { transform: translateX(0.5rem); }
+  45% { transform: translateX(-0.375rem); }
+  60% { transform: translateX(0.375rem); }
+  75% { transform: translateX(-0.1875rem); }
+  90% { transform: translateX(0.1875rem); }
+}
+
+.modal__card--nudge {
+  animation: modal-nudge 400ms ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modal__card--nudge {
+    animation: none;
   }
 }
 

--- a/app/components/avo/keyboard_shortcuts_component.html.erb
+++ b/app/components/avo/keyboard_shortcuts_component.html.erb
@@ -2,7 +2,6 @@
   class: "hotkey",
   title: "Keyboard shortcuts",
   width: :xl,
-  hidden: true,
   behavior: :persistent
 ) do %>
   <div class="hotkey__grid">

--- a/app/components/avo/modal_component.html.erb
+++ b/app/components/avo/modal_component.html.erb
@@ -1,19 +1,16 @@
-<%= tag.div class: class_names("modal", @class, {"modal--width-#{@width}": @width.present?, "modal--height-#{@height}": @height.present?}), tabindex: -1, data: {
+<%# Native HTML popover: rendered in the top layer with a `::backdrop` pseudo-element.
+    `manual` (not `auto`) keeps backdrop-click / Escape dismissal under our control so
+    `close_modal_on_backdrop_click` is honoured. A click on the modal's own centering
+    area (event.target === the modal) light-dismisses it; see #close in the controller. %>
+<%= tag.div class: class_names("modal", @class, {"modal--width-#{@width}": @width.present?, "modal--height-#{@height}": @height.present?}), tabindex: -1, popover: "manual", data: {
   controller: "#{ctrl} modal-size",
   "#{ctrl}-target": "modal",
   "#{ctrl}-close-modal-on-backdrop-click-value": close_modal_on_backdrop_click,
   "modal-size-current-width-value": @width,
   "modal-size-current-height-value": @height,
+  action: "click->#{ctrl}#closeOnBackdrop",
   **@data
-}, **(@hidden ? { hidden: true } : {}) do %>
-  <%= tag.div(
-    aria: { expanded: true },
-    class: "modal__overlay",
-    data: {
-      "#{ctrl}-target": "backdrop",
-      action: "click->#{ctrl}#close"
-    }
-  ) %>
+} do %>
   <div
     aria-expanded="true"
     role="dialog"
@@ -21,7 +18,7 @@
     class="modal__card-container"
     data-modal-size-target="container"
   >
-    <div class="modal__card">
+    <div class="modal__card" data-<%= ctrl %>-target="card">
       <div class="card">
         <div class="card__wrapper">
           <% if has_header? %>

--- a/app/components/avo/modal_component.rb
+++ b/app/components/avo/modal_component.rb
@@ -11,10 +11,9 @@ class Avo::ModalComponent < Avo::BaseComponent
   prop :title
   prop :description
   prop :show_close_button, default: true
-  prop :behavior, default: :ephemeral # :ephemeral removes from DOM on close, :persistent toggles hidden attribute
+  prop :behavior, default: :ephemeral # :ephemeral removes from DOM on close, :persistent toggles the popover open/closed
   prop :class, default: ""
   prop :data, default: {}.freeze
-  prop :hidden, default: false
 
   def stimulus_controller
     (@behavior == :persistent) ? "persistent-modal" : "modal"

--- a/app/javascript/js/controllers/base_modal_controller.js
+++ b/app/javascript/js/controllers/base_modal_controller.js
@@ -3,11 +3,17 @@ import { Controller } from '@hotwired/stimulus'
 /**
  * Shared behaviour for both modal strategies (destroy & toggle).
  * Not registered with Stimulus directly — subclasses are.
+ *
+ * The modal is a native popover (`popover="manual"`) rendered in the top layer.
+ * Enter/leave animations are pure CSS (`@starting-style` + `transition-behavior:
+ * allow-discrete`); this controller only opens/closes the popover and manages the
+ * `modal-open` body state.
  */
 export default class extends Controller {
-  static targets = ['modal', 'backdrop']
+  static targets = ['modal', 'card']
 
-  // Keep in sync with the --modal-transition-duration CSS variable.
+  // Fallback for removing an ephemeral modal when no leave transition fires
+  // (e.g. prefers-reduced-motion). Keep >= the --modal-transition-duration CSS var.
   static TRANSITION_MS = 90
 
   static values = {
@@ -28,16 +34,52 @@ export default class extends Controller {
   // -- shared actions -------------------------------------------------------
 
   handleKeydown(event) {
-    if (event.key === 'Escape' && this.isOpen() && this.closeModalOnBackdropClickValue) {
+    if (event.key !== 'Escape' || !this.isOpen()) return
+
+    // Escape dismisses, or — when backdrop/Escape closing is disabled — nods "no".
+    if (this.closeModalOnBackdropClickValue) {
       this.closeModal()
+    } else {
+      this.nudge()
     }
   }
 
-  /** Backdrop click action — wired via data-action="click->…#close" */
-  close(event) {
-    if (event.target === this.backdropTarget && !this.closeModalOnBackdropClickValue) return
+  /** Explicit close — wired to buttons (Cancel, the X, etc.). Always closes. */
+  close() {
+    this.closeModal()
+  }
+
+  /**
+   * Backdrop click — wired via data-action="click->…#closeOnBackdrop" on the
+   * modal element. The native `::backdrop` sits behind the modal, so a click on
+   * the empty centering area lands on the modal element itself (event.target ===
+   * the modal). Clicks bubbling up from buttons/card content are ignored here so
+   * they don't double-fire alongside their own #close action.
+   */
+  closeOnBackdrop(event) {
+    if (event.target !== this.modalTarget) return
+
+    // When dismissal is disabled, shake the card to signal "no" instead of closing.
+    if (!this.closeModalOnBackdropClickValue) {
+      this.nudge()
+      return
+    }
 
     this.closeModal()
+  }
+
+  /**
+   * Head-shake "no" on the card — used when the modal refuses to dismiss. The
+   * remove + reflow + re-add lets the animation restart on rapid repeat attempts.
+   */
+  nudge() {
+    if (!this.hasCardTarget) return
+
+    const card = this.cardTarget
+    card.classList.remove('modal__card--nudge')
+    void card.offsetWidth // force reflow so the animation replays
+    card.classList.add('modal__card--nudge')
+    card.addEventListener('animationend', () => card.classList.remove('modal__card--nudge'), { once: true })
   }
 
   // -- helpers --------------------------------------------------------------
@@ -48,30 +90,6 @@ export default class extends Controller {
 
   removeModalOpen() {
     document.body.classList.remove('modal-open')
-  }
-
-  // -- enter / leave transitions --------------------------------------------
-
-  /**
-   * Reveal the card with the scale-in transition. The element must already be
-   * visible (in the DOM / not `hidden`) so the closed styles paint first; the
-   * double rAF guarantees that initial frame before we flip to the open state.
-   */
-  reveal() {
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        this.modalTarget.classList.add('modal--open')
-      })
-    })
-  }
-
-  /**
-   * Play the leave transition, then run `onComplete` (remove or hide the
-   * element). Falls back to a timeout in case `transitionend` never fires.
-   */
-  conceal(onComplete) {
-    this.modalTarget.classList.remove('modal--open')
-    window.setTimeout(onComplete, this.constructor.TRANSITION_MS)
   }
 
   dispatchClose() {

--- a/app/javascript/js/controllers/modal_controller.js
+++ b/app/javascript/js/controllers/modal_controller.js
@@ -3,15 +3,16 @@ import BaseModalController from './base_modal_controller'
 /**
  * Inject / destroy strategy.
  *
- * The modal is added to the DOM (usually via Turbo) when it should appear
- * and removed entirely when it is closed.
+ * The modal is added to the DOM (usually via Turbo) when it should appear and
+ * removed entirely when it is closed. Showing/hiding the popover drives the CSS
+ * enter/leave transition; the element is removed once the leave transition ends.
  */
 export default class extends BaseModalController {
   connect() {
     this.connectModal()
     this.addModalOpen()
+    this.modalTarget.showPopover()
     this.modalTarget.focus()
-    this.reveal()
   }
 
   disconnect() {
@@ -26,10 +27,19 @@ export default class extends BaseModalController {
   }
 
   closeModal() {
-    this.conceal(() => {
-      this.modalTarget.remove()
-      this.dispatchClose()
-    })
     this.removeModalOpen()
+
+    const remove = () => {
+      window.clearTimeout(timer)
+      this.modalTarget.removeEventListener('transitionend', remove)
+      if (this.modalTarget.isConnected) this.modalTarget.remove()
+      this.dispatchClose()
+    }
+
+    // Remove once the leave transition finishes, with a timeout fallback for
+    // reduced-motion (no transition → no `transitionend`).
+    const timer = window.setTimeout(remove, this.constructor.TRANSITION_MS + 50)
+    this.modalTarget.addEventListener('transitionend', remove)
+    this.modalTarget.hidePopover()
   }
 }

--- a/app/javascript/js/controllers/persistent_modal_controller.js
+++ b/app/javascript/js/controllers/persistent_modal_controller.js
@@ -3,8 +3,8 @@ import BaseModalController from './base_modal_controller'
 /**
  * Persistent / show-hide strategy.
  *
- * The modal lives in the DOM at all times. It starts with the `hidden`
- * attribute and is revealed / hidden by toggling that attribute.
+ * The modal lives in the DOM at all times. It starts closed (the native popover
+ * is hidden until shown) and is revealed / hidden by toggling the popover.
  */
 export default class extends BaseModalController {
   connect() {
@@ -25,22 +25,19 @@ export default class extends BaseModalController {
   // -- strategy implementation ----------------------------------------------
 
   isOpen() {
-    return !this.modalTarget.hasAttribute('hidden')
+    return this.modalTarget.matches(':popover-open')
   }
 
   closeModal() {
-    this.conceal(() => {
-      this.modalTarget.setAttribute('hidden', '')
-    })
+    this.modalTarget.hidePopover()
     this.removeModalOpen()
     this.dispatchClose()
   }
 
   openModal() {
-    this.modalTarget.removeAttribute('hidden')
+    this.modalTarget.showPopover()
     this.addModalOpen()
     this.modalTarget.focus()
-    this.reveal()
   }
 
   toggleModal() {

--- a/spec/system/avo/group_1/hotkey_spec.rb
+++ b/spec/system/avo/group_1/hotkey_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Keyboard shortcuts", type: :system do
   it "opens the keyboard shortcuts panel and closes it with escape" do
     visit "/admin/resources/projects"
 
-    expect(page).to have_css(".hotkey[hidden]", visible: false)
+    expect(page).to have_css(".hotkey", visible: :hidden)
 
     dispatch_keydown("?", code: "Slash", shift_key: true)
 
@@ -97,7 +97,7 @@ RSpec.describe "Keyboard shortcuts", type: :system do
 
     dispatch_keydown("Escape")
 
-    expect(page).to have_css(".hotkey[hidden]", visible: false)
+    expect(page).to have_css(".hotkey", visible: :hidden)
   end
 
   it "does not open the keyboard shortcuts panel while typing in a search field" do
@@ -109,7 +109,7 @@ RSpec.describe "Keyboard shortcuts", type: :system do
     search_input.send_keys("?")
 
     expect(search_input.value).to include("?")
-    expect(page).to have_css(".hotkey[hidden]", visible: false)
+    expect(page).to have_css(".hotkey", visible: :hidden)
   end
 
   it "toggles the hotkeys-hide-badges class on the html element when pressing Shift+K" do
@@ -465,7 +465,7 @@ RSpec.describe "Keyboard shortcuts", type: :system do
     it "still renders the keyboard shortcuts modal" do
       visit "/admin/resources/projects"
 
-      expect(page).to have_css(".hotkey[hidden]", visible: false)
+      expect(page).to have_css(".hotkey", visible: :hidden)
 
       dispatch_keydown("?", code: "Slash", shift_key: true)
 

--- a/spec/system/avo/group_3/actions_spec.rb
+++ b/spec/system/avo/group_3/actions_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe "Actions", type: :system do
 
       click_on "Actions"
       click_on "Export CSV"
-      find('[data-modal-target="backdrop"]').trigger("click")
+      find('[data-modal-target="modal"]').trigger("click")
 
       expect(page).not_to have_selector '[data-controller="modal"]'
     end
@@ -190,7 +190,7 @@ RSpec.describe "Actions", type: :system do
 
       click_on "Actions"
       click_on "Export CSV"
-      find('[data-modal-target="backdrop"]').trigger("click")
+      find('[data-modal-target="modal"]').trigger("click")
 
       expect(page).to have_selector '[data-controller~="modal"]'
 


### PR DESCRIPTION
## Summary

Rebuilds Avo's modal on top of the **native HTML popover API** instead of a manual overlay element and JS-toggled visibility class. The modal now renders in the browser's top layer (`popover="manual"`), gets a real `::backdrop` pseudo-element for free, and runs its enter/leave animations entirely in CSS. The Stimulus controllers shrink to just opening and closing the popover.

The behavioral contract is unchanged — `close_modal_on_backdrop_click`, Escape handling, and the ephemeral vs. persistent strategies all work as before — with one addition: when a modal refuses to dismiss, the card now plays a head-shake "no" animation instead of doing nothing.

## What changed

| Area | Before | After |
|------|--------|-------|
| Layering | `.modal__overlay` div, `z-1000` | Native popover top layer, no z-index |
| Backdrop | `.modal__overlay` element | `::backdrop` pseudo-element |
| Enter/leave | JS `reveal()`/`conceal()` toggling `.modal--open` + rAF/timeout | CSS `@starting-style` + `transition-behavior: allow-discrete` |
| Open state | `.modal--open` class / `hidden` attribute | `:popover-open` + `showPopover()`/`hidePopover()` |
| Dismiss blocked | No feedback | Head-shake `modal__card--nudge` animation |

### Backdrop dismissal

`manual` (not `auto`) popover mode keeps Escape/backdrop dismissal under our control so `close_modal_on_backdrop_click` is still honoured. Because the `::backdrop` sits *behind* the modal element, a click on the empty centering area lands on the modal element itself — `closeOnBackdrop` checks `event.target === this.modalTarget` so clicks bubbling up from card content are ignored and don't double-fire.

### Controller surface

- `base_modal_controller.js` — drops the `reveal()`/`conceal()` transition machinery and the `backdrop` target; adds a `card` target, `closeOnBackdrop`, and `nudge`. `TRANSITION_MS` is now only a reduced-motion fallback for removing ephemeral modals.
- `modal_controller.js` (ephemeral) — `showPopover()` on connect; on close, `hidePopover()` then remove the element once `transitionend` fires (timeout fallback for reduced motion).
- `persistent_modal_controller.js` — `isOpen()` reads `:popover-open`; open/close call `showPopover()`/`hidePopover()` instead of toggling the `hidden` attribute.
- `ModalComponent` — drops the now-unused `hidden` prop; persistent behavior toggles popover state rather than the `hidden` attribute.

## Test plan

The two system specs were updated for the new DOM:

- `actions_spec.rb` — backdrop dismissal now clicks `[data-modal-target="modal"]` (the old `backdrop` target is gone).
- `hotkey_spec.rb` — the persistent hotkeys modal asserts `visible: :hidden` instead of a `[hidden]` attribute, since closed state is now popover state.

Worth a manual pass across browsers, since `@starting-style` / `allow-discrete` / `popover` are recent platform features: open/close animation, Escape and backdrop dismissal (both enabled and disabled → nudge), the persistent keyboard-shortcuts modal, and `prefers-reduced-motion`.

---

[![Compound Engineering v2.59.0](https://img.shields.io/badge/Compound_Engineering-v2.59.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.8 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core modal UX (layering, dismiss, animations) across ephemeral and persistent flows; behavior depends on newer CSS/popover support, though contracts are preserved and specs were updated.
> 
> **Overview**
> Replaces Avo's modal stack with the **native HTML `popover="manual"` API**: the root `.modal` element lives in the top layer (no overlay div, no `z-1000`), dimming comes from **`::backdrop`**, and open/closed styling uses **`:popover-open`** plus CSS **`@starting-style`** / **`allow-discrete`** instead of JS toggling `.modal--open` via `reveal()` / `conceal()`.
> 
> **Stimulus** now only calls `showPopover()` / `hidePopover()`: ephemeral modals remove the node after `transitionend` (with a timeout fallback); persistent modals use `:popover-open` instead of the `hidden` attribute. Backdrop dismissal clicks the modal element itself (`closeOnBackdrop` + `event.target === modal`); **`close_modal_on_backdrop_click: false`** triggers a new **`modal__card--nudge`** head-shake on backdrop click or Escape instead of silently ignoring. **`ModalComponent`** drops the overlay markup, `hidden` prop, and adds `popover: "manual"`; keyboard shortcuts no longer pass `hidden: true`.
> 
> System specs were updated for popover visibility and backdrop targets (`[data-modal-target="modal"]`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32731370a33e45ef31ec3ee89b0b9cab6d2d415b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->