### PR TITLE
Remove humanize and downcase usages

### DIFF
--- a/app/components/avo/fields/preview_field/index_component.rb
+++ b/app/components/avo/fields/preview_field/index_component.rb
@@ -2,7 +2,7 @@
 
 class Avo::Fields::PreviewField::IndexComponent < Avo::Fields::IndexComponent
   def render_preview
-    link_to resource_view_path, title: t("avo.view_item", item: @resource.name).humanize do
+    link_to resource_view_path, title: t("avo.view_item", item: @resource.name) do
       helpers.svg(
         "tabler/outline/zoom-scan",
         class: "block h-6 text-content-secondary",

--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -250,7 +250,7 @@ class Avo::ResourceComponent < Avo::BaseComponent
         turbo_method: :delete,
         turbo_confirm: "Are you sure you want to detach this #{title}."
       } do
-      control.label || t("avo.detach_item", item: title).humanize
+      control.label || t("avo.detach_item", item: title)
     end
   end
 

--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -63,7 +63,7 @@
 
         <% header.with_controls do %>
           <div class="flex gap-3 flex-wrap">
-            <% @resource.render_index_controls(item: singular_resource_name.downcase).each do |control| %>
+            <% @resource.render_index_controls(item: singular_resource_name).each do |control| %>
               <%= render_control control %>
             <% end %>
           </div>

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -21,7 +21,7 @@ module Avo
     layout :choose_layout
 
     def index
-      @page_title = @resource.plural_name.humanize
+      @page_title = @resource.plural_name
 
       if @reflection.present? && !turbo_frame_request?
         # A good rule of thumb is that the resource name entry (Users) gets just the initials
@@ -29,7 +29,7 @@ module Avo
         add_breadcrumb title: @record.class.to_s.pluralize, path: resources_path(resource: @parent_resource), initials: @parent_resource.class.initials
         add_breadcrumb title: @parent_resource.record_title, path: resource_path(record: @record, resource: @parent_resource), initials: @parent_resource.initials, avatar: @parent_resource.avatar
       end
-      add_breadcrumb title: @resource.plural_name.humanize, initials: @resource.class.initials
+      add_breadcrumb title: @resource.plural_name, initials: @resource.class.initials
 
       set_applied_filters
       set_index_params
@@ -116,12 +116,12 @@ module Avo
         add_breadcrumb title: via_resource.plural_name, path: resources_path(resource: via_resource), initials: via_resource.class.initials
         add_breadcrumb title: via_resource.record_title, path: resource_path(record: via_record, resource: via_resource), avatar: via_resource.avatar, initials: via_resource.initials
 
-        add_breadcrumb title: @resource.plural_name.humanize, initials: @resource.class.initials
+        add_breadcrumb title: @resource.plural_name, initials: @resource.class.initials
       else
-        add_breadcrumb title: @resource.plural_name.humanize, path: resources_path(resource: @resource), initials: @resource.class.initials
+        add_breadcrumb title: @resource.plural_name, path: resources_path(resource: @resource), initials: @resource.class.initials
       end
 
-      add_breadcrumb title: t("avo.new").humanize
+      add_breadcrumb title: t("avo.new")
 
       set_component_for __method__, fallback_view: :edit
 
@@ -164,8 +164,8 @@ module Avo
       saved = save_record
       @resource.hydrate(record: @record, view: Avo::ViewInquirer.new(:new), user: _current_user)
 
-      add_breadcrumb title: @resource.plural_name.humanize, path: resources_path(resource: @resource), initials: @resource.class.initials
-      add_breadcrumb title: t("avo.new").humanize, path: nil, avatar: @resource.avatar, initials: @resource.initials
+      add_breadcrumb title: @resource.plural_name, path: resources_path(resource: @resource), initials: @resource.class.initials
+      add_breadcrumb title: t("avo.new"), path: nil, avatar: @resource.avatar, initials: @resource.initials
       set_actions
 
       set_component_for :edit
@@ -435,13 +435,13 @@ module Avo
           via_resource_class: params[:via_resource_class],
           via_record_id: params[:via_record_id]
         }
-        add_breadcrumb title: @resource.plural_name.humanize, initials: @resource.class.initials
+        add_breadcrumb title: @resource.plural_name, initials: @resource.class.initials
       else
-        add_breadcrumb title: @resource.plural_name.humanize, path: resources_path(resource: @resource), initials: @resource.class.initials
+        add_breadcrumb title: @resource.plural_name, path: resources_path(resource: @resource), initials: @resource.class.initials
       end
 
       add_breadcrumb title: @resource.record_title, path: resource_path(record: @resource.record, resource: @resource, **last_crumb_args), avatar: @resource.avatar, initials: @resource.initials
-      add_breadcrumb title: t("avo.edit").humanize
+      add_breadcrumb title: t("avo.edit")
     end
 
     def create_success_action
