### PR TITLE
Remove obsolete deprecated APIs for Avo 4 (AVO-1153)

### DIFF
--- a/app/components/avo/fields/common/files/view_type/grid_item_component.rb
+++ b/app/components/avo/fields/common/files/view_type/grid_item_component.rb
@@ -19,19 +19,19 @@ class Avo::Fields::Common::Files::ViewType::GridItemComponent < Avo::BaseCompone
   end
 
   def is_image?
-    file.image? || @field.is_image
+    file.image?
   rescue
     false
   end
 
   def is_audio?
-    file.audio? || @field.is_audio
+    file.audio?
   rescue
     false
   end
 
   def is_video?
-    file.video? || @field.is_video
+    file.video?
   rescue
     false
   end

--- a/app/components/avo/fields/file_field/edit_component.html.erb
+++ b/app/components/avo/fields/file_field/edit_component.html.erb
@@ -10,7 +10,7 @@
     <div data-controller="clear-input">
       <%= render Avo::UI::FileUploadInputComponent.new(
         id: upload_input_id,
-        title: @field.is_audio ? "Upload audio" : "Click to upload",
+        title: @field.accept&.include?("audio") ? "Upload audio" : "Click to upload",
         subtitle: "or drag and drop",
         description: @field.accept.present? ? "Accepts #{@field.accept}" : nil,
         disabled: disabled?,

--- a/app/components/avo/fields/file_field/index_component.html.erb
+++ b/app/components/avo/fields/file_field/index_component.html.erb
@@ -1,8 +1,8 @@
 <%= index_field_wrapper(**field_wrapper_args, flush: flush?) do %>
   <% if @field.value.present? %>
-    <% if @field.value.attached? && @field.value.representable? && @field.is_image %>
+    <% if @field.value.attached? && @field.value.representable? && @field.value.image? %>
       <%= link_to_if @field.link_to_record, image_tag(helpers.main_app.url_for(@field.value), class: 'h-10'), resource_view_path, class: 'block' %>
-    <% elsif @field.value.attached? && @field.is_audio %>
+    <% elsif @field.value.attached? && @field.value.audio? %>
       <%= link_to_if @field.link_to_record, audio_tag(helpers.main_app.url_for(@field.value), controls: true, preload: false, class: 'max-h-full h-10'), resource_view_path, class: 'block h-8' %>
     <% else %>
       <%= @field.value.filename %>

--- a/app/components/avo/fields/file_field/index_component.rb
+++ b/app/components/avo/fields/file_field/index_component.rb
@@ -6,10 +6,10 @@ class Avo::Fields::FileField::IndexComponent < Avo::Fields::IndexComponent
   end
 
   def has_image_tag?
-    field.value.present? && field.value.attached? && field.value.representable? && field.is_image
+    field.value.present? && field.value.attached? && field.value.representable? && field.value.image?
   end
 
   def has_audio_tag?
-    field.value.present? && field.value.attached? && field.is_audio
+    field.value.present? && field.value.attached? && field.value.audio?
   end
 end

--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -22,7 +22,6 @@ module Avo
       # Show on all other views
       true
     }
-    class_attribute :may_download_file
     class_attribute :turbo
     class_attribute :authorize, default: true
     class_attribute :close_modal_on_backdrop_click, default: true
@@ -141,10 +140,6 @@ module Avo
 
       @response ||= {}
       @response[:messages] = []
-
-      if may_download_file.present?
-        puts "[Avo->] WARNING! Since version 3.2.2 'may_download_file' is unecessary and deprecated on actions. Can be safely removed from #{self.class.name}"
-      end
     end
 
     # Blank method

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -80,13 +80,7 @@ module Avo
         @nullable = args[:nullable] || false
         @null_values = args[:null_values] || [nil, ""]
         @format_using = args[:format_using]
