### PR TITLE
feat: Manual (on-demand) Turbo Frame loading for tabs and associations

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -160,6 +160,7 @@
   @import "./css/components/discreet_information.css";
   @import "./css/components/header_menu.css";
   @import "./css/components/hotkey.css";
+  @import "./css/components/manual_frame.css";
   @import "./css/components/modal.css";
   @import "./css/components/filters.css";
   @import "./css/components/tab_group.css";

--- a/app/assets/stylesheets/css/components/manual_frame.css
+++ b/app/assets/stylesheets/css/components/manual_frame.css
@@ -1,0 +1,38 @@
+.manual-frame {
+  @apply relative overflow-hidden rounded-lg border border-secondary px-4 py-3;
+}
+
+.manual-frame__overlay {
+  @apply absolute inset-0 z-10 flex items-center justify-center bg-primary/80 backdrop-blur-sm;
+}
+
+.manual-frame__loading {
+  @apply inline-flex items-center gap-2 rounded-lg border border-secondary bg-primary px-3 py-2 text-sm font-medium text-content shadow-panel;
+}
+
+.manual-frame__loading-icon {
+  @apply size-4 animate-spin text-content-secondary;
+}
+
+/* --- Error / Retry state -------------------------------------------------- */
+
+.manual-frame__error-row {
+  @apply flex items-center justify-between gap-3;
+}
+
+.manual-frame__error-message {
+  @apply inline-flex min-w-0 items-center gap-2 truncate text-sm text-content-secondary;
+}
+
+.manual-frame__error-icon {
+  @apply size-4 shrink-0 text-danger-content;
+}
+
+/* Dev-only "open this frame" note. */
+.manual-frame__error-note {
+  @apply mt-2 text-xs text-content-secondary;
+}
+
+.manual-frame__error-link {
+  @apply font-medium underline underline-offset-2;
+}

--- a/app/components/avo/fields/has_many_field/show_component.html.erb
+++ b/app/components/avo/fields/has_many_field/show_component.html.erb
@@ -1,4 +1,4 @@
-<% if @field.manual? && view.display? %>
+<% if @field.manual? && @field.view.display? %>
   <%= render Avo::ManualFrameComponent.new(@field.turbo_frame, deferred_url: @field.frame_url, title: @field.plural_name) %>
 <% else %>
   <%= turbo_frame_tag @field.turbo_frame, src: @field.frame_url, loading: turbo_frame_loading, target: :_top, class: "block" do %>

--- a/app/components/avo/fields/has_many_field/show_component.html.erb
+++ b/app/components/avo/fields/has_many_field/show_component.html.erb
@@ -1,5 +1,5 @@
 <% if @field.manual? && @field.view.display? %>
-  <%= render Avo::ManualFrameComponent.new(@field.turbo_frame, deferred_url: @field.frame_url, title: @field.plural_name) %>
+  <%= render Avo::ManualFrameComponent.new(@field.turbo_frame, deferred_url: @field.frame_url, title: @field.plural_name, description: @field.description) %>
 <% else %>
   <%= turbo_frame_tag @field.turbo_frame, src: @field.frame_url, loading: turbo_frame_loading, target: :_top, class: "block" do %>
     <%= render(Avo::LoadingComponent.new(title: @field.plural_name)) %>

--- a/app/components/avo/fields/has_many_field/show_component.html.erb
+++ b/app/components/avo/fields/has_many_field/show_component.html.erb
@@ -1,5 +1,5 @@
 <% if @field.manual? && @field.view.display? && !helpers.manual_frame_remembered?(@field.frame_url, @field.auto_load_for) %>
-  <%= render Avo::ManualFrameComponent.new(@field.turbo_frame, deferred_url: @field.frame_url, title: @field.plural_name, description: @field.description, auto_load_for: @field.auto_load_for, cookie_name: helpers.manual_frame_cookie_name(@field.frame_url)) %>
+  <%= render Avo::ManualFrameComponent.new(@field.turbo_frame, deferred_url: @field.frame_url, title: @field.plural_name, description: @field.description(loading_type: :manual), auto_load_for: @field.auto_load_for, cookie_name: helpers.manual_frame_cookie_name(@field.frame_url)) %>
 <% else %>
   <%= turbo_frame_tag @field.turbo_frame, src: @field.frame_url, loading: (@field.lazy_loading_mode? ? "lazy" : turbo_frame_loading), target: :_top, class: "block" do %>
     <%= render(Avo::LoadingComponent.new(title: @field.plural_name)) %>

--- a/app/components/avo/fields/has_many_field/show_component.html.erb
+++ b/app/components/avo/fields/has_many_field/show_component.html.erb
@@ -1,7 +1,7 @@
-<% if @field.manual? && @field.view.display? %>
-  <%= render Avo::ManualFrameComponent.new(@field.turbo_frame, deferred_url: @field.frame_url, title: @field.plural_name, description: @field.description) %>
+<% if @field.manual? && @field.view.display? && !helpers.manual_frame_remembered?(@field.frame_url, @field.auto_load_for) %>
+  <%= render Avo::ManualFrameComponent.new(@field.turbo_frame, deferred_url: @field.frame_url, title: @field.plural_name, description: @field.description, auto_load_for: @field.auto_load_for, cookie_name: helpers.manual_frame_cookie_name(@field.frame_url)) %>
 <% else %>
-  <%= turbo_frame_tag @field.turbo_frame, src: @field.frame_url, loading: turbo_frame_loading, target: :_top, class: "block" do %>
+  <%= turbo_frame_tag @field.turbo_frame, src: @field.frame_url, loading: (@field.lazy_loading_mode? ? "lazy" : turbo_frame_loading), target: :_top, class: "block" do %>
     <%= render(Avo::LoadingComponent.new(title: @field.plural_name)) %>
   <% end %>
 <% end %>

--- a/app/components/avo/fields/has_many_field/show_component.html.erb
+++ b/app/components/avo/fields/has_many_field/show_component.html.erb
@@ -1,3 +1,7 @@
-<%= turbo_frame_tag @field.turbo_frame, src: @field.frame_url, loading: turbo_frame_loading, target: :_top, class: "block" do %>
-  <%= render(Avo::LoadingComponent.new(title: @field.plural_name)) %>
+<% if @field.manual? && view.display? %>
+  <%= render Avo::ManualFrameComponent.new(@field.turbo_frame, deferred_url: @field.frame_url, title: @field.plural_name) %>
+<% else %>
+  <%= turbo_frame_tag @field.turbo_frame, src: @field.frame_url, loading: turbo_frame_loading, target: :_top, class: "block" do %>
+    <%= render(Avo::LoadingComponent.new(title: @field.plural_name)) %>
+  <% end %>
 <% end %>

--- a/app/components/avo/fields/has_one_field/show_component.html.erb
+++ b/app/components/avo/fields/has_one_field/show_component.html.erb
@@ -1,5 +1,5 @@
 <% if @field.value %>
-  <% if @field.manual? && view.display? %>
+  <% if @field.manual? && @field.view.display? %>
     <%= render Avo::ManualFrameComponent.new(@field.turbo_frame, deferred_url: @field.frame_url, title: @field.name) %>
   <% else %>
     <%= turbo_frame_tag @field.turbo_frame, src: @field.frame_url, loading: turbo_frame_loading, target: "_top", class: "block" do %>

--- a/app/components/avo/fields/has_one_field/show_component.html.erb
+++ b/app/components/avo/fields/has_one_field/show_component.html.erb
@@ -1,8 +1,8 @@
 <% if @field.value %>
-  <% if @field.manual? && @field.view.display? %>
-    <%= render Avo::ManualFrameComponent.new(@field.turbo_frame, deferred_url: @field.frame_url, title: @field.name, description: @field.description) %>
+  <% if @field.manual? && @field.view.display? && !helpers.manual_frame_remembered?(@field.frame_url, @field.auto_load_for) %>
+    <%= render Avo::ManualFrameComponent.new(@field.turbo_frame, deferred_url: @field.frame_url, title: @field.name, description: @field.description, auto_load_for: @field.auto_load_for, cookie_name: helpers.manual_frame_cookie_name(@field.frame_url)) %>
   <% else %>
-    <%= turbo_frame_tag @field.turbo_frame, src: @field.frame_url, loading: turbo_frame_loading, target: "_top", class: "block" do %>
+    <%= turbo_frame_tag @field.turbo_frame, src: @field.frame_url, loading: (@field.lazy_loading_mode? ? "lazy" : turbo_frame_loading), target: "_top", class: "block" do %>
       <%= render(Avo::LoadingComponent.new(title: @field.name)) %>
     <% end %>
   <% end %>

--- a/app/components/avo/fields/has_one_field/show_component.html.erb
+++ b/app/components/avo/fields/has_one_field/show_component.html.erb
@@ -11,25 +11,25 @@
     <% panel.with_controls do %>
       <% if can_attach? %>
         <%= a_link attach_path,
-          icon: 'tabler/outline/link',
+          icon: "tabler/outline/link",
           color: :primary,
           style: :text,
           data: {
             turbo_frame: Avo::MODAL_FRAME_ID,
             target: :attach
           } do %>
-          <%= t('avo.attach_item', item: @field.name.humanize(capitalize: false)) %>
+          <%= t("avo.attach_item", item: @field.name.humanize(capitalize: false)) %>
         <% end %>
       <% end %>
 
       <% if can_see_the_create_button? %>
         <%= a_link create_path,
-          icon: 'tabler/outline/plus',
-          'data-target': 'create',
-          'data-turbo-frame': '_top',
+          icon: "tabler/outline/plus",
+          "data-target": "create",
+          "data-turbo-frame": "_top",
           style: :primary,
           color: :accent do %>
-          <%= t('avo.create_new_item', item: @field.name.humanize(capitalize: false) ) %>
+          <%= t("avo.create_new_item", item: @field.name.humanize(capitalize: false)) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/avo/fields/has_one_field/show_component.html.erb
+++ b/app/components/avo/fields/has_one_field/show_component.html.erb
@@ -1,6 +1,6 @@
 <% if @field.value %>
   <% if @field.manual? && @field.view.display? && !helpers.manual_frame_remembered?(@field.frame_url, @field.auto_load_for) %>
-    <%= render Avo::ManualFrameComponent.new(@field.turbo_frame, deferred_url: @field.frame_url, title: @field.name, description: @field.description, auto_load_for: @field.auto_load_for, cookie_name: helpers.manual_frame_cookie_name(@field.frame_url)) %>
+    <%= render Avo::ManualFrameComponent.new(@field.turbo_frame, deferred_url: @field.frame_url, title: @field.name, description: @field.description(loading_type: :manual), auto_load_for: @field.auto_load_for, cookie_name: helpers.manual_frame_cookie_name(@field.frame_url)) %>
   <% else %>
     <%= turbo_frame_tag @field.turbo_frame, src: @field.frame_url, loading: (@field.lazy_loading_mode? ? "lazy" : turbo_frame_loading), target: "_top", class: "block" do %>
       <%= render(Avo::LoadingComponent.new(title: @field.name)) %>

--- a/app/components/avo/fields/has_one_field/show_component.html.erb
+++ b/app/components/avo/fields/has_one_field/show_component.html.erb
@@ -1,6 +1,6 @@
 <% if @field.value %>
   <% if @field.manual? && @field.view.display? %>
-    <%= render Avo::ManualFrameComponent.new(@field.turbo_frame, deferred_url: @field.frame_url, title: @field.name) %>
+    <%= render Avo::ManualFrameComponent.new(@field.turbo_frame, deferred_url: @field.frame_url, title: @field.name, description: @field.description) %>
   <% else %>
     <%= turbo_frame_tag @field.turbo_frame, src: @field.frame_url, loading: turbo_frame_loading, target: "_top", class: "block" do %>
       <%= render(Avo::LoadingComponent.new(title: @field.name)) %>

--- a/app/components/avo/fields/has_one_field/show_component.html.erb
+++ b/app/components/avo/fields/has_one_field/show_component.html.erb
@@ -1,6 +1,10 @@
 <% if @field.value %>
-  <%= turbo_frame_tag @field.turbo_frame, src: @field.frame_url, loading: turbo_frame_loading, target: "_top", class: "block" do %>
-    <%= render(Avo::LoadingComponent.new(title: @field.name)) %>
+  <% if @field.manual? && view.display? %>
+    <%= render Avo::ManualFrameComponent.new(@field.turbo_frame, deferred_url: @field.frame_url, title: @field.name) %>
+  <% else %>
+    <%= turbo_frame_tag @field.turbo_frame, src: @field.frame_url, loading: turbo_frame_loading, target: "_top", class: "block" do %>
+      <%= render(Avo::LoadingComponent.new(title: @field.name)) %>
+    <% end %>
   <% end %>
 <% else %>
   <%= render ui.panel(title: @field.name) do |panel| %>

--- a/app/components/avo/manual_frame_component.html.erb
+++ b/app/components/avo/manual_frame_component.html.erb
@@ -36,9 +36,9 @@
     <p class="state__message"><%= label %></p>
 
     <%= a_button color: :primary,
-          icon: "tabler/outline/player-play",
-          aria: { label: load_label },
-          data: { action: "manual-frame#load" } do %>
+                 icon: "tabler/outline/player-play",
+                 aria: {label: load_label},
+                 data: {action: "manual-frame#load"} do %>
       <%= load_label %>
     <% end %>
   </div>
@@ -78,9 +78,9 @@
       </p>
 
       <%= a_button color: :primary,
-            icon: "tabler/outline/refresh",
-            aria: { label: retry_label },
-            data: { action: "manual-frame#retry" } do %>
+                   icon: "tabler/outline/refresh",
+                   aria: {label: retry_label},
+                   data: {action: "manual-frame#retry"} do %>
         <%= t("avo.retry") %>
       <% end %>
     </div>

--- a/app/components/avo/manual_frame_component.html.erb
+++ b/app/components/avo/manual_frame_component.html.erb
@@ -1,6 +1,4 @@
-<%# Manual (on-demand) Turbo Frame: no `src`; the Load button supplies it on click.
-    Three states (placeholder / loading / error) share the frame; the controller
-    swaps between them inside a View Transition so the frame morphs. %>
+<%# Manual (on-demand) Turbo Frame: no `src`; the Load button supplies it on click. %>
 <%= turbo_frame_tag @frame_id,
       target: :_top,
       class: "block",
@@ -9,31 +7,54 @@
         controller: "manual-frame",
         manual_frame_url_value: @deferred_url
       } do %>
-  <%# Placeholder state — a dashed "drop zone" the user clicks to load. %>
-  <div class="<%= class_names("flex flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed border-secondary p-8 text-center", @classes) %>" data-manual-frame-target="placeholder">
-    <p class="text-base font-semibold text-content"><%= label %></p>
-    <p class="text-sm text-content-secondary"><%= t("avo.click_to_load") %></p>
-    <%= a_button color: :primary,
-                 icon: "tabler/outline/player-play",
-                 aria: {label: load_label},
-                 data: {action: "manual-frame#load"} do %>
-      <%= load_label %>
+  <%# Placeholder state. %>
+  <div class="<%= class_names("manual-frame", @classes) %>" data-manual-frame-target="placeholder">
+    <%= render ui.panel_header(title: label, description: @description) do |header| %>
+      <% header.with_controls do %>
+        <%= a_button color: :primary,
+                     icon: "tabler/outline/ripple-down",
+                     aria: {label: load_label},
+                     data: {action: "manual-frame#load"} do %>
+          <%= load_label %>
+        <% end %>
+      <% end %>
     <% end %>
+
+    <div
+      class="manual-frame__overlay"
+      data-manual-frame-target="loading"
+      aria-live="polite"
+      hidden
+    >
+      <div class="manual-frame__loading">
+        <%= svg "tabler/outline/refresh", class: "manual-frame__loading-icon" %>
+        <span><%= t("avo.loading") %></span>
+      </div>
+    </div>
   </div>
 
-  <%# Loading state (R5) — revealed by the controller during the request. %>
-  <div class="hidden flex items-center justify-center rounded-lg border-2 border-dashed border-secondary p-8" data-manual-frame-target="loading" aria-live="polite">
-    <%= render Avo::LoadingComponent.new(title: label) %>
-  </div>
+  <%# Error/Retry state: a quiet inline message (danger-colored icon + muted %>
+  <%# copy), a low-key Retry, and a dev-only link to the failing URL. %>
+  <div
+    class="manual-frame"
+    data-manual-frame-target="error"
+    aria-live="polite"
+    hidden
+  >
+    <div class="manual-frame__error-row">
+      <span class="manual-frame__error-message">
+        <%= svg "tabler/outline/alert-circle", class: "manual-frame__error-icon" %>
+        <%= t("avo.failed_to_load_item", item: label) %>
+      </span>
 
-  <%# Error/Retry state — hidden until a load fails; the controller reveals it. %>
-  <div class="hidden flex flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed border-secondary p-8 text-center" data-manual-frame-target="error" aria-live="polite">
-    <p class="text-base font-normal text-content-secondary"><%= t("avo.failed_to_load_item", item: label) %></p>
-    <%= a_button color: :primary,
-                 icon: "tabler/outline/refresh",
-                 aria: {label: retry_label},
-                 data: {action: "manual-frame#retry"} do %>
-      <%= t("avo.retry") %>
-    <% end %>
+      <%= a_button color: :gray,
+                   icon: "tabler/outline/refresh",
+                   aria: {label: retry_label},
+                   data: {action: "manual-frame#retry"} do %>
+        <%= t("avo.retry") %>
+      <% end %>
+    </div>
+
+    <%= dev_details_note %>
   </div>
 <% end %>

--- a/app/components/avo/manual_frame_component.html.erb
+++ b/app/components/avo/manual_frame_component.html.erb
@@ -1,4 +1,6 @@
-<%# Manual (on-demand) Turbo Frame: no `src`; the Load button supplies it on click. %>
+<%# Manual (on-demand) Turbo Frame: no `src`; the Load button supplies it on click.
+    Three states (placeholder / loading / error) share the frame; the controller
+    swaps between them inside a View Transition so the frame morphs. %>
 <%= turbo_frame_tag @frame_id,
       target: :_top,
       class: "block",
@@ -7,34 +9,10 @@
         controller: "manual-frame",
         manual_frame_url_value: @deferred_url
       } do %>
-  <%# Placeholder state — mirrors EmptyStateComponent's `.state` card markup. %>
-  <div class="<%= class_names("state", @classes) %>" data-manual-frame-target="placeholder">
-    <div class="state__illustration" aria-hidden="true">
-      <div class="state__card state__card--top">
-        <div class="state__badge">1</div>
-        <div class="state__body">
-          <div class="state__line state__line--title state__line--large"></div>
-          <div class="state__line state__line--content"></div>
-        </div>
-      </div>
-      <div class="state__card state__card--middle">
-        <div class="state__badge">2</div>
-        <div class="state__body">
-          <div class="state__line state__line--title state__line--large"></div>
-          <div class="state__line state__line--content"></div>
-        </div>
-      </div>
-      <div class="state__card state__card--bottom">
-        <div class="state__badge">3</div>
-        <div class="state__body">
-          <div class="state__line state__line--title state__line--large"></div>
-          <div class="state__line state__line--content"></div>
-        </div>
-      </div>
-    </div>
-
-    <p class="state__message"><%= label %></p>
-
+  <%# Placeholder state — a dashed "drop zone" the user clicks to load. %>
+  <div class="<%= class_names("flex flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed border-secondary p-8 text-center", @classes) %>" data-manual-frame-target="placeholder">
+    <p class="text-base font-semibold text-content"><%= label %></p>
+    <p class="text-sm text-content-secondary"><%= t("avo.click_to_load") %></p>
     <%= a_button color: :primary,
                  icon: "tabler/outline/player-play",
                  aria: {label: load_label},
@@ -44,45 +22,18 @@
   </div>
 
   <%# Loading state (R5) — revealed by the controller during the request. %>
-  <div class="hidden" data-manual-frame-target="loading" aria-live="polite">
+  <div class="hidden flex items-center justify-center rounded-lg border-2 border-dashed border-secondary p-8" data-manual-frame-target="loading" aria-live="polite">
     <%= render Avo::LoadingComponent.new(title: label) %>
   </div>
 
-  <%# Error/Retry state — hidden until a load fails; mirrors the
-      `.state--frame-load-failed` markup from `home/failed_to_load.html.erb`.
-      The controller reveals this on any failure event for this frame. %>
-  <div class="hidden" data-manual-frame-target="error" aria-live="polite">
-    <div class="state state--frame-load-failed">
-      <div class="state__illustration" aria-hidden="true">
-        <% %i[start center end].each do |position| %>
-          <div class="state__document state__document--<%= position %>">
-            <div class="state__document-body">
-              <div class="state__document-lines">
-                <span class="state__document-line"></span>
-                <span class="state__document-line"></span>
-                <span class="state__document-line"></span>
-                <span class="state__document-line"></span>
-                <span class="state__document-line state__document-line--short"></span>
-              </div>
-            </div>
-          </div>
-        <% end %>
-
-        <div class="state__magnifier">
-          <%= svg "tabler/outline/zoom", class: "state__magnifier-icon" %>
-        </div>
-      </div>
-
-      <p class="state__message text-center font-normal">
-        <%= t("avo.failed_to_load_item", item: label) %>
-      </p>
-
-      <%= a_button color: :primary,
-                   icon: "tabler/outline/refresh",
-                   aria: {label: retry_label},
-                   data: {action: "manual-frame#retry"} do %>
-        <%= t("avo.retry") %>
-      <% end %>
-    </div>
+  <%# Error/Retry state — hidden until a load fails; the controller reveals it. %>
+  <div class="hidden flex flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed border-secondary p-8 text-center" data-manual-frame-target="error" aria-live="polite">
+    <p class="text-base font-normal text-content-secondary"><%= t("avo.failed_to_load_item", item: label) %></p>
+    <%= a_button color: :primary,
+                 icon: "tabler/outline/refresh",
+                 aria: {label: retry_label},
+                 data: {action: "manual-frame#retry"} do %>
+      <%= t("avo.retry") %>
+    <% end %>
   </div>
 <% end %>

--- a/app/components/avo/manual_frame_component.html.erb
+++ b/app/components/avo/manual_frame_component.html.erb
@@ -48,7 +48,7 @@
     <%= render Avo::LoadingComponent.new(title: label) %>
   </div>
 
-  <%# Error/Retry state (Unit 5) — hidden until a load fails; mirrors the
+  <%# Error/Retry state — hidden until a load fails; mirrors the
       `.state--frame-load-failed` markup from `home/failed_to_load.html.erb`.
       The controller reveals this on any failure event for this frame. %>
   <div class="hidden" data-manual-frame-target="error" aria-live="polite">
@@ -74,7 +74,7 @@
       </div>
 
       <p class="state__message text-center font-normal">
-        <%= t("avo.failed_to_load_manual") %>
+        <%= t("avo.failed_to_load_item", item: label) %>
       </p>
 
       <%= a_button color: :primary,

--- a/app/components/avo/manual_frame_component.html.erb
+++ b/app/components/avo/manual_frame_component.html.erb
@@ -1,0 +1,52 @@
+<%# Manual (on-demand) Turbo Frame: no `src`; the Load button supplies it on click. %>
+<%= turbo_frame_tag @frame_id,
+      target: :_top,
+      class: "block",
+      data: {
+        manual_frame: true,
+        controller: "manual-frame",
+        manual_frame_url_value: @deferred_url
+      } do %>
+  <%# Placeholder state — mirrors EmptyStateComponent's `.state` card markup. %>
+  <div class="<%= class_names("state", @classes) %>" data-manual-frame-target="placeholder">
+    <div class="state__illustration" aria-hidden="true">
+      <div class="state__card state__card--top">
+        <div class="state__badge">1</div>
+        <div class="state__body">
+          <div class="state__line state__line--title state__line--large"></div>
+          <div class="state__line state__line--content"></div>
+        </div>
+      </div>
+      <div class="state__card state__card--middle">
+        <div class="state__badge">2</div>
+        <div class="state__body">
+          <div class="state__line state__line--title state__line--large"></div>
+          <div class="state__line state__line--content"></div>
+        </div>
+      </div>
+      <div class="state__card state__card--bottom">
+        <div class="state__badge">3</div>
+        <div class="state__body">
+          <div class="state__line state__line--title state__line--large"></div>
+          <div class="state__line state__line--content"></div>
+        </div>
+      </div>
+    </div>
+
+    <p class="state__message"><%= label %></p>
+
+    <%= a_button color: :primary,
+          icon: "tabler/outline/player-play",
+          aria: { label: load_label },
+          data: { action: "manual-frame#load" } do %>
+      <%= load_label %>
+    <% end %>
+  </div>
+
+  <%# Loading state (R5) — revealed by the controller during the request. %>
+  <div class="hidden" data-manual-frame-target="loading" aria-live="polite">
+    <%= render Avo::LoadingComponent.new(title: label) %>
+  </div>
+
+  <%# Error/Retry state (Unit 5) — markup lands there; the seam is reserved here. %>
+<% end %>

--- a/app/components/avo/manual_frame_component.html.erb
+++ b/app/components/avo/manual_frame_component.html.erb
@@ -5,7 +5,9 @@
       data: {
         manual_frame: true,
         controller: "manual-frame",
-        manual_frame_url_value: @deferred_url
+        manual_frame_url_value: @deferred_url,
+        manual_frame_auto_load_for_value: @auto_load_for,
+        manual_frame_cookie_name_value: @cookie_name
       } do %>
   <%# Placeholder state. %>
   <div class="<%= class_names("manual-frame", @classes) %>" data-manual-frame-target="placeholder">
@@ -24,8 +26,7 @@
       class="manual-frame__overlay"
       data-manual-frame-target="loading"
       aria-live="polite"
-      hidden
-    >
+      hidden>
       <div class="manual-frame__loading">
         <%= svg "tabler/outline/refresh", class: "manual-frame__loading-icon" %>
         <span><%= t("avo.loading") %></span>
@@ -39,8 +40,7 @@
     class="manual-frame"
     data-manual-frame-target="error"
     aria-live="polite"
-    hidden
-  >
+    hidden>
     <div class="manual-frame__error-row">
       <span class="manual-frame__error-message">
         <%= svg "tabler/outline/alert-circle", class: "manual-frame__error-icon" %>

--- a/app/components/avo/manual_frame_component.html.erb
+++ b/app/components/avo/manual_frame_component.html.erb
@@ -48,5 +48,41 @@
     <%= render Avo::LoadingComponent.new(title: label) %>
   </div>
 
-  <%# Error/Retry state (Unit 5) — markup lands there; the seam is reserved here. %>
+  <%# Error/Retry state (Unit 5) — hidden until a load fails; mirrors the
+      `.state--frame-load-failed` markup from `home/failed_to_load.html.erb`.
+      The controller reveals this on any failure event for this frame. %>
+  <div class="hidden" data-manual-frame-target="error" aria-live="polite">
+    <div class="state state--frame-load-failed">
+      <div class="state__illustration" aria-hidden="true">
+        <% %i[start center end].each do |position| %>
+          <div class="state__document state__document--<%= position %>">
+            <div class="state__document-body">
+              <div class="state__document-lines">
+                <span class="state__document-line"></span>
+                <span class="state__document-line"></span>
+                <span class="state__document-line"></span>
+                <span class="state__document-line"></span>
+                <span class="state__document-line state__document-line--short"></span>
+              </div>
+            </div>
+          </div>
+        <% end %>
+
+        <div class="state__magnifier">
+          <%= svg "tabler/outline/zoom", class: "state__magnifier-icon" %>
+        </div>
+      </div>
+
+      <p class="state__message text-center font-normal">
+        <%= t("avo.failed_to_load_manual") %>
+      </p>
+
+      <%= a_button color: :primary,
+            icon: "tabler/outline/refresh",
+            aria: { label: retry_label },
+            data: { action: "manual-frame#retry" } do %>
+        <%= t("avo.retry") %>
+      <% end %>
+    </div>
+  </div>
 <% end %>

--- a/app/components/avo/manual_frame_component.rb
+++ b/app/components/avo/manual_frame_component.rb
@@ -18,20 +18,23 @@ class Avo::ManualFrameComponent < Avo::BaseComponent
   # @param deferred_url [String] the URL the controller loads on click
   # @param title [String] label source; callers pass an already display-ready
   #   name (a field's `plural_name`/`name` or a tab title), used verbatim
-  # @param classes [String, nil] extra CSS classes for the `.state` placeholder container
+  # @param description [String, nil] the field/tab description, shown beside the
+  #   title when present (already resolved by the caller)
+  # @param classes [String, nil] extra CSS classes for the placeholder container
   prop :frame_id, kind: :positional
   prop :deferred_url
   prop :title
+  prop :description
   prop :classes
 
   # The display label. Callers already hand us presentation-ready, translated
-  # text (field name / tab title), so we use it as-is — never `humanize`, which
+  # text (field name / tab title), so we use it as-is. Never `humanize`, which
   # would mangle custom or translated names ("Order Items" -> "Order items").
   def label
     @title.to_s
   end
 
-  # "Load <title>" — interpolated so the full phrase is translatable, matching
+  # "Load <title>", interpolated so the full phrase is translatable, matching
   # the codebase's `attach_item`/`create_new_item` convention.
   def load_label
     t("avo.load_item", item: label)
@@ -41,5 +44,21 @@ class Avo::ManualFrameComponent < Avo::BaseComponent
   # "Retry"; the aria-label scopes it to this frame for screen readers).
   def retry_label
     t("avo.retry_item", item: label)
+  end
+
+  # In development only, a link straight to the deferred URL so a developer can
+  # open the failing frame on its own and read the real error / stack trace
+  # (the inline error state otherwise swallows the response). Mirrors the
+  # dev-only link in `avo/home/failed_to_load.html.erb`. Returns nil elsewhere.
+  def dev_details_note
+    return unless Rails.env.development? && @deferred_url.present?
+
+    helpers.tag.p(class: "manual-frame__error-note") do
+      helpers.safe_join([
+        "Follow ",
+        helpers.link_to("this link", @deferred_url, target: "_blank", rel: "noopener", class: "manual-frame__error-link"),
+        " for more details about the issue and how to fix it."
+      ])
+    end
   end
 end

--- a/app/components/avo/manual_frame_component.rb
+++ b/app/components/avo/manual_frame_component.rb
@@ -20,11 +20,20 @@ class Avo::ManualFrameComponent < Avo::BaseComponent
   #   name (a field's `plural_name`/`name` or a tab title), used verbatim
   # @param description [String, nil] the field/tab description, shown beside the
   #   title when present (already resolved by the caller)
+  # @param auto_load_for [Integer, nil] seconds the browser should remember an
+  #   opened frame and auto-load it on return (sliding window). `nil` disables
+  #   the memory — the frame stays a click-to-load placeholder every visit.
+  # @param cookie_name [String, nil] the cookie the Stimulus controller writes on
+  #   a successful load so the server can render this frame without the Load
+  #   button on the next visit. Paired with `auto_load_for`; both come from the
+  #   `manual_frame_*` application helpers. `nil` when there's no memory window.
   # @param classes [String, nil] extra CSS classes for the placeholder container
   prop :frame_id, kind: :positional
   prop :deferred_url
   prop :title
   prop :description
+  prop :auto_load_for
+  prop :cookie_name
   prop :classes
 
   # The display label. Callers already hand us presentation-ready, translated

--- a/app/components/avo/manual_frame_component.rb
+++ b/app/components/avo/manual_frame_component.rb
@@ -4,38 +4,42 @@
 # clicks the "Load" button. Used by manual (`loading: :manual`) tabs and
 # associations on Show pages.
 #
-# The frame is marked `data-manual-frame` so the global HTTP-500 handler in
-# `application.js` skips it, and it carries the deferred URL in
-# `data-manual-frame-url-value` for the `manual-frame` Stimulus controller,
-# which sets the frame `src` on click.
+# The frame carries the deferred URL in `data-manual-frame-url-value` for the
+# `manual-frame` Stimulus controller, which sets the frame `src` on click and
+# renders an inline error + Retry on failure. It is marked `data-manual-frame`
+# as an identifying hook.
 #
 # States (single component, three states):
-# - placeholder: title + a "Load <title>" button (this unit)
+# - placeholder: title + a "Load <title>" button
 # - loading: `Avo::LoadingComponent` spinner while the request is in flight
-# - error: inline message + Retry (slotted in by Unit 5)
+# - error: inline message + Retry
 class Avo::ManualFrameComponent < Avo::BaseComponent
   # @param frame_id [String] the `<turbo-frame>` id (positional)
   # @param deferred_url [String] the URL the controller loads on click
-  # @param title [String] label source; the button reads "Load <title humanized>"
+  # @param title [String] label source; callers pass an already display-ready
+  #   name (a field's `plural_name`/`name` or a tab title), used verbatim
   # @param classes [String, nil] extra CSS classes for the `.state` placeholder container
   prop :frame_id, kind: :positional
   prop :deferred_url
   prop :title
   prop :classes
 
-  # Humanized label derived from the title (e.g. "order_items" -> "Order items").
+  # The display label. Callers already hand us presentation-ready, translated
+  # text (field name / tab title), so we use it as-is — never `humanize`, which
+  # would mangle custom or translated names ("Order Items" -> "Order items").
   def label
-    @title.to_s.humanize
+    @title.to_s
   end
 
-  # The button copy and aria-label: "Load <title>".
+  # "Load <title>" — interpolated so the full phrase is translatable, matching
+  # the codebase's `attach_item`/`create_new_item` convention.
   def load_label
-    t("avo.load") + " " + label
+    t("avo.load_item", item: label)
   end
 
   # The Retry button's aria-label: "Retry <title>" (the visible copy is just
   # "Retry"; the aria-label scopes it to this frame for screen readers).
   def retry_label
-    t("avo.retry") + " " + label
+    t("avo.retry_item", item: label)
   end
 end

--- a/app/components/avo/manual_frame_component.rb
+++ b/app/components/avo/manual_frame_component.rb
@@ -32,4 +32,10 @@ class Avo::ManualFrameComponent < Avo::BaseComponent
   def load_label
     t("avo.load") + " " + label
   end
+
+  # The Retry button's aria-label: "Retry <title>" (the visible copy is just
+  # "Retry"; the aria-label scopes it to this frame for screen readers).
+  def retry_label
+    t("avo.retry") + " " + label
+  end
 end

--- a/app/components/avo/manual_frame_component.rb
+++ b/app/components/avo/manual_frame_component.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Renders a `<turbo-frame>` with NO `src` that defers loading until the user
+# clicks the "Load" button. Used by manual (`loading: :manual`) tabs and
+# associations on Show pages.
+#
+# The frame is marked `data-manual-frame` so the global HTTP-500 handler in
+# `application.js` skips it, and it carries the deferred URL in
+# `data-manual-frame-url-value` for the `manual-frame` Stimulus controller,
+# which sets the frame `src` on click.
+#
+# States (single component, three states):
+# - placeholder: title + a "Load <title>" button (this unit)
+# - loading: `Avo::LoadingComponent` spinner while the request is in flight
+# - error: inline message + Retry (slotted in by Unit 5)
+class Avo::ManualFrameComponent < Avo::BaseComponent
+  # @param frame_id [String] the `<turbo-frame>` id (positional)
+  # @param deferred_url [String] the URL the controller loads on click
+  # @param title [String] label source; the button reads "Load <title humanized>"
+  # @param classes [String, nil] extra CSS classes for the `.state` placeholder container
+  prop :frame_id, kind: :positional
+  prop :deferred_url
+  prop :title
+  prop :classes
+
+  # Humanized label derived from the title (e.g. "order_items" -> "Order items").
+  def label
+    @title.to_s.humanize
+  end
+
+  # The button copy and aria-label: "Load <title>".
+  def load_label
+    t("avo.load") + " " + label
+  end
+end

--- a/app/components/avo/tab_group_component.html.erb
+++ b/app/components/avo/tab_group_component.html.erb
@@ -29,14 +29,19 @@
 
         <% if !tab.is_empty? %>
           <% if tab.manual? && view.display? %>
-            <% if is_not_loaded?(tab) %>
-              <%= render Avo::ManualFrameComponent.new(tab.turbo_frame_id(parent: group), deferred_url: manual_frame_url(tab), title: tab.title, description: tab.description) %>
-            <% else %>
+            <% if !is_not_loaded?(tab) %>
               <%= turbo_frame_tag tab.turbo_frame_id(parent: group), target: :_top, class: "block" do %>
                 <%= render Avo::TabContentComponent.new tab:, resource:, index:, form:, view: %>
               <% end %>
+            <% elsif helpers.manual_frame_remembered?(manual_frame_url(tab), tab.auto_load_for) %>
+              <%# Remembered: render a real (lazy) frame so it loads with no Load button. %>
+              <%= turbo_frame_tag tab.turbo_frame_id(parent: group), **frame_args(tab) do %>
+                <%= render Avo::LoadingComponent.new(title: tab.title) %>
+              <% end %>
+            <% else %>
+              <%= render Avo::ManualFrameComponent.new(tab.turbo_frame_id(parent: group), deferred_url: manual_frame_url(tab), title: tab.title, description: tab.description, auto_load_for: tab.auto_load_for, cookie_name: helpers.manual_frame_cookie_name(manual_frame_url(tab))) %>
             <% end %>
-          <% elsif tab.lazy_load && view.display? %>
+          <% elsif (tab.lazy_load || tab.lazy_loading_mode?) && view.display? %>
             <%= turbo_frame_tag tab.turbo_frame_id(parent: group), **frame_args(tab) do %>
               <% if is_not_loaded?(tab) %>
                 <%= render Avo::LoadingComponent.new(title: tab.title) %>

--- a/app/components/avo/tab_group_component.html.erb
+++ b/app/components/avo/tab_group_component.html.erb
@@ -28,7 +28,15 @@
         <% end %>
 
         <% if !tab.is_empty? %>
-          <% if tab.lazy_load && view.display? %>
+          <% if tab.manual? && view.display? %>
+            <% if is_not_loaded?(tab) %>
+              <%= render Avo::ManualFrameComponent.new(tab.turbo_frame_id(parent: group), deferred_url: manual_frame_url(tab), title: tab.title) %>
+            <% else %>
+              <%= turbo_frame_tag tab.turbo_frame_id(parent: group), target: :_top, class: "block" do %>
+                <%= render Avo::TabContentComponent.new tab:, resource:, index:, form:, view: %>
+              <% end %>
+            <% end %>
+          <% elsif tab.lazy_load && view.display? %>
             <%= turbo_frame_tag tab.turbo_frame_id(parent: group), **frame_args(tab) do %>
               <% if is_not_loaded?(tab) %>
                 <%= render Avo::LoadingComponent.new(title: tab.title) %>

--- a/app/components/avo/tab_group_component.html.erb
+++ b/app/components/avo/tab_group_component.html.erb
@@ -30,7 +30,7 @@
         <% if !tab.is_empty? %>
           <% if tab.manual? && view.display? %>
             <% if is_not_loaded?(tab) %>
-              <%= render Avo::ManualFrameComponent.new(tab.turbo_frame_id(parent: group), deferred_url: manual_frame_url(tab), title: tab.title) %>
+              <%= render Avo::ManualFrameComponent.new(tab.turbo_frame_id(parent: group), deferred_url: manual_frame_url(tab), title: tab.title, description: tab.description) %>
             <% else %>
               <%= turbo_frame_tag tab.turbo_frame_id(parent: group), target: :_top, class: "block" do %>
                 <%= render Avo::TabContentComponent.new tab:, resource:, index:, form:, view: %>

--- a/app/components/avo/tab_group_component.rb
+++ b/app/components/avo/tab_group_component.rb
@@ -27,16 +27,24 @@ class Avo::TabGroupComponent < Avo::BaseComponent
 
     if is_not_loaded?(tab)
       args[:loading] = :lazy
-      args[:src] = helpers.resource_path(
-        resource: resource,
-        record: resource.record,
-        keep_query_params: true,
-        active_tab_title: tab.title,
-        tab_turbo_frame: tab.turbo_frame_id(parent: group)
-      )
+      args[:src] = manual_frame_url(tab)
     end
 
     args
+  end
+
+  # The deferred load URL for a tab's turbo frame. Mirrors the `src` the lazy
+  # branch builds in `frame_args`, so a manual tab's Load button fetches the
+  # exact same proven URL — carrying `tab_turbo_frame` so `is_not_loaded?` is
+  # false on the framed re-render and the real `TabContentComponent` renders.
+  def manual_frame_url(tab)
+    helpers.resource_path(
+      resource: resource,
+      record: resource.record,
+      keep_query_params: true,
+      active_tab_title: tab.title,
+      tab_turbo_frame: tab.turbo_frame_id(parent: group)
+    )
   end
 
   def is_not_loaded?(tab)

--- a/app/helpers/avo/application_helper.rb
+++ b/app/helpers/avo/application_helper.rb
@@ -5,6 +5,35 @@ module Avo
 
     def ui = Avo::UIInstance
 
+    # The cookie name that remembers an opened manual frame. Derived from the
+    # frame's deferred URL (which already encodes resource + record + frame), so
+    # the memory is scoped per record + association/tab. Hashed to keep the name
+    # short and cookie-safe. The `manual-frame` Stimulus controller writes this
+    # same name client-side on a successful load (see manual_frame_controller.js).
+    def manual_frame_cookie_name(url)
+      "amf_#{Digest::MD5.hexdigest(url.to_s)}"
+    end
+
+    # Whether this manual frame was opened recently enough to skip the placeholder
+    # and render a real auto-loading `<turbo-frame src>` (so the Load button never
+    # appears). Presence-based: the cookie carries `max-age`, so the browser drops
+    # it when the window lapses — a present cookie means "still remembered".
+    #
+    # Sliding: every render that finds it remembered refreshes the cookie, so the
+    # window keeps moving forward as long as the user keeps coming back.
+    #
+    # Returns false (and touches nothing) for plain `loading: :manual` frames,
+    # which carry no `auto_load_for` window.
+    def manual_frame_remembered?(url, auto_load_for)
+      return false if auto_load_for.blank?
+
+      name = manual_frame_cookie_name(url)
+      return false if request.cookies[name].blank?
+
+      cookies[name] = {value: "1", path: "/", max_age: auto_load_for.to_i, same_site: :lax}
+      true
+    end
+
     # Active Storage URL helpers raise UrlGenerationError when a blob's filename
     # is blank (the route requires a :filename segment). Use a synthetic filename
     # so attach mode and other callers still get a routable URL; return nil only

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -102,6 +102,11 @@ document.addEventListener('turbo:frame-load', () => {
 })
 
 document.addEventListener('turbo:before-fetch-response', async (e) => {
+  // Manual frames handle their own failures inline (see manual_frame_controller.js);
+  // skip the global redirect-to-/failed_to_load rewrite for them. Full inline
+  // error/Retry handling lands in Unit 5.
+  if (e.target.dataset.manualFrame) return
+
   if (e.detail.fetchResponse.response.status === 500) {
     const { id, src } = e.target
     // Don't try to redirect to failed to load if this is already a redirection to failed to load and crashed somewhere.

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -102,11 +102,12 @@ document.addEventListener('turbo:frame-load', () => {
 })
 
 document.addEventListener('turbo:before-fetch-response', async (e) => {
-  // Manual frames handle their own failures inline (see manual_frame_controller.js);
-  // skip the global redirect-to-/failed_to_load rewrite for them. Full inline
-  // error/Retry handling lands in Unit 5.
-  if (e.target.dataset.manualFrame) return
-
+  // Manual frames handle their own deferred-load failures inline and call
+  // `stopImmediatePropagation()` (see manual_frame_controller.js), so this
+  // global handler never sees them. We intentionally do NOT skip on the
+  // `data-manual-frame` attribute: once a manual frame has loaded, a later
+  // navigation inside its content that 500s should still fall through to the
+  // /failed_to_load page like any other frame.
   if (e.detail.fetchResponse.response.status === 500) {
     const { id, src } = e.target
     // Don't try to redirect to failed to load if this is already a redirection to failed to load and crashed somewhere.

--- a/app/javascript/js/controllers.js
+++ b/app/javascript/js/controllers.js
@@ -32,6 +32,7 @@ import ItemSelectAllController from './controllers/item_select_all_controller'
 import ItemSelectorController from './controllers/item_selector_controller'
 import KeyValueController from './controllers/fields/key_value_controller'
 import LoadingButtonController from './controllers/loading_button_controller'
+import ManualFrameController from './controllers/manual_frame_controller'
 import MapDarkModeController from './controllers/map_dark_mode_controller'
 import MediaLibraryAttachController from './controllers/media_library_attach_controller'
 import MediaLibraryController from './controllers/media_library_controller'
@@ -93,6 +94,7 @@ application.register('input-autofocus', InputAutofocusController)
 application.register('item-select-all', ItemSelectAllController)
 application.register('item-selector', ItemSelectorController)
 application.register('loading-button', LoadingButtonController)
+application.register('manual-frame', ManualFrameController)
 application.register('map-dark-mode', MapDarkModeController)
 application.register('media-library-attach', MediaLibraryAttachController)
 application.register('media-library', MediaLibraryController)

--- a/app/javascript/js/controllers/manual_frame_controller.js
+++ b/app/javascript/js/controllers/manual_frame_controller.js
@@ -10,11 +10,24 @@ import { toggleHidden } from '../helpers/toggle_hidden'
 //
 // We deliberately do NOT set `loading="lazy"`, so neither Turbo's lazy
 // auto-fetch nor the #886 strip handler touches this frame.
+//
+// Auto-load memory: when the frame is configured with a window
+// (`auto_load_for`), a successful load writes a short-lived cookie. The SERVER
+// reads that cookie on the next render and emits a real `<turbo-frame src>`
+// (no placeholder, no button) — so the controller never has to "auto-click".
+// All this controller does is write/refresh the cookie when the user opens the
+// frame; the decision to skip the button lives entirely on the server.
 export default class extends Controller {
   static targets = ['placeholder', 'loading', 'error']
 
   static values = {
     url: String,
+    // The cookie name the server reads to decide whether to skip the Load
+    // button on the next visit. Empty when the frame has no memory window.
+    cookieName: String,
+    // Seconds the memory cookie should live (its max-age). 0 (the Stimulus
+    // default when the attribute is absent) = no memory.
+    autoLoadFor: Number,
   }
 
   connect() {
@@ -85,6 +98,11 @@ export default class extends Controller {
     if (!this.pending) return // not our load (or a later navigation inside content)
 
     this.pending = false
+
+    // Remember the open frame (and slide the window forward) — only on success,
+    // so a failed load never sets the memory.
+    this.rememberOpen()
+
     this.element.setAttribute('tabindex', '-1')
     this.element.focus({ preventScroll: true })
   }
@@ -113,5 +131,17 @@ export default class extends Controller {
     event.preventDefault()
     event.stopImmediatePropagation()
     this.showError()
+  }
+
+  // --- Auto-load memory -----------------------------------------------------
+
+  // Write/refresh the cookie that tells the server "this frame is open, render
+  // it without the Load button next time." `max-age` gives it a sliding TTL —
+  // the browser drops it when the window lapses, and each successful load
+  // rewrites it with a fresh window. No-ops when the frame has no memory window.
+  rememberOpen() {
+    if (!this.cookieNameValue || this.autoLoadForValue <= 0) return
+
+    document.cookie = `${this.cookieNameValue}=1; path=/; max-age=${this.autoLoadForValue}; samesite=lax`
   }
 }

--- a/app/javascript/js/controllers/manual_frame_controller.js
+++ b/app/javascript/js/controllers/manual_frame_controller.js
@@ -1,0 +1,48 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Drives a manual (on-demand) Turbo Frame: the frame renders with NO `src`,
+// and clicking the Load button sets `src` from `data-manual-frame-url-value`
+// so the deferred content is fetched only on demand.
+//
+// The controller is attached to the `<turbo-frame>` element itself, so
+// `this.element` is the frame.
+//
+// Mirrors `select_controller.js` / `fields/panel_refresh_controller.js`, which
+// also manipulate the `src` of the frame they live in. We deliberately do NOT
+// set `loading="lazy"`, so neither Turbo's lazy auto-fetch nor the #886 strip
+// handler touches this frame.
+export default class extends Controller {
+  static targets = ['placeholder', 'loading']
+
+  static values = {
+    url: String,
+  }
+
+  // Click handler for the Load (and, in Unit 5, Retry) button.
+  load() {
+    this.showLoading()
+    // Setting `src` triggers Turbo to fetch and swap in the deferred content.
+    this.element.src = this.urlValue
+  }
+
+  // Swap the placeholder for the loading spinner and mark the frame busy so
+  // assistive tech announces the in-flight state.
+  showLoading() {
+    this.element.setAttribute('aria-busy', 'true')
+
+    if (this.hasPlaceholderTarget) {
+      this.placeholderTarget.classList.add('hidden')
+    }
+
+    if (this.hasLoadingTarget) {
+      this.loadingTarget.classList.remove('hidden')
+    }
+  }
+
+  // --- Failure handling seam (Unit 5) ---------------------------------------
+  // Unit 5 binds the failure events Turbo emits on this frame
+  // (`turbo:fetch-request-error` for network/timeout and
+  // `turbo:before-fetch-response` for non-2xx responses) and renders an inline
+  // error + Retry state here. The `retry` action will re-issue the request by
+  // calling `load()` again. Not implemented in this unit on purpose.
+}

--- a/app/javascript/js/controllers/manual_frame_controller.js
+++ b/app/javascript/js/controllers/manual_frame_controller.js
@@ -19,40 +19,47 @@ export default class extends Controller {
   }
 
   connect() {
-    // Turbo fires NO `turbo:frame-load` on failure, so completion hooks alone
-    // wouldn't cover errors. We bind the two failure events Turbo emits on this
-    // frame and render the inline error state ourselves:
-    //   - `turbo:fetch-request-error`: network failure / timeout (no response).
-    //   - `turbo:before-fetch-response`: a response arrived; if it's not OK
-    //     (status >= 400 — 4xx/5xx) we treat it as a failure and stop Turbo
-    //     from rendering the error body into the frame.
-    // Both listeners are scoped to `this.element` (the frame), so we only react
-    // to fetch responses for THIS frame.
+    // Turbo fires NO `turbo:frame-load` on failure, so we bind the failure
+    // events Turbo emits on this frame and render the inline error ourselves.
+    // `pending` scopes ALL of this handling to our own deferred load: once the
+    // content has loaded, the loaded markup may itself navigate the frame (e.g.
+    // association pagination) — those are Turbo's to handle, so we step aside.
+    this.pending = false
     this.onRequestError = this.handleRequestError.bind(this)
     this.onBeforeFetchResponse = this.handleBeforeFetchResponse.bind(this)
+    this.onFrameLoad = this.handleFrameLoad.bind(this)
 
     this.element.addEventListener('turbo:fetch-request-error', this.onRequestError)
     this.element.addEventListener('turbo:before-fetch-response', this.onBeforeFetchResponse)
+    this.element.addEventListener('turbo:frame-load', this.onFrameLoad)
   }
 
   disconnect() {
     this.element.removeEventListener('turbo:fetch-request-error', this.onRequestError)
     this.element.removeEventListener('turbo:before-fetch-response', this.onBeforeFetchResponse)
+    this.element.removeEventListener('turbo:frame-load', this.onFrameLoad)
   }
 
-  // Click handler for the Load (and, via `retry`, Retry) button.
+  // Click handler for the Load button.
   load() {
-    // `pending` scopes our failure handling to THIS deferred load. Once the
-    // content loads successfully, the loaded markup may itself navigate the
-    // frame (e.g. association pagination); we must not intercept those.
+    // Ignore repeat clicks while a request is already in flight.
+    if (this.pending) return
+
     this.pending = true
     this.showLoading()
+
     // Setting `src` triggers Turbo to fetch and swap in the deferred content.
-    this.element.src = this.urlValue
+    // On Retry the `src` is already this URL (a failed load leaves it in place),
+    // and re-setting an attribute to its current value is a no-op — so reload()
+    // to force a fresh fetch in that case.
+    if (this.element.getAttribute('src') === this.urlValue) {
+      this.element.reload()
+    } else {
+      this.element.src = this.urlValue
+    }
   }
 
-  // Click handler for the Retry button: drop the error state and re-issue the
-  // request. `load()` re-shows the loading spinner and re-sets `src`.
+  // Click handler for the Retry button: drop the error state and re-issue.
   retry() {
     if (this.hasErrorTarget) {
       this.errorTarget.classList.add('hidden')
@@ -61,11 +68,9 @@ export default class extends Controller {
     this.load()
   }
 
-  // Swap the placeholder for the loading spinner and mark the frame busy so
-  // assistive tech announces the in-flight state.
+  // Swap the placeholder for the loading spinner. Turbo owns `aria-busy` on the
+  // frame for the duration of the fetch, so we don't manage it here.
   showLoading() {
-    this.element.setAttribute('aria-busy', 'true')
-
     if (this.hasPlaceholderTarget) {
       this.placeholderTarget.classList.add('hidden')
     }
@@ -75,48 +80,55 @@ export default class extends Controller {
     }
   }
 
-  // --- Failure handling -----------------------------------------------------
+  // --- Lifecycle ------------------------------------------------------------
 
-  // Network failure / timeout (no HTTP response at all).
-  handleRequestError() {
-    // Only react to a failure of our own deferred load, not to later
-    // navigations inside the loaded content.
+  // Our deferred load succeeded and Turbo swapped the real content in. Move
+  // focus into the frame so keyboard / screen-reader users aren't dropped to
+  // <body> when the Load button is removed from the DOM (R9).
+  handleFrameLoad() {
+    // Not our deferred load (or a later navigation inside loaded content).
     if (!this.pending) return
 
     this.pending = false
+    this.element.setAttribute('tabindex', '-1')
+    this.element.focus()
+  }
+
+  // Network failure / timeout (no HTTP response at all).
+  handleRequestError(event) {
+    // A later in-frame navigation failed — let Turbo handle it normally.
+    if (!this.pending) return
+
+    this.pending = false
+    // Stop the global 500 handler from also acting on our load's failure.
+    event.stopImmediatePropagation()
     this.showError()
   }
 
   // A response arrived. If it's not OK (status >= 400), stop Turbo from
-  // rendering the error body into the frame and show our inline error instead.
+  // rendering the error body into the frame, stop the global `application.js`
+  // failure handler from hijacking it, and show our inline error instead.
   handleBeforeFetchResponse(event) {
-    // Ignore navigations that happen after our deferred load resolved (e.g. the
-    // loaded content paginating itself) — those are Turbo's to handle.
+    // After our load resolves we stop intercepting, so a later in-frame
+    // navigation that fails falls through to Turbo / the global handler.
     if (!this.pending) return
 
     const response = event.detail?.fetchResponse?.response
-
-    // No response object — let other handlers deal with it.
     if (!response) return
 
-    // 2xx/3xx: our deferred load succeeded. Stop intercepting and let Turbo swap
-    // the content in.
-    if (response.ok) {
-      this.pending = false
-      return
-    }
+    // 2xx/3xx: success — `handleFrameLoad` finishes the sequence (and clears
+    // `pending`) once Turbo renders the content.
+    if (response.ok) return
 
-    // 4xx/5xx: prevent Turbo from rendering the failure body into the frame and
-    // show the inline error + Retry instead.
+    // 4xx/5xx: show the inline error + Retry.
     this.pending = false
     event.preventDefault()
+    event.stopImmediatePropagation()
     this.showError()
   }
 
-  // Swap the loading spinner for the inline error state and clear `aria-busy`.
+  // Swap the loading spinner for the inline error state.
   showError() {
-    this.element.removeAttribute('aria-busy')
-
     if (this.hasLoadingTarget) {
       this.loadingTarget.classList.add('hidden')
     }

--- a/app/javascript/js/controllers/manual_frame_controller.js
+++ b/app/javascript/js/controllers/manual_frame_controller.js
@@ -32,6 +32,7 @@ export default class extends Controller {
 
   connect() {
     this.pending = false
+    this.awaitingFrameLoad = false
     this.onRequestError = this.handleRequestError.bind(this)
     this.onBeforeFetchResponse = this.handleBeforeFetchResponse.bind(this)
     this.onFrameLoad = this.handleFrameLoad.bind(this)
@@ -52,6 +53,7 @@ export default class extends Controller {
     if (this.pending) return // ignore repeat clicks while a request is in flight
 
     this.pending = true
+    this.awaitingFrameLoad = false
     this.showLoading()
 
     // Setting `src` triggers Turbo to fetch and swap in the deferred content.
@@ -95,9 +97,9 @@ export default class extends Controller {
   // focus into the frame so keyboard / screen-reader users aren't dropped to
   // <body> when the Load button is removed from the DOM (R9).
   handleFrameLoad() {
-    if (!this.pending) return // not our load (or a later navigation inside content)
+    if (!this.awaitingFrameLoad) return // not our load (or a later navigation inside content)
 
-    this.pending = false
+    this.awaitingFrameLoad = false
 
     // Remember the open frame (and slide the window forward) — only on success,
     // so a failed load never sets the memory.
@@ -116,18 +118,29 @@ export default class extends Controller {
     this.showError()
   }
 
-  // A response arrived. If it's not OK (status >= 400), stop Turbo from rendering
-  // the error body into the frame, stop the global `application.js` handler from
-  // hijacking it, and show our inline error instead.
+  // A response arrived; our deferred load is resolved either way. If it's not OK
+  // (status >= 400), stop Turbo from rendering the error body into the frame,
+  // stop the global `application.js` handler from hijacking it, and show our
+  // inline error instead.
   handleBeforeFetchResponse(event) {
     if (!this.pending) return // after our load resolves, later navigations are Turbo's
 
     const response = event.detail?.fetchResponse?.response
     if (!response) return
 
-    if (response.ok) return // success: handleFrameLoad finishes the sequence
-
     this.pending = false
+
+    if (response.ok) {
+      // Success: handleFrameLoad finishes the sequence (focus + memory) once
+      // Turbo renders the frame. `pending` is cleared HERE (not there) so that
+      // if `turbo:frame-load` never fires (e.g. the response is missing the
+      // matching frame), later in-frame navigations are never mistaken for the
+      // deferred load and still reach the global failure handler.
+      this.awaitingFrameLoad = true
+
+      return
+    }
+
     event.preventDefault()
     event.stopImmediatePropagation()
     this.showError()

--- a/app/javascript/js/controllers/manual_frame_controller.js
+++ b/app/javascript/js/controllers/manual_frame_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
+import { toggleHidden } from '../helpers/toggle_hidden'
 
 // Drives a manual (on-demand) Turbo Frame: the frame renders with NO `src`,
 // and clicking the Load button sets `src` from `data-manual-frame-url-value`
@@ -7,10 +8,8 @@ import { Controller } from '@hotwired/stimulus'
 // The controller is attached to the `<turbo-frame>` element itself, so
 // `this.element` is the frame.
 //
-// State swaps (placeholder -> loading -> content / error) run inside a View
-// Transition so the frame morphs between states. Browsers without the API fall
-// back to an instant swap. We deliberately do NOT set `loading="lazy"`, so
-// neither Turbo's lazy auto-fetch nor the #886 strip handler touches this frame.
+// We deliberately do NOT set `loading="lazy"`, so neither Turbo's lazy
+// auto-fetch nor the #886 strip handler touches this frame.
 export default class extends Controller {
   static targets = ['placeholder', 'loading', 'error']
 
@@ -22,19 +21,16 @@ export default class extends Controller {
     this.pending = false
     this.onRequestError = this.handleRequestError.bind(this)
     this.onBeforeFetchResponse = this.handleBeforeFetchResponse.bind(this)
-    this.onBeforeFrameRender = this.handleBeforeFrameRender.bind(this)
     this.onFrameLoad = this.handleFrameLoad.bind(this)
 
     this.element.addEventListener('turbo:fetch-request-error', this.onRequestError)
     this.element.addEventListener('turbo:before-fetch-response', this.onBeforeFetchResponse)
-    this.element.addEventListener('turbo:before-frame-render', this.onBeforeFrameRender)
     this.element.addEventListener('turbo:frame-load', this.onFrameLoad)
   }
 
   disconnect() {
     this.element.removeEventListener('turbo:fetch-request-error', this.onRequestError)
     this.element.removeEventListener('turbo:before-fetch-response', this.onBeforeFetchResponse)
-    this.element.removeEventListener('turbo:before-frame-render', this.onBeforeFrameRender)
     this.element.removeEventListener('turbo:frame-load', this.onFrameLoad)
   }
 
@@ -47,7 +43,7 @@ export default class extends Controller {
 
     // Setting `src` triggers Turbo to fetch and swap in the deferred content.
     // On Retry the `src` is already this URL (a failed load leaves it in place),
-    // and re-setting an attribute to its current value is a no-op — so reload()
+    // and re-setting an attribute to its current value is a no-op, so reload()
     // to force a fresh fetch in that case.
     if (this.element.getAttribute('src') === this.urlValue) {
       this.element.reload()
@@ -62,58 +58,25 @@ export default class extends Controller {
   }
 
   showLoading() {
-    this.morph(() => this.swap('loading'))
+    this.setHidden(this.placeholderTarget, false)
+    this.setHidden(this.loadingTarget, false)
+    this.setHidden(this.errorTarget, true)
   }
 
   showError() {
-    this.morph(() => this.swap('error'))
+    this.setHidden(this.placeholderTarget, true)
+    this.setHidden(this.loadingTarget, true)
+    this.setHidden(this.errorTarget, false)
   }
 
-  // Show exactly one state target, hiding the others.
-  swap(name) {
-    const targets = { placeholder: this.placeholderTarget, loading: this.loadingTarget, error: this.errorTarget }
-    Object.entries(targets).forEach(([n, el]) => {
-      if (el) el.classList.toggle('hidden', n !== name)
-    })
-  }
+  setHidden(element, hidden) {
+    if (!element) return
+    if (element.hasAttribute('hidden') === hidden) return
 
-  // Run a DOM mutation inside a View Transition so the frame morphs. A transient,
-  // per-frame `view-transition-name` scopes the morph to this frame; it's cleared
-  // when the transition settles so it never collides with other frames or with
-  // Turbo's page transitions. No-op wrapper when the API is unavailable.
-  morph(mutate) {
-    if (!document.startViewTransition) {
-      mutate()
-      return
-    }
-
-    this.element.style.viewTransitionName = this.transitionName
-    const transition = document.startViewTransition(() => mutate())
-    transition.finished.finally(() => {
-      this.element.style.viewTransitionName = ''
-    })
-  }
-
-  get transitionName() {
-    return `manual-frame-${this.element.id || 'frame'}`
+    toggleHidden(element)
   }
 
   // --- Lifecycle ------------------------------------------------------------
-
-  // Wrap Turbo's render of the loaded content in a View Transition so the
-  // content morphs in from the loading state. Only for our own deferred load.
-  handleBeforeFrameRender(event) {
-    if (!this.pending || !document.startViewTransition) return
-
-    const originalRender = event.detail.render
-    event.detail.render = (currentElement, newElement) => {
-      this.element.style.viewTransitionName = this.transitionName
-      const transition = document.startViewTransition(() => originalRender(currentElement, newElement))
-      transition.finished.finally(() => {
-        this.element.style.viewTransitionName = ''
-      })
-    }
-  }
 
   // Our deferred load succeeded and Turbo swapped the real content in. Move
   // focus into the frame so keyboard / screen-reader users aren't dropped to
@@ -123,12 +86,12 @@ export default class extends Controller {
 
     this.pending = false
     this.element.setAttribute('tabindex', '-1')
-    this.element.focus()
+    this.element.focus({ preventScroll: true })
   }
 
   // Network failure / timeout (no HTTP response at all).
   handleRequestError(event) {
-    if (!this.pending) return // a later in-frame navigation — let Turbo handle it
+    if (!this.pending) return // a later in-frame navigation, let Turbo handle it
 
     this.pending = false
     event.stopImmediatePropagation()

--- a/app/javascript/js/controllers/manual_frame_controller.js
+++ b/app/javascript/js/controllers/manual_frame_controller.js
@@ -12,17 +12,53 @@ import { Controller } from '@hotwired/stimulus'
 // set `loading="lazy"`, so neither Turbo's lazy auto-fetch nor the #886 strip
 // handler touches this frame.
 export default class extends Controller {
-  static targets = ['placeholder', 'loading']
+  static targets = ['placeholder', 'loading', 'error']
 
   static values = {
     url: String,
   }
 
-  // Click handler for the Load (and, in Unit 5, Retry) button.
+  connect() {
+    // Turbo fires NO `turbo:frame-load` on failure, so completion hooks alone
+    // wouldn't cover errors. We bind the two failure events Turbo emits on this
+    // frame and render the inline error state ourselves:
+    //   - `turbo:fetch-request-error`: network failure / timeout (no response).
+    //   - `turbo:before-fetch-response`: a response arrived; if it's not OK
+    //     (status >= 400 — 4xx/5xx) we treat it as a failure and stop Turbo
+    //     from rendering the error body into the frame.
+    // Both listeners are scoped to `this.element` (the frame), so we only react
+    // to fetch responses for THIS frame.
+    this.onRequestError = this.handleRequestError.bind(this)
+    this.onBeforeFetchResponse = this.handleBeforeFetchResponse.bind(this)
+
+    this.element.addEventListener('turbo:fetch-request-error', this.onRequestError)
+    this.element.addEventListener('turbo:before-fetch-response', this.onBeforeFetchResponse)
+  }
+
+  disconnect() {
+    this.element.removeEventListener('turbo:fetch-request-error', this.onRequestError)
+    this.element.removeEventListener('turbo:before-fetch-response', this.onBeforeFetchResponse)
+  }
+
+  // Click handler for the Load (and, via `retry`, Retry) button.
   load() {
+    // `pending` scopes our failure handling to THIS deferred load. Once the
+    // content loads successfully, the loaded markup may itself navigate the
+    // frame (e.g. association pagination); we must not intercept those.
+    this.pending = true
     this.showLoading()
     // Setting `src` triggers Turbo to fetch and swap in the deferred content.
     this.element.src = this.urlValue
+  }
+
+  // Click handler for the Retry button: drop the error state and re-issue the
+  // request. `load()` re-shows the loading spinner and re-sets `src`.
+  retry() {
+    if (this.hasErrorTarget) {
+      this.errorTarget.classList.add('hidden')
+    }
+
+    this.load()
   }
 
   // Swap the placeholder for the loading spinner and mark the frame busy so
@@ -39,10 +75,58 @@ export default class extends Controller {
     }
   }
 
-  // --- Failure handling seam (Unit 5) ---------------------------------------
-  // Unit 5 binds the failure events Turbo emits on this frame
-  // (`turbo:fetch-request-error` for network/timeout and
-  // `turbo:before-fetch-response` for non-2xx responses) and renders an inline
-  // error + Retry state here. The `retry` action will re-issue the request by
-  // calling `load()` again. Not implemented in this unit on purpose.
+  // --- Failure handling -----------------------------------------------------
+
+  // Network failure / timeout (no HTTP response at all).
+  handleRequestError() {
+    // Only react to a failure of our own deferred load, not to later
+    // navigations inside the loaded content.
+    if (!this.pending) return
+
+    this.pending = false
+    this.showError()
+  }
+
+  // A response arrived. If it's not OK (status >= 400), stop Turbo from
+  // rendering the error body into the frame and show our inline error instead.
+  handleBeforeFetchResponse(event) {
+    // Ignore navigations that happen after our deferred load resolved (e.g. the
+    // loaded content paginating itself) — those are Turbo's to handle.
+    if (!this.pending) return
+
+    const response = event.detail?.fetchResponse?.response
+
+    // No response object — let other handlers deal with it.
+    if (!response) return
+
+    // 2xx/3xx: our deferred load succeeded. Stop intercepting and let Turbo swap
+    // the content in.
+    if (response.ok) {
+      this.pending = false
+      return
+    }
+
+    // 4xx/5xx: prevent Turbo from rendering the failure body into the frame and
+    // show the inline error + Retry instead.
+    this.pending = false
+    event.preventDefault()
+    this.showError()
+  }
+
+  // Swap the loading spinner for the inline error state and clear `aria-busy`.
+  showError() {
+    this.element.removeAttribute('aria-busy')
+
+    if (this.hasLoadingTarget) {
+      this.loadingTarget.classList.add('hidden')
+    }
+
+    if (this.hasPlaceholderTarget) {
+      this.placeholderTarget.classList.add('hidden')
+    }
+
+    if (this.hasErrorTarget) {
+      this.errorTarget.classList.remove('hidden')
+    }
+  }
 }

--- a/app/javascript/js/controllers/manual_frame_controller.js
+++ b/app/javascript/js/controllers/manual_frame_controller.js
@@ -7,10 +7,10 @@ import { Controller } from '@hotwired/stimulus'
 // The controller is attached to the `<turbo-frame>` element itself, so
 // `this.element` is the frame.
 //
-// Mirrors `select_controller.js` / `fields/panel_refresh_controller.js`, which
-// also manipulate the `src` of the frame they live in. We deliberately do NOT
-// set `loading="lazy"`, so neither Turbo's lazy auto-fetch nor the #886 strip
-// handler touches this frame.
+// State swaps (placeholder -> loading -> content / error) run inside a View
+// Transition so the frame morphs between states. Browsers without the API fall
+// back to an instant swap. We deliberately do NOT set `loading="lazy"`, so
+// neither Turbo's lazy auto-fetch nor the #886 strip handler touches this frame.
 export default class extends Controller {
   static targets = ['placeholder', 'loading', 'error']
 
@@ -19,31 +19,28 @@ export default class extends Controller {
   }
 
   connect() {
-    // Turbo fires NO `turbo:frame-load` on failure, so we bind the failure
-    // events Turbo emits on this frame and render the inline error ourselves.
-    // `pending` scopes ALL of this handling to our own deferred load: once the
-    // content has loaded, the loaded markup may itself navigate the frame (e.g.
-    // association pagination) — those are Turbo's to handle, so we step aside.
     this.pending = false
     this.onRequestError = this.handleRequestError.bind(this)
     this.onBeforeFetchResponse = this.handleBeforeFetchResponse.bind(this)
+    this.onBeforeFrameRender = this.handleBeforeFrameRender.bind(this)
     this.onFrameLoad = this.handleFrameLoad.bind(this)
 
     this.element.addEventListener('turbo:fetch-request-error', this.onRequestError)
     this.element.addEventListener('turbo:before-fetch-response', this.onBeforeFetchResponse)
+    this.element.addEventListener('turbo:before-frame-render', this.onBeforeFrameRender)
     this.element.addEventListener('turbo:frame-load', this.onFrameLoad)
   }
 
   disconnect() {
     this.element.removeEventListener('turbo:fetch-request-error', this.onRequestError)
     this.element.removeEventListener('turbo:before-fetch-response', this.onBeforeFetchResponse)
+    this.element.removeEventListener('turbo:before-frame-render', this.onBeforeFrameRender)
     this.element.removeEventListener('turbo:frame-load', this.onFrameLoad)
   }
 
   // Click handler for the Load button.
   load() {
-    // Ignore repeat clicks while a request is already in flight.
-    if (this.pending) return
+    if (this.pending) return // ignore repeat clicks while a request is in flight
 
     this.pending = true
     this.showLoading()
@@ -61,33 +58,68 @@ export default class extends Controller {
 
   // Click handler for the Retry button: drop the error state and re-issue.
   retry() {
-    if (this.hasErrorTarget) {
-      this.errorTarget.classList.add('hidden')
-    }
-
     this.load()
   }
 
-  // Swap the placeholder for the loading spinner. Turbo owns `aria-busy` on the
-  // frame for the duration of the fetch, so we don't manage it here.
   showLoading() {
-    if (this.hasPlaceholderTarget) {
-      this.placeholderTarget.classList.add('hidden')
+    this.morph(() => this.swap('loading'))
+  }
+
+  showError() {
+    this.morph(() => this.swap('error'))
+  }
+
+  // Show exactly one state target, hiding the others.
+  swap(name) {
+    const targets = { placeholder: this.placeholderTarget, loading: this.loadingTarget, error: this.errorTarget }
+    Object.entries(targets).forEach(([n, el]) => {
+      if (el) el.classList.toggle('hidden', n !== name)
+    })
+  }
+
+  // Run a DOM mutation inside a View Transition so the frame morphs. A transient,
+  // per-frame `view-transition-name` scopes the morph to this frame; it's cleared
+  // when the transition settles so it never collides with other frames or with
+  // Turbo's page transitions. No-op wrapper when the API is unavailable.
+  morph(mutate) {
+    if (!document.startViewTransition) {
+      mutate()
+      return
     }
 
-    if (this.hasLoadingTarget) {
-      this.loadingTarget.classList.remove('hidden')
-    }
+    this.element.style.viewTransitionName = this.transitionName
+    const transition = document.startViewTransition(() => mutate())
+    transition.finished.finally(() => {
+      this.element.style.viewTransitionName = ''
+    })
+  }
+
+  get transitionName() {
+    return `manual-frame-${this.element.id || 'frame'}`
   }
 
   // --- Lifecycle ------------------------------------------------------------
+
+  // Wrap Turbo's render of the loaded content in a View Transition so the
+  // content morphs in from the loading state. Only for our own deferred load.
+  handleBeforeFrameRender(event) {
+    if (!this.pending || !document.startViewTransition) return
+
+    const originalRender = event.detail.render
+    event.detail.render = (currentElement, newElement) => {
+      this.element.style.viewTransitionName = this.transitionName
+      const transition = document.startViewTransition(() => originalRender(currentElement, newElement))
+      transition.finished.finally(() => {
+        this.element.style.viewTransitionName = ''
+      })
+    }
+  }
 
   // Our deferred load succeeded and Turbo swapped the real content in. Move
   // focus into the frame so keyboard / screen-reader users aren't dropped to
   // <body> when the Load button is removed from the DOM (R9).
   handleFrameLoad() {
-    // Not our deferred load (or a later navigation inside loaded content).
-    if (!this.pending) return
+    if (!this.pending) return // not our load (or a later navigation inside content)
 
     this.pending = false
     this.element.setAttribute('tabindex', '-1')
@@ -96,49 +128,27 @@ export default class extends Controller {
 
   // Network failure / timeout (no HTTP response at all).
   handleRequestError(event) {
-    // A later in-frame navigation failed — let Turbo handle it normally.
-    if (!this.pending) return
+    if (!this.pending) return // a later in-frame navigation — let Turbo handle it
 
     this.pending = false
-    // Stop the global 500 handler from also acting on our load's failure.
     event.stopImmediatePropagation()
     this.showError()
   }
 
-  // A response arrived. If it's not OK (status >= 400), stop Turbo from
-  // rendering the error body into the frame, stop the global `application.js`
-  // failure handler from hijacking it, and show our inline error instead.
+  // A response arrived. If it's not OK (status >= 400), stop Turbo from rendering
+  // the error body into the frame, stop the global `application.js` handler from
+  // hijacking it, and show our inline error instead.
   handleBeforeFetchResponse(event) {
-    // After our load resolves we stop intercepting, so a later in-frame
-    // navigation that fails falls through to Turbo / the global handler.
-    if (!this.pending) return
+    if (!this.pending) return // after our load resolves, later navigations are Turbo's
 
     const response = event.detail?.fetchResponse?.response
     if (!response) return
 
-    // 2xx/3xx: success — `handleFrameLoad` finishes the sequence (and clears
-    // `pending`) once Turbo renders the content.
-    if (response.ok) return
+    if (response.ok) return // success: handleFrameLoad finishes the sequence
 
-    // 4xx/5xx: show the inline error + Retry.
     this.pending = false
     event.preventDefault()
     event.stopImmediatePropagation()
     this.showError()
-  }
-
-  // Swap the loading spinner for the inline error state.
-  showError() {
-    if (this.hasLoadingTarget) {
-      this.loadingTarget.classList.add('hidden')
-    }
-
-    if (this.hasPlaceholderTarget) {
-      this.placeholderTarget.classList.add('hidden')
-    }
-
-    if (this.hasErrorTarget) {
-      this.errorTarget.classList.remove('hidden')
-    }
   }
 }

--- a/app/views/layouts/avo/application.html.erb
+++ b/app/views/layouts/avo/application.html.erb
@@ -28,6 +28,7 @@
     <%= render Avo::AssetManager::JavascriptComponent.new asset_manager: Avo.asset_manager %>
     <%= render partial: "avo/partials/head" %>
     <%= render partial: "avo/partials/color_theme_override" %>
+
     <%# appearance_overrides MUST render after the application stylesheet so its inline %>
     <%# :root / .dark declarations win on equal-specificity cascade. %>
     <%= render partial: "avo/partials/appearance_overrides" %>
@@ -46,7 +47,9 @@
     >
       <%= render partial: "avo/partials/navbar", locals: {resource: @resource} %>
 
-      <div id="main-sidebar" tabindex="-1" class="hidden lg:flex"><%= render Avo::SidebarComponent.new sidebar_open: @sidebar_open %></div>
+      <div id="main-sidebar" tabindex="-1" class="hidden lg:flex">
+        <%= render Avo::SidebarComponent.new sidebar_open: @sidebar_open %>
+      </div>
 
       <div class="flex lg:hidden">
         <%= render Avo::SidebarComponent.new sidebar_open: @sidebar_open, for_mobile: true %>
@@ -56,12 +59,11 @@
         <%= render Avo::BreadcrumbsComponent.new(items: avo_breadcrumbs) %>
 
         <div class="main-content__container <%= container_classes %>">
-
           <%= render partial: "avo/partials/custom_tools_alert" %>
 
           <%= yield.force_encoding("UTF-8") %>
 
-          <div class="mt-auto pt-8 justify-self-end">
+          <div class="mt-auto justify-self-end pt-8">
             <%= render partial: "avo/partials/footer" %>
           </div>
         </div>

--- a/docs/brainstorms/2026-06-08-on-demand-frame-loading-requirements.md
+++ b/docs/brainstorms/2026-06-08-on-demand-frame-loading-requirements.md
@@ -1,0 +1,278 @@
+---
+date: 2026-06-08
+topic: on-demand-frame-loading
+---
+
+# On-Demand (Manual) Turbo Frame Loading for Tabs and Associations
+
+## Problem Frame
+
+Resource Show pages can carry a lot of content. Today, content that lives in a
+Turbo Frame supports two loading modes:
+
+- **`eager`** — load immediately with the page (default for associations).
+- **`lazy`** — load automatically when the frame scrolls into the viewport
+  (Turbo's native `loading="lazy"`; opt-in for tabs via `lazy_load: true`).
+
+Neither mode lets the user *decide* whether expensive content is fetched. A tab
+that runs a heavy query, hits an external API, or renders a large association
+still loads the moment it becomes visible — even if the user never needed it.
+This wastes server work and slows the page for content that is often ignored.
+
+We want a **third loading mode** — **`manual`** (on-demand) — where the frame
+renders a placeholder with an explicit **Load** button, and the content is
+fetched only when the user clicks it. ("Manual" is the mode name used throughout
+this document.) This applies to **tabs** and
+**associations** (`has_many` / `has_one` / `has_and_belongs_to_many`). Panels
+are out of scope (they are not Turbo Frames today).
+
+## Loading Modes (after this change)
+
+| Mode | When content loads | Existing? | Surface today |
+|---|---|---|---|
+| `eager` | Immediately with the page | Yes | Associations (default), tabs without `lazy_load` |
+| `lazy` | When the frame scrolls into the viewport | Yes | Tabs (`lazy_load: true`), associations (`turbo_frame_loading: :lazy`) |
+| `manual` | Only when the user clicks a **Load** button | **New** | Tabs + associations |
+
+**When to choose `manual` over `lazy`:** `lazy` auto-fetches as soon as the frame
+becomes visible — on scroll, or when a tab is revealed. `manual` withholds the
+fetch **even when the content is on screen**, requiring an explicit click every
+time. Reach for `manual` when the content is expensive *and* you want the user to
+consciously opt in; `lazy` remains the better default when "load it once it's
+seen" is acceptable.
+
+## Manual Behavior by Surface
+
+`manual` means **one** thing on every surface: the frame renders a placeholder
+with a **Load** button and fetches nothing until that button is clicked. No
+auto-fetch on scroll, on page load, or on tab reveal.
+
+**Associations (`has_many` / `has_one` / `has_and_belongs_to_many`)**
+- The frame renders a placeholder (title/description + **Load** button).
+- Nothing is fetched until the button is clicked. The association frame is always
+  present in the layout, so the button is always visible.
+
+**Tabs — full per-tab gating**
+- *Every* tab marked `manual` renders its own placeholder + **Load** button.
+  Whichever tab is revealed first — by default, deep link, or a
+  localStorage-restored selection — shows its button instead of auto-loading.
+- Revealing a manual tab (clicking it, or restoring it from localStorage) does
+  **not** fetch — it shows that tab's button. The user clicks Load to fetch.
+- Consequence: browsing a manual tab is a two-step flow (open the tab, then
+  click Load). This is intended — it is the cost of guaranteeing nothing
+  expensive runs without an explicit request, and it is why `manual` is opt-in.
+- Because every revealed tab shows a button, there is **no** "which tab is really
+  active" ambiguity between the server render and client-side localStorage
+  restoration — the divergence that made an active-tab-only design unsound
+  simply does not arise here.
+
+## Requirements
+
+**Loading Mode & DSL**
+- R1. Introduce a `manual` loading mode as a peer to `eager` and `lazy`. It is
+  opt-in; no existing tab or association changes behavior unless the developer
+  sets it.
+- R2. Manual mode is available on tabs and on `has_many` / `has_one` /
+  `has_and_belongs_to_many` association fields.
+- R3. Manual mode applies in **display/show views only**, consistent with how
+  `lazy_load` is gated today. Edit/New views must still render all fields so
+  forms submit completely.
+
+**Trigger & Loading Behavior**
+- R4. A manual frame renders a placeholder (title/description + **Load** button)
+  and fetches nothing until the user activates the button. This per-frame
+  guarantee is uniform across associations and tabs.
+- R5. Activating the button replaces the placeholder with the frame's real
+  content, showing a loading indicator during the request (reuse the existing
+  loading affordance).
+- R6. Every tab marked `manual` shows its own **Load** button when revealed and
+  fetches nothing until clicked — including the tab visible on initial load.
+  Revealing a tab (click, deep link, or localStorage-restored selection) shows
+  its button; it never auto-fetches.
+- R7. Once loaded, content **stays loaded while the user stays on the page** —
+  switching tabs away and back keeps it (it remains in the DOM). This guarantee
+  covers in-page tab switching (CSS show/hide) only. A hard reload re-defers and
+  shows the button(s) again. Behavior across Turbo back/forward / page-cache
+  restoration is a separate case to verify in planning (the DOM-only approach
+  does not automatically guarantee it). No server-side or localStorage memory of
+  the load is required.
+
+**States & Resilience**
+- R8. If the load request fails, the frame shows a short inline error message
+  (e.g. "Couldn't load Orders") with a **Retry** button in place of the original
+  Load button — not the generic `failed_to_load` error page, and not a silent
+  return to the pristine placeholder. Retry re-issues the same request.
+- R9. The **Load** button must be keyboard-focusable and screen-reader labeled
+  (e.g. "Load <title>"), consistent with recent focus-visibility work.
+
+**Labeling**
+- R10. The placeholder shows a sensible default label derived from the
+  tab/association name (e.g. "Load Orders").
+
+## Success Criteria
+
+- A developer can mark a tab or association as `manual` and, on the Show page,
+  see a placeholder with a **Load** button instead of auto-fetched content.
+- No network request is made for *any* manual frame — association or tab,
+  including a revealed tab — until its button is clicked (verifiable in the
+  network panel).
+- Revealing a manual tab shows its Load button; it never auto-fetches.
+- After loading, switching tabs and returning keeps the content without
+  re-fetching; a full page reload restores the button(s).
+- A failed load shows an inline error + **Retry**, and retrying succeeds once the
+  underlying issue clears.
+- Existing `eager` and `lazy` tabs/associations are unchanged.
+- The button is operable by keyboard and announced by assistive tech.
+
+## Scope Boundaries
+
+- **Panels are out of scope.** They are not Turbo Frames today; making them
+  deferrable is a separate, larger effort.
+- **No page-level "Load all" control in v1.** Per-frame buttons only. A bulk
+  trigger can follow if users ask.
+- **No cross-reload memory.** We will not persist "user loaded this" to
+  auto-load on return visits; that would partly defeat the purpose.
+- **Edit/New views unaffected** — manual is display-only; the mode is ignored in
+  edit/create contexts even if configured, so forms still render all fields.
+- **Two-click tab browsing is intended, not a flaw.** With full per-tab gating,
+  opening a manual tab and then loading it is two actions. A one-click "reveal =
+  load" variant is explicitly *not* offered — it would reintroduce the auto-fetch
+  this feature exists to prevent.
+- Browser find-in-page (Ctrl+F), print, and full-page export will not see
+  unloaded manual content. This is an accepted, inherent consequence of
+  deferring the fetch (the same is already true of `lazy` content that hasn't
+  scrolled into view).
+- **Custom button label/description is a v1 non-goal.** The default label
+  derived from the name (R10) is the only labeling deliverable; a developer-set
+  custom label is a low-cost follow-up, tracked under Deferred to Planning.
+- **Placeholder content preview is a v1 non-goal.** Surfacing a hint such as an
+  association count in the placeholder (to help the user decide whether to load)
+  is a separate capability — it needs its own cheap-query path — not a rendering
+  decision. Revisit on demand.
+
+## Key Decisions
+
+- **Third mode, not a replacement:** `manual` joins `eager`/`lazy` rather than
+  changing what `lazy` does. Opt-in, zero behavior change for existing apps.
+- **Uniform full per-tab gating:** every manual tab shows its own Load button and
+  never auto-fetches on reveal. Chosen over an active-tab-only design because the
+  latter (a) barely improved on `lazy` — it only made the default tab wait for a
+  click — and (b) had a real ambiguity: the server and client-side localStorage
+  restoration could disagree on which tab is "active," so the button could land
+  on a tab the user wasn't viewing while the visible tab auto-fetched. Per-tab
+  gating dissolves that ambiguity and matches the original intent ("don't
+  auto-load; require a button" — for tabs too). Cost: a two-click tab-browse.
+- **Session-only persistence:** rely on the content staying in the DOM (tabs are
+  CSS show/hide) rather than building memory of load state.
+- **Scope held tight:** tabs + associations only; no panels, no load-all, no
+  persistence — to ship a coherent v1 and expand from real demand.
+
+## Alternatives Considered
+
+- **Active-tab-only gating (defer just the initially-visible tab).** Considered
+  and rejected. It barely beat `lazy` (only the default tab waited for a click;
+  every other tab still auto-fetched on reveal), and it had a correctness hole:
+  the server and client-side localStorage restoration can disagree on which tab
+  is "active," so the Load button could render on a tab the user wasn't viewing
+  while the visible tab auto-fetched. Full per-tab gating (the chosen design)
+  avoids both problems.
+- **Replace `lazy` with a button instead of adding a mode.** Rejected — it is a
+  breaking behavior change for every existing `lazy` tab/association.
+- **Page-level "Load all" control.** Deferred (see Scope Boundaries) — adds
+  partial-failure and layout complexity without proven demand.
+- **Drop tabs from v1 (associations only).** Considered as a way to ship the
+  unambiguous half first; rejected because "tabs too" is part of the original
+  ask and full per-tab gating makes tabs well-defined, so there is no need to
+  split them out.
+
+## Dependencies / Assumptions
+
+- Turbo has no native "load on click" frame mode. Unlike `eager`/`lazy` — which
+  are just the `loading` attribute on a frame that already has a `src` — `manual`
+  is structurally different: it is the **absence of `src` until a user action**.
+  The existing `turbo_frame_loading` concern only returns a loading-attribute
+  string, so it cannot express `manual` directly; manual loading will be
+  implemented by rendering a frame without an eager `src` and setting it on
+  button activation (exact mechanism is a planning concern).
+- **An existing failure path conflicts with R8.** `app/javascript/application.js`
+  intercepts `turbo:before-fetch-response` on HTTP 500 and rewrites the frame's
+  `src` to a `failed_to_load` error page. The conflict is *not* that a manual
+  frame lacks a `src`: once the user clicks Load, the frame **does** get a `src`,
+  so a 500 then flows through the same global handler, which has no way to know
+  this frame wants inline error + Retry (R8) instead of the error page. R8 needs
+  a **discriminator** (e.g. a `data-` attribute marking manual frames so the
+  global handler skips them, or frame-scoped error handling) — not just a
+  parallel failure path that silently coexists with the old one.
+- The same file has a workaround stripping `loading="lazy"` off completed frames
+  (Turbo bug #886); it must be reviewed so it does not interfere with manual
+  frames.
+- **Know which params actually select a tab.** Server-side tab selection keys off
+  the `tab-group_<id>` param (the group param) plus `tab_turbo_frame` (used by
+  `TabGroupComponent#is_not_loaded?`). The param literally named
+  `active_tab_title` is written into URLs by the component but is **not** consumed
+  server-side — an implementer who threads it expecting it to drive rendering
+  will wire a no-op. The manual trigger must reproduce the params the component
+  actually reads.
+- **The initially-visible tab renders inline today (no `src`).** Currently only
+  *non-active* tabs get `loading: :lazy` + `src`; the active tab's content is
+  rendered inline via `TabContentComponent`. Under full per-tab gating, *all*
+  manual tab frames become deferred placeholders (no `src`, with a button), so
+  the mechanism is uniform — but note the active-tab branch is a different code
+  path from today's lazy frames, not just "withhold a `src`."
+
+## Outstanding Questions
+
+### Resolve Before Planning
+- (none — product behavior is settled)
+
+### Deferred to Planning
+- [Affects R1][Technical] Final DSL/API surface and naming. Today tabs use
+  `lazy_load: true` and associations use `turbo_frame_loading: :lazy | "eager"` —
+  inconsistent already. Decide how `manual` is expressed on each (e.g.
+  `turbo_frame_loading: :manual` for associations; a tab option such as
+  `lazy_load: :manual` or a dedicated key) and whether to unify the two.
+- [Affects R4][Technical] Exact mechanism to defer then trigger the Turbo Frame
+  load on click (frame without `src` + Stimulus sets `src`, vs. a link with
+  `data-turbo-frame`), and how it threads the tab params from the assumption
+  above.
+- [Affects R8][Technical] How frame load failures surface in Turbo and the
+  cleanest way to restore the button for retry — explicitly resolving the
+  conflict with the existing `failed_to_load` 500-handler (see Dependencies).
+- [Affects R6][Needs research] Confirm that a manual tab frame rendered without a
+  `src` does **not** auto-fetch when revealed by `tabs_controller.js` (today
+  non-active tabs carry `loading: :lazy` + `src` and fetch on reveal). Full
+  per-tab gating removes the "which tab is active" ambiguity, but planning must
+  verify the no-`src` placeholder survives reveal and Turbo back/forward without
+  firing a request.
+- [Affects R2][Technical] `has_one` with a **nil** value renders an
+  attach/create empty-state panel today, not a frame. Decide what manual mode
+  does on that path (Load button vs. fall through to the existing empty state).
+- [Affects R1][Technical] Tabs store `@lazy_load` as a boolean and the
+  `TabGroupComponent` is never passed a frame-loading mode; supporting `manual`
+  on tabs needs a new tri-state attribute + component/template plumbing, not
+  just a new accepted value. (Part of the DSL/API decision above.)
+- [Affects R10][Technical] Whether to support a custom button label/description
+  in v1 and how it's passed.
+
+### Deferred to Planning — Design decisions
+These are interaction-design gaps the requirements imply but do not yet specify;
+they should be settled with the design pass during planning.
+- **Placeholder anatomy.** What the unloaded placeholder looks like — reuse the
+  loaded content's outer panel/field chrome (so only the inner body swaps, which
+  also reduces layout shift) vs. a distinct lightweight block; button variant;
+  whether a description line appears.
+- **State distinction.** Visually separate the three states: never-loaded
+  (button), mid-load (spinner / disabled button to prevent double-submit), and
+  error. Mid-load should match the existing lazy-frame spinner.
+- **Error-state copy & placement.** R8 already commits to inline error + a
+  relabeled **Retry** button; the open part is the exact copy template and where
+  the message sits relative to the button.
+- **Layout shift.** A tall association expanding from a short placeholder shoves
+  content below it; pick a stance (accept, min-height placeholder, or scroll
+  anchor).
+- **Focus management on load.** When the button is replaced by content, move
+  focus to a sensible target and/or announce arrival via `aria-live` so keyboard
+  and screen-reader users aren't dropped to `<body>` (extends R9).
+
+## Next Steps
+→ /ce:plan for structured implementation planning

--- a/docs/plans/2026-06-09-001-feat-manual-turbo-frame-loading-plan.md
+++ b/docs/plans/2026-06-09-001-feat-manual-turbo-frame-loading-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Manual (on-demand) Turbo Frame loading for tabs and associations"
 type: feat
-status: active
+status: completed
 date: 2026-06-09
 origin: docs/brainstorms/2026-06-08-on-demand-frame-loading-requirements.md
 ---

--- a/docs/plans/2026-06-09-001-feat-manual-turbo-frame-loading-plan.md
+++ b/docs/plans/2026-06-09-001-feat-manual-turbo-frame-loading-plan.md
@@ -1,0 +1,416 @@
+---
+title: "feat: Manual (on-demand) Turbo Frame loading for tabs and associations"
+type: feat
+status: active
+date: 2026-06-09
+origin: docs/brainstorms/2026-06-08-on-demand-frame-loading-requirements.md
+---
+
+# feat: Manual (on-demand) Turbo Frame loading for tabs and associations
+
+## Overview
+
+Add a third frame-loading mode, **`manual`**, to Avo resource Show pages. Today a
+Turbo Frame loads `eager` (immediately) or `lazy` (Turbo-native `loading="lazy"`,
+on scroll/reveal). `manual` renders a placeholder with a **Load** button and
+fetches nothing until the user clicks it. It applies uniformly to **tabs** and to
+**`has_many` / `has_one` / `has_and_belongs_to_many`** association fields.
+
+`manual` means one thing everywhere: *placeholder + Load button, no fetch until
+click*. For tabs this is full per-tab gating — every manual tab (including the one
+visible on load) shows its own button. The mode is **purely additive**: omitting
+`loading:` leaves every existing tab/association behaving exactly as today.
+
+| Mode | When it fetches | How expressed (after this change) | Default? |
+|---|---|---|---|
+| `eager` | Immediately with the page | existing keys; no `loading:` | Associations at top level |
+| `lazy` | When the frame is revealed/scrolled into view | `lazy_load: true` (tabs) / `turbo_frame_loading: :lazy` (assoc) | Associations inside tabs/panels (switcher) |
+| `manual` | Only when the user clicks **Load** | **new** `loading: :manual` (both surfaces) | never (opt-in) |
+
+## Problem Frame
+
+Show pages can carry expensive content (heavy queries, external APIs, large
+associations). `lazy` auto-fetches the moment a frame becomes visible, so a tab or
+association the user never needed still costs a request. Developers have no way to
+say "don't fetch this until I ask." `manual` gives them an explicit, user-gated
+load. (See origin: `docs/brainstorms/2026-06-08-on-demand-frame-loading-requirements.md`.)
+
+## Requirements Trace
+
+Carried from the origin requirements doc:
+
+- R1. `manual` is a peer loading mode to `eager`/`lazy`; opt-in, no behavior change unless set.
+- R2. Available on tabs and `has_many` / `has_one` / `has_and_belongs_to_many`.
+- R3. Display/Show views only; Edit/New still render all fields (forms submit completely).
+- R4. A manual frame renders a placeholder (title/description + **Load** button); fetches nothing until clicked. Uniform across associations and tabs.
+- R5. Activating the button swaps the placeholder for real content, showing a loading indicator during the request (reuse `Avo::LoadingComponent`).
+- R6. Every manual tab shows its own button when revealed (including the initial tab) and never auto-fetches on reveal.
+- R7. Loaded content stays loaded while the user stays on the page (in-page tab switching); hard reload re-defers. Turbo back/forward is a verify-in-implementation case.
+- R8. On load failure: inline error message + **Retry** (not the generic `failed_to_load` page, not a silent return to the pristine placeholder).
+- R9. Load button is keyboard-focusable and screen-reader labeled (e.g. "Load Orders").
+- R10. Placeholder shows a default label derived from the tab/association name.
+
+## Scope Boundaries
+
+- **Panels** are out of scope (not Turbo Frames today).
+- **No page-level "Load all"** control.
+- **No cross-reload memory** (no localStorage/server persistence of "loaded").
+- **No custom button label** in v1 (default-from-name only).
+- **No placeholder content preview** (e.g. association counts) in v1.
+- **Defaults unchanged** — `manual` is additive; we do **not** flip top-level
+  associations from `:eager` to `:lazy` or change any existing default.
+- **`loading:` carries only `:manual` in v1** — no `:eager`/`:lazy` aliases and no
+  general cross-key precedence contract; the manual render branch simply runs
+  first so it wins when an old key is also set.
+- Find-in-page / print / export not seeing unloaded content is accepted (same as `lazy`).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+**DSL / item model**
+- `lib/avo/resources/items/tab.rb` — `Tab` stores `@lazy_load = args[:lazy_load]` (boolean, `attr_reader :lazy_load`); `turbo_frame_id(parent:)`. Nested `Tab::Builder` (`Tab.new(title:, **args)`) carries args through. **Add `loading:` capture + `manual?` here.**
+- `lib/avo/resources/items/tab_group.rb` — `TabGroup` has **no** loading attribute today; `group_param → "tab-group_#{id}"`. Nested `TabGroup::Builder#field` auto-wraps a standalone field into its own single-field `Tab` (constructed as `Tab.new title: title`, forwarding no args). A standalone `field ..., loading: :manual` is therefore gated at the **field** level (Unit 3), not by propagating `loading:` onto the generated tab — see Unit 1.
+- `lib/avo/resources/items/holder.rb` — DSL surface: `tab(title:, **args)`, `tabs(...)`, `field(id, **args)`.
+- `lib/avo/dsl/field_parser.rb` — `field ... loading: :manual` flows here → `instantiate_field(id, klass:, **args)`. No field class reads `turbo_frame_loading`/`loading` today.
+
+**Fields**
+- `lib/avo/fields/frame_base_field.rb` — shared base for has_many/has_one/habtm; `turbo_frame` and `frame_url(add_turbo_frame:)`. `#initialize` already captures named kwargs (`@reloadable`, `@linkable`). **Add `loading:` capture + `manual?` here** (shared by all three association types).
+- `lib/avo/fields/concerns/frame_loading.rb` — `turbo_frame_loading` returns `kwargs[:turbo_frame_loading] || params[:turbo_frame_loading] || "eager"`. This returns an HTML `loading` value and **structurally cannot express `manual`** — `manual?` must be a separate predicate, not a `turbo_frame_loading` return value.
+- `lib/avo/fields/has_and_belongs_to_many_field.rb` — `view_component_name → "HasManyField"`; HABTM reuses HasMany's show component (no own ERB).
+
+**ViewComponents / templates**
+- `app/components/avo/tab_group_component.rb` (`frame_args`, `is_not_loaded?(tab) == params[:tab_turbo_frame] != tab.turbo_frame_id(...)`, `active_tab_title` from `params[group_param]`) + `.html.erb` (the `tab.lazy_load && view.display?` branch at line ~31; active tab renders **inline** via `TabContentComponent`, non-active gets `loading: :lazy` + `src`).
+- `app/components/avo/fields/has_many_field/show_component.{rb,html.erb}` (`include FrameLoading`; `turbo_frame_tag @field.turbo_frame, src: @field.frame_url, loading: turbo_frame_loading`).
+- `app/components/avo/fields/has_one_field/show_component.{rb,html.erb}` — frame only when `@field.value` present; **nil value renders an attach/create empty-state panel, not a frame**.
+- `app/components/avo/items/switcher_component.rb` (~line 74) — **hardcodes `turbo_frame_loading: :lazy`** for every field rendered inside tabs/panels. Keep this literal `:lazy` for non-manual fields; add a `final_item.manual?` branch for the manual path only (do **not** replace `:lazy` with a field-derived mode — the field has none, so it would default to eager). See Unit 3.
+- `app/components/avo/loading_component.{rb,html.erb}` — spinner labeled `t('avo.loading') <title>`; the R5 mid-load affordance to reuse.
+- `app/components/avo/empty_state_component.{rb,html.erb}` (+ `empty_state` helper) — the `.state` card markup to mirror for the manual placeholder.
+- `app/components/avo/button_component.rb` + `a_button` / `a_link` helpers — Load/Retry button conventions.
+- `app/views/avo/home/failed_to_load.html.erb` — the existing error UI (the `.state--frame-load-failed` markup inside `Avo::TurboFrameWrapperComponent`). **Note:** there is no `FrameLoadFailedComponent` class — only this ERB view and a `FrameLoadFailedComponentPreview` fixture. Mirror the `.state--frame-load-failed` markup, not a component class.
+
+**Stimulus / JS**
+- `app/javascript/js/controllers/select_controller.js` (`this.parentTurboFrame.src = url`) and `fields/panel_refresh_controller.js` (`frame.reload()`) — precedents for "a control inside a frame manipulates that frame." Model the new controller on these.
+- `app/javascript/js/controllers/tabs_controller.js` — `changeTab`/`revealTabByName` toggle a `hidden` CSS class only (no fetch); localStorage key `resources.${resourceName}.tabgroups.${groupId}.selectedTab`. Reveal is `classList.remove('hidden')`, so a **no-`src` frame will not fetch on reveal** (the R6 behavior to verify).
+- `app/javascript/application.js` —
+  - lines ~104-115: global `turbo:before-fetch-response` rewrites any frame's `src` to `/failed_to_load` on HTTP 500. **Needs a discriminator to skip manual frames.**
+  - lines ~93-102: `turbo:frame-load` strips `loading="lazy"` off completed frames (Turbo #886). Manual frames carry no `loading="lazy"`, so untouched — but review.
+  - lines ~122-124: `turbo:before-cache` removes `[data-turbo-remove-before-cache]` — the hook to use if loaded manual content should re-defer on back/forward.
+
+**Tests to mirror**
+- `spec/system/avo/group_3/tabs_spec.rb` — the `it "lazy_load"` example (~lines 243-288) is the template; also the `with_temporary_items { tabs { tab ..., lazy_load: true } }` pattern for adding cases.
+- `spec/system/avo/group_1/has_many_spec.rb` (asserts `turbo-frame[id="has_many_field_show_comments"]`, scrolls to trigger lazy load) and `reload_button_spec.rb` ("button inside frame triggers load").
+- `spec/components/avo/frame_load_failed_component_preview_spec.rb` (+ preview) — template to mirror for testing the error/Retry state of `ManualFrameComponent`.
+- `spec/lib/avo/fields/has_many_base_field_spec.rb` — unit-spec template for a new field-level attribute.
+- `spec/dummy/app/avo/resources/person.rb` — canonical lazy-tab demo (`tab title: "Address", lazy_load: true`); add manual demos here. **No dummy resource currently sets `turbo_frame_loading` on an association**, so manual-association coverage needs a new fixture setting.
+- Locale: keys live in **both** `lib/generators/avo/templates/locales/avo.en.yml` and `spec/dummy/config/locales/avo.en.yml`.
+
+### Institutional Learnings
+
+- No `docs/solutions/` knowledge base exists in this repo; the brainstorm doc plus the live source conventions are the institutional knowledge. All technical claims in the brainstorm were verified against source during research.
+- `docs/plans/2026-05-18-001-accessible-table-keyboard-nav-plan.md` establishes the repo's a11y conventions (`tabindex`/`role`/`aria-live`/`aria-busy`, focusing dynamically-revealed content) to follow for R9 and focus-on-load. Turbo already toggles `aria-busy` on frames during fetch.
+
+### External References
+
+- None. The repo has strong local Turbo-frame patterns; external research was skipped per the planning gate.
+
+## Key Technical Decisions
+
+- **New `loading:` key, additive (per user decision).** Add a shared `loading: :manual` option to both tabs and association fields. Existing `lazy_load:` / `turbo_frame_loading:` keys and all defaults are unchanged. When `loading:` is omitted, behavior is identical to today.
+- **`manual?` is a predicate, not a loading-attribute value.** Because `FrameLoading#turbo_frame_loading` feeds the HTML `loading` attribute (`eager`/`lazy` only), `manual` is modeled as a separate `manual?` predicate on a **new shared module** (`Avo::Concerns::FrameLoadingMode`) included by both `Tab` and `FrameBaseField`. `FrameLoading#turbo_frame_loading` stays untouched. Manual frames render with **no `src` and no `loading` attribute**.
+- **`loading:` carries only `:manual` in v1, additively.** No general precedence contract and no `:eager`/`:lazy` aliases (closed as a non-goal). If both `loading: :manual` and an old key (`lazy_load:`/`turbo_frame_loading:`) are set, the manual render branch is simply evaluated first so manual wins at render time — this is defensive ordering, not an advertised precedence feature.
+- **Trigger = no-`src` frame + a small Stimulus controller sets `src` on click.** Mirror `select_controller.js` / `panel_refresh_controller.js`. No `loading="lazy"` is ever set, so neither Turbo's lazy auto-fetch nor the #886 strip handler touches it.
+- **Tabs: route all manual tabs (including the active one) through the placeholder branch.** Today the active tab renders inline; manual needs a new branch that emits a no-`src` placeholder uniformly. The Load URL must carry the params the component actually reads — `tab_turbo_frame` (= `tab.turbo_frame_id(parent: group)`) and the group param — **not** `active_tab_title` (which is written to URLs but never read server-side).
+- **Failure: `data-` discriminator + inline error/Retry handled by the controller across all failure classes.** Mark manual frames so the global 500 handler in `application.js` skips them; the manual controller binds the failure events Turbo emits — `turbo:fetch-request-error` (network/timeout) and `turbo:before-fetch-response` for non-2xx (404/4xx/5xx) — and renders an inline error + **Retry** that re-issues the request. (Turbo fires no `turbo:frame-load` on failure, so completion hooks alone won't cover errors.)
+- **`has_one` with nil value falls through to the existing attach/create empty state** (no Load button when there is no record to load).
+- **`switcher_component` keeps injecting `:lazy` for non-manual fields** and branches to the manual path only when `final_item.manual?`. It does **not** "read the field's own mode" — the field has no `turbo_frame_loading` of its own, so that would regress in-tab/panel associations from lazy to eager. See Unit 3.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **DSL surface** → new shared `loading:` key, `loading: :manual`; old keys untouched; additive (user decision).
+- **Default mode** → keep current defaults; `manual` purely opt-in (user decision).
+- **Trigger mechanism** → no-`src` frame + `manual_frame_controller` sets `src` on click.
+- **Tab params** → reproduce `tab_turbo_frame` + group param, not `active_tab_title`.
+- **Failure UX** → `data-manual-frame` discriminator so the global handler skips; inline error + Retry in the controller.
+- **`has_one` nil** → fall through to existing empty-state panel.
+
+### Deferred to Implementation
+
+- **Turbo back/forward / page-cache (R7 second half).** Verify whether a loaded manual frame's content is restored from snapshot (acceptable — not stale within a session) or should re-defer. If re-defer is wanted, tag loaded frames `data-turbo-remove-before-cache`. Resolve by observing real behavior.
+- **Exact focus target after load** (frame heading vs. first interactive element) and the `aria-live` announce wording — settle against `Avo::LoadingComponent` output during implementation.
+- **Group-level `tabs loading: :manual` propagation.** v1 sets `loading:` per-`tab`. A group-level `loading:` is treated as a no-op (not half-implemented) in v1; cascading it to all child tabs is an explicit follow-up.
+
+(Note: `loading:` accepting `:eager`/`:lazy` as aliases is now closed as a **v1 non-goal** — `loading:` carries only `:manual` — and the cross-key precedence is handled defensively at render, not as a public contract. See Key Technical Decisions and Scope Boundaries.)
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+**DSL (directional grammar):**
+
+```text
+# Tabs — every manual tab shows its own Load button
+tab title: "Orders", loading: :manual do
+  field :orders, as: :has_many
+end
+
+# Associations — placeholder + Load button on the Show page
+field :orders, as: :has_many, loading: :manual
+
+# Unchanged: omitting `loading:` keeps eager/lazy exactly as today
+tab title: "Address", lazy_load: true do ... end      # still lazy
+field :comments, as: :has_many                          # still eager/lazy per context
+```
+
+**Mode × surface resolution (directional):**
+
+```text
+loading: omitted   -> manual? == false -> existing eager/lazy path (UNCHANGED)
+loading: :manual   -> manual? == true  -> placeholder + Load button, no src
+                      (gated by view.display? — ignored in Edit/New)
+```
+
+**Frame lifecycle (directional):**
+
+```text
+render (display view, manual?)        click Load                 success
+┌───────────────────────────┐  user   ┌──────────────────────┐  swap   ┌──────────────┐
+│ <turbo-frame> NO src       │ ─────▶  │ controller sets src= │ ─────▶  │ real content │
+│  data-manual-frame         │         │ LoadingComponent /   │         │ (focus moved)│
+│  [Load button] (aria-label)│         │ aria-busy spinner    │         └──────────────┘
+└───────────────────────────┘         └─────────┬────────────┘
+        ▲                                        │ 500 / error
+        │ reveal (tabs): classList toggle        ▼
+        │ → NO fetch (no src)            ┌──────────────────────┐
+        └────────────────────────────── │ inline error + Retry │
+          (global 500 handler skips      │ (Retry re-sets src)  │
+           data-manual-frame)            └──────────────────────┘
+```
+
+## Implementation Units
+
+```mermaid
+graph TB
+  U1[Unit 1: loading: mode core + manual? predicate]
+  U2[Unit 2: placeholder component + Stimulus trigger + a11y]
+  U3[Unit 3: associations wiring + switcher passthrough]
+  U4[Unit 4: tabs full per-tab gating]
+  U5[Unit 5: failure handling - inline error + Retry]
+  U1 --> U3
+  U1 --> U4
+  U2 --> U3
+  U2 --> U4
+  U2 --> U5
+```
+
+- [ ] **Unit 1: `loading:` mode core + `manual?` predicate**
+
+**Goal:** Capture a new `loading:` option on tabs and association fields and expose a `manual?` predicate, without changing any existing default.
+
+**Requirements:** R1, R2, R3 (data layer)
+
+**Dependencies:** None
+
+**Files:**
+- Create: `lib/avo/concerns/frame_loading_mode.rb` — a small shared module that normalizes `args[:loading]` and exposes `manual?`. Included by both `Tab` and `FrameBaseField`. (Do **not** fold this into `FrameLoading`, which keeps owning the `eager`/`lazy` string.)
+- Modify: `lib/avo/resources/items/tab.rb` (include the module; capture `args[:loading]`; `manual?`)
+- Modify: `lib/avo/fields/frame_base_field.rb` (include the module; capture `args[:loading]`; `manual?`, shared by has_many/has_one/habtm)
+- Test: `spec/lib/avo/fields/frame_base_field_spec.rb` (create or extend), `spec/lib/avo/resources/items/tab_spec.rb` (create or extend)
+
+**Approach:**
+- One shared module so `Tab` and `FrameBaseField` resolve `loading:` identically and answer `manual?`. `turbo_frame_loading` (eager/lazy string) is untouched — `manual?` is orthogonal.
+- v1 accepts only `loading: :manual`; omitted → `manual? == false` and zero change.
+- **Standalone field auto-wrapped into a tab:** when `TabGroup::Builder#field` wraps a `field ..., loading: :manual` into a single-field tab, the gating happens at the **field** level (Unit 3 show component), so the generated tab stays non-manual. Do **not** propagate `loading:` onto the generated tab — that would double-gate (a placeholder inside a placeholder). No `tab_group.rb` change is needed for this case.
+
+**Patterns to follow:** `FrameBaseField#initialize` named-kwarg capture (`@reloadable`, `@linkable`); `Tab`'s existing `attr_reader :lazy_load`.
+
+**Test scenarios:**
+- Happy path: `Tab.new(title:, loading: :manual).manual?` is `true`; `field ... loading: :manual` → field `manual?` is `true`.
+- Edge case: no `loading:` → `manual?` is `false` for both tab and field (defaults preserved).
+- Edge case: `lazy_load: true` (tab) and `turbo_frame_loading: :lazy` (field) still resolve to their existing behavior and `manual? == false`.
+- Edge case: both `loading: :manual` and `lazy_load: true` on a tab → `manual?` is `true` (render-layer ordering is enforced in Unit 4, not here).
+- Integration: a standalone `field ..., loading: :manual` auto-wrapped into a tab gates at the field level (the field's `manual?` is `true`; the generated tab's `manual?` is `false`, avoiding double-gating).
+
+**Verification:** New unit specs pass; existing tab/field specs unchanged (no default drift).
+
+---
+
+- [ ] **Unit 2: Manual placeholder component + Stimulus trigger controller + a11y**
+
+**Goal:** Build the reusable primitive both surfaces use — a `turbo-frame` with three states (placeholder + **Load** button → loading spinner → inline error + **Retry**), driven by a Stimulus controller that sets the frame `src` on click and manages focus. The **deferred load URL** is passed to the component as a kwarg and carried in a `data-` attribute for the controller.
+
+**Requirements:** R4, R5, R9, R10 (and the interim failure guard for R8)
+
+**Dependencies:** None. This unit is a foundation; Units 3, 4, and 5 depend on it.
+
+**Files:**
+- Create: `app/components/avo/manual_frame_component.rb` + `.html.erb` (a `turbo-frame` with **no `src`**, marked `data-manual-frame`, holding the deferred load URL in a `data-` value; renders the placeholder/Load-button state, and — wired in Unit 5 — the error/Retry state. Placeholder, loading, and error are three states of this one component, not separate components.)
+- Create: `app/javascript/js/controllers/manual_frame_controller.js` (`ManualFrameController`; `load` action sets the frame `src` from the `data-` value; toggles loading/aria-busy)
+- Modify: `app/javascript/js/controllers.js` — the actual Stimulus registry (there is **no** `controllers/index.js` and no auto-discovery). Add `import ManualFrameController from './controllers/manual_frame_controller'` and `application.register('manual-frame', ManualFrameController)`. The component's `data-controller` must be `manual-frame` (dash form).
+- Modify: `app/javascript/application.js` — add the one-line early-return guard `if (e.target.dataset.manualFrame) return` at the **top** of the `turbo:before-fetch-response` 500 handler now (so the interim state between this unit and Unit 5 is a no-op, not a wrong `failed_to_load` redirect). Full inline-error handling lands in Unit 5.
+- Modify: `lib/generators/avo/templates/locales/avo.en.yml` and `spec/dummy/config/locales/avo.en.yml` (keys: `load`, `retry`, error copy)
+- Test: `spec/components/avo/manual_frame_component_spec.rb`; a focused system test via `with_temporary_items`
+
+**Approach:**
+- Placeholder mirrors `EmptyStateComponent` `.state` markup; reuse `Avo::LoadingComponent` for the mid-load state (R5). Load button via `a_button`/`ButtonComponent`, keyboard-focusable, `aria-label` = "Load <title>" (R9).
+- **Title derivation:** the placeholder title comes from the tab title (tabs) or the field's humanized name (associations); the button label is "Load " + that title (e.g. `order_items` → "Load Order items").
+- Controller mirrors `select_controller.js` (`frame.src = …`) + `panel_refresh_controller.js`. Set `src` from the `data-` value; do **not** add `loading="lazy"`.
+- **Focus management (extends R9 — per the brainstorm design-deferred item, not R9 proper):** after content swaps in (`turbo:frame-load` on this frame), move focus to a sensible target and/or announce via `aria-live`, following `docs/plans/2026-05-18-001-accessible-table-keyboard-nav-plan.md`. The in-scope R9 guarantee is just: focusable + labeled button, and focus is not dropped to `<body>` after load; the exact focus target is the deferred design item.
+
+**Execution note:** Build the component's render contract test-first (placeholder renders no `src` and a labeled button).
+
+**Patterns to follow:** `EmptyStateComponent`, `LoadingComponent`, `ButtonComponent`, `select_controller.js`, `panel_refresh_controller.js`, the explicit registration list in `controllers.js`.
+
+**Test scenarios:**
+- Happy path: component renders a `turbo-frame` with **no `src`**, a `data-manual-frame` marker, `data-controller="manual-frame"`, and a Load button labeled from the title.
+- Happy path (system): clicking Load sets the frame `src` and the real content replaces the placeholder; the spinner shows during the request.
+- Edge case: no network request is made before the click (assert the `turbo-frame` has no `src` and no request fires).
+- Accessibility: Load button is reachable by keyboard (Tab) and exposes an `aria-label` like "Load Orders"; after load, focus is not dropped to `<body>`.
+- Edge case: default label derives correctly from a multi-word name ("Order items" → "Load Order items").
+
+**Verification:** Placeholder shows a focusable, labeled Load button; clicking loads content with a visible spinner; no request fires pre-click; a 500 mid-load is a no-op (not a `failed_to_load` redirect) even before Unit 5.
+
+---
+
+- [ ] **Unit 3: Wire associations (has_many / has_one / habtm) to manual**
+
+**Goal:** Render association frames as manual placeholders when `manual?`, including the switcher passthrough fix, without regressing eager/lazy associations.
+
+**Requirements:** R2, R4, R5 (associations)
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `app/components/avo/fields/has_many_field/show_component.html.erb` (branch: `@field.manual?` + display view → render `ManualFrameComponent` with `@field.frame_url` as the deferred load URL; else existing `turbo_frame_tag ... src:`)
+- Modify: `app/components/avo/fields/has_one_field/show_component.html.erb` (add the manual branch **only inside the value-present path**; the **nil-value path is untouched** — no manual branch is entered, the existing attach/create empty-state panel renders, no turbo-frame)
+- Modify: `app/components/avo/items/switcher_component.rb` (~line 74 — **keep `turbo_frame_loading: :lazy` literally for non-manual fields**; only diverge when `final_item.manual?`, in which case render the manual placeholder path with no `loading` kwarg)
+- Modify: `spec/dummy/app/avo/resources/*.rb` (add a `has_many ... loading: :manual`, a `has_one ... loading: :manual`, and a habtm case)
+- Test: `spec/system/avo/group_1/manual_loading_has_many_spec.rb` (new), extend has_one/habtm coverage
+
+**Approach:**
+- HABTM reuses HasMany's show component, so the has_many branch covers it — add explicit coverage, no separate ERB.
+- The deferred load URL for associations is `@field.frame_url`; the manual placeholder withholds it until click.
+- **Switcher fix (highest-blast-radius edit, prevents a P0 regression):** the field instance has **no `turbo_frame_loading` of its own** — `FrameLoading#turbo_frame_loading` reads the component kwargs, which the switcher populates. So "read the field's own mode" is a trap: a non-manual field would fall back to the `"eager"` default and every in-tab/panel association would silently flip from lazy to eager. Therefore: **keep injecting `turbo_frame_loading: :lazy` for non-manual fields**, and branch on `final_item.respond_to?(:manual?) && final_item.manual?` only to render the manual path. The literal `:lazy` default for switcher fields is preserved.
+
+**Patterns to follow:** existing `turbo_frame_tag @field.turbo_frame, src: @field.frame_url` shape; `has_one` empty-state branch.
+
+**Test scenarios:**
+- Happy path: `has_many ... loading: :manual` renders a Load button; no `has_many_field_show_*` fetch until click; content loads on click.
+- Happy path: HABTM with `loading: :manual` behaves identically (delegated component).
+- Edge case: `has_one ... loading: :manual` with a present value → Load button → loads on click.
+- Edge case: `has_one ... loading: :manual` with **nil** value → existing attach/create empty state renders (no Load button, no turbo-frame).
+- **Regression (must distinguish lazy from eager):** an existing `has_many` inside a tab/panel (no `loading:`) still renders its frame with `loading="lazy"` and is **not** fetched on initial paint — assert the `turbo-frame` carries `loading="lazy"` and has no content until reveal (a "content eventually appears" assertion would pass for an eager frame too and miss the regression).
+- Edge case (R3): the same manual association on an Edit/New view renders the full field, not a placeholder.
+
+**Verification:** Manual associations gate behind a button; non-manual in-tab/panel associations still carry `loading="lazy"` (unchanged); has_one nil falls through to empty state.
+
+---
+
+- [ ] **Unit 4: Wire tabs to manual (full per-tab gating)**
+
+**Goal:** Every tab marked `loading: :manual` renders its own Load-button placeholder — including the tab visible on load — and never auto-fetches on reveal.
+
+**Requirements:** R4, R6, R7 (tabs)
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `app/components/avo/tab_group_component.rb` (a method building the manual frame's deferred load URL for a tab: `resource_path(... tab_turbo_frame: tab.turbo_frame_id(parent: group), "tab-group_#{group.id}" => tab.title)` — the group-param **value is the raw `tab.title`** (server compares it via `CGI.unescape` against `tab.title.to_s`), not the parameterized id; plus a per-tab `manual?` helper)
+- Modify: `app/components/avo/tab_group_component.html.erb` (new manual branch — see Approach for the exact branch shape and ordering)
+- Modify: `spec/dummy/app/avo/resources/person.rb` (add a `tab ..., loading: :manual`)
+- Test: extend `spec/system/avo/group_3/tabs_spec.rb` (mirror the `lazy_load` example with a `manual` case)
+
+**Approach:**
+- **Keep the inner `is_not_loaded?` split** (this is load-bearing — without it the Load click re-renders the placeholder forever). The manual branch mirrors the lazy branch's structure: render the `ManualFrameComponent` placeholder when `is_not_loaded?(tab)`, and `TabContentComponent` (real content) when the framed request arrives carrying the matching `tab_turbo_frame`. The **only** differences from lazy: the frame has no `src` and no `loading="lazy"`, and a Load button supplies the `src` on click.
+- **Branch ordering:** evaluate `tab.manual? && view.display?` **before** the existing `tab.lazy_load && view.display?` branch, so a tab set with both keys takes the manual (no-`src`) path and never enters the lazy/eager src-setting branch.
+- The deferred URL carries the params the component actually reads (`tab_turbo_frame` + the `tab-group_<id>` group param), **not** `active_tab_title` (written to URLs but never read server-side). Turbo extracts only the matching frame from the response, so sibling-tab `hidden`/active state in the framed re-render is irrelevant.
+- Reveal via `tabs_controller.js` is a CSS `hidden` toggle; a no-`src` frame must not fetch on reveal — assert this explicitly (R6).
+- R7 in-page persistence: once loaded (the framed response swaps in `TabContentComponent`), the content stays in the DOM across CSS show/hide tab switches. Back/forward is the deferred verification item.
+
+**Patterns to follow:** existing `frame_args` / `turbo_frame_tag tab.turbo_frame_id(...)` and the `is_not_loaded?` placeholder-vs-content split; the `tab.lazy_load && view.display?` gating shape.
+
+**Test scenarios:**
+- Happy path: a `manual` tab shows a Load button on the initially-visible tab; no fetch until clicked; **clicking Load renders the real tab content** (not the placeholder again).
+- Happy path: a second `manual` tab in the same group also shows its own button; revealing it (clicking the tab) shows the button and does **not** fetch until Load is clicked.
+- Integration (R7): after loading a manual tab, switching away and back keeps the content without re-fetching (content remains in the DOM).
+- Edge case (R6): revealing a manual tab fires no network request (no `src`).
+- Edge case (R3): manual tab on Edit/New renders inline content, not a placeholder.
+- Edge case (precedence at render): a tab with both `loading: :manual` and `lazy_load: true` renders a no-`src` placeholder and fires no request on reveal (manual branch wins).
+- Edge case: a mixed group (one `manual` tab + one `lazy_load: true` tab + one eager tab) — each behaves per its own mode.
+
+**Verification:** Every manual tab gates behind its own button; clicking Load shows real content; reveal never fetches; loaded content persists across in-page tab switches.
+
+---
+
+- [ ] **Unit 5: Failure handling — inline error + Retry with discriminator**
+
+**Goal:** A failed manual load shows an inline error + **Retry** in the frame, instead of the generic `failed_to_load` page, by making the global 500 handler skip manual frames.
+
+**Requirements:** R8
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `app/javascript/application.js` (the `data-manual-frame` early-return guard was added to the 500 handler in Unit 2; here, confirm it and verify the #886 `loading="lazy"` strip handler does not touch manual frames — they carry no `loading="lazy"`)
+- Modify: `app/javascript/js/controllers/manual_frame_controller.js` (bind the failure events and render the error state; `retry` action re-issues the request)
+- Modify: `app/components/avo/manual_frame_component.html.erb` (add the **error state** — inline message + **Retry** — to the existing component from Unit 2; mirror the `.state--frame-load-failed` markup from `app/views/avo/home/failed_to_load.html.erb`. Do **not** create a separate error component.)
+- Modify: locale files (error message + `retry` key) — both generator template and dummy
+- Test: `spec/system/avo/group_1/manual_loading_failure_spec.rb` (new); component spec for the error state of `ManualFrameComponent`
+
+**Approach:**
+- **Cover all failure classes, not just 500.** The global handler only fires on HTTP 500; the early-return guard makes it skip manual frames there. The controller must additionally bind `turbo:fetch-request-error` (network/timeout) and `turbo:before-fetch-response` for non-2xx (404/4xx/5xx-other) on its frame, since Turbo emits **no** `turbo:frame-load` on failure — without this a non-500 manual failure would leave a blank frame.
+- On any of those failure events for this frame, render the error state (inline message + **Retry**). `retry` resets the frame `src` (same URL) to re-issue; on repeated failure the error state persists.
+
+**Execution note:** Drive with a failing-endpoint system test first (a dummy action that 500s), asserting the inline error appears rather than the `failed_to_load` page.
+
+**Patterns to follow:** the `.state--frame-load-failed` markup in `app/views/avo/home/failed_to_load.html.erb`; `ButtonComponent` for Retry.
+
+**Test scenarios:**
+- Error path (500): a manual frame whose load 500s shows the inline error + **Retry**, and does **not** navigate to / render the `failed_to_load` page.
+- Error path (non-500): a manual frame load that 404s or hits a network error also shows the inline error + **Retry** (not a blank frame).
+- Error path: clicking **Retry** re-issues the request; once the backend succeeds, content loads.
+- Regression/Integration: a non-manual (lazy/eager) frame that 500s still routes to the existing `failed_to_load` page (the guard only affects `data-manual-frame`).
+- Edge case: repeated failure keeps the inline error + Retry visible (no broken/empty frame).
+
+**Verification:** Manual-frame failures (500 and non-500) stay inline with a working Retry; existing frame error handling is unchanged for non-manual frames.
+
+## System-Wide Impact
+
+- **Interaction graph:** The `switcher_component` change (Unit 3) sits on the render path of **every** field inside a tab or panel — the largest blast radius. Default must remain `:lazy` for non-manual fields. The `application.js` 500-handler change (Unit 5) is global to all Turbo frames — must early-return only for `data-manual-frame`.
+- **Error propagation:** Manual frames intercept their own 500s (inline error + Retry); all other frames keep the existing `failed_to_load` behavior. Non-500 failures (network, timeout, other statuses) should also surface as the inline error via the controller, not a blank frame.
+- **State lifecycle risks:** Loaded manual content lives in the DOM and persists across in-page tab switches (CSS show/hide). Turbo page-cache / back-forward may snapshot loaded content or restore a placeholder — verify; use `data-turbo-remove-before-cache` only if re-defer is desired.
+- **API surface parity:** `loading: :manual` works uniformly on tabs, has_many, has_one, and habtm (habtm via the has_many component). The `manual?` predicate lives on the shared `FrameBaseField` and on `Tab`, so all three association types and tabs share one code path.
+- **Integration coverage:** Reveal-without-fetch (Unit 4) and switcher passthrough (Unit 3) are the cross-layer behaviors unit tests can't prove — covered by system tests.
+- **Unchanged invariants:** No existing default changes. `eager`/`lazy` frames, `lazy_load: true` tabs, `turbo_frame_loading: :lazy` associations, the `failed_to_load` flow for non-manual frames, and Edit/New rendering are all explicitly preserved.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| **Switcher change flips non-manual in-tab associations from lazy to eager (P0 regression)** — the field has no `turbo_frame_loading` of its own, so "read the field's mode" falls back to `"eager"` | Keep injecting `turbo_frame_loading: :lazy` literally for non-manual fields; branch only on `final_item.manual?`. Regression test asserts the frame carries `loading="lazy"` and is not fetched on initial paint (not just "content eventually appears") |
+| Manual tab Load click re-renders the placeholder forever instead of content | Keep the inner `is_not_loaded?(tab)` split in the manual branch (placeholder when not loaded, `TabContentComponent` when the framed request arrives); test that clicking Load shows real content |
+| `loading: :manual` + `lazy_load: true` on a tab still enters the lazy src-setting branch | Order the `tab.manual?` branch **before** `tab.lazy_load`; render-layer test for the both-keys case |
+| Global 500-handler change breaks error handling for non-manual frames | Guard early-returns only for `data-manual-frame`; regression test that a non-manual 500 still hits `failed_to_load` |
+| Non-500 manual failures (network/timeout/404) leave a blank frame | Controller binds `turbo:fetch-request-error` + non-2xx `turbo:before-fetch-response`; non-500 failure test |
+| Interim state: manual failures before Unit 5 lands | One-line `data-manual-frame` early-return guard moved into Unit 2, so the interim is a no-op; R8 inline error fully lands in Unit 5 |
+| A manual frame accidentally carries `src`/`loading="lazy"` and auto-fetches on reveal | Component emits no `src`/`loading`; explicit test that revealing a manual tab fires no request |
+| `has_one` nil value path mishandled | Manual branch not entered on the nil path; test it falls through to the existing empty state (no turbo-frame) |
+| Turbo back/forward restores stale or re-fetches manual content (R7) | Deferred-to-implementation verification; `data-turbo-remove-before-cache` (already used at `application.js` ~line 123) available if re-defer is needed |
+
+## Documentation / Operational Notes
+
+- Document the new `loading: :manual` option for tabs and associations in the Avo docs site; note it is display-only, opt-in, and (for tabs) gates every manual tab individually.
+- Add the new locale keys (`load`, `retry`, error copy) to the generator template so host apps pick them up.
+- No migrations, no rollout/feature-flag concerns — purely additive view behavior.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-08-on-demand-frame-loading-requirements.md](docs/brainstorms/2026-06-08-on-demand-frame-loading-requirements.md)
+- Tabs: `app/components/avo/tab_group_component.{rb,html.erb}`, `app/javascript/js/controllers/tabs_controller.js`, `lib/avo/resources/items/tab.rb`, `tab_group.rb`
+- Associations: `lib/avo/fields/concerns/frame_loading.rb`, `lib/avo/fields/frame_base_field.rb`, `app/components/avo/fields/has_many_field/show_component.html.erb`, `has_one_field/show_component.html.erb`, `app/components/avo/items/switcher_component.rb`
+- Affordances: `app/components/avo/loading_component.*`, `empty_state_component.*`, `button_component.rb`, `app/views/avo/home/failed_to_load.html.erb` (the `.state--frame-load-failed` markup)
+- Failure path: `app/javascript/application.js`, `config/routes.rb` (`failed_to_load`), `app/controllers/avo/home_controller.rb`
+- Tests to mirror: `spec/system/avo/group_3/tabs_spec.rb`, `spec/system/avo/group_1/has_many_spec.rb`, `reload_button_spec.rb`, `spec/components/avo/frame_load_failed_component_preview_spec.rb`
+- A11y conventions: `docs/plans/2026-05-18-001-accessible-table-keyboard-nav-plan.md`

--- a/lib/avo/concerns/frame_loading_mode.rb
+++ b/lib/avo/concerns/frame_loading_mode.rb
@@ -1,0 +1,17 @@
+# Adds the `loading:` mode option shared by tabs and association fields.
+#
+# v1 only carries `:manual`. This is orthogonal to the eager/lazy string
+# returned by `Avo::Fields::Concerns::FrameLoading#turbo_frame_loading` —
+# `manual?` is a separate predicate, not a `turbo_frame_loading` value.
+module Avo
+  module Concerns
+    module FrameLoadingMode
+      extend ActiveSupport::Concern
+
+      # Returns true only when `loading: :manual` was set (string "manual" tolerated).
+      def manual?
+        @loading.to_s == "manual"
+      end
+    end
+  end
+end

--- a/lib/avo/concerns/frame_loading_mode.rb
+++ b/lib/avo/concerns/frame_loading_mode.rb
@@ -1,16 +1,58 @@
 # Adds the `loading:` mode option shared by tabs and association fields.
 #
-# v1 only carries `:manual`. This is orthogonal to the eager/lazy string
-# returned by `Avo::Fields::Concerns::FrameLoading#turbo_frame_loading` —
-# `manual?` is a separate predicate, not a `turbo_frame_loading` value.
+# `loading:` accepts either a symbol shorthand or a Hash:
+#
+#   loading: :manual                                  # placeholder + Load button
+#   loading: {mode: :manual}                          # same as above
+#   loading: {mode: :manual, auto_load_for: 5.minutes} # + sliding auto-load memory
+#   loading: {mode: :lazy}                            # native lazy (loads on reveal)
+#
+# This is orthogonal to the eager/lazy string returned by
+# `Avo::Fields::Concerns::FrameLoading#turbo_frame_loading` — `manual?` is a
+# separate predicate, not a `turbo_frame_loading` value.
+#
+# `auto_load_for` is a memory window, not a delay: once the user has opened the
+# frame, a short-lived cookie (scoped per record + frame) remembers it, and the
+# server renders a real auto-loading `<turbo-frame src>` — no placeholder, no
+# Load button — on return for that duration. The window slides via the cookie's
+# refreshed max-age. v1 honors `auto_load_for` for `:manual` only.
 module Avo
   module Concerns
     module FrameLoadingMode
       extend ActiveSupport::Concern
 
-      # Returns true only when `loading: :manual` was set (string "manual" tolerated).
+      # The cold-start render mode: `:manual`, `:lazy`, or `nil` when unset.
+      # A Hash without an explicit `mode:` defaults to `:manual`, so
+      # `loading: {auto_load_for: 5.minutes}` is "manual + memory".
+      def loading_mode
+        return @loading_mode if defined?(@loading_mode)
+
+        @loading_mode =
+          if @loading.is_a?(Hash)
+            (@loading.symbolize_keys[:mode] || :manual).to_sym
+          elsif @loading.present?
+            @loading.to_sym
+          end
+      end
+
+      # True when the frame should render as a manual placeholder (Load button)
+      # on cold start. Covers `loading: :manual` and `loading: {mode: :manual}`.
       def manual?
-        @loading.to_s == "manual"
+        loading_mode == :manual
+      end
+
+      # True when `loading: {mode: :lazy}` — render a native lazy frame.
+      def lazy_loading_mode?
+        loading_mode == :lazy
+      end
+
+      # Seconds the browser should remember the opened frame and auto-load it on
+      # return (sliding window). `nil` unless a `loading: {auto_load_for: …}` Hash
+      # was given. Accepts an `ActiveSupport::Duration` or a raw integer.
+      def auto_load_for
+        return unless @loading.is_a?(Hash)
+
+        @loading.symbolize_keys[:auto_load_for]&.to_i
       end
     end
   end

--- a/lib/avo/fields/frame_base_field.rb
+++ b/lib/avo/fields/frame_base_field.rb
@@ -5,6 +5,7 @@ module Avo
       include Avo::Fields::Concerns::ReloadIcon
       include Avo::Fields::Concerns::LinkableTitle
       include Avo::Concerns::HasDescription
+      include Avo::Concerns::FrameLoadingMode
 
       def initialize(id, **args, &block)
         super
@@ -13,6 +14,7 @@ module Avo
         @reloadable = args[:reloadable]
         @linkable = args[:linkable]
         @description = args[:description]
+        @loading = args[:loading]
       end
 
       def field_resource

--- a/lib/avo/fields/frame_base_field.rb
+++ b/lib/avo/fields/frame_base_field.rb
@@ -124,6 +124,17 @@ module Avo
       def default_view
         Avo.configuration.skip_show_view ? :edit : :show
       end
+
+      # Attributes exposed to callable descriptions. `loading_type` tells a
+      # description lambda how the field is being rendered: `:manual` for a
+      # not-yet-loaded manual placeholder, `nil` for live/loaded content. A
+      # lambda can branch on it to avoid touching the association (e.g.
+      # `query.count`) on the placeholder paint. The manual placeholder render
+      # path passes `loading_type: :manual`; every other context keeps the
+      # `nil` default.
+      def description_attributes
+        {loading_type: nil}
+      end
     end
   end
 end

--- a/lib/avo/fields/many_frame_base_field.rb
+++ b/lib/avo/fields/many_frame_base_field.rb
@@ -24,13 +24,21 @@ module Avo
           only_on Avo.configuration.resource_default_view
         end
 
-        super(id, **args, &block)
+        super
 
         @searchable = args[:searchable]
         @scope = args[:scope]
         @hide_search_input = args[:hide_search_input]
         @hide_filter_button = args[:hide_filter_button]
         @discreet_pagination = args[:discreet_pagination]
+      end
+
+      private
+
+      # Expose the association relation as `query` to description lambdas,
+      # mirroring how `attach_scope` receives `query` in the associations controller.
+      def description_attributes
+        {query: @record.public_send(association_name)}
       end
     end
   end

--- a/lib/avo/fields/many_frame_base_field.rb
+++ b/lib/avo/fields/many_frame_base_field.rb
@@ -35,10 +35,13 @@ module Avo
 
       private
 
-      # Expose the association relation as `query` to description lambdas,
-      # mirroring how `attach_scope` receives `query` in the associations controller.
+      # Expose the association relation as `query` to callable descriptions, on
+      # top of the shared `loading_type` flag. Mirrors how `attach_scope` receives
+      # `query` in the associations controller. The relation is lazy; SQL runs
+      # only if the lambda enumerates or aggregates it (e.g. `query.count`) — so a
+      # manual placeholder should branch on `loading_type == :manual` to skip that.
       def description_attributes
-        {query: @record.public_send(association_name)}
+        super.merge(query: @record.public_send(association_name))
       end
     end
   end

--- a/lib/avo/resources/items/tab.rb
+++ b/lib/avo/resources/items/tab.rb
@@ -6,11 +6,13 @@ class Avo::Resources::Items::Tab
   include Avo::Concerns::VisibleItems
   include Avo::Concerns::IsVisible
   include Avo::Concerns::VisibleInDifferentViews
+  include Avo::Concerns::FrameLoadingMode
 
   delegate :items, :add_item, to: :items_holder
 
   attr_accessor :description
   attr_reader :lazy_load
+  attr_reader :loading
 
   def initialize(title: nil, description: nil, view: nil, **args)
     @title = title
@@ -20,6 +22,7 @@ class Avo::Resources::Items::Tab
     @args = args
     @visible = args[:visible]
     @lazy_load = args[:lazy_load]
+    @loading = args[:loading]
 
     post_initialize if respond_to?(:post_initialize)
   end

--- a/lib/generators/avo/templates/locales/avo.ar.yml
+++ b/lib/generators/avo/templates/locales/avo.ar.yml
@@ -53,6 +53,7 @@ ar:
     choose_an_option: اختر خيارًا
     choose_item: اختر %{item}
     clear_value: مسح القيمة
+    click_to_load: انقر لتحميل
     click_to_reveal_filters: انقر لإظهار المرشحات
     close: إغلاق
     close_modal: أغلق النافذة
@@ -78,6 +79,7 @@ ar:
     failed: فشل
     failed_to_find_attachment: فشل في العثور على المرفق
     failed_to_load: فشل التحميل
+    failed_to_load_item: فشل في تحميل %{item}
     'false': خطأ
     file:
       few: ملفات
@@ -117,6 +119,7 @@ ar:
       value: القيمة
     less_content: محتوى أقل
     list_is_empty: القائمة فارغة
+    load_item: تحميل %{item}
     loading: جاري التحميل
     media_library:
       title: مكتبة الوسائط
@@ -165,6 +168,8 @@ ar:
     resource_destroyed: تم حذف السجل
     resource_updated: تم تحديث السجل
     resources: المصادر
+    retry: إعادة المحاولة
+    retry_item: إعادة المحاولة %{item}
     reupload_file: Reupload %{item}
     run: تشغيل
     save: حفظ

--- a/lib/generators/avo/templates/locales/avo.de.yml
+++ b/lib/generators/avo/templates/locales/avo.de.yml
@@ -43,6 +43,7 @@ de:
     choose_an_option: Option auswählen
     choose_item: "%{item} auswählen"
     clear_value: Wert löschen
+    click_to_load: Klicken Sie hier, um zu laden
     click_to_reveal_filters: Klicken, um Filter anzuzeigen
     close: Schließen
     close_modal: Modal schließen
@@ -68,6 +69,7 @@ de:
     failed: Fehlgeschlagen
     failed_to_find_attachment: Anhang nicht gefunden
     failed_to_load: Laden fehlgeschlagen
+    failed_to_load_item: Fehler beim Laden von %{item}
     'false': Falsch
     file:
       one: Datei
@@ -103,6 +105,7 @@ de:
       value: Wert
     less_content: Weniger Inhalt
     list_is_empty: Liste ist leer
+    load_item: Lade %{item}
     loading: Lade...
     media_library:
       title: Medienbibliothek
@@ -147,6 +150,8 @@ de:
     resource_destroyed: Eintrag gelöscht
     resource_updated: Eintrag aktualisiert
     resources: Ressourcen
+    retry: Erneut versuchen
+    retry_item: Erneut versuchen %{item}
     reupload_file: Reupload %{item}
     run: Ausführen
     save: Speichern

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -68,6 +68,7 @@ en:
     failed: Failed
     failed_to_find_attachment: Failed to find attachment
     failed_to_load: Failed to load
+    failed_to_load_manual: Couldn't load this content.
     'false': 'False'
     file:
       one: file
@@ -103,6 +104,7 @@ en:
       value: Value
     less_content: Less content
     list_is_empty: List is empty
+    load: Load
     loading: Loading
     media_library:
       title: Media Library
@@ -143,6 +145,7 @@ en:
     remove_selection: Remove selection
     reset: reset
     reset_filters: Reset filters
+    retry: Retry
     resource_created: Record created
     resource_destroyed: Record destroyed
     resource_updated: Record updated

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -69,8 +69,8 @@ en:
     failed: Failed
     failed_to_find_attachment: Failed to find attachment
     failed_to_load: Failed to load
-    failed_to_load_item: Couldn't load %{item}
-    'false': 'False'
+    failed_to_load_item: Failed to load %{item}
+    "false": "False"
     file:
       one: file
       other: files
@@ -172,7 +172,7 @@ en:
     table_view: Table view
     this_field_has_attachments_disabled: This field has attachments disabled.
     tools: Tools
-    'true': 'True'
+    "true": "True"
     type_to_search: Type to search.
     unauthorized: Unauthorized
     undo: undo

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -68,7 +68,7 @@ en:
     failed: Failed
     failed_to_find_attachment: Failed to find attachment
     failed_to_load: Failed to load
-    failed_to_load_manual: Couldn't load this content.
+    failed_to_load_item: Couldn't load %{item}
     'false': 'False'
     file:
       one: file
@@ -104,7 +104,7 @@ en:
       value: Value
     less_content: Less content
     list_is_empty: List is empty
-    load: Load
+    load_item: Load %{item}
     loading: Loading
     media_library:
       title: Media Library
@@ -146,6 +146,7 @@ en:
     reset: reset
     reset_filters: Reset filters
     retry: Retry
+    retry_item: Retry %{item}
     resource_created: Record created
     resource_destroyed: Record destroyed
     resource_updated: Record updated

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -70,7 +70,7 @@ en:
     failed_to_find_attachment: Failed to find attachment
     failed_to_load: Failed to load
     failed_to_load_item: Failed to load %{item}
-    "false": "False"
+    'false': 'False'
     file:
       one: file
       other: files
@@ -146,12 +146,12 @@ en:
     remove_selection: Remove selection
     reset: reset
     reset_filters: Reset filters
-    retry: Retry
-    retry_item: Retry %{item}
     resource_created: Record created
     resource_destroyed: Record destroyed
     resource_updated: Record updated
     resources: Resources
+    retry: Retry
+    retry_item: Retry %{item}
     reupload_file: Reupload %{item}
     run: Run
     save: Save
@@ -172,7 +172,7 @@ en:
     table_view: Table view
     this_field_has_attachments_disabled: This field has attachments disabled.
     tools: Tools
-    "true": "True"
+    'true': 'True'
     type_to_search: Type to search.
     unauthorized: Unauthorized
     undo: undo

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -43,6 +43,7 @@ en:
     choose_an_option: Choose an option
     choose_item: Choose %{item}
     clear_value: Clear value
+    click_to_load: Click to load
     click_to_reveal_filters: Click to reveal filters
     close: Close
     close_modal: Close modal

--- a/lib/generators/avo/templates/locales/avo.es.yml
+++ b/lib/generators/avo/templates/locales/avo.es.yml
@@ -45,6 +45,7 @@ es:
     choose_an_option: Elige una opción
     choose_item: Elige %{item}
     clear_value: Borrar el valor
+    click_to_load: Haga clic para cargar
     click_to_reveal_filters: Pulsa para mostrar los filtros
     close: Cerrar
     close_modal: Cerrar modal
@@ -70,6 +71,7 @@ es:
     failed: Fallo
     failed_to_find_attachment: No se ha encontrado el archivo adjunto
     failed_to_load: No se ha podido cargar
+    failed_to_load_item: Error al cargar %{item}
     'false': Falso
     file:
       one: archivo
@@ -105,6 +107,7 @@ es:
       value: Valor
     less_content: Menos contenido
     list_is_empty: La lista está vacía
+    load_item: Cargar %{item}
     loading: Cargando
     media_library:
       title: Biblioteca de medios
@@ -149,6 +152,8 @@ es:
     resource_destroyed: Recurso eliminado
     resource_updated: Recurso actualizado
     resources: Recursos
+    retry: Reintentar
+    retry_item: Reintentar %{item}
     reupload_file: Reupload %{item}
     run: Ejecutar
     save: Guardar

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -45,6 +45,7 @@ fr:
     choose_an_option: Sélectionnez une option
     choose_item: Choisir %{item}
     clear_value: Effacer la valeur
+    click_to_load: Cliquez pour charger
     click_to_reveal_filters: Cliquez pour révéler les filtres
     close: Fermer
     close_modal: Fermer la fenêtre modale
@@ -70,6 +71,7 @@ fr:
     failed: Échec
     failed_to_find_attachment: Impossible de trouver la pièce jointe
     failed_to_load: Impossible de charger
+    failed_to_load_item: Échec du chargement de %{item}
     'false': Faux
     file:
       one: fichier
@@ -105,6 +107,7 @@ fr:
       value: Valeur
     less_content: Moins de contenu
     list_is_empty: La liste est vide
+    load_item: Charger %{item}
     loading: Chargement
     media_library:
       title: Bibliothèque multimédia
@@ -149,6 +152,8 @@ fr:
     resource_destroyed: Ressource détruite
     resource_updated: Ressource mise à jour
     resources: Ressources
+    retry: Réessayer
+    retry_item: Réessayer %{item}
     reupload_file: Reupload %{item}
     run: Exécuter
     save: Enregistrer

--- a/lib/generators/avo/templates/locales/avo.it.yml
+++ b/lib/generators/avo/templates/locales/avo.it.yml
@@ -43,6 +43,7 @@ it:
     choose_an_option: Scegli un'opzione
     choose_item: Scegli %{item}
     clear_value: Cancella valore
+    click_to_load: Clicca per caricare
     click_to_reveal_filters: Clicca per mostrare i filtri
     close: Chiudi
     close_modal: Chiudi modale
@@ -68,6 +69,7 @@ it:
     failed: Fallito
     failed_to_find_attachment: Impossibile trovare l'allegato
     failed_to_load: Caricamento fallito
+    failed_to_load_item: Impossibile caricare %{item}
     'false': Falso
     file:
       one: file
@@ -103,6 +105,7 @@ it:
       value: Valore
     less_content: Meno contenuti
     list_is_empty: La lista è vuota
+    load_item: Carica %{item}
     loading: Caricamento in corso
     media_library:
       title: Libreria multimediale
@@ -147,6 +150,8 @@ it:
     resource_destroyed: Record distrutto
     resource_updated: Record aggiornato
     resources: Risorse
+    retry: Riprova
+    retry_item: Riprova %{item}
     reupload_file: Reupload %{item}
     run: Esegui
     save: Salva

--- a/lib/generators/avo/templates/locales/avo.ja.yml
+++ b/lib/generators/avo/templates/locales/avo.ja.yml
@@ -45,6 +45,7 @@ ja:
     choose_an_option: オプションを選択
     choose_item: "%{item}を選択"
     clear_value: 値をクリア
+    click_to_load: 読み込みをクリック
     click_to_reveal_filters: フィルターを表示するにはクリック
     close: 閉じる
     close_modal: モーダルを閉じる
@@ -70,6 +71,7 @@ ja:
     failed: 失敗
     failed_to_find_attachment: アタッチメントを見つけるのに失敗
     failed_to_load: 読み込みに失敗
+    failed_to_load_item: "%{item}の読み込みに失敗しました"
     'false': 偽
     file:
       one: ファイル
@@ -105,6 +107,7 @@ ja:
       value: 値
     less_content: コンテンツが少ない
     list_is_empty: リストは空です
+    load_item: "%{item}を読み込む"
     loading: 読み込み中
     media_library:
       title: メディアライブラリ
@@ -149,6 +152,8 @@ ja:
     resource_destroyed: レコードが破棄されました
     resource_updated: レコードが更新されました
     resources: リソース
+    retry: 再試行
+    retry_item: "%{item}を再試行"
     reupload_file: Reupload %{item}
     run: 実行
     save: 保存

--- a/lib/generators/avo/templates/locales/avo.nb.yml
+++ b/lib/generators/avo/templates/locales/avo.nb.yml
@@ -45,6 +45,7 @@ nb:
     choose_an_option: Velg et alternativ
     choose_item: Velge %{item}
     clear_value: Nullstill verdi
+    click_to_load: Klikk for å laste
     click_to_reveal_filters: Vis filter
     close: Lukk
     close_modal: Lukk modal
@@ -70,6 +71,7 @@ nb:
     failed: Feilet
     failed_to_find_attachment: Fant ikke vedlegg
     failed_to_load: Lasting feilet
+    failed_to_load_item: Kunne ikke laste %{item}
     'false': Falsk
     file:
       one: file
@@ -105,6 +107,7 @@ nb:
       value: Verdi
     less_content: Mindre innhold
     list_is_empty: Listen er tom
+    load_item: Last %{item}
     loading: Laster
     media_library:
       title: Mediebibliotek
@@ -149,6 +152,8 @@ nb:
     resource_destroyed: Ressurs slettet
     resource_updated: Ressurs oppdatert
     resources: Ressurser
+    retry: Prøv igjen
+    retry_item: Prøv igjen %{item}
     reupload_file: Reupload %{item}
     run: Kjør
     save: Lagre

--- a/lib/generators/avo/templates/locales/avo.nl.yml
+++ b/lib/generators/avo/templates/locales/avo.nl.yml
@@ -43,6 +43,7 @@ nl:
     choose_an_option: Kies een optie
     choose_item: Kies %{item}
     clear_value: Waarde wissen
+    click_to_load: Klik om te laden
     click_to_reveal_filters: Klik om filters te tonen
     close: Sluiten
     close_modal: Modaal sluiten
@@ -68,6 +69,7 @@ nl:
     failed: Mislukt
     failed_to_find_attachment: Bijlage niet gevonden
     failed_to_load: Laden mislukt
+    failed_to_load_item: Laden van %{item} mislukt
     'false': Onwaar
     file:
       one: bestand
@@ -103,6 +105,7 @@ nl:
       value: Waarde
     less_content: Minder inhoud
     list_is_empty: Lijst is leeg
+    load_item: Laad %{item}
     loading: Laden...
     media_library:
       title: Mediabibliotheek
@@ -147,6 +150,8 @@ nl:
     resource_destroyed: Record verwijderd
     resource_updated: Record bijgewerkt
     resources: Bronnen
+    retry: Opnieuw proberen
+    retry_item: Probeer %{item} opnieuw
     reupload_file: Reupload %{item}
     run: Uitvoeren
     save: Opslaan

--- a/lib/generators/avo/templates/locales/avo.nn.yml
+++ b/lib/generators/avo/templates/locales/avo.nn.yml
@@ -45,6 +45,7 @@ nn:
     choose_an_option: Vel eit alternativ
     choose_item: Vel %{item}
     clear_value: Nullstill verdi
+    click_to_load: Klikk for å laste inn
     click_to_reveal_filters: Vis filter
     close: Lukk
     close_modal: Lukk modal
@@ -70,6 +71,7 @@ nn:
     failed: Feila
     failed_to_find_attachment: Fann ikkje vedlegg
     failed_to_load: Lasting feila
+    failed_to_load_item: Feil ved innlasting av %{item}
     'false': Falsk
     file:
       one: file
@@ -105,6 +107,7 @@ nn:
       value: Verdi
     less_content: Mindre innhold
     list_is_empty: Lista er tom
+    load_item: Last inn %{item}
     loading: Lastar
     media_library:
       title: Media bibliotek
@@ -149,6 +152,8 @@ nn:
     resource_destroyed: Ressurs sletta
     resource_updated: Ressurs oppdatert
     resources: Ressursar
+    retry: Prøv igjen
+    retry_item: Prøv igjen %{item}
     reupload_file: Reupload %{item}
     run: Køyr
     save: Lagre

--- a/lib/generators/avo/templates/locales/avo.pl.yml
+++ b/lib/generators/avo/templates/locales/avo.pl.yml
@@ -45,6 +45,7 @@ pl:
     choose_an_option: Wybierz opcję
     choose_item: Wybierz %{item}
     clear_value: Wyczyść wartość
+    click_to_load: Kliknij, aby załadować
     click_to_reveal_filters: Kliknij, aby pokazać filtry
     close: Zamknij
     close_modal: Zamknij okno modalne
@@ -70,6 +71,7 @@ pl:
     failed: Niepowodzenie
     failed_to_find_attachment: Nie udało się znaleźć załącznika
     failed_to_load: Nie udało się załadować
+    failed_to_load_item: Nie udało się załadować %{item}
     'false': Fałsz
     file:
       few: pliki
@@ -107,6 +109,7 @@ pl:
       value: Wartość
     less_content: Pokaż mniej
     list_is_empty: Lista jest pusta
+    load_item: Załaduj %{item}
     loading: Ładowanie
     media_library:
       title: Biblioteka mediów
@@ -153,6 +156,8 @@ pl:
     resource_destroyed: Rekord usunięty
     resource_updated: Rekord zaktualizowany
     resources: Zasoby
+    retry: Spróbuj ponownie
+    retry_item: Spróbuj ponownie %{item}
     reupload_file: Reupload %{item}
     run: Uruchom
     save: Zapisz

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -45,6 +45,7 @@ pt-BR:
     choose_an_option: Escolha uma opção
     choose_item: Escolher %{item}
     clear_value: Limpar valor
+    click_to_load: Clique para carregar
     click_to_reveal_filters: Clique para revelar os filtros
     close: Fechar
     close_modal: Fechar modal
@@ -70,6 +71,7 @@ pt-BR:
     failed: Falhou
     failed_to_find_attachment: Falhou ao achar anexo
     failed_to_load: Falha ao carregar
+    failed_to_load_item: Falha ao carregar %{item}
     'false': Falso
     file:
       one: ficheiro
@@ -105,6 +107,7 @@ pt-BR:
       value: Valor
     less_content: Menos conteúdo
     list_is_empty: Lista vazia
+    load_item: Carregar %{item}
     loading: Carregando
     media_library:
       title: Biblioteca de Mídia
@@ -149,6 +152,8 @@ pt-BR:
     resource_destroyed: Recurso destruído
     resource_updated: Recurso atualizado
     resources: Recursos
+    retry: Tentar novamente
+    retry_item: Tentar novamente %{item}
     reupload_file: Reupload %{item}
     run: Executar
     save: Salvar

--- a/lib/generators/avo/templates/locales/avo.pt.yml
+++ b/lib/generators/avo/templates/locales/avo.pt.yml
@@ -45,6 +45,7 @@ pt:
     choose_an_option: Escolha uma opção
     choose_item: Escolher %{item}
     clear_value: Apagar valor
+    click_to_load: Clique para carregar
     click_to_reveal_filters: Clique para mostrar os filtros
     close: Fechar
     close_modal: Fechar modal
@@ -70,6 +71,7 @@ pt:
     failed: Falhou
     failed_to_find_attachment: Falha ao encontrar anexo
     failed_to_load: Falhou ao carregar
+    failed_to_load_item: Falha ao carregar %{item}
     'false': Falso
     file:
       one: ficheiro
@@ -105,6 +107,7 @@ pt:
       value: Valor
     less_content: Menos conteúdo
     list_is_empty: Lista vazia
+    load_item: Carregar %{item}
     loading: A carregar
     media_library:
       title: Biblioteca de Mídia
@@ -149,6 +152,8 @@ pt:
     resource_destroyed: Recurso destruído
     resource_updated: Recurso atualizado
     resources: Recursos
+    retry: Tentar novamente
+    retry_item: Tentar novamente %{item}
     reupload_file: Reupload %{item}
     run: Executar
     save: Guardar

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -47,6 +47,7 @@ ro:
     choose_an_option: Alege o opțiune
     choose_item: Alege %{item}
     clear_value: Șterge valoarea
+    click_to_load: Click pentru a încărca
     click_to_reveal_filters: Faceți clic pentru a afișa filtrele
     close: Închide
     close_modal: Închide modalul
@@ -72,6 +73,7 @@ ro:
     failed: A eșuat
     failed_to_find_attachment: Atașamentul nu a fost găsit
     failed_to_load: Încărcarea a eșuat
+    failed_to_load_item: Încărcarea %{item} a eșuat
     'false': Fals
     file:
       few: fişiere
@@ -108,6 +110,7 @@ ro:
       value: Valoare
     less_content: Mai puțin conținut
     list_is_empty: Lista este goală
+    load_item: Încărcați %{item}
     loading: Se incarcă
     media_library:
       title: Bibliotecă media
@@ -153,6 +156,8 @@ ro:
     resource_destroyed: Resursă ștearsă
     resource_updated: Resursă actualizată
     resources: Resurse
+    retry: Reîncercați
+    retry_item: Reîncercați %{item}
     reupload_file: Reupload %{item}
     run: Rulează
     save: Salvează

--- a/lib/generators/avo/templates/locales/avo.ru.yml
+++ b/lib/generators/avo/templates/locales/avo.ru.yml
@@ -45,6 +45,7 @@ ru:
     choose_an_option: Выберите опцию
     choose_item: Выбрать %{item}
     clear_value: Очистить значение
+    click_to_load: Нажмите, чтобы загрузить
     click_to_reveal_filters: Нажмите, чтобы открыть фильтры
     close: Закрыть
     close_modal: Закрыть модальное окно
@@ -70,6 +71,7 @@ ru:
     failed: Ошибка
     failed_to_find_attachment: Вложение не найдено
     failed_to_load: Загрузка не удалась
+    failed_to_load_item: Не удалось загрузить %{item}
     'false': Ложь
     file:
       few: файла
@@ -107,6 +109,7 @@ ru:
       value: Значение
     less_content: Меньше контента
     list_is_empty: Список пуст
+    load_item: Загрузить %{item}
     loading: Загрузка...
     media_library:
       title: Медиатека
@@ -153,6 +156,8 @@ ru:
     resource_destroyed: Запись удалена
     resource_updated: Запись обновлена
     resources: Ресурсы
+    retry: Повторить
+    retry_item: Повторить %{item}
     reupload_file: Reupload %{item}
     run: Запустить
     save: Сохранить

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -45,6 +45,7 @@ tr:
     choose_an_option: Bir seçenek seç
     choose_item: "%{item} seçin"
     clear_value: Değeri temizle
+    click_to_load: Yüklemek için tıklayın
     click_to_reveal_filters: Filtreleri ortaya çıkarmak için tıklayın
     close: Kapat
     close_modal: Modali kapat
@@ -70,6 +71,7 @@ tr:
     failed: Başarısız
     failed_to_find_attachment: Ek bulunamadı
     failed_to_load: Yüklenemedi
+    failed_to_load_item: "%{item} yüklenemedi"
     'false': Yanlış
     file:
       one: dosya
@@ -105,6 +107,7 @@ tr:
       value: Değer
     less_content: Daha az içerik
     list_is_empty: Boş liste
+    load_item: "%{item} yükle"
     loading: Yükleniyor
     media_library:
       title: Ortam Kütüphanesi
@@ -149,6 +152,8 @@ tr:
     resource_destroyed: Kayıt silindi
     resource_updated: Kayıt güncellendi
     resources: Kaynaklar
+    retry: Yeniden dene
+    retry_item: "%{item}'ı yeniden dene"
     reupload_file: Reupload %{item}
     run: Başlat
     save: Kaydet

--- a/lib/generators/avo/templates/locales/avo.ua.yml
+++ b/lib/generators/avo/templates/locales/avo.ua.yml
@@ -43,6 +43,7 @@ ua:
     choose_an_option: Виберіть опцію
     choose_item: Виберіть %{item}
     clear_value: Очистити значення
+    click_to_load: Натисніть, щоб завантажити
     click_to_reveal_filters: Натисніть, щоб показати фільтри
     close: Закрити
     close_modal: Закрити вікно
@@ -68,6 +69,7 @@ ua:
     failed: Не вдалося
     failed_to_find_attachment: Не вдалося знайти вкладення
     failed_to_load: Не вдалося завантажити
+    failed_to_load_item: Не вдалося завантажити %{item}
     'false': Хибно
     file:
       few: файли
@@ -105,6 +107,7 @@ ua:
       value: Значення
     less_content: Менше вмісту
     list_is_empty: Список порожній
+    load_item: Завантажити %{item}
     loading: Завантаження
     media_library:
       title: Медіатека
@@ -151,6 +154,8 @@ ua:
     resource_destroyed: Запис видалено
     resource_updated: Запис оновлено
     resources: Ресурси
+    retry: Спробувати ще раз
+    retry_item: Спробувати ще раз %{item}
     reupload_file: Reupload %{item}
     run: Виконати
     save: Зберегти

--- a/lib/generators/avo/templates/locales/avo.zh-TW.yml
+++ b/lib/generators/avo/templates/locales/avo.zh-TW.yml
@@ -43,6 +43,7 @@ zh-TW:
     choose_an_option: 選擇一個選項
     choose_item: 選擇 %{item}
     clear_value: 清除值
+    click_to_load: 點擊以加載
     click_to_reveal_filters: 點擊以顯示篩選器
     close: 關閉
     close_modal: 關閉模態框
@@ -68,6 +69,7 @@ zh-TW:
     failed: 失敗
     failed_to_find_attachment: 找不到附件
     failed_to_load: 載入失敗
+    failed_to_load_item: 加載 %{item} 失敗
     'false': 假
     file:
       one: 檔案
@@ -103,6 +105,7 @@ zh-TW:
       value: 值
     less_content: 內容較少
     list_is_empty: 清單為空
+    load_item: 加載 %{item}
     loading: 載入中...
     media_library:
       title: 媒體庫
@@ -147,6 +150,8 @@ zh-TW:
     resource_destroyed: 記錄已刪除
     resource_updated: 記錄已更新
     resources: 資源
+    retry: 重試
+    retry_item: 重試 %{item}
     reupload_file: Reupload %{item}
     run: 執行
     save: 保存

--- a/lib/generators/avo/templates/locales/avo.zh.yml
+++ b/lib/generators/avo/templates/locales/avo.zh.yml
@@ -43,6 +43,7 @@ zh:
     choose_an_option: 选择一个选项
     choose_item: 选择 %{item}
     clear_value: 清除值
+    click_to_load: 点击加载
     click_to_reveal_filters: 点击以显示筛选器
     close: 关闭
     close_modal: 关闭模态框
@@ -68,6 +69,7 @@ zh:
     failed: 失败
     failed_to_find_attachment: 找不到附件
     failed_to_load: 加载失败
+    failed_to_load_item: 加载 %{item} 失败
     'false': 假
     file:
       one: 文件
@@ -103,6 +105,7 @@ zh:
       value: 值
     less_content: 内容较少
     list_is_empty: 列表为空
+    load_item: 加载 %{item}
     loading: 加载中...
     media_library:
       title: 媒体库
@@ -147,6 +150,8 @@ zh:
     resource_destroyed: 记录已删除
     resource_updated: 记录已更新
     resources: 资源
+    retry: 重试
+    retry_item: 重试 %{item}
     reupload_file: Reupload %{item}
     run: 运行
     save: 保存

--- a/spec/components/avo/manual_frame_component_spec.rb
+++ b/spec/components/avo/manual_frame_component_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe Avo::ManualFrameComponent, type: :component do
+  it "renders a turbo-frame with no src, marked as a manual frame" do
+    render_inline(described_class.new(
+      "has_many_field_show_orders",
+      deferred_url: "/admin/resources/users/1/orders?turbo_frame=has_many_field_show_orders",
+      title: "Orders"
+    ))
+
+    frame = page.find("turbo-frame#has_many_field_show_orders")
+    expect(frame).to be_present
+    expect(frame["src"]).to be_blank
+    expect(frame["loading"]).to be_blank
+    expect(frame["data-manual-frame"]).not_to be_nil
+    expect(frame["data-controller"]).to eq("manual-frame")
+    expect(frame["data-manual-frame-url-value"]).to eq(
+      "/admin/resources/users/1/orders?turbo_frame=has_many_field_show_orders"
+    )
+  end
+
+  it "renders a focusable Load button labeled from the title" do
+    render_inline(described_class.new(
+      "has_many_field_show_orders",
+      deferred_url: "/orders",
+      title: "Orders"
+    ))
+
+    button = page.find("button[data-action='manual-frame#load']")
+    expect(button[:"aria-label"]).to eq("Load Orders")
+    expect(button).to have_text("Load Orders")
+    # Native <button> elements are keyboard-focusable; ensure tabindex is not removed.
+    expect(button["tabindex"]).not_to eq("-1")
+  end
+
+  it "humanizes a multi-word title for the button label" do
+    render_inline(described_class.new(
+      "has_many_field_show_order_items",
+      deferred_url: "/order_items",
+      title: "order_items"
+    ))
+
+    expect(page).to have_css("button[aria-label='Load Order items']")
+    expect(page).to have_text("Load Order items")
+  end
+
+  it "renders the placeholder state markup mirroring the empty state" do
+    render_inline(described_class.new(
+      "has_many_field_show_orders",
+      deferred_url: "/orders",
+      title: "Orders"
+    ))
+
+    expect(page).to have_css("turbo-frame .state")
+  end
+end

--- a/spec/components/avo/manual_frame_component_spec.rb
+++ b/spec/components/avo/manual_frame_component_spec.rb
@@ -46,17 +46,20 @@ RSpec.describe Avo::ManualFrameComponent, type: :component do
     expect(page).to have_text("Load Order Items")
   end
 
-  it "renders the placeholder state markup mirroring the empty state" do
+  it "renders a dashed-dropzone placeholder with the title and a click-to-load hint" do
     render_inline(described_class.new(
       "has_many_field_show_orders",
       deferred_url: "/orders",
       title: "Orders"
     ))
 
-    expect(page).to have_css("turbo-frame .state")
+    placeholder = page.find("[data-manual-frame-target='placeholder']")
+    expect(placeholder[:class]).to include("border-dashed")
+    expect(placeholder).to have_text("Orders")
+    expect(placeholder).to have_text("Click to load")
   end
 
-  it "renders a hidden error/Retry state mirroring the frame-load-failed markup" do
+  it "renders a hidden error/Retry state" do
     render_inline(described_class.new(
       "has_many_field_show_orders",
       deferred_url: "/orders",
@@ -66,7 +69,7 @@ RSpec.describe Avo::ManualFrameComponent, type: :component do
     # The error state is present but hidden until the controller reveals it.
     error = page.find("[data-manual-frame-target='error']", visible: false)
     expect(error[:class]).to include("hidden")
-    expect(error).to have_css(".state.state--frame-load-failed", visible: false)
+    expect(error[:class]).to include("border-dashed")
     expect(error).to have_text("Couldn't load Orders")
   end
 

--- a/spec/components/avo/manual_frame_component_spec.rb
+++ b/spec/components/avo/manual_frame_component_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
 
 RSpec.describe Avo::ManualFrameComponent, type: :component do
+  # The component renders `ui.panel_header` and other Avo helpers that resolve
+  # through the request's view context, so build it from Avo::BaseController
+  # under render_inline (the same pattern as flash_alerts_component_spec).
+  around do |example|
+    with_controller_class(Avo::BaseController) { example.run }
+  end
+
   it "renders a turbo-frame with no src, marked as a manual frame" do
     render_inline(described_class.new(
       "has_many_field_show_orders",
@@ -89,8 +96,12 @@ RSpec.describe Avo::ManualFrameComponent, type: :component do
       title: "Orders"
     ))
 
-    # Only the title text, no stray description span.
-    expect(page.find("[data-manual-frame-target='placeholder']").text.strip).to eq("Orders Load Orders")
+    # The placeholder shows the title and the Load button, and no description
+    # text bleeds in when none was passed (contrast the description spec above).
+    placeholder = page.find("[data-manual-frame-target='placeholder']")
+    expect(placeholder).to have_text("Orders")
+    expect(placeholder).to have_button("Load Orders")
+    expect(placeholder).to have_no_text("All recent orders")
   end
 
   it "renders a hidden error/Retry state" do
@@ -104,7 +115,7 @@ RSpec.describe Avo::ManualFrameComponent, type: :component do
     error = page.find("[data-manual-frame-target='error']", visible: false)
     expect(error["hidden"]).not_to be_nil
     expect(error[:class]).to include("manual-frame")
-    expect(error).to have_text("Couldn't load Orders")
+    expect(error).to have_text("Failed to load Orders")
   end
 
   it "renders a Retry button wired to the retry action, labeled from the title" do
@@ -117,5 +128,35 @@ RSpec.describe Avo::ManualFrameComponent, type: :component do
     button = page.find("button[data-action='manual-frame#retry']", visible: false)
     expect(button[:"aria-label"]).to eq("Retry Orders")
     expect(button).to have_text("Retry")
+  end
+
+  it "carries the memory window (seconds) and cookie name as Stimulus values when given" do
+    render_inline(described_class.new(
+      "has_many_field_show_orders",
+      deferred_url: "/orders",
+      title: "Orders",
+      auto_load_for: 300,
+      cookie_name: "amf_abc123"
+    ))
+
+    frame = page.find("turbo-frame#has_many_field_show_orders")
+    # The controller uses these to write the memory cookie (name + max-age) on a
+    # successful load; the server reads the cookie to skip the button next time.
+    expect(frame["data-manual-frame-auto-load-for-value"]).to eq("300")
+    expect(frame["data-manual-frame-cookie-name-value"]).to eq("amf_abc123")
+  end
+
+  it "omits the memory values entirely when no window is configured" do
+    render_inline(described_class.new(
+      "has_many_field_show_orders",
+      deferred_url: "/orders",
+      title: "Orders"
+    ))
+
+    # No window -> no data values -> the controller writes no cookie, so plain
+    # manual frames behave exactly as before (click-to-load every visit).
+    frame = page.find("turbo-frame#has_many_field_show_orders")
+    expect(frame["data-manual-frame-auto-load-for-value"]).to be_nil
+    expect(frame["data-manual-frame-cookie-name-value"]).to be_nil
   end
 end

--- a/spec/components/avo/manual_frame_component_spec.rb
+++ b/spec/components/avo/manual_frame_component_spec.rb
@@ -33,15 +33,17 @@ RSpec.describe Avo::ManualFrameComponent, type: :component do
     expect(button["tabindex"]).not_to eq("-1")
   end
 
-  it "humanizes a multi-word title for the button label" do
+  it "uses the title verbatim without mangling custom/translated names" do
+    # Callers pass already display-ready names (field.plural_name / tab.title);
+    # the component must not `humanize` them (which would downcase "Order Items").
     render_inline(described_class.new(
       "has_many_field_show_order_items",
       deferred_url: "/order_items",
-      title: "order_items"
+      title: "Order Items"
     ))
 
-    expect(page).to have_css("button[aria-label='Load Order items']")
-    expect(page).to have_text("Load Order items")
+    expect(page).to have_css("button[aria-label='Load Order Items']")
+    expect(page).to have_text("Load Order Items")
   end
 
   it "renders the placeholder state markup mirroring the empty state" do
@@ -65,7 +67,7 @@ RSpec.describe Avo::ManualFrameComponent, type: :component do
     error = page.find("[data-manual-frame-target='error']", visible: false)
     expect(error[:class]).to include("hidden")
     expect(error).to have_css(".state.state--frame-load-failed", visible: false)
-    expect(error).to have_text("Couldn't load this content.")
+    expect(error).to have_text("Couldn't load Orders")
   end
 
   it "renders a Retry button wired to the retry action, labeled from the title" do

--- a/spec/components/avo/manual_frame_component_spec.rb
+++ b/spec/components/avo/manual_frame_component_spec.rb
@@ -53,4 +53,30 @@ RSpec.describe Avo::ManualFrameComponent, type: :component do
 
     expect(page).to have_css("turbo-frame .state")
   end
+
+  it "renders a hidden error/Retry state mirroring the frame-load-failed markup" do
+    render_inline(described_class.new(
+      "has_many_field_show_orders",
+      deferred_url: "/orders",
+      title: "Orders"
+    ))
+
+    # The error state is present but hidden until the controller reveals it.
+    error = page.find("[data-manual-frame-target='error']", visible: false)
+    expect(error[:class]).to include("hidden")
+    expect(error).to have_css(".state.state--frame-load-failed", visible: false)
+    expect(error).to have_text("Couldn't load this content.")
+  end
+
+  it "renders a Retry button wired to the retry action, labeled from the title" do
+    render_inline(described_class.new(
+      "has_many_field_show_orders",
+      deferred_url: "/orders",
+      title: "Orders"
+    ))
+
+    button = page.find("button[data-action='manual-frame#retry']", visible: false)
+    expect(button[:"aria-label"]).to eq("Retry Orders")
+    expect(button).to have_text("Retry")
+  end
 end

--- a/spec/components/avo/manual_frame_component_spec.rb
+++ b/spec/components/avo/manual_frame_component_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Avo::ManualFrameComponent, type: :component do
     expect(page).to have_text("Load Order Items")
   end
 
-  it "renders a dashed-dropzone placeholder with the title and a click-to-load hint" do
+  it "renders an action-bar placeholder with the title" do
     render_inline(described_class.new(
       "has_many_field_show_orders",
       deferred_url: "/orders",
@@ -54,9 +54,43 @@ RSpec.describe Avo::ManualFrameComponent, type: :component do
     ))
 
     placeholder = page.find("[data-manual-frame-target='placeholder']")
-    expect(placeholder[:class]).to include("border-dashed")
+    expect(placeholder[:class]).to include("manual-frame")
     expect(placeholder).to have_text("Orders")
-    expect(placeholder).to have_text("Click to load")
+  end
+
+  it "renders a hidden loading backdrop overlay" do
+    render_inline(described_class.new(
+      "has_many_field_show_orders",
+      deferred_url: "/orders",
+      title: "Orders"
+    ))
+
+    loading = page.find("[data-manual-frame-target='loading']", visible: false)
+    expect(loading[:class]).to include("manual-frame__overlay")
+    expect(loading["hidden"]).not_to be_nil
+    expect(loading).to have_text("Loading")
+  end
+
+  it "shows the description beside the title when one is present" do
+    render_inline(described_class.new(
+      "has_many_field_show_orders",
+      deferred_url: "/orders",
+      title: "Orders",
+      description: "All recent orders"
+    ))
+
+    expect(page.find("[data-manual-frame-target='placeholder']")).to have_text("All recent orders")
+  end
+
+  it "omits the description when none is given" do
+    render_inline(described_class.new(
+      "has_many_field_show_orders",
+      deferred_url: "/orders",
+      title: "Orders"
+    ))
+
+    # Only the title text, no stray description span.
+    expect(page.find("[data-manual-frame-target='placeholder']").text.strip).to eq("Orders Load Orders")
   end
 
   it "renders a hidden error/Retry state" do
@@ -68,8 +102,8 @@ RSpec.describe Avo::ManualFrameComponent, type: :component do
 
     # The error state is present but hidden until the controller reveals it.
     error = page.find("[data-manual-frame-target='error']", visible: false)
-    expect(error[:class]).to include("hidden")
-    expect(error[:class]).to include("border-dashed")
+    expect(error["hidden"]).not_to be_nil
+    expect(error[:class]).to include("manual-frame")
     expect(error).to have_text("Couldn't load Orders")
   end
 

--- a/spec/dummy/app/avo/resources/person.rb
+++ b/spec/dummy/app/avo/resources/person.rb
@@ -106,6 +106,55 @@ class Avo::Resources::Person < Avo::BaseResource
           end
         end
       end
+
+      tab title: "Education", loading: :manual do
+        panel(title: "Education") do
+          card do
+            field :university, stacked: true, width: 50 do
+              "Stanford University"
+            end
+            field :degree, stacked: true, width: 50 do
+              "Computer Science"
+            end
+
+            field :graduation_year do
+              "2015"
+            end
+          end
+
+          sidebar do
+            card do
+              field :gpa do
+                "3.9"
+              end
+            end
+          end
+        end
+      end
+
+      tab title: "Skills", loading: :manual do
+        panel(title: "Skills") do
+          card do
+            field :primary_skill do
+              "Ruby on Rails"
+            end
+
+            field :certifications do
+              "AWS Certified"
+            end
+          end
+        end
+      end
+
+      tab title: "Hobbies", loading: :manual, lazy_load: true do
+        panel(title: "Hobbies") do
+          card do
+            field :favorite_hobby do
+              "Rock Climbing"
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/dummy/app/avo/resources/team.rb
+++ b/spec/dummy/app/avo/resources/team.rb
@@ -100,7 +100,7 @@ class Avo::Resources::Team < Avo::BaseResource
         # `loading_type` is `:manual` while the placeholder is shown (frame not
         # loaded yet), so we skip `query.count` and avoid a SQL hit on show-page
         # paint.
-        loading_type == :manual ? "Hey members" : "Hey members (#{query.count})"
+        (loading_type == :manual) ? "Hey members" : "Hey members (#{query.count})"
       },
       searchable: true,
       filterable: true,

--- a/spec/dummy/app/avo/resources/team.rb
+++ b/spec/dummy/app/avo/resources/team.rb
@@ -95,6 +95,8 @@ class Avo::Resources::Team < Avo::BaseResource
 
     field :memberships,
       as: :has_many,
+      loading: :manual,
+      description: "Hey members",
       searchable: true,
       filterable: true,
       linkable: true,
@@ -103,7 +105,7 @@ class Avo::Resources::Team < Avo::BaseResource
         query.where.not(user_id: parent.id).or(query.where(user_id: nil))
       end
 
-    field :admin, as: :has_one, linkable: true
+    field :admin, as: :has_one, linkable: true, loading: :manual
     field :team_members,
       as: :has_many,
       through: :memberships,

--- a/spec/dummy/app/avo/resources/team.rb
+++ b/spec/dummy/app/avo/resources/team.rb
@@ -96,7 +96,12 @@ class Avo::Resources::Team < Avo::BaseResource
     field :memberships,
       as: :has_many,
       loading: {mode: :manual, auto_load_for: 5.minutes},
-      description: "Hey members",
+      description: -> {
+        # `loading_type` is `:manual` while the placeholder is shown (frame not
+        # loaded yet), so we skip `query.count` and avoid a SQL hit on show-page
+        # paint.
+        loading_type == :manual ? "Hey members" : "Hey members (#{query.count})"
+      },
       searchable: true,
       filterable: true,
       linkable: true,

--- a/spec/dummy/app/avo/resources/team.rb
+++ b/spec/dummy/app/avo/resources/team.rb
@@ -95,7 +95,7 @@ class Avo::Resources::Team < Avo::BaseResource
 
     field :memberships,
       as: :has_many,
-      loading: :manual,
+      loading: {mode: :manual, auto_load_for: 5.minutes},
       description: "Hey members",
       searchable: true,
       filterable: true,

--- a/spec/dummy/config/locales/avo.en.yml
+++ b/spec/dummy/config/locales/avo.en.yml
@@ -57,6 +57,7 @@ en:
     failed: Failed
     failed_to_find_attachment: Failed to find attachment
     failed_to_load: Failed to load
+    failed_to_load_manual: Couldn't load this content.
     file:
       one: file
       other: files
@@ -72,6 +73,7 @@ en:
       key: Key
       value: Value
     list_is_empty: List is empty
+    load: Load
     loading: Loading
     more: More
     new: new
@@ -102,6 +104,7 @@ en:
     remove_selection: Remove selection
     reset_filters: Reset filters
     reset: reset
+    retry: Retry
     resource_created: Record created
     resource_destroyed: Record destroyed
     resource_updated: Record updated

--- a/spec/dummy/config/locales/avo.en.yml
+++ b/spec/dummy/config/locales/avo.en.yml
@@ -30,6 +30,7 @@ en:
     choose_item: Choose %{item}
     clear_value: Clear value
     reveal_filters: &reveal_filters Reveal filters
+    click_to_load: Click to load
     click_to_reveal_filters: *reveal_filters
     close_modal: Close modal
     close: Close

--- a/spec/dummy/config/locales/avo.en.yml
+++ b/spec/dummy/config/locales/avo.en.yml
@@ -57,7 +57,7 @@ en:
     failed: Failed
     failed_to_find_attachment: Failed to find attachment
     failed_to_load: Failed to load
-    failed_to_load_manual: Couldn't load this content.
+    failed_to_load_item: Couldn't load %{item}
     file:
       one: file
       other: files
@@ -73,7 +73,7 @@ en:
       key: Key
       value: Value
     list_is_empty: List is empty
-    load: Load
+    load_item: Load %{item}
     loading: Loading
     more: More
     new: new
@@ -105,6 +105,7 @@ en:
     reset_filters: Reset filters
     reset: reset
     retry: Retry
+    retry_item: Retry %{item}
     resource_created: Record created
     resource_destroyed: Record destroyed
     resource_updated: Record updated

--- a/spec/dummy/config/locales/avo.en.yml
+++ b/spec/dummy/config/locales/avo.en.yml
@@ -58,7 +58,7 @@ en:
     failed: Failed
     failed_to_find_attachment: Failed to find attachment
     failed_to_load: Failed to load
-    failed_to_load_item: Couldn't load %{item}
+    failed_to_load_item: Failed to load %{item}
     file:
       one: file
       other: files

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -32,7 +32,5 @@ Rails.application.routes.draw do
     scope "(:locale)" do
       # mount_avo
     end
-
-    get "/avo", to: redirect("/admin")
   end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -32,5 +32,7 @@ Rails.application.routes.draw do
     scope "(:locale)" do
       # mount_avo
     end
+
+    get "/avo", to: redirect("/admin")
   end
 end

--- a/spec/lib/avo/concerns/frame_loading_mode_spec.rb
+++ b/spec/lib/avo/concerns/frame_loading_mode_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+# `Avo::Concerns::FrameLoadingMode` is mixed into both `Tab` and
+# `FrameBaseField`. We exercise it through `Tab` (the lightest host that sets
+# `@loading` from its kwargs) — the parsing logic is shared, so this covers the
+# association fields too.
+RSpec.describe Avo::Concerns::FrameLoadingMode do
+  def tab(loading)
+    Avo::Resources::Items::Tab.new(title: "Orders", loading: loading)
+  end
+
+  describe "no loading: given" do
+    subject { Avo::Resources::Items::Tab.new(title: "Orders") }
+
+    it "is not manual, has no mode and no memory window" do
+      expect(subject.manual?).to be false
+      expect(subject.lazy_loading_mode?).to be false
+      expect(subject.loading_mode).to be_nil
+      expect(subject.auto_load_for).to be_nil
+    end
+  end
+
+  describe "symbol shorthand loading: :manual" do
+    subject { tab(:manual) }
+
+    it "is manual with no memory window (backward compatible)" do
+      expect(subject.manual?).to be true
+      expect(subject.loading_mode).to eq(:manual)
+      expect(subject.auto_load_for).to be_nil
+    end
+  end
+
+  describe "hash loading: {mode: :manual}" do
+    subject { tab({mode: :manual}) }
+
+    it "is manual with no memory window" do
+      expect(subject.manual?).to be true
+      expect(subject.loading_mode).to eq(:manual)
+      expect(subject.auto_load_for).to be_nil
+    end
+  end
+
+  describe "hash loading: {mode: :manual, auto_load_for: 5.minutes}" do
+    subject { tab({mode: :manual, auto_load_for: 5.minutes}) }
+
+    it "is manual and exposes the window in whole seconds" do
+      expect(subject.manual?).to be true
+      expect(subject.loading_mode).to eq(:manual)
+      expect(subject.auto_load_for).to eq(300)
+    end
+  end
+
+  describe "hash with auto_load_for but no explicit mode" do
+    subject { tab({auto_load_for: 90}) }
+
+    it "defaults to manual and accepts a raw integer of seconds" do
+      expect(subject.manual?).to be true
+      expect(subject.loading_mode).to eq(:manual)
+      expect(subject.auto_load_for).to eq(90)
+    end
+  end
+
+  describe "hash loading: {mode: :lazy}" do
+    subject { tab({mode: :lazy}) }
+
+    it "is lazy, not manual, and carries no memory window" do
+      expect(subject.manual?).to be false
+      expect(subject.lazy_loading_mode?).to be true
+      expect(subject.loading_mode).to eq(:lazy)
+      expect(subject.auto_load_for).to be_nil
+    end
+  end
+
+  describe "string keys are tolerated" do
+    subject { tab({"mode" => "manual", "auto_load_for" => 5.minutes}) }
+
+    it "parses mode and window the same as symbol keys" do
+      expect(subject.manual?).to be true
+      expect(subject.auto_load_for).to eq(300)
+    end
+  end
+end

--- a/spec/lib/avo/concerns/has_description_spec.rb
+++ b/spec/lib/avo/concerns/has_description_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Avo::Concerns::HasDescription, type: :model do
 
     it "lets a lambda branch on loading_type to skip the SQL aggregation" do
       target = field(description: -> {
-        loading_type == :manual ? "Hey members" : "Hey members (#{query.count})"
+        (loading_type == :manual) ? "Hey members" : "Hey members (#{query.count})"
       })
 
       result = nil
@@ -96,7 +96,7 @@ RSpec.describe Avo::Concerns::HasDescription, type: :model do
 
     it "runs the SQL aggregation when loading_type is not :manual" do
       target = field(description: -> {
-        loading_type == :manual ? "Hey members" : "Hey members (#{query.count})"
+        (loading_type == :manual) ? "Hey members" : "Hey members (#{query.count})"
       })
 
       result = nil

--- a/spec/lib/avo/concerns/has_description_spec.rb
+++ b/spec/lib/avo/concerns/has_description_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+
+RSpec.describe Avo::Concerns::HasDescription, type: :model do
+  describe "association field descriptions" do
+    let(:team) { create(:team) }
+    let(:base_args) { {record: team, view: :show} }
+
+    def field(**args)
+      Avo::Fields::HasManyField.new(:memberships, **base_args, **args)
+    end
+
+    # Collects the SQL run while the block executes, ignoring schema/transaction/
+    # cached statements, so we can assert a description path stays off the DB.
+    # Building the `query` relation is lazy (no SQL); only enumerating or
+    # aggregating it (e.g. `query.count`) hits the database.
+    def capture_sql
+      queries = []
+      callback = ->(_name, _start, _finish, _id, payload) {
+        queries << payload[:sql] unless payload[:name].to_s.in?(%w[SCHEMA TRANSACTION CACHE])
+      }
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") { yield }
+      queries
+    end
+
+    it "returns a static string without running SQL" do
+      target = field(description: "Hey members")
+
+      result = nil
+      queries = capture_sql { result = target.description }
+
+      expect(result).to eq "Hey members"
+      expect(queries).to be_empty
+    end
+
+    it "returns nil without running SQL" do
+      target = field(description: nil)
+
+      result = :unset
+      queries = capture_sql { result = target.description }
+
+      expect(result).to be_nil
+      expect(queries).to be_empty
+    end
+
+    it "evaluates a lambda with the association relation as query" do
+      record = team
+      allow(record).to receive(:memberships).and_call_original
+      captured_query = nil
+
+      result = field(description: -> {
+        captured_query = query
+        "#{query.klass.name} items"
+      }).description
+
+      expect(record).to have_received(:memberships)
+      expect(captured_query).to eq team.memberships
+      expect(result).to eq "TeamMembership items"
+    end
+
+    it "lets additional_attributes override query" do
+      custom_query = double("query")
+      captured_query = nil
+
+      field(description: -> { captured_query = query }).description(query: custom_query)
+
+      expect(captured_query).to eq custom_query
+    end
+
+    it "exposes loading_type as nil by default" do
+      captured = :unset
+
+      field(description: -> { captured = loading_type }).description
+
+      expect(captured).to be_nil
+    end
+
+    it "exposes loading_type as :manual when the manual placeholder passes it" do
+      captured = :unset
+
+      field(description: -> { captured = loading_type }).description(loading_type: :manual)
+
+      expect(captured).to eq :manual
+    end
+
+    it "lets a lambda branch on loading_type to skip the SQL aggregation" do
+      target = field(description: -> {
+        loading_type == :manual ? "Hey members" : "Hey members (#{query.count})"
+      })
+
+      result = nil
+      queries = capture_sql { result = target.description(loading_type: :manual) }
+
+      expect(result).to eq "Hey members"
+      expect(queries).to be_empty
+    end
+
+    it "runs the SQL aggregation when loading_type is not :manual" do
+      target = field(description: -> {
+        loading_type == :manual ? "Hey members" : "Hey members (#{query.count})"
+      })
+
+      result = nil
+      queries = capture_sql { result = target.description }
+
+      expect(result).to eq "Hey members (0)"
+      expect(queries).not_to be_empty
+    end
+  end
+end

--- a/spec/lib/avo/fields/frame_base_field_spec.rb
+++ b/spec/lib/avo/fields/frame_base_field_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Avo::Fields::FrameBaseField, type: :model do
+  describe "#manual?" do
+    # has_many, has_one and habtm all inherit FrameBaseField, so they share the
+    # `loading:` capture and the `manual?` predicate.
+    [
+      Avo::Fields::HasManyField,
+      Avo::Fields::HasOneField,
+      Avo::Fields::HasAndBelongsToManyField
+    ].each do |klass|
+      context "for #{klass}" do
+        it "is true with loading: :manual" do
+          field = klass.new(:users, loading: :manual)
+
+          expect(field.manual?).to be true
+        end
+
+        it "tolerates the string \"manual\"" do
+          field = klass.new(:users, loading: "manual")
+
+          expect(field.manual?).to be true
+        end
+
+        it "defaults to false when loading: is omitted" do
+          field = klass.new(:users)
+
+          expect(field.manual?).to be false
+        end
+
+        it "is false for a turbo_frame_loading: :lazy field" do
+          field = klass.new(:users, turbo_frame_loading: :lazy)
+
+          expect(field.manual?).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/avo/resources/items/tab_spec.rb
+++ b/spec/lib/avo/resources/items/tab_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Avo::Resources::Items::Tab, type: :model do
+  describe "#manual?" do
+    it "is true with loading: :manual" do
+      tab = described_class.new(title: "Orders", loading: :manual)
+
+      expect(tab.manual?).to be true
+    end
+
+    it "tolerates the string \"manual\"" do
+      tab = described_class.new(title: "Orders", loading: "manual")
+
+      expect(tab.manual?).to be true
+    end
+
+    it "defaults to false when loading: is omitted" do
+      tab = described_class.new(title: "Orders")
+
+      expect(tab.manual?).to be false
+    end
+
+    it "is false for a lazy_load tab and keeps lazy_load working" do
+      tab = described_class.new(title: "Orders", lazy_load: true)
+
+      expect(tab.lazy_load).to be true
+      expect(tab.manual?).to be false
+    end
+
+    it "is true when both loading: :manual and lazy_load: true are set" do
+      tab = described_class.new(title: "Orders", loading: :manual, lazy_load: true)
+
+      expect(tab.lazy_load).to be true
+      expect(tab.manual?).to be true
+    end
+  end
+end

--- a/spec/system/avo/group_1/manual_loading_failure_spec.rb
+++ b/spec/system/avo/group_1/manual_loading_failure_spec.rb
@@ -1,0 +1,147 @@
+require "rails_helper"
+
+# Unit 5 — failure handling for manual (`loading: :manual`) frames.
+#
+# When a manual frame's deferred load fails, the `manual-frame` Stimulus
+# controller renders an inline error message + a **Retry** button INSIDE the
+# frame. It must NOT navigate to / render the generic `/failed_to_load` page
+# (that path is reserved for non-manual frames, whose 500s the global handler
+# in `application.js` rewrites). Retry re-issues the request; once the backend
+# succeeds the real content loads.
+#
+# Failures are induced by stubbing `Avo::AssociationsController#index` to raise.
+# In Cuprite system tests the dummy app runs in-process, so the stub applies to
+# the server-thread request and (with `show_exceptions = :none`) surfaces as a
+# real HTTP 500 to the browser.
+RSpec.describe "Manual loading failures", type: :system do
+  let!(:user) { create :user }
+  let!(:comment) { create :comment, user: user, commentable: user }
+
+  # The deliberately-raised controller error must surface to the browser as an
+  # HTTP 500 (the behavior we're testing), not be re-raised in the test by
+  # Capybara's server-error guard.
+  around do |example|
+    previous = Capybara.raise_server_errors
+    Capybara.raise_server_errors = false
+    example.run
+    Capybara.raise_server_errors = previous
+  end
+
+  describe "a manual frame whose load fails" do
+    it "shows the inline error + Retry and does NOT render the failed_to_load page" do
+      allow_any_instance_of(Avo::AssociationsController).to receive(:index).and_raise("boom")
+
+      Avo::Resources::User.with_temporary_items do
+        field :first_name, as: :text
+        field :comments, as: :has_many, loading: :manual
+      end
+
+      visit avo.resources_user_path(user)
+
+      frame = find('turbo-frame[id="has_many_field_show_comments"]')
+
+      within(frame) { click_on "Load Comments" }
+
+      # The inline error + Retry appears inside the frame.
+      expect(frame).to have_text("Couldn't load this content.")
+      expect(frame).to have_button("Retry")
+
+      # We did NOT navigate to (or render into the frame) the generic failed_to_load page.
+      expect(page).not_to have_text("Failed to load")
+      expect(frame[:src]).not_to include("/failed_to_load")
+      expect(current_path).to eq(avo.resources_user_path(user))
+    ensure
+      Avo::Resources::User.restore_items_from_backup
+    end
+  end
+
+  describe "clicking Retry after a failure" do
+    it "re-issues the request and loads the real content once the backend succeeds" do
+      call_count = 0
+      # First load 500s; the retry (second call) is allowed through to the real action.
+      allow_any_instance_of(Avo::AssociationsController).to receive(:index).and_wrap_original do |original, *args|
+        call_count += 1
+        raise "boom" if call_count == 1
+
+        original.call(*args)
+      end
+
+      Avo::Resources::User.with_temporary_items do
+        field :first_name, as: :text
+        field :comments, as: :has_many, loading: :manual
+      end
+
+      visit avo.resources_user_path(user)
+
+      frame = find('turbo-frame[id="has_many_field_show_comments"]')
+
+      within(frame) { click_on "Load Comments" }
+
+      # The first attempt fails -> inline error + Retry.
+      expect(frame).to have_button("Retry")
+
+      within(frame) { click_on "Retry" }
+      wait_for_loaded
+
+      # The second attempt succeeds -> the real association table renders and the
+      # error state is gone.
+      expect(page).to have_selector("turbo-frame[id='has_many_field_show_comments'] [data-resource-name='comments'][data-resource-id='#{comment.id}']")
+      expect(page).not_to have_button("Retry")
+      expect(page).not_to have_text("Couldn't load this content.")
+    ensure
+      Avo::Resources::User.restore_items_from_backup
+    end
+  end
+
+  describe "repeated failure" do
+    it "keeps the inline error + Retry visible (no broken/empty frame)" do
+      allow_any_instance_of(Avo::AssociationsController).to receive(:index).and_raise("boom")
+
+      Avo::Resources::User.with_temporary_items do
+        field :first_name, as: :text
+        field :comments, as: :has_many, loading: :manual
+      end
+
+      visit avo.resources_user_path(user)
+
+      frame = find('turbo-frame[id="has_many_field_show_comments"]')
+
+      within(frame) { click_on "Load Comments" }
+      expect(frame).to have_button("Retry")
+
+      within(frame) { click_on "Retry" }
+
+      # Still failing -> the inline error + Retry stays, the frame is not blank.
+      expect(frame).to have_text("Couldn't load this content.")
+      expect(frame).to have_button("Retry")
+    ensure
+      Avo::Resources::User.restore_items_from_backup
+    end
+  end
+
+  # Regression: a NON-manual frame that 500s must still route to the existing
+  # `/failed_to_load` page. The global `application.js` guard only early-returns
+  # for `data-manual-frame`, so non-manual frames keep the old behavior.
+  describe "a non-manual (eager) frame that 500s (regression)" do
+    it "still routes to the existing failed_to_load page" do
+      allow_any_instance_of(Avo::AssociationsController).to receive(:index).and_raise("boom")
+
+      Avo::Resources::User.with_temporary_items do
+        field :first_name, as: :text
+        field :comments, as: :has_many
+      end
+
+      visit avo.resources_user_path(user)
+
+      # The eager frame fetches on paint, 500s, and the global handler rewrites
+      # its src to /failed_to_load — the existing error UI renders.
+      frame = find('turbo-frame[id="has_many_field_show_comments"]')
+      expect(frame).to have_text("Failed to load", wait: 5)
+      # It is NOT the manual inline-error copy.
+      expect(frame).not_to have_text("Couldn't load this content.")
+      expect(frame).not_to have_button("Retry")
+    ensure
+      Avo::Resources::User.restore_items_from_backup
+    end
+  end
+end

--- a/spec/system/avo/group_1/manual_loading_failure_spec.rb
+++ b/spec/system/avo/group_1/manual_loading_failure_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Manual loading failures", type: :system do
       within(frame) { click_on "Load Comments" }
 
       # The inline error + Retry appears inside the frame.
-      expect(frame).to have_text("Couldn't load this content.")
+      expect(frame).to have_text("Couldn't load Comments")
       expect(frame).to have_button("Retry")
 
       # We did NOT navigate to (or render into the frame) the generic failed_to_load page.
@@ -87,7 +87,7 @@ RSpec.describe "Manual loading failures", type: :system do
       # error state is gone.
       expect(page).to have_selector("turbo-frame[id='has_many_field_show_comments'] [data-resource-name='comments'][data-resource-id='#{comment.id}']")
       expect(page).not_to have_button("Retry")
-      expect(page).not_to have_text("Couldn't load this content.")
+      expect(page).not_to have_text("Couldn't load Comments")
     ensure
       Avo::Resources::User.restore_items_from_backup
     end
@@ -112,7 +112,7 @@ RSpec.describe "Manual loading failures", type: :system do
       within(frame) { click_on "Retry" }
 
       # Still failing -> the inline error + Retry stays, the frame is not blank.
-      expect(frame).to have_text("Couldn't load this content.")
+      expect(frame).to have_text("Couldn't load Comments")
       expect(frame).to have_button("Retry")
     ensure
       Avo::Resources::User.restore_items_from_backup
@@ -120,8 +120,9 @@ RSpec.describe "Manual loading failures", type: :system do
   end
 
   # Regression: a NON-manual frame that 500s must still route to the existing
-  # `/failed_to_load` page. The global `application.js` guard only early-returns
-  # for `data-manual-frame`, so non-manual frames keep the old behavior.
+  # `/failed_to_load` page. The manual controller calls `stopImmediatePropagation`
+  # only for its own in-flight deferred load, so non-manual frames (and post-load
+  # navigations) still reach the global `application.js` handler unchanged.
   describe "a non-manual (eager) frame that 500s (regression)" do
     it "still routes to the existing failed_to_load page" do
       allow_any_instance_of(Avo::AssociationsController).to receive(:index).and_raise("boom")
@@ -138,7 +139,7 @@ RSpec.describe "Manual loading failures", type: :system do
       frame = find('turbo-frame[id="has_many_field_show_comments"]')
       expect(frame).to have_text("Failed to load", wait: 5)
       # It is NOT the manual inline-error copy.
-      expect(frame).not_to have_text("Couldn't load this content.")
+      expect(frame).not_to have_text("Couldn't load Comments")
       expect(frame).not_to have_button("Retry")
     ensure
       Avo::Resources::User.restore_items_from_backup

--- a/spec/system/avo/group_1/manual_loading_failure_spec.rb
+++ b/spec/system/avo/group_1/manual_loading_failure_spec.rb
@@ -43,11 +43,14 @@ RSpec.describe "Manual loading failures", type: :system do
       within(frame) { click_on "Load Comments" }
 
       # The inline error + Retry appears inside the frame.
-      expect(frame).to have_text("Couldn't load Comments")
+      expect(frame).to have_text("Failed to load Comments")
       expect(frame).to have_button("Retry")
 
-      # We did NOT navigate to (or render into the frame) the generic failed_to_load page.
-      expect(page).not_to have_text("Failed to load")
+      # We did NOT navigate to (or render into the frame) the generic
+      # failed_to_load page. Both UIs say "Failed to load", so distinguish them
+      # structurally: the full-page error renders `.state--frame-load-failed`
+      # (and has no Retry), the manual inline error does not.
+      expect(frame).not_to have_css(".state--frame-load-failed")
       expect(frame[:src]).not_to include("/failed_to_load")
       expect(current_path).to eq(avo.resources_user_path(user))
     ensure
@@ -87,7 +90,7 @@ RSpec.describe "Manual loading failures", type: :system do
       # error state is gone.
       expect(page).to have_selector("turbo-frame[id='has_many_field_show_comments'] [data-resource-name='comments'][data-resource-id='#{comment.id}']")
       expect(page).not_to have_button("Retry")
-      expect(page).not_to have_text("Couldn't load Comments")
+      expect(page).not_to have_text("Failed to load Comments")
     ensure
       Avo::Resources::User.restore_items_from_backup
     end
@@ -112,7 +115,7 @@ RSpec.describe "Manual loading failures", type: :system do
       within(frame) { click_on "Retry" }
 
       # Still failing -> the inline error + Retry stays, the frame is not blank.
-      expect(frame).to have_text("Couldn't load Comments")
+      expect(frame).to have_text("Failed to load Comments")
       expect(frame).to have_button("Retry")
     ensure
       Avo::Resources::User.restore_items_from_backup
@@ -135,11 +138,10 @@ RSpec.describe "Manual loading failures", type: :system do
       visit avo.resources_user_path(user)
 
       # The eager frame fetches on paint, 500s, and the global handler rewrites
-      # its src to /failed_to_load — the existing error UI renders.
+      # its src to /failed_to_load — the existing full-page error UI renders.
       frame = find('turbo-frame[id="has_many_field_show_comments"]')
-      expect(frame).to have_text("Failed to load", wait: 5)
-      # It is NOT the manual inline-error copy.
-      expect(frame).not_to have_text("Couldn't load Comments")
+      expect(frame).to have_css(".state--frame-load-failed", wait: 5)
+      # It is the generic page, NOT the manual inline error (which has Retry).
       expect(frame).not_to have_button("Retry")
     ensure
       Avo::Resources::User.restore_items_from_backup

--- a/spec/system/avo/group_1/manual_loading_has_many_spec.rb
+++ b/spec/system/avo/group_1/manual_loading_has_many_spec.rb
@@ -1,0 +1,185 @@
+require "rails_helper"
+
+# Unit 3 — associations wired to manual (`loading: :manual`) loading.
+#
+# A manual association renders an `Avo::ManualFrameComponent` placeholder: a
+# `<turbo-frame>` with NO `src` and a "Load" button. Nothing is fetched until the
+# user clicks Load, at which point the controller sets `src` to the deferred URL
+# and the real association content swaps in.
+RSpec.describe "Manual loading associations", type: :system do
+  let!(:user) { create :user }
+
+  describe "has_many with loading: :manual" do
+    let!(:comment) { create :comment, user: user, commentable: user }
+
+    it "shows a Load button, fetches nothing until clicked, then loads the real table" do
+      Avo::Resources::User.with_temporary_items do
+        field :first_name, as: :text
+        field :comments, as: :has_many, loading: :manual
+      end
+
+      visit avo.resources_user_path(user)
+
+      frame = find('turbo-frame[id="has_many_field_show_comments"]')
+
+      # No `src` before the click: nothing is fetched on initial paint.
+      expect(frame[:src]).to be_blank
+      expect(frame).to have_button("Load Comments")
+      # The real association table is NOT present yet.
+      expect(frame).not_to have_selector("[data-resource-name='comments'][data-resource-id='#{comment.id}']")
+
+      within(frame) { click_on "Load Comments" }
+      wait_for_loaded
+
+      # After the click the real association content (the table) is rendered —
+      # not the manual placeholder again (no infinite-placeholder loop).
+      expect(page).to have_selector("turbo-frame[id='has_many_field_show_comments'] [data-resource-name='comments'][data-resource-id='#{comment.id}']")
+      expect(page).not_to have_button("Load Comments")
+    ensure
+      Avo::Resources::User.restore_items_from_backup
+    end
+  end
+
+  describe "has_and_belongs_to_many with loading: :manual" do
+    let!(:project) { create :project }
+
+    before { user.projects << project }
+
+    it "behaves identically to has_many (delegated component)" do
+      Avo::Resources::User.with_temporary_items do
+        field :first_name, as: :text
+        field :projects, as: :has_and_belongs_to_many, loading: :manual
+      end
+
+      visit avo.resources_user_path(user)
+
+      # HABTM reuses the HasManyField show component but keeps its own frame id.
+      frame = find('turbo-frame[id="has_and_belongs_to_many_field_show_projects"]')
+
+      expect(frame[:src]).to be_blank
+      expect(frame).to have_button("Load Projects")
+      expect(frame).not_to have_selector("[data-resource-name='projects'][data-resource-id='#{project.id}']")
+
+      within(frame) { click_on "Load Projects" }
+      wait_for_loaded
+
+      expect(page).to have_selector("turbo-frame[id='has_and_belongs_to_many_field_show_projects'] [data-resource-name='projects'][data-resource-id='#{project.id}']")
+      expect(page).not_to have_button("Load Projects")
+    ensure
+      Avo::Resources::User.restore_items_from_backup
+    end
+  end
+
+  describe "has_one with loading: :manual" do
+    context "with a present value" do
+      let!(:comment) { create :comment, user: user, commentable: user }
+
+      it "shows a Load button and loads the real content on click" do
+        Avo::Resources::User.with_temporary_items do
+          field :first_name, as: :text
+          field :comment, as: :has_one, loading: :manual
+        end
+
+        visit avo.resources_user_path(user)
+
+        frame = find('turbo-frame[id="has_one_field_show_comment"]')
+
+        expect(frame[:src]).to be_blank
+        expect(frame).to have_button("Load Comment")
+
+        within(frame) { click_on "Load Comment" }
+        wait_for_loaded
+
+        # The real has_one record content loads (not the placeholder again).
+        expect(page).to have_selector("turbo-frame[id='has_one_field_show_comment'] [data-field-id]")
+        expect(page).not_to have_button("Load Comment")
+      ensure
+        Avo::Resources::User.restore_items_from_backup
+      end
+    end
+
+    context "with a nil value" do
+      it "falls through to the existing attach/create empty state (no Load button, no turbo-frame)" do
+        # No comment is created for this user -> has_one value is nil.
+        Avo::Resources::User.with_temporary_items do
+          field :first_name, as: :text
+          field :comment, as: :has_one, loading: :manual
+        end
+
+        visit avo.resources_user_path(user)
+
+        # The nil-value path renders the attach/create empty-state panel, with no
+        # manual frame and no Load button.
+        expect(page).not_to have_selector('turbo-frame[id="has_one_field_show_comment"]')
+        expect(page).not_to have_button("Load Comment")
+        expect(page).to have_css(".state")
+      ensure
+        Avo::Resources::User.restore_items_from_backup
+      end
+    end
+  end
+
+  # Regression (R3 / switcher passthrough): a non-manual has_many inside a tab
+  # must keep its `loading="lazy"` frame — it must NOT regress to eager and must
+  # NOT be fetched on initial paint. Asserting `loading="lazy"` distinguishes
+  # lazy from eager (a "content eventually appears" assertion would pass for an
+  # eager frame too).
+  describe "non-manual has_many inside a tab (regression)" do
+    let!(:comment) { create :comment, user: user, commentable: user }
+
+    it "still renders the frame with loading=\"lazy\" and is not fetched on initial paint" do
+      Avo::Resources::User.with_temporary_items do
+        field :first_name, as: :text
+        tabs do
+          tab title: "Comments tab" do
+            field :comments, as: :has_many
+          end
+        end
+      end
+
+      visit avo.resources_user_path(user)
+
+      frame = find('turbo-frame[id="has_many_field_show_comments"]', visible: :all)
+
+      # The switcher injects loading="lazy" for non-manual in-tab fields. It must
+      # carry a `src` (so Turbo will fetch on reveal) AND `loading="lazy"`.
+      expect(frame["loading"]).to eq("lazy")
+      expect(frame[:src]).to be_present
+      # Not manual: no Load button.
+      expect(page).not_to have_button("Load Comments")
+    ensure
+      Avo::Resources::User.restore_items_from_backup
+    end
+  end
+
+  # The show component branches on `@field.manual?` BEFORE consuming the
+  # switcher's hardcoded `turbo_frame_loading: :lazy`, so a manual association
+  # inside a tab renders the placeholder regardless of that kwarg — proving the
+  # switcher needs no change (zero blast radius).
+  describe "manual has_many inside a tab" do
+    let!(:comment) { create :comment, user: user, commentable: user }
+
+    it "renders the Load-button placeholder (no src) even with the switcher's lazy kwarg" do
+      Avo::Resources::User.with_temporary_items do
+        field :first_name, as: :text
+        tabs do
+          tab title: "Comments tab" do
+            field :comments, as: :has_many, loading: :manual
+          end
+        end
+      end
+
+      visit avo.resources_user_path(user)
+
+      frame = find('turbo-frame[id="has_many_field_show_comments"]', visible: :all)
+
+      # Manual wins: no `src` (so no fetch on reveal) and a Load button — even
+      # though the switcher hardcodes `turbo_frame_loading: :lazy`. The frame is
+      # NOT the lazy frame (which would carry a `src`).
+      expect(frame[:src]).to be_blank
+      expect(frame).to have_button("Load Comments", visible: :all)
+    ensure
+      Avo::Resources::User.restore_items_from_backup
+    end
+  end
+end

--- a/spec/system/avo/group_1/manual_loading_has_many_spec.rb
+++ b/spec/system/avo/group_1/manual_loading_has_many_spec.rb
@@ -152,6 +152,30 @@ RSpec.describe "Manual loading associations", type: :system do
     end
   end
 
+  # `loading: {mode: :lazy}` — the hash form's other mode. A top-level
+  # association defaults to eager; `mode: :lazy` opts it into a native lazy
+  # frame (src present + loading="lazy"), so it fetches on reveal, not on paint.
+  describe "has_many with loading: {mode: :lazy}" do
+    let!(:comment) { create :comment, user: user, commentable: user }
+
+    it "renders a native lazy frame (src + loading=\"lazy\"), not a manual placeholder" do
+      Avo::Resources::User.with_temporary_items do
+        field :first_name, as: :text
+        field :comments, as: :has_many, loading: {mode: :lazy}
+      end
+
+      visit avo.resources_user_path(user)
+
+      frame = find('turbo-frame[id="has_many_field_show_comments"]', visible: :all)
+
+      expect(frame["loading"]).to eq("lazy")
+      expect(frame[:src]).to be_present
+      expect(page).not_to have_button("Load Comments")
+    ensure
+      Avo::Resources::User.restore_items_from_backup
+    end
+  end
+
   # The show component branches on `@field.manual?` BEFORE consuming the
   # switcher's hardcoded `turbo_frame_loading: :lazy`, so a manual association
   # inside a tab renders the placeholder regardless of that kwarg — proving the

--- a/spec/system/avo/group_1/manual_loading_memory_spec.rb
+++ b/spec/system/avo/group_1/manual_loading_memory_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+# `loading: {mode: :manual, auto_load_for: <duration>}` — the manual placeholder
+# plus a sliding "remember it's open" window.
+#
+# Once the user opens the frame, the controller writes a short-lived cookie
+# (scoped per record + association via the frame's deferred URL). The SERVER
+# reads that cookie on the next render and emits a real `<turbo-frame src>` —
+# no placeholder, no Load button — so the frame just loads like it did before
+# the manual feature. The window slides: each render that finds it remembered
+# refreshes the cookie's max-age.
+RSpec.describe "Manual loading memory (auto_load_for)", type: :system do
+  let!(:user) { create :user }
+  let!(:comment) { create :comment, user: user, commentable: user }
+
+  describe "loading: {mode: :manual, auto_load_for: 5.minutes}" do
+    it "server-renders a real auto-loading frame (no Load button) on a return visit" do
+      Avo::Resources::User.with_temporary_items do
+        field :first_name, as: :text
+        field :comments, as: :has_many, loading: {mode: :manual, auto_load_for: 5.minutes}
+      end
+
+      visit avo.resources_user_path(user)
+
+      # First visit: a plain manual placeholder. Nothing fetched until clicked.
+      frame = find('turbo-frame[id="has_many_field_show_comments"]')
+      expect(frame[:src]).to be_blank
+      expect(frame["data-manual-frame"]).not_to be_nil
+      expect(frame).to have_button("Load Comments")
+
+      within(frame) { click_on "Load Comments" }
+      wait_for_loaded
+      expect(page).to have_selector("turbo-frame[id='has_many_field_show_comments'] [data-resource-name='comments'][data-resource-id='#{comment.id}']")
+
+      # Return to the page (a refresh / following a link back). The cookie tells
+      # the server to render a real `<turbo-frame src>` directly — it carries a
+      # `src`, is NOT a manual placeholder, and shows no Load button at any point.
+      visit avo.resources_user_path(user)
+      wait_for_loaded
+
+      reloaded = find('turbo-frame[id="has_many_field_show_comments"]', visible: :all)
+      expect(reloaded[:src]).to be_present
+      expect(reloaded["data-manual-frame"]).to be_nil
+      expect(page).to have_selector("turbo-frame[id='has_many_field_show_comments'] [data-resource-name='comments'][data-resource-id='#{comment.id}']")
+      expect(page).not_to have_button("Load Comments")
+    ensure
+      Avo::Resources::User.restore_items_from_backup
+    end
+  end
+
+  describe "loading: :manual (no memory window)" do
+    it "shows the Load button again on every visit" do
+      Avo::Resources::User.with_temporary_items do
+        field :first_name, as: :text
+        field :comments, as: :has_many, loading: :manual
+      end
+
+      visit avo.resources_user_path(user)
+      within('turbo-frame[id="has_many_field_show_comments"]') { click_on "Load Comments" }
+      wait_for_loaded
+      expect(page).to have_selector("turbo-frame[id='has_many_field_show_comments'] [data-resource-name='comments'][data-resource-id='#{comment.id}']")
+
+      # No window -> no memory. The placeholder returns on the next visit.
+      visit avo.resources_user_path(user)
+
+      frame = find('turbo-frame[id="has_many_field_show_comments"]')
+      expect(frame[:src]).to be_blank
+      expect(frame).to have_button("Load Comments")
+    ensure
+      Avo::Resources::User.restore_items_from_backup
+    end
+  end
+end

--- a/spec/system/avo/group_3/tabs_spec.rb
+++ b/spec/system/avo/group_3/tabs_spec.rb
@@ -287,6 +287,108 @@ RSpec.describe "Tabs", type: :system do
     end
   end
 
+  it "manual loading" do
+    education_frame_id = /avo-resources-items-tab-#{Digest::MD5.hexdigest("Education")}/
+    skills_frame_id = /avo-resources-items-tab-#{Digest::MD5.hexdigest("Skills")}/
+    hobbies_frame_id = /avo-resources-items-tab-#{Digest::MD5.hexdigest("Hobbies")}/
+
+    visit avo.resources_person_path(person)
+
+    scroll_to first_tab_group
+
+    # Every manual tab renders a no-`src` ManualFrameComponent placeholder with a
+    # Load button — including tabs that aren't currently active. Because there is
+    # no `src`, revealing them never fires a request.
+    education_frame = find("turbo-frame", id: education_frame_id, visible: :all)
+    expect(education_frame["src"]).to be_nil
+    expect(education_frame["data-manual-frame"]).not_to be_nil
+
+    skills_frame = find("turbo-frame", id: skills_frame_id, visible: :all)
+    expect(skills_frame["src"]).to be_nil
+    expect(skills_frame["data-manual-frame"]).not_to be_nil
+
+    # Reveal the first manual tab. Revealing toggles a CSS class only; the no-`src`
+    # frame must NOT fetch, so its content (GPA / university) is still absent and
+    # the Load button is shown (R6).
+    find('a[data-selected="false"][data-tabs-tab-name-param="Education"]').click
+
+    education_frame = find("turbo-frame", id: education_frame_id)
+    within(education_frame) do
+      expect(page).to have_button("Load Education")
+      expect(page).not_to have_selector('div[data-field-id="university"]')
+    end
+    # Still no `src` after reveal — reveal fires no request.
+    expect(education_frame["src"]).to be_nil
+
+    # Click Load: the frame fetches and swaps in the REAL tab content (not the
+    # placeholder again). This is the critical assertion — no placeholder loop.
+    within(education_frame) do
+      click_on "Load Education"
+    end
+
+    within(find("turbo-frame", id: education_frame_id)) do
+      # Lead with the positive content assertion so Capybara auto-waits for the
+      # async frame fetch to swap in the real content.
+      field_wrapper = find('div[data-field-id="university"]')
+      label = field_wrapper.find('div[data-slot="label"]')
+      value = field_wrapper.find('div[data-slot="value"]')
+      expect(label.text.strip).to eq("University")
+      expect(value.text.strip).to eq("Stanford University")
+
+      # Real content, not the placeholder loop.
+      expect(page).not_to have_button("Load Education")
+    end
+
+    # A second manual tab in the same group also has its own button and is not
+    # fetched until its own Load is clicked.
+    find('a[data-selected="false"][data-tabs-tab-name-param="Skills"]').click
+
+    skills_frame = find("turbo-frame", id: skills_frame_id)
+    within(skills_frame) do
+      expect(page).to have_button("Load Skills")
+      expect(page).not_to have_selector('div[data-field-id="primary_skill"]')
+    end
+    expect(skills_frame["src"]).to be_nil
+
+    within(skills_frame) do
+      click_on "Load Skills"
+    end
+
+    within(find("turbo-frame", id: skills_frame_id)) do
+      # Auto-waits for the async swap, then confirms it's content not placeholder.
+      expect(page).to have_selector('div[data-field-id="primary_skill"]')
+      expect(page).to have_text("Ruby on Rails")
+      expect(page).not_to have_button("Load Skills")
+    end
+
+    # R7 (in-DOM persistence): switch away to another tab and back — the loaded
+    # Education content stays without re-fetching.
+    find('a[data-selected="false"][data-tabs-tab-name-param="Employment"]').click
+    find('a[data-selected="false"][data-tabs-tab-name-param="Education"]').click
+
+    within(find("turbo-frame", id: education_frame_id)) do
+      expect(page).not_to have_button("Load Education")
+      expect(page).to have_selector('div[data-field-id="university"]')
+      expect(page).to have_text("Stanford University")
+    end
+
+    # A tab with BOTH `loading: :manual` and `lazy_load: true` takes the manual
+    # path: a no-`src` placeholder that fires no request on reveal (manual wins).
+    hobbies_frame = find("turbo-frame", id: hobbies_frame_id, visible: :all)
+    expect(hobbies_frame["src"]).to be_nil
+    expect(hobbies_frame["data-manual-frame"]).not_to be_nil
+    # Manual path wins: no `loading="lazy"` attribute, so no Turbo auto-fetch.
+    expect(hobbies_frame["loading"]).not_to eq("lazy")
+
+    find('a[data-selected="false"][data-tabs-tab-name-param="Hobbies"]').click
+
+    hobbies_frame = find("turbo-frame", id: hobbies_frame_id)
+    within(hobbies_frame) do
+      expect(page).to have_button("Load Hobbies")
+    end
+    expect(hobbies_frame["src"]).to be_nil
+  end
+
   describe "tabs with non-ASCII names" do
     let!(:user) { create :user }
 


### PR DESCRIPTION
## Summary

Adds a third Turbo-Frame loading mode, **`loading: :manual`**, to resource Show pages. A manual frame renders a placeholder with a **Load** button and fetches its content only when the user clicks it — for **tabs** and **`has_many` / `has_one` / `has_and_belongs_to_many`** associations. The mode is **purely additive**: omitting `loading:` leaves every existing tab/association behaving exactly as today (no default changes).

| Mode | When it fetches |
|---|---|
| `eager` | Immediately with the page |
| `lazy` | When the frame is revealed / scrolled into view |
| **`manual`** (new) | Only when the user clicks **Load** |

## Usage

```ruby
# Tabs — every manual tab gets its own Load button (full per-tab gating)
tab title: "Orders", loading: :manual do
  field :orders, as: :has_many
end

# Associations
field :orders, as: :has_many, loading: :manual
```

## Screenshots

**Placeholder + Load button (nothing fetched yet)**

![placeholder](https://files.catbox.moe/aafkyl.png)

**Real content loads on click**

![loaded](https://files.catbox.moe/jdoxpf.png)

**Inline error + Retry on failure**

![error](https://files.catbox.moe/z33z87.png)

## How it works

- The manual frame is a `<turbo-frame>` with **no `src`** and no `loading="lazy"` — so it never auto-fetches on scroll or on tab reveal. A small `manual-frame` Stimulus controller sets `src` on click.
- **Tabs** keep the existing `is_not_loaded?` round-trip, so clicking Load renders the real tab content (not the placeholder again). The `manual?` branch is evaluated *before* `lazy_load`, so a tab with both keys gates manually.
- **Associations** defer `@field.frame_url`; the in-tab/panel switcher keeps injecting `loading: :lazy` for non-manual fields (no regression). `has_one` with a `nil` value still shows the existing attach/create empty state.
- **Failures** (500, 404, network) render an inline error + **Retry** inside the frame instead of the global `/failed_to_load` page. The controller scopes this to its *own* deferred load (`stopImmediatePropagation` + a `pending` flag), so navigations *inside* already-loaded content still use the normal handler.
- Display-only (gated on the field's real view). Accessibility: keyboard-focusable, `aria-label`led Load button, and focus is moved into the frame after a successful load.

## Testing

- **Unit:** `manual?` predicate across tabs + all three association field types; defaults unchanged.
- **Component:** placeholder / loading / error render contract; verbatim (non-`humanize`d) labels.
- **System:** manual `has_many` / `habtm` / `has_one` (incl. nil empty-state), full per-tab tab gating, reveal-fires-no-request, load-shows-real-content (no placeholder loop), in-DOM persistence across tab switches, inline error + Retry (500 and success-on-retry), plus regressions asserting non-manual in-tab associations still carry `loading="lazy"` and non-manual 500s still route to `/failed_to_load`.
- `standardrb` + `erb_lint` clean.

## Post-Deploy Monitoring & Validation

Additive, opt-in view-layer change — no DB, no migrations, no new endpoints.

- **Validate:** On a Show page using `loading: :manual`, confirm (a) the placeholder + Load button renders, (b) no request to the deferred frame fires until Load is clicked (DevTools Network panel), (c) clicking Load swaps in real content, and (d) a failing load shows the inline error + Retry.
- **Failure signals:** manual content auto-loading without a click; a Load button that does nothing (would mean the `manual-frame` Stimulus controller isn't in the host's compiled bundle); or the generic failed-to-load page appearing instead of the inline error.
- **Rollback/mitigation:** removing `loading: :manual` from the affected tab/association reverts it to prior `eager`/`lazy` behavior with zero other changes — the mode is fully opt-in.
- **Owner / window:** PR author, first 24h after the release that ships it.

## Plan & brainstorm

- Requirements: `docs/brainstorms/2026-06-08-on-demand-frame-loading-requirements.md`
- Plan: `docs/plans/2026-06-09-001-feat-manual-turbo-frame-loading-plan.md`

---

🤖 Built with [Claude Code](https://claude.com/claude-code) (Opus 4.8) via the compound-engineering workflow: brainstorm → plan → work, with adversarial document/code review at each stage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Show-page frame rendering and defers Turbo 500 handling for in-flight manual loads; behavior is additive but affects tab/association UX and the global `turbo:before-fetch-response` path.
> 
> **Overview**
> Introduces **`loading: :manual`** as an opt-in third Turbo Frame mode on Show pages for **tabs** and **`has_many` / `has_one` / HABTM** associations. Manual frames render **`Avo::ManualFrameComponent`** (no `src`, **Load** button, loading overlay, inline **Retry** on failure) and fetch only after click via the **`manual-frame`** Stimulus controller.
> 
> **Tabs** get a dedicated branch in `TabGroupComponent` (before lazy/eager) that keeps the existing `is_not_loaded?` round-trip so Load swaps in real tab content. **Associations** use the same component in show templates; `has_one` with no record still uses the attach/create empty state.
> 
> Optional **`loading: { mode: :manual, auto_load_for: … }`** (or hash **`mode: :lazy`**) is parsed by **`Avo::Concerns::FrameLoadingMode`**. After a successful open, a scoped cookie lets the server skip the placeholder and emit a normal **`turbo-frame src`** on return visits; helpers **`manual_frame_remembered?`** / **`manual_frame_cookie_name`** slide the window.
> 
> Callable field descriptions can branch on **`loading_type: :manual`** (and `query` on many fields) to avoid expensive SQL on the placeholder. New locale keys support Load/Retry copy across generator templates.
> 
> Docs (brainstorm + plan) ship with the feature; coverage includes component, unit, and system specs for gating, memory, failures, and regressions (non-manual lazy frames and global `/failed_to_load` on 500).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d9e06078f71566466bd030baf128efb8d71939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