@@ -723,9 +723,9 @@ module Avo
         add_breadcrumb title: via_resource.plural_name, path: resources_path(resource: via_resource), initials: via_resource.class.initials
         add_breadcrumb title: via_resource.record_title, path: resource_path(record: via_record, resource: via_resource), avatar: via_resource.avatar, initials: via_resource.initials
 
-        add_breadcrumb title: @resource.plural_name.humanize, path: nil, initials: @resource.class.initials
+        add_breadcrumb title: @resource.plural_name, path: nil, initials: @resource.class.initials
       else
-        add_breadcrumb title: @resource.plural_name.humanize, path: resources_path(resource: @resource), initials: @resource.class.initials
+        add_breadcrumb title: @resource.plural_name, path: resources_path(resource: @resource), initials: @resource.class.initials
       end
     end
 

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -140,11 +140,11 @@ module Avo
       end
 
       def translated_name(default:)
-        t(translation_key, count: 1, default: default).humanize
+        t(translation_key, count: 1, default: default)
       end
 
       def translated_plural_name(default:)
-        t(translation_key, count: 2, default: default).humanize
+        t(translation_key, count: 2, default: default)
       end
 
       def width_class

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -233,7 +233,7 @@ module Avo
         #       product:
         #         save: "Save product"
         def name_from_translation_key(count:, default:)
-          t(translation_key, count:, default:).humanize
+          t(translation_key, count:, default:)
         rescue I18n::InvalidPluralizationData
           default
         end
@@ -243,7 +243,7 @@ module Avo
         end
 
         def navigation_label
-          plural_name.humanize
+          plural_name
         end
 
         def find_record(id, query: nil, params: nil)

--- a/lib/avo/resources/controls/create_button.rb
+++ b/lib/avo/resources/controls/create_button.rb
@@ -6,7 +6,7 @@ module Avo
           super(**args)
 
           if args[:item].present?
-            @label = I18n.t("avo.create_new_item", item: args[:item].humanize(capitalize: false)) if label.nil?
+            @label = I18n.t("avo.create_new_item", item: args[:item]) if label.nil?
           end
         end
       end

--- a/lib/avo/resources/controls/delete_button.rb
+++ b/lib/avo/resources/controls/delete_button.rb
@@ -7,7 +7,7 @@ module Avo
 
           @label = args[:label] || I18n.t("avo.delete").capitalize
           if args[:item].present?
-            @title = I18n.t("avo.delete_item", item: args[:item]).humanize if title.nil?
+            @title = I18n.t("avo.delete_item", item: args[:item]) if title.nil?
             @confirmation_message = I18n.t("avo.are_you_sure") if confirmation_message.nil?
           end
         end

--- a/lib/avo/resources/controls/detach_button.rb
+++ b/lib/avo/resources/controls/detach_button.rb
@@ -6,7 +6,7 @@ module Avo
           super(**args)
 
           if args[:item].present?
-            @title = I18n.t("avo.detach_item", item: args[:item]).humanize if title.nil?
+            @title = I18n.t("avo.detach_item", item: args[:item]) if title.nil?
             @confirmation_message = I18n.t("avo.are_you_sure_detach_item", item: args[:item]) if confirmation_message.nil?
           end
         end

--- a/lib/avo/resources/controls/edit_button.rb
+++ b/lib/avo/resources/controls/edit_button.rb
@@ -7,7 +7,7 @@ module Avo
 
           @label = args[:label] || I18n.t("avo.edit").capitalize
           if args[:item].present?
-            @title = I18n.t("avo.edit_item", item: args[:item]).humanize if title.nil?
+            @title = I18n.t("avo.edit_item", item: args[:item]) if title.nil?
           end
         end
       end

--- a/lib/avo/resources/controls/show_button.rb
+++ b/lib/avo/resources/controls/show_button.rb
@@ -6,7 +6,7 @@ module Avo
           super(**args)
 
           if args[:item].present?
-            @title = I18n.t("avo.view_item", item: args[:item]).humanize if title.nil?
+            @title = I18n.t("avo.view_item", item: args[:item]) if title.nil?
           end
         end
       end


### PR DESCRIPTION
# Description

Removes some usages of humanize and downcase.

Fixes parts of #4186

While in the english language, downcasing most words works well, in e.g. german, nouns are written with a capital letter at the start, so e.g. writing "New location" in german would need to be `Neuer Standort` and not `Neuer standort`. 

I'd like to point out that I did some experiments locally with rbspy to find out why Avo is not as fast as I'd expect it to be - and in the flamegraph, the `humanize` method was very present, as it uses a Regex-Replace with gsub internally. I'm not sure if this is really a culprit for less-than-ideal performance, but it could probably help to only call humanize when it's absolutely neccessary 🙂