### PR TITLE
UI4 - give the switcher controls a resting transparent outline at the focus

### DIFF
--- a/app/assets/stylesheets/css/components/color_scheme_switcher.css
+++ b/app/assets/stylesheets/css/components/color_scheme_switcher.css
@@ -148,18 +148,6 @@
   }
 }
 
-/* Focus ring starts at the focus color but transparent, so it fades into view
-   rather than starting from the control's (gray) text color. Only the outline
-   color changes between resting and :focus-visible; width/offset stay constant. */
-.color-scheme-switcher__button,
-.color-scheme-switcher__compact-trigger,
-.color-scheme-switcher__theme-option,
-.color-scheme-switcher__accent-option,
-.color-scheme-switcher__scheme-button {
-  outline: var(--focus-outline-width) solid transparent;
-  outline-offset: var(--focus-outline-offset);
-}
-
 /* Scheme buttons - idle vs active state. The active "pill" stands out against
    the inline pill background through the scoped navbar active tokens. */
 .color-scheme-switcher__button[data-scheme="light"],
@@ -284,6 +272,16 @@
   @apply rounded-md transition-all duration-150;
   @apply hover:bg-tertiary;
   @apply border-0 bg-transparent cursor-pointer;
+}
+
+/* Focus ring instant, not animated. Must come after the five control rules. */
+.color-scheme-switcher__button,
+.color-scheme-switcher__compact-trigger,
+.color-scheme-switcher__theme-option,
+.color-scheme-switcher__accent-option,
+.color-scheme-switcher__scheme-button {
+  transition-property: all, outline, outline-offset;
+  transition-duration: 150ms, 0s, 0s;
 }
 
 .color-scheme-switcher__accent-option--active {

--- a/app/assets/stylesheets/css/components/color_scheme_switcher.css
+++ b/app/assets/stylesheets/css/components/color_scheme_switcher.css
@@ -148,6 +148,18 @@
   }
 }
 
+/* Focus ring starts at the focus color but transparent, so it fades into view
+   rather than starting from the control's (gray) text color. Only the outline
+   color changes between resting and :focus-visible; width/offset stay constant. */
+.color-scheme-switcher__button,
+.color-scheme-switcher__compact-trigger,
+.color-scheme-switcher__theme-option,
+.color-scheme-switcher__accent-option,
+.color-scheme-switcher__scheme-button {
+  outline: var(--focus-outline-width) solid transparent;
+  outline-offset: var(--focus-outline-offset);
+}
+
 /* Scheme buttons - idle vs active state. The active "pill" stands out against
    the inline pill background through the scoped navbar active tokens. */
 .color-scheme-switcher__button[data-scheme="light"],

--- a/app/assets/stylesheets/css/pagination.css
+++ b/app/assets/stylesheets/css/pagination.css
@@ -87,13 +87,11 @@
 
   & a:not([role="separator"]) {
     @apply inline-flex items-center justify-center min-w-8 px-3 py-0.5 rounded-lg border border-transparent
-      text-sm font-medium leading-tight text-content no-underline transition-colors;
+      text-sm font-medium leading-tight text-content no-underline transition-all duration-150;
 
-    /* Resting transparent outline so the focus-visible ring fades its color in
-       from transparent instead of morphing from the link's (black) text color.
-       Offset is held at the focused (inset) value so only the color changes. */
-    outline: var(--focus-outline-width) solid transparent;
-    outline-offset: var(--focus-outline-offset-inset);
+    /* Focus ring instant, not animated. */
+    transition-property: all, outline, outline-offset;
+    transition-duration: 150ms, 0s, 0s;
 
     &:hover:not([aria-current="page"]):not([aria-disabled="true"]) {
       @apply bg-secondary;
@@ -112,7 +110,6 @@
     }
 
     &:focus-visible {
-      outline: var(--focus-outline);
       outline-offset: var(--focus-outline-offset-inset);
     }
   }

--- a/app/assets/stylesheets/css/pagination.css
+++ b/app/assets/stylesheets/css/pagination.css
@@ -89,6 +89,12 @@
     @apply inline-flex items-center justify-center min-w-8 px-3 py-0.5 rounded-lg border border-transparent
       text-sm font-medium leading-tight text-content no-underline transition-colors;
 
+    /* Resting transparent outline so the focus-visible ring fades its color in
+       from transparent instead of morphing from the link's (black) text color.
+       Offset is held at the focused (inset) value so only the color changes. */
+    outline: var(--focus-outline-width) solid transparent;
+    outline-offset: var(--focus-outline-offset-inset);
+
     &:hover:not([aria-current="page"]):not([aria-disabled="true"]) {
       @apply bg-secondary;
     }
@@ -106,6 +112,7 @@
     }
 
     &:focus-visible {
+      outline: var(--focus-outline);
       outline-offset: var(--focus-outline-offset-inset);
     }
   }


### PR DESCRIPTION
# Description
Fixes the focus-ring color flash on switcher controls and pagination page links, where focusing flashed a gray/black ring that morphed to the focus blue.

Cause
 These controls had no resting outline, so on focus outline-color animated from its default (the control's own gray/black currentColor) to the focus color. With a transition covering outline-color, that gray/black→blue interpolation was visible as a two-color morph.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording

https://github.com/user-attachments/assets/d1876925-0a52-4a26-936d-66f22ac9ab0d
https://github.com/user-attachments/assets/f3b28830-b561-485f-86a8-caa58174fd34

