### PR TITLE
feat: add `rounded: :full` option to ButtonComponent

### DIFF
--- a/app/assets/stylesheets/css/components/button.css
+++ b/app/assets/stylesheets/css/components/button.css
@@ -351,6 +351,17 @@
       border-radius: 9999px;
       corner-shape: round;
     }
+
+    /* `.button:focus-visible` also sets `rounded-lg` and wins on specificity. */
+    &.button--focus-visible,
+    &:focus-visible {
+      @apply rounded-full;
+
+      @supports (corner-shape: squircle) {
+        border-radius: 9999px;
+        corner-shape: round;
+      }
+    }
   }
 
   /* Size variants */

--- a/app/assets/stylesheets/css/components/button.css
+++ b/app/assets/stylesheets/css/components/button.css
@@ -340,6 +340,19 @@
     }
   }
 
+  /* Fully rounded (pill) shape — opt-in via `rounded: :full`. Overrides the
+     base `rounded-lg`/squircle radius. Wins on source order (single class, same
+     specificity as `.button`). Switches corner-shape back to `round` so the
+     squircle radius bump doesn't distort the pill. */
+  .button--rounded-full {
+    @apply rounded-full;
+
+    @supports (corner-shape: squircle) {
+      border-radius: 9999px;
+      corner-shape: round;
+    }
+  }
+
   /* Size variants */
   .button--size-xs {
     @apply text-xs px-2 py-1 gap-1 min-w-6;
@@ -427,7 +440,15 @@
 
   /* Icon spacing */
   .button__icon {
-    @apply pointer-events-none shrink-0 grow-0 w-auto -my-px;
+    @apply pointer-events-none shrink-0 grow-0 w-auto;
+  }
+
+  /* The `-my-px` pulls the icon tight against the text line, so it only applies
+     when there's a label. On icon-only buttons it would shave 2px off the height
+     and turn the box into an oval — so scope it here rather than overriding it
+     back out later (no cascade fight). */
+  .button:has(.button__label) .button__icon {
+    @apply -my-px;
   }
 
   .button__icon:not(:last-child) {

--- a/app/components/avo/button_component.rb
+++ b/app/components/avo/button_component.rb
@@ -4,6 +4,7 @@
 # style: primary/outline/text
 # size: :sm, :md, :lg
 # padding: nil (default), :sm or :xs for tighter, equal padding
+# rounded: nil (default, uses the standard radius), :full for a pill shape
 # color: nil, :primary, :accent, :gray, :red, :green, :blue, or any other tailwind color
 # icon: "tabler/outline/paperclip" as specified in the docs (https://docs.avohq.io/3.0/icons.html)
 class Avo::ButtonComponent < Avo::BaseComponent
@@ -11,6 +12,7 @@ class Avo::ButtonComponent < Avo::BaseComponent
   prop :size, default: :md
   prop :padding
   prop :style, default: :outline
+  prop :rounded
   prop :color
   prop :icon do |value|
     value&.to_sym
@@ -43,7 +45,8 @@ class Avo::ButtonComponent < Avo::BaseComponent
       "button--style-#{@style}",
       @class,
       "button--color-#{@color}": @color.present?,
-      "button--padding-#{@padding}": @padding.present?
+      "button--padding-#{@padding}": @padding.present?,
+      "button--rounded-#{@rounded}": @rounded.present?
     ]
     base_classes << "button--loading" if @args[:loading]
 

--- a/spec/dummy/test/components/previews/button_component_preview.rb
+++ b/spec/dummy/test/components/previews/button_component_preview.rb
@@ -6,9 +6,10 @@ class ButtonComponentPreview < Lookbook::Preview
   # @param size select { choices: [xs, sm, md, lg, xl] }
   # @param style select { choices: [primary, outline, tertiary, text, icon] }
   # @param color select { choices: [gray, red, green, blue] }
+  # @param rounded select { choices: [nil, full] }
   # @param icon text "Icon to display in the button"
-  def default(label: "Label", size: :md, style: :primary, color: :gray, icon: "tabler/outline/arrow-up")
-    a_button(size:, style:, color:, icon:) do
+  def default(label: "Label", size: :md, style: :primary, color: :gray, rounded: nil, icon: "tabler/outline/arrow-up")
+    a_button(size:, style:, color:, rounded:, icon:) do
       label
     end
   end

--- a/spec/dummy/test/components/previews/button_component_preview/styles.html.erb
+++ b/spec/dummy/test/components/previews/button_component_preview/styles.html.erb
@@ -19,4 +19,13 @@
     <%= render Avo::ButtonComponent.new(style: :text, size: :sm, icon: "tabler/outline/arrow-up") { "Label" } %>
     <%= render Avo::ButtonComponent.new(style: :text, size: :lg, icon: "tabler/outline/arrow-up") { "Label" } %>
   </div>
+
+  <h2 class="text-xl font-semibold">Rounded (<code>rounded: :full</code>)</h2>
+  <p class="text-sm text-content-secondary">An orthogonal shape modifier — combine it with any style.</p>
+  <div class="flex gap-3 flex-wrap items-center">
+    <%= render Avo::ButtonComponent.new(style: :primary, rounded: :full, icon: "tabler/outline/arrow-up") { "Primary" } %>
+    <%= render Avo::ButtonComponent.new(style: :outline, rounded: :full, icon: "tabler/outline/arrow-up") { "Outline" } %>
+    <%= render Avo::ButtonComponent.new(style: :text, rounded: :full, icon: "tabler/outline/arrow-up") { "Text" } %>
+    <%= render Avo::ButtonComponent.new(style: :outline, rounded: :full, icon: "tabler/outline/plus") %>
+  </div>
 </div>


### PR DESCRIPTION
## What

Adds a new `rounded:` shape prop to `Avo::ButtonComponent` (defaults to `nil`). It's an orthogonal modifier — it combines with any `style`, `size`, or `color`.

```erb
<%= a_button(rounded: :full) { "Pill" } %>
<%= a_button(style: :primary, rounded: :full, icon: "tabler/outline/plus") { "New" } %>
<%= a_button(style: :outline, rounded: :full, icon: "tabler/outline/plus") %> <%# perfect circle %>
```

`rounded: :full` renders a pill shape — and a **perfect circle** for icon-only buttons.

## Why a prop, not a style

Shape is independent of visual style. Modeling it as `style: :rounded` would have forced a coupling (you couldn't have a rounded *primary* or rounded *outline*). As a `button--rounded-#{value}` modifier it stays composable and is trivial to extend later (e.g. `:none`, `:lg`).

## Bonus fix: icon-only buttons were a slight oval

While testing `rounded: :full` on icon-only buttons they came out ~26×24 (an oval, not a circle). Root cause: `.button__icon` carries `-my-px` to hug a text label, but with **no label** that negative margin just shaved 2px off the cross axis. Fixed by scoping the negative margin to buttons that actually have a `.button__label`, so icon-only buttons stay square — no higher-specificity override or cascade fight needed.

## Changes

- `button_component.rb` — new `prop :rounded`; emits `button--rounded-#{@rounded}` only when set (same pattern as `padding`/`color`).
- `button.css` — `.button--rounded-full` (handles the squircle `corner-shape` override so the pill isn't distorted); scoped the icon `-my-px` to `.button:has(.button__label)`.
- Previews — `rounded` dropdown on the `default` preview + a "Rounded" section in the styles preview.

## Notes

Docs for this option live in a separate repo (`avocado/docs`) and will go up separately — that page (`avo-button-component.md`) was a stub, so it's being fleshed out and registered in the 4.0 sidebar there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI/CSS and an opt-in component prop with no auth, data, or API surface changes.
> 
> **Overview**
> Adds an optional **`rounded: :full`** prop to `Avo::ButtonComponent` so buttons can render as pills (or circles when icon-only) without changing `style`, `size`, or `color`. When set, the component emits `button--rounded-full`, backed by new CSS that forces a full radius (including on `:focus-visible`) and resets **squircle** `corner-shape` so pills stay round.
> 
> Also fixes **icon-only** buttons looking slightly oval by moving `.button__icon`’s `-my-px` from the global icon rule to **only** buttons that have a `.button__label`. Lookbook previews gain a `rounded` control and a styles section demonstrating `rounded: :full` across primary, outline, text, and icon-only cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc7738e7c9859e78c09d3dd73d24030b45e3ba3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->