### PR TITLE
AVO-1312: Harden Avo::EngineDSL load order

### DIFF
--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -1,10 +1,11 @@
+require_relative "avo/engine_dsl"
+
 require "zeitwerk"
 require "net/http"
 require "active_support/inflector"
 require_relative "avo/version"
 require_relative "avo/tailwind_builder"
 require_relative "avo/configuration"
-require_relative "avo/engine_dsl"
 require_relative "avo/engine" if defined?(Rails)
 
 loader = Zeitwerk::Loader.for_gem
@@ -15,6 +16,7 @@ loader.inflector.inflect(
   "engine_dsl" => "EngineDSL"
 )
 loader.ignore("#{__dir__}/generators")
+loader.ignore("#{__dir__}/avo/engine_dsl.rb")
 loader.setup
 
 module Avo

--- a/spec/lib/avo/engine_dsl_spec.rb
+++ b/spec/lib/avo/engine_dsl_spec.rb
@@ -1,5 +1,12 @@
 require "rails_helper"
 
+RSpec.describe "Avo::EngineDSL load order" do
+  it "is available via standalone require without full avo boot" do
+    expect(Avo::EngineDSL).to be_a(Module)
+    expect(Avo::EngineDSL.instance_methods).to include(:avo_engine)
+  end
+end
+
 RSpec.describe Avo::EngineDSL do
   before do
     stub_const("Avo::EngineDSLSpec", Module.new)


### PR DESCRIPTION
## Summary
- Loads `engine_dsl` before Zeitwerk setup and ignores it from eager_load.
- Adds regression specs for standalone `Avo::EngineDSL` require.

Fixes [AVO-1312](https://linear.app/avo-hq/issue/AVO-1312) (`rails c` NameError in plugin gems).

## Test plan
- [ ] `bundle exec rspec spec/lib/avo/engine_dsl_spec.rb`
- [ ] Path dep this `avo` branch in a plugin gem; `rails c` boots

Made with [Cursor](https://cursor.com)