### PR TITLE
Fix disabled dropdown actions remaining tab-accessible

### DIFF
--- a/app/components/avo/actions_component.rb
+++ b/app/components/avo/actions_component.rb
@@ -92,7 +92,11 @@ class Avo::ActionsComponent < Avo::BaseComponent
     link_to action.link_arguments(resource: @resource, arguments: action.arguments).first,
       data: action_data_attributes(action),
       title: action.action_name,
-      class: action_css_class(action) do
+      class: action_css_class(action),
+      # Keep disabled actions out of the tab order and announce their state.
+      # The href stays put: item_selector_controller reads it to toggle actions.
+      tabindex: (-1 if action.disabled?),
+      aria: {disabled: action.disabled?} do
         raw("#{icon(icon || action.icon)} #{action.action_name}")
       end
   end

--- a/app/javascript/js/controllers/item_selector_controller.js
+++ b/app/javascript/js/controllers/item_selector_controller.js
@@ -81,6 +81,9 @@ export default class extends Controller {
         link.classList.remove(link.dataset.disabledClasses)
         link.setAttribute('data-href', link.getAttribute('href'))
         link.dataset.disabled = false
+        // Re-enabled actions rejoin the keyboard tab order.
+        link.removeAttribute('tabindex')
+        link.setAttribute('aria-disabled', 'false')
       }
     })
   }
@@ -93,6 +96,9 @@ export default class extends Controller {
         link.classList.add(link.dataset.disabledClasses)
         link.setAttribute('href', link.getAttribute('data-href'))
         link.dataset.disabled = true
+        // Keep disabled actions out of the tab order and announce their state.
+        link.setAttribute('tabindex', '-1')
+        link.setAttribute('aria-disabled', 'true')
       }
     })
   }

--- a/spec/system/avo/group_3/actions_spec.rb
+++ b/spec/system/avo/group_3/actions_spec.rb
@@ -17,6 +17,22 @@ RSpec.describe "Actions", type: :system do
         expect(page.find("a", text: "Dummy action")["data-disabled"]).to eq "false"
         expect(page.find("a", text: "Download file")["data-disabled"]).to eq "false"
       end
+
+      it "keeps disabled actions out of the keyboard tab order" do
+        visit "/admin/resources/users"
+
+        click_on "Actions"
+
+        # Disabled actions must not be reachable via Tab and must announce their state.
+        toggle_inactive = page.find("a", text: "Toggle inactive")
+        expect(toggle_inactive["tabindex"]).to eq "-1"
+        expect(toggle_inactive["aria-disabled"]).to eq "true"
+
+        # Enabled actions stay in the natural tab order.
+        dummy_action = page.find("a", text: "Dummy action")
+        expect(dummy_action["tabindex"]).to be_nil
+        expect(dummy_action["aria-disabled"]).to eq "false"
+      end
     end
 
     context "show" do


### PR DESCRIPTION
# Description
  Disabled actions in the Actions dropdown were greyed out via CSS only, so they were still reachable with the keyboard `Tab` key.

Fixes # (issue)
  - `actions_component.rb`: disabled action links now render with `tabindex="-1"`
    (removed from the tab order) and `aria-disabled="true"` (announced to screen
    readers). The `href` is kept intact since `item_selector_controller` reads it
    to toggle actions client-side.
  - `item_selector_controller.js`: when actions are enabled/disabled on row
    selection, `tabindex` / `aria-disabled` are kept in sync.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<img width="297" height="181" alt="Screenshot 2026-06-09 at 10 04 56" src="https://github.com/user-attachments/assets/dc15fe3d-1738-4673-9e09-ad0f89a4fc36" />