-        @format_display_using = args[:format_display_using] || args[:decorate]
-
-        unless Rails.env.production?
-          if args[:decorate].present?
-            puts "[Avo DEPRECATION WARNING]: The `decorate` field configuration option is nolonger supported and will be removed in future versions. Please discontinue its use and solely utilize `format_display_using` instead."
-          end
-        end
+        @format_display_using = args[:format_display_using]
 
         @format_index_using = args[:format_index_using]
         @format_show_using = args[:format_show_using]
@@ -94,7 +88,6 @@ module Avo
         @format_new_using = args[:format_new_using]
         @format_form_using = args[:format_form_using]
         @update_using = args[:update_using]
-        @decorate = args[:decorate]
         @placeholder = args[:placeholder]
         @autocomplete = args[:autocomplete]
         @help = args[:help]
@@ -235,13 +228,7 @@ module Avo
         end
 
         # Format value based on available formatter
-        final_value = format_value(final_value)
-
-        if @decorate.present? && @view.display?
-          final_value = execute_context(@decorate, value: final_value)
-        end
-
-        final_value
+        format_value(final_value)
       end
 
       def execute_context(target, **extra_args)

--- a/lib/avo/fields/file_field.rb
+++ b/lib/avo/fields/file_field.rb
@@ -3,8 +3,6 @@ module Avo
     class FileField < BaseField
       attr_accessor :link_to_record
       attr_accessor :is_avatar
-      attr_accessor :is_image
-      attr_accessor :is_audio
       attr_accessor :direct_upload
       attr_accessor :accept
       attr_reader :display_filename
@@ -14,8 +12,6 @@ module Avo
 
         @link_to_record = args[:link_to_record].present? ? args[:link_to_record] : false
         @is_avatar = args[:is_avatar].present? ? args[:is_avatar] : false
-        @is_image = args[:is_image].present? ? args[:is_image] : @is_avatar
-        @is_audio = args[:is_audio].present? ? args[:is_audio] : false
         @direct_upload = args[:direct_upload].present? ? args[:direct_upload] : false
         @accept = args[:accept].present? ? args[:accept] : nil
         @display_filename = args[:display_filename].nil? ? true : args[:display_filename]

--- a/lib/avo/fields/files_field.rb
+++ b/lib/avo/fields/files_field.rb
@@ -1,8 +1,6 @@
 module Avo
   module Fields
     class FilesField < BaseField
-      attr_accessor :is_audio
-      attr_accessor :is_image
       attr_accessor :direct_upload
       attr_accessor :accept
       attr_reader :display_filename
@@ -12,8 +10,6 @@ module Avo
       def initialize(id, **args, &block)
         super
 
-        @is_audio = args[:is_audio].present? ? args[:is_audio] : false
-        @is_image = args[:is_image].present? ? args[:is_image] : @is_avatar
         @direct_upload = args[:direct_upload].present? ? args[:direct_upload] : false
         @accept = args[:accept].present? ? args[:accept] : nil
         @display_filename = args[:display_filename].nil? || args[:display_filename]

--- a/lib/avo/fields/tags_field.rb
+++ b/lib/avo/fields/tags_field.rb
@@ -20,14 +20,6 @@ module Avo
         add_string_prop args, :suggestions_max_items
         add_string_prop args, :mode, nil
         add_string_prop args, :fetch_values_from
-
-        @format_using ||= args[:fetch_labels]
-
-        unless Rails.env.production?
-          if args[:fetch_labels].present?
-            puts "[Avo DEPRECATION WARNING]: The `fetch_labels` field configuration option is no longer supported and will be removed in future versions. Please discontinue its use and solely utilize the `format_using` instead."
-          end
-        end
       end
 
       def select_mode?

--- a/lib/avo/resources/items/holder.rb
+++ b/lib/avo/resources/items/holder.rb
@@ -28,21 +28,13 @@ class Avo::Resources::Items::Holder
     if field_parser.invalid?
       as = args.fetch(:as, nil)
 
