### PR TITLE
Default explicit_authorization to true

### DIFF
--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -140,7 +140,7 @@ module Avo
       @license_key = nil
       @current_user = proc {}
       @authenticate = proc {}
-      @explicit_authorization = false
+      @explicit_authorization = true
       @authorization_methods = {
         index: "index?",
         show: "show?",

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -37,7 +37,7 @@ Avo.configure do |config|
   # }
   # config.raise_error_on_missing_policy = false
   config.authorization_client = nil
-  config.explicit_authorization = true
+  # config.explicit_authorization = true
 
   ## == Localization ==
   # config.locale = 'en-US'


### PR DESCRIPTION
## Summary

Changes the default value of `config.explicit_authorization` from `false` to `true`, making explicit authorization the out-of-the-box behavior in Avo 4.

With `explicit_authorization` enabled, Avo requires policy methods to be explicitly defined rather than falling back to permissive defaults — a safer default for new installs.

## Changes

- `lib/avo/configuration.rb` — flips the `@explicit_authorization` initializer default to `true`.
- `lib/generators/avo/templates/initializer/avo.tt` — comments out the `config.explicit_authorization` line in the generated initializer, since the value now matches the default.

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 62e818aede3bd9089071d6da50b5c5571286be69. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->