### PR TITLE
Empty-state illustration: relative cards, no fixed height

### DIFF
--- a/app/assets/stylesheets/css/components/ui/state.css
+++ b/app/assets/stylesheets/css/components/ui/state.css
@@ -7,11 +7,11 @@
 }
 
 .state__illustration {
-  @apply relative h-36 w-60 flex items-center justify-center;
+  @apply relative w-60 flex flex-col items-start;
 }
 
 .state__card {
-  @apply absolute flex h-11 w-44 items-center gap-1.5 rounded-lg border border-secondary p-2.5;
+  @apply relative flex h-11 w-44 items-center gap-1.5 rounded-lg border border-secondary p-2.5;
 
   background: linear-gradient(194deg, var(--color-primary) 27%, var(--color-background) 65%);
   box-shadow: var(--box-shadow-card);
@@ -22,11 +22,11 @@
 }
 
 .state__card--middle {
-  @apply start-14 top-8;
+  @apply start-14 -top-3;
 }
 
 .state__card--bottom {
-  @apply start-5 top-20;
+  @apply start-5 -top-2;
 }
 
 .state__badge {
@@ -66,12 +66,18 @@
 }
 
 .state__message {
-  @apply text-base font-normal leading-6 text-content-secondary;
+  @apply text-sm font-mediumˆ leading-tight text-content-secondary;
 }
 
 /*  Frame Load Failed Component */
 .state--frame-load-failed {
   @apply max-w-96 gap-1 min-w-0;
+}
+
+/* This variant's documents/magnifier are absolutely positioned, so its
+   illustration keeps the original fixed-height, centered layout. */
+.state--frame-load-failed .state__illustration {
+  @apply h-36 flex-row items-center justify-center;
 }
 
 .state__document {

--- a/app/assets/stylesheets/css/components/ui/state.css
+++ b/app/assets/stylesheets/css/components/ui/state.css
@@ -66,7 +66,7 @@
 }
 
 .state__message {
-  @apply text-sm font-mediumˆ leading-tight text-content-secondary;
+  @apply text-sm font-medium leading-tight text-content-secondary;
 }
 
 /*  Frame Load Failed Component */


### PR DESCRIPTION
## What & why

<img width="708" height="508" alt="CleanShot 2026-06-08 at 22 13 09@2x" src="https://github.com/user-attachments/assets/63de6a33-178b-4f97-ae82-4cd319713f3f" />



The empty-state illustration was pinned to a fixed `h-36` because its cards were absolutely positioned (out of flow), so the container couldn't size to them. This makes the cards `position: relative` so they drive the illustration's height, and removes the fixed height.

## Same size & position

The cards render at the exact same coordinates as before — only the mechanism changed:

| Card | Before (absolute) | After (relative) | Renders at |
|---|---|---|---|
| top | `start-0 top-0` | `start-0 top-0` | x0, y0–44 |
| middle | `start-14 top-8` | `start-14 -top-3` | x56, y32–76 |
| bottom | `start-5 top-20` | `start-5 -top-2` | x20, y80–124 |

In `flex-col` the cards stack at y = 0 / 44 / 88; the `-top-3` (−12px) and `-top-2` (−8px) relative nudges land them on the same 32 / 80 as the old absolute values. Horizontal `start-*` offsets are unchanged (logical props, so RTL still works).

## Shared class guarded

`.state__illustration` is also used by the frame-load-failed view, whose `.state__document` / `.state__magnifier` are absolutely positioned and depend on the fixed-height, centered context. That layout is restored for that variant only:

```css
.state--frame-load-failed .state__illustration {
  @apply h-36 flex-row items-center justify-center;
}
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation changes in the state component with an explicit override for the frame-load-failed variant.
> 
> **Overview**
> **Empty-state illustration** in `state.css` no longer uses a fixed `h-36` on `.state__illustration`. Cards switch from **absolute** to **relative** positioning in a `flex-col` stack, with middle/bottom cards nudged via negative `top` so they land on the same visual coordinates as before.
> 
> **Frame-load-failed** keeps the old centered, fixed-height illustration via `.state--frame-load-failed .state__illustration` (`h-36`, `flex-row`, centered), since that variant still relies on absolutely positioned documents/magnifier.
> 
> `.state__message` typography is tightened to `text-sm`, `font-medium`, and `leading-tight`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd37bf95a88b2c45383af0fdefa2baf9617d9055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->