### PR TITLE
UI4 - fix navbar dropdown color

### DIFF
--- a/app/assets/stylesheets/css/layout.css
+++ b/app/assets/stylesheets/css/layout.css
@@ -218,7 +218,7 @@
 /* Links inside the always-dark navbar use primitive neutral tokens so they
    stay readable in both light and dark mode — matching the search input and
    sidebar toggle treatment. */
-.top-navbar .header-menu a {
+.top-navbar .header-menu__row a {
   color: var(--color-avo-neutral-300);
 
   &:hover {


### PR DESCRIPTION
# Description
Fix the color for navbar dropdown 

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
Before
<img width="480" height="353" alt="Screenshot 2026-06-08 at 09 00 20" src="https://github.com/user-attachments/assets/d72511e5-098f-4161-8ca1-e247e48537c6" />


After
<img width="205" height="161" alt="Screenshot 2026-06-08 at 09 01 03" src="https://github.com/user-attachments/assets/c39fa8e4-8b88-4209-aacb-114d07a69ca1" />
<img width="185" height="160" alt="Screenshot 2026-06-08 at 09 00 55" src="https://github.com/user-attachments/assets/be8d2184-c4cb-40c8-bae9-4bf1305084e4" />