-      alert_type = :error
       message = "Invalid field configuration"
       description = "Check your resource file for: <code>field :#{field_name}, as: :#{as}</code>"
 
-      if as == :markdown
-        alert_type = :warning
-        message = "Deprecated field type :markdown"
-        description = "In Avo 3.16.2 we renamed <code>:markdown</code> to <code>:easy_mde</code>. You may continue to use that one or the new and improved one with Active Storage support. Read more about it in the <a href=\"https://docs.avohq.io/3.0/fields/markdown.html\" target=\"_blank\">docs</a>."
-      end
-
-      # End execution here and add the field to the invalid_fields payload so we know to warn the developer about that.
       return add_invalid_field({
         name: field_name,
         as:,
-        alert_type:,
+        alert_type: :error,
         message:,
         description:
       })

--- a/spec/dummy/app/avo/resources/event.rb
+++ b/spec/dummy/app/avo/resources/event.rb
@@ -41,8 +41,8 @@ class Avo::Resources::Event < Avo::BaseResource
         foo: :bar
       }
 
-    field :avatar, as: :file, is_image: true, only_on: :forms
-    field :cover, as: :file, is_image: true, only_on: :forms
+    field :avatar, as: :file, only_on: :forms
+    field :cover, as: :file, only_on: :forms
 
     if params[:show_location_field] == "1"
       # Example for error message when resource is missing

--- a/spec/dummy/app/avo/resources/photo_comment.rb
+++ b/spec/dummy/app/avo/resources/photo_comment.rb
@@ -18,7 +18,7 @@ class Avo::Resources::PhotoComment < Avo::BaseResource
     field :id, as: :id
     field :body, as: :textarea
     field :tiny_name, as: :text, only_on: :index
-    field :photo, as: :file, is_image: true, full_width: true, hide_on: [], accept: "image/*"
+    field :photo, as: :file, full_width: true, hide_on: [], accept: "image/*"
     field :user, as: :belongs_to
     field :commentable_type, as: :hidden, default: "Post"
     field :commentable_id, as: :hidden, default: -> { Avo::Current.params[:via_record_id] }

--- a/spec/dummy/app/avo/resources/playground.rb
+++ b/spec/dummy/app/avo/resources/playground.rb
@@ -42,8 +42,8 @@ class Avo::Resources::Playground < Avo::BaseResource
     end
     field :external_image_url, as: :external_image
     field :gravatar_email, as: :gravatar, size: 48
-    field :file_attachment, as: :file, is_image: true
-    field :files_attachments, as: :files, is_image: true
+    field :file_attachment, as: :file
+    field :files_attachments, as: :files
 
     field :geo_heading, as: :heading, name: "Geo fields"
     field :location_coordinates, as: :location, stored_as: [:latitude, :longitude]

--- a/spec/dummy/app/avo/resources/post.rb
+++ b/spec/dummy/app/avo/resources/post.rb
@@ -73,9 +73,9 @@ class Avo::Resources::Post < Avo::BaseResource
           hide_attachment_url: true,
           hide_attachment_filename: true,
           hide_attachment_filesize: true
-        field :cover, as: :file, is_image: true, full_width: true, hide_on: [], accept: "image/*", stacked: true
+        field :cover, as: :file, full_width: true, hide_on: [], accept: "image/*", stacked: true
         field :cover, as: :external_image, name: "Cover photo", required: true, hide_on: :all, link_to_record: true, format_using: -> { value.present? ? value&.url : nil }
-        field :audio, as: :file, is_audio: true, accept: "audio/*"
+        field :audio, as: :file, accept: "audio/*"
 
         field :user, as: :belongs_to, placeholder: "—"
         field :status, as: :select, enum: ::Post.statuses, display_value: false, summarizable: true

--- a/spec/dummy/app/avo/resources/product.rb
+++ b/spec/dummy/app/avo/resources/product.rb
@@ -62,7 +62,7 @@ class Avo::Resources::Product < Avo::BaseResource
         }
         field :price, as: :money, currencies: %w[EUR USD RON PEN]
         field :description, as: :tiptap, placeholder: "Enter text", always_show: false
-        field :image, as: :file, is_image: true
+        field :image, as: :file
         field :category, as: :select, enum: ::Product.categories
         field :sizes, as: :select, multiple: true, options: {Large: :large, Medium: :medium, Small: :small}
       end

--- a/spec/dummy/app/avo/resources/z_post.rb
+++ b/spec/dummy/app/avo/resources/z_post.rb
@@ -56,9 +56,9 @@ class Avo::Resources::ZPost < Avo::BaseResource
       suggestions: -> { Post.tags_suggestions },
       enforce_suggestions: true,
       help: "The only allowed values here are `one`, `two`, and `three`"
-    field :cover, as: :file, is_image: true, full_width: true, hide_on: [], accept: "image/*"
+    field :cover, as: :file, full_width: true, hide_on: [], accept: "image/*"
     field :cover, as: :external_image, name: "Cover photo", required: true, hide_on: :all, link_to_record: true, format_using: ->(value) { value.present? ? value&.url : nil }
-    field :audio, as: :file, is_audio: true, accept: "audio/*"
+    field :audio, as: :file, accept: "audio/*"
     field :is_featured, as: :boolean, visible: -> { Avo::Current.context[:user].is_admin? }
     field :is_published, as: :boolean do
       record.published_at.present?

--- a/spec/features/avo/text_field_spec.rb
+++ b/spec/features/avo/text_field_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "TextField", type: :feature do
     end
   end
 
-  describe "decorate" do
+  describe "format_display_using" do
     let!(:city) { create :city, population: 18000 }
 
     it "only on display" do

--- a/spec/system/avo/group_2/tags_spec.rb
+++ b/spec/system/avo/group_2/tags_spec.rb
@@ -183,30 +183,7 @@ RSpec.describe "Tags", type: :system do
     end
   end
 
-  describe "fetch labels" do
-    let!(:users) { create_list :user, 2 }
-    let!(:courses) { create_list :course, 2, skills: users.pluck(:id) }
-
-    it "fetches the labels" do
-      Avo::Resources::Course.with_temporary_items do
-        field :skills, as: :tags,
-          fetch_labels: -> {
-            User.where(id: record.skills)
-              .pluck(:first_name, :last_name)
-              .map { |first_name, last_name| "FL #{first_name} #{last_name}" }
-          }
-      end
-
-      visit "/admin/resources/courses"
-
-      expect(page).to have_text "FL #{users[0].first_name} #{users[0].last_name}"
-      expect(page).to have_text "FL #{users[1].first_name} #{users[1].last_name}"
-    ensure
-      Avo::Resources::Course.restore_items_from_backup
-    end
-  end
-
-  describe "format_using (same as deprecated fetch_labels) with fetch_values_from" do
+  describe "format_using with fetch_values_from" do
     let!(:users) { create_list :user, 2, first_name: "Bob" }
     let!(:courses) { create_list :course, 2, skills: users.pluck(:id) }
     let(:field_value_slot) { tags_element(find_field_value_element("skills")) }


### PR DESCRIPTION
## Summary

- Remove backward-compat shims and runtime deprecation warnings for `decorate`, `fetch_labels`, and `may_download_file`
- Remove `is_image`, `is_audio`, and `is_video` file field options; rendering now relies on Active Storage content-type detection
- Drop the special `:markdown` invalid-field migration message in favor of the standard invalid field error
- TipTap field is **kept** — only the other deprecated APIs are removed
- Update dummy app resources and specs to use current APIs

Closes AVO-1153

## Test plan

- [ ] `bundle exec rspec spec/features/avo/text_field_spec.rb`
- [ ] `bundle exec rspec spec/system/avo/tags_spec.rb`
- [ ] Verify file fields still render images/audio/video correctly on index and edit views
- [ ] Confirm TipTap field specs still pass