### PR TITLE
refactor: streamline query handling in belongs_to_field.rb

### DIFF
--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -328,7 +328,8 @@ module Avo
       private
 
       def scoped_target_query(resource, parent_record, for_find: false)
-        query = for_find ? resource.class.find_scope : resource.query_scope
+        resource_class = resource.is_a?(Class) ? resource : resource.class
+        query = for_find ? resource_class.find_scope : resource_class.query_scope
 
         return query if attach_scope.blank?
 

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -119,11 +119,7 @@ module Avo
         resource = target_resource
         resource = Avo.resource_manager.get_resource_by_model_class model if model.present?
 
-        query = resource.query_scope
-
-        if attach_scope.present?
-          query = Avo::ExecutionContext.new(target: attach_scope, query: query, parent: get_record).handle
-        end
+        query = scoped_target_query(resource, get_record)
 
         query.all.limit(Avo.configuration.associations_lookup_list_limit).map do |record|
           [resource.new(record: record).record_title, record.to_param]
@@ -212,12 +208,18 @@ module Avo
           if valid_model_class.blank? || id_from_param.blank?
             record.send(:"#{polymorphic_as}_id=", nil)
           else
-            record_id = target_resource(record:, polymorphic_model_class: value.safe_constantize).find_record(id_from_param).id
+            target = target_resource(record:, polymorphic_model_class: value.safe_constantize)
+            record_id = target.find_record(id_from_param, query: scoped_target_query(target, record, for_find: true)).id
 
             record.send(:"#{polymorphic_as}_id=", record_id)
           end
         else
-          record_id = value.blank? ? value : target_resource(record:).find_record(value).send(reflection.association_primary_key)
+          target = target_resource(record:)
+          record_id = if value.blank?
+            value
+          else
+            target.find_record(value, query: scoped_target_query(target, record, for_find: true)).send(reflection.association_primary_key)
+          end
 
           record.send(:"#{key}=", record_id)
         end
@@ -324,6 +326,14 @@ module Avo
       end
 
       private
+
+      def scoped_target_query(resource, parent_record, for_find: false)
+        query = for_find ? resource.class.find_scope : resource.query_scope
+
+        return query if attach_scope.blank?
+
+        Avo::ExecutionContext.new(target: attach_scope, query: query, parent: parent_record).handle
+      end
 
       def get_model_class(record)
         if record.nil?

--- a/spec/lib/avo/fields/belongs_to_field_spec.rb
+++ b/spec/lib/avo/fields/belongs_to_field_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe Avo::Fields::BelongsToField, type: :model do
+  describe "#fill_field" do
+    let(:post) { Post.new }
+    let(:post_resource) { Avo::Resources::Post.new(record: post, view: Avo::ViewInquirer.new(:new)) }
+    let(:user_resource) { Avo::Resources::User.new }
+    let!(:out_of_scope_user) { create(:user, first_name: "OutOfScope") }
+    let!(:in_scope_user) { create(:user, first_name: "InScope") }
+
+    let(:field) do
+      described_class.new(:user, attach_scope: -> { ::User.all })
+        .hydrate(record: post, resource: post_resource, view: Avo::ViewInquirer.new(:new))
+    end
+
+    before do
+      allow(field).to receive(:target_resource).with(record: post).and_return(user_resource)
+      allow(field).to receive(:reflection).and_return(Post.reflect_on_association(:user))
+      allow(Avo::Resources::User).to receive(:find_scope).and_return(User.where(id: in_scope_user.id))
+    end
+
+    it "resolves the associated record using attach_scope instead of only find_scope" do
+      field.fill_field(post, :user_id, out_of_scope_user.id.to_s, {})
+
+      expect(post.user_id).to eq(out_of_scope_user.id)
+    end
+
+    it "clears the association when the value is blank" do
+      post.user_id = in_scope_user.id
+
+      field.fill_field(post, :user_id, "", {})
+
+      expect(post.user_id).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
- Replaced direct query handling with a new `scoped_target_query` method to improve readability and maintainability.
- Updated record ID retrieval logic to utilize the new query method, ensuring consistent query scoping for both find and association operations.