### PR TITLE
Respect user .limit() in search queries (AVO-1310)

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -252,17 +252,6 @@ module Avo
       }
     end
 
-    def search_results_count(resource)
-      if resource.search_results_count
-        Avo::ExecutionContext.new(
-          target: resource.search_results_count,
-          params: params
-        ).handle
-      else
-        Avo.configuration.search_results_count
-      end
-    end
-
     def parse_results(query, resource)
       # When using custom search services query should return an array of hashes
       if query.is_a?(Array)
@@ -274,18 +263,15 @@ module Avo
         # Force count to 0 until implement an API to pass the count
         results_count = 0
 
-        # Apply the limit
-        results = query.first(search_results_count(resource))
+        results = Avo::Search::ResultsLimiter.apply(query)
       else
         query = apply_scope(query) if should_apply_any_scope?
 
         # Get the count
         results_count = query.reselect(resource.model_class.primary_key).count
 
-        # Get the results
-        query = query.limit(search_results_count(resource))
-
-        results = apply_search_metadata(query, resource)
+        limited_query = Avo::Search::ResultsLimiter.apply(query)
+        results = apply_search_metadata(limited_query, resource)
       end
 
       [results_count, results]

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -272,10 +272,6 @@ module Avo
           search.dig(:query)
         end
 
-        def search_results_count
-          search.dig(:results_count)
-        end
-
         def fetch_search(key, record: nil)
           # self.class.fetch_search
           Avo::ExecutionContext.new(target: search[key], resource: self, record: record).handle

--- a/lib/avo/search/results_limiter.rb
+++ b/lib/avo/search/results_limiter.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Avo
+  module Search
+    module ResultsLimiter
+      def self.apply(query)
+        return query if query.is_a?(Array)
+
+        query = query.all if query.is_a?(Class)
+        return query if query.limit_value.present?
+
+        query.limit(Avo.configuration.search_results_count)
+      end
+    end
+  end
+end

--- a/spec/lib/avo/search/results_limiter_spec.rb
+++ b/spec/lib/avo/search/results_limiter_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Avo::Search::ResultsLimiter do
+  describe ".apply" do
+    context "with an Array" do
+      it "returns the array unchanged" do
+        array = [{_label: "a"}, {_label: "b"}, {_label: "c"}]
+
+        expect(described_class.apply(array)).to eq(array)
+      end
+    end
+
+    context "with an ActiveRecord relation" do
+      before do
+        10.times { |i| create(:user, first_name: "LimitUser#{i}") }
+      end
+
+      it "applies the default limit when the relation has no user limit" do
+        query = User.where("first_name LIKE ?", "LimitUser%")
+
+        result = described_class.apply(query)
+
+        expect(result.limit_value).to eq(Avo.configuration.search_results_count)
+        expect(result.count).to eq(Avo.configuration.search_results_count)
+      end
+
+      it "keeps the user limit when one is already applied" do
+        query = User.where("first_name LIKE ?", "LimitUser%").limit(20)
+
+        result = described_class.apply(query)
+
+        expect(result.limit_value).to eq(20)
+        expect(result.count).to eq(10)
+      end
+    end
+
+    context "with a model class" do
+      it "coerces to a relation and applies the default limit" do
+        3.times { |i| create(:user, first_name: "ClassLimit#{i}") }
+
+        allow(Avo.configuration).to receive(:search_results_count).and_return(2)
+
+        result = described_class.apply(User)
+
+        expect(result.limit_value).to eq(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Avo::Search::ResultsLimiter` to apply `config.search_results_count` only when the search relation has no user-applied `.limit()`
- Leave array results from custom search providers uncapped
- Remove per-resource `search[:results_count]` from `SearchController` and `Avo::Resources::Base`

## Test plan
- [x] `bundle exec rspec spec/lib/avo/search/results_limiter_spec.rb`
- [ ] Verify legacy JSON search (`SearchController`) respects `.limit()` in resource query procs
- [ ] Verify resources without a user limit still default to `config.search_results_count`


Made with [Cursor](https://cursor.com)