### PR TITLE
Center icons within input action buttons' focus rings

### DIFF
--- a/app/assets/stylesheets/css/components/filters.css
+++ b/app/assets/stylesheets/css/components/filters.css
@@ -51,7 +51,7 @@
 }
 
 .filters-date-input__action {
-  @apply absolute inset-y-0 end-0 flex items-center pe-2.5 text-content-secondary rounded-lg;
+  @apply absolute inset-y-0 end-0 flex items-center justify-center px-2.5 text-content-secondary rounded-lg;
 
   outline-offset: var(--focus-outline-offset-inset);
 }

--- a/app/assets/stylesheets/css/components/input.css
+++ b/app/assets/stylesheets/css/components/input.css
@@ -150,9 +150,9 @@
     ========================================================================== */
 
   .input-field__password-toggle {
-    @apply absolute text-content-secondary inset-y-0 end-0 flex items-center cursor-pointer rounded-lg;
+    @apply absolute text-content-secondary inset-y-0 end-0 flex items-center justify-center cursor-pointer rounded-lg;
 
-    padding-inline-end: var(--input-icon-offset);
+    padding-inline: var(--input-icon-offset);
     outline-offset: var(--focus-outline-offset-inset);
   }
 

--- a/app/components/avo/fields/date_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_field/edit_component.html.erb
@@ -36,16 +36,17 @@
     %>
 
     <%= content_tag :button,
-      class: "absolute end-0 self-center me-2 uppercase font-semibold text-xs disabled:cursor-not-allowed disabled:opacity-50 text-content-secondary cursor-pointer rounded-md",
+      class: "absolute inset-y-0 end-0 flex items-center justify-center px-2.5 uppercase font-semibold text-xs disabled:cursor-not-allowed disabled:opacity-50 text-content-secondary cursor-pointer rounded-md",
       id: :reset,
       type: :button,
       title: t("avo.reset").capitalize,
       disabled: disabled?,
+      style: "outline-offset: var(--focus-outline-offset-inset)",
       data: {
         action: "click->date-field#clear",
         tippy: :tooltip
       } do %>
-      <%= helpers.svg "tabler/outline/x", class: "h-4" %>
+      <%= helpers.svg "tabler/outline/x", class: "size-4" %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/avo/fields/date_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_field/edit_component.html.erb
@@ -36,7 +36,7 @@
     %>
 
     <%= content_tag :button,
-      class: "absolute inset-y-0 end-0 flex items-center justify-center px-2.5 uppercase font-semibold text-xs disabled:cursor-not-allowed disabled:opacity-50 text-content-secondary cursor-pointer rounded-md",
+      class: "absolute inset-y-0 end-0 flex items-center justify-center px-2.5 uppercase font-semibold text-xs disabled:cursor-not-allowed disabled:opacity-50 text-content-secondary cursor-pointer rounded-lg",
       id: :reset,
       type: :button,
       title: t("avo.reset").capitalize,

--- a/app/components/avo/fields/date_time_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_time_field/edit_component.html.erb
@@ -37,7 +37,7 @@
       style: @field.get_html(:style, view: view, element: :input)
     %>
     <%= content_tag :button,
-      class: "absolute inset-y-0 end-0 flex items-center justify-center px-2.5 uppercase font-semibold text-xs disabled:cursor-not-allowed disabled:opacity-50 text-content-secondary cursor-pointer rounded-md",
+      class: "absolute inset-y-0 end-0 flex items-center justify-center px-2.5 uppercase font-semibold text-xs disabled:cursor-not-allowed disabled:opacity-50 text-content-secondary cursor-pointer rounded-lg",
       id: :reset,
       type: :button,
       title: t("avo.reset").capitalize,

--- a/app/components/avo/fields/date_time_field/edit_component.html.erb
+++ b/app/components/avo/fields/date_time_field/edit_component.html.erb
@@ -37,16 +37,17 @@
       style: @field.get_html(:style, view: view, element: :input)
     %>
     <%= content_tag :button,
-      class: "absolute end-0 self-center me-2 uppercase font-semibold text-xs disabled:cursor-not-allowed disabled:opacity-50 text-content-secondary cursor-pointer rounded-md",
+      class: "absolute inset-y-0 end-0 flex items-center justify-center px-2.5 uppercase font-semibold text-xs disabled:cursor-not-allowed disabled:opacity-50 text-content-secondary cursor-pointer rounded-md",
       id: :reset,
       type: :button,
       title: t("avo.reset").capitalize,
       disabled: disabled?,
+      style: "outline-offset: var(--focus-outline-offset-inset)",
       data: {
         action: "click->date-field#clear",
         tippy: :tooltip
       } do %>
-      <%= helpers.svg "tabler/outline/x", class: "h-4" %>
+      <%= helpers.svg "tabler/outline/x", class: "size-4" %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/avo/fields/time_field/edit_component.html.erb
+++ b/app/components/avo/fields/time_field/edit_component.html.erb
@@ -37,7 +37,7 @@
       style: @field.get_html(:style, view: view, element: :input)
     %>
     <%= content_tag :button,
-      class: "absolute inset-y-0 end-0 flex items-center justify-center px-2.5 uppercase font-semibold text-xs disabled:cursor-not-allowed disabled:opacity-50 text-content-secondary cursor-pointer rounded-md",
+      class: "absolute inset-y-0 end-0 flex items-center justify-center px-2.5 uppercase font-semibold text-xs disabled:cursor-not-allowed disabled:opacity-50 text-content-secondary cursor-pointer rounded-lg",
       id: :reset,
       type: :button,
       title: t("avo.reset").capitalize,

--- a/app/components/avo/fields/time_field/edit_component.html.erb
+++ b/app/components/avo/fields/time_field/edit_component.html.erb
@@ -37,16 +37,17 @@
       style: @field.get_html(:style, view: view, element: :input)
     %>
     <%= content_tag :button,
-      class: "absolute end-0 self-center me-2 uppercase font-semibold text-xs disabled:cursor-not-allowed disabled:opacity-50 text-content-secondary cursor-pointer rounded-md",
+      class: "absolute inset-y-0 end-0 flex items-center justify-center px-2.5 uppercase font-semibold text-xs disabled:cursor-not-allowed disabled:opacity-50 text-content-secondary cursor-pointer rounded-md",
       id: :reset,
       type: :button,
       title: t("avo.reset").capitalize,
       disabled: disabled?,
+      style: "outline-offset: var(--focus-outline-offset-inset)",
       data: {
         action: "click->date-field#clear",
         tippy: :tooltip
       } do %>
-      <%= helpers.svg "tabler/outline/x", class: "h-4" %>
+      <%= helpers.svg "tabler/outline/x", class: "size-4" %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
# Description
Centers the icon within the focus-visible ring for input action buttons:

  - Date filter clear (X)
  - Date / datetime / time field clear (X)
  - Password visibility toggle (eye)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<img width="816" height="330" alt="Screenshot 2026-06-09 at 15 04 19" src="https://github.com/user-attachments/assets/5f84ecf1-75b0-4218-87e5-7d8876caf419" />
<img width="426" height="132" alt="Screenshot 2026-06-09 at 15 04 09" src="https://github.com/user-attachments/assets/cbdef8d4-3f76-4054-9fe4-010e658ba720" />
<img width="610" height="61" alt="Screenshot 2026-06-09 at 15 36 54" src="https://github.com/user-attachments/assets/4f8ea90f-cdc3-41e4-a499-ef1d2e3edcb6" />
<img width="845" height="57" alt="Screenshot 2026-06-10 at 07 29 02" src="https://github.com/user-attachments/assets/c67acbae-4d99-4cef-bc16-29574c232c23" />

