### PR TITLE
UI4 - refine breadcrumbs sticky positioning and focus offset

### DIFF
--- a/app/assets/stylesheets/css/components/breadcrumbs.css
+++ b/app/assets/stylesheets/css/components/breadcrumbs.css
@@ -1,19 +1,6 @@
 .breadcrumbs {
   @apply sticky z-40 w-full bg-(--color-main-content-background) mb-4;
-  top: calc(var(--top-navbar-height) + var(--spacing) * 2);
-  margin-top: --spacing(-2);
-
-  /* Fake background so the content scrolling underneath the breadcrumbs doesn't look like it's bleeding through */
-  &::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    inset-inline: 0.25rem;
-    height: calc(0.5rem);
-    transform: translateY(-100%);
-    background: var(--color-main-content-background);
-    pointer-events: none;
-  }
+  top: calc(var(--top-navbar-height));
 }
 
 /* Soft fade strip just below the sticky breadcrumbs. Eases the seam between
@@ -35,7 +22,7 @@
 }
 
 .breadcrumbs__container {
-  @apply flex flex-wrap gap-y-0 gap-x-px sm:gap-2 items-center;
+  @apply flex flex-wrap gap-y-0 gap-x-px sm:gap-2 items-center pt-0 mt-0 mb-2;
 }
 
 .breadcrumbs__separator {

--- a/app/assets/stylesheets/css/layout.css
+++ b/app/assets/stylesheets/css/layout.css
@@ -85,7 +85,7 @@
 .main-content.focused,
 .main-content:focus-visible {
   outline: 2px solid var(--color-content);
-  outline-offset: 2px;
+  outline-offset: var(--focus-outline-offset-inset);
 }
 
 .main-content__container {
@@ -159,10 +159,6 @@
 
   > * {
     @apply pointer-events-auto;
-  }
-
-  .breadcrumbs__container {
-    @apply flex-nowrap overflow-x-auto;
   }
 
   /* Inverted arches at the top corners of the content area: a square just


### PR DESCRIPTION
## What

Small UI4 cleanup to the breadcrumbs bar and focused main-content styling.

## Changes

- **Breadcrumbs sticky offset** — simplify `top` to just `var(--top-navbar-height)` (dropping the extra `+ var(--spacing) * 2` and the `margin-top: --spacing(-2)` nudge).
- **Remove fake `::before` backdrop** — the soft fade strip (`.breadcrumbs::after`) already handles the seam with the scrolling content, so the opaque `::before` patch is no longer needed.
- **Tighten container spacing** — `.breadcrumbs__container` now uses `pt-0 mt-0 mb-2`.
- **Focus offset** — focused/`:focus-visible` `.main-content` now uses `var(--focus-outline-offset-inset)` so the ring stays inside and isn't clipped by the navbar/sidebar.
- **Drop mobile nowrap override** — removed the `.breadcrumbs__container { flex-nowrap overflow-x-auto }` mobile rule; breadcrumbs wrap normally.

## Notes

CSS-only, no behavior changes beyond layout/spacing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only spacing and focus-outline adjustments in non-critical layout components.
> 
> **Overview**
> **UI4 breadcrumbs and focus ring tweaks** — CSS-only layout polish with no functional behavior changes beyond spacing and how focus outlines render.
> 
> The sticky **breadcrumbs** bar now pins at `var(--top-navbar-height)` only (no extra spacing nudge), drops the opaque `::before` “fake background” patch in favor of the existing `::after` gradient fade, and tightens `.breadcrumbs__container` with `pt-0 mt-0 mb-2`. The **top navbar** no longer forces breadcrumbs to `flex-nowrap` with horizontal scroll on small screens, so they wrap like the default component styles.
> 
> **Focused main content** (`.main-content.focused` / `:focus-visible`) switches from a fixed `2px` outline offset to `var(--focus-outline-offset-inset)` so the focus ring stays inset and is less likely to be clipped by the navbar or sidebar chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 813f8032ed63809a533232d7f20a8d9cdd48ee94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->