### PR TITLE
remove the min-w-48 from the dropdown

### DIFF
--- a/app/assets/stylesheets/css/components/ui/dropdown.css
+++ b/app/assets/stylesheets/css/components/ui/dropdown.css
@@ -19,7 +19,7 @@
 }
 
 .dropdown-menu {
-  @apply flex flex-col w-full rounded-lg border border-tertiary bg-primary min-w-48;
+  @apply flex flex-col w-full rounded-lg border border-tertiary bg-primary;
 }
 
 .dropdown-menu--scrollable {


### PR DESCRIPTION
# Description
Remove the min-w-48 from the dropdown card

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<img width="280" height="222" alt="Screenshot 2026-06-09 at 14 44 10" src="https://github.com/user-attachments/assets/23140624-f108-4677-a502-c64b5b2ef956" />
<img width="451" height="180" alt="Screenshot 2026-06-09 at 14 43 05" src="https://github.com/user-attachments/assets/3a624e54-09cc-4d9d-aa0a-ef954c06b09d" />
