### PR TITLE
UI4: modal scroll/sizing fixes and field-stacked variant (mobile fixes)

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,6 +1,11 @@
 /* @layer base, components, utilities; */
 @import "tailwindcss";
 
+@source not "*/tmp/cache";
+@source not "*/tmp/pids";
+@source not "*/tmp/screenshots";
+@source not "*/tmp/storage";
+
 /* TODO: Figure out a way to add those dynamically */
 /* Find a long term solution for this. */
 /* Basically this is a hack to make sure that we dont have specificity issues with the packages stylesheets. */
@@ -86,6 +91,23 @@
 @custom-variant resource-show-view (&:where(.resource-show-view *));
 @custom-variant resource-edit-view (&:where(.resource-edit-view *));
 @custom-variant resource-new-view (&:where(.resource-new-view *));
+
+/* Field wrappers use the same stacked layout below md, when the whole page
+   forces stacked fields, and when an individual field is explicitly stacked.
+   The component styles live in field-wrapper.css under `@variant field-stacked`. */
+@custom-variant field-stacked {
+  @media (width < 48rem) {
+    @slot;
+  }
+
+  &:is(.all-fields-stacked .field-wrapper, .field-wrapper.field-wrapper--stacked) {
+    @slot;
+  }
+
+  :is(.all-fields-stacked .field-wrapper, .field-wrapper.field-wrapper--stacked) & {
+    @slot;
+  }
+}
 
 /* Used to determine if the filters buttons is displayed. */
 @custom-variant index-missing-resources (&:where(.index-missing-resources *));

--- a/app/assets/stylesheets/css/components/field-wrapper.css
+++ b/app/assets/stylesheets/css/components/field-wrapper.css
@@ -85,24 +85,25 @@
 }
 
 /* Stacked modifier */
-.all-fields-stacked .field-wrapper,
-.field-wrapper.field-wrapper--stacked {
-  @apply md:flex-col md:items-start gap-y-2 py-3;
+.field-wrapper {
+  @variant field-stacked {
+    @apply flex-col items-start gap-y-2 py-3;
 
-  .field-wrapper__label {
-    @apply md:w-full min-h-0 pt-0;
-  }
+    .field-wrapper__label {
+      @apply w-full min-h-0 pt-0;
+    }
 
-  .field-wrapper__label-help {
-    @apply pb-0;
-  }
+    .field-wrapper__label-help {
+      @apply pb-0;
+    }
 
-  .field-wrapper__content {
-    @apply pt-0 px-4 w-full;
-  }
+    .field-wrapper__content {
+      @apply pt-0 px-4 w-full;
+    }
 
-  .field-wrapper__content-wrapper {
-    @apply w-full;
+    .field-wrapper__content-wrapper {
+      @apply w-full;
+    }
   }
 }
 

--- a/app/assets/stylesheets/css/components/modal.css
+++ b/app/assets/stylesheets/css/components/modal.css
@@ -17,7 +17,7 @@
   /* size-full + m-0 + border-0/p-0/bg-transparent reset the popover UA chrome
      (fit-content sizing, auto margins, border, padding, background) so the
      element stays a transparent, full-viewport flex container that centers the card. */
-  @apply fixed inset-0 size-full m-0 border-0 p-0 bg-transparent justify-center items-center;
+  @apply fixed inset-0 size-full m-0 border-0 p-0 bg-transparent justify-center items-center overflow-hidden;
 
   /* Enter/leave transition duration, shared by the card and the backdrop.
      Keep in sync with TRANSITION_MS in base_modal_controller.js. */
@@ -59,16 +59,20 @@
 }
 
 .modal__card-container {
-  @apply flex flex-col items-center justify-center relative shrink-0 w-full;
+  @apply flex flex-col items-center justify-center relative min-h-0 size-full;
 }
 
 .modal__card {
-  @apply relative w-full shrink-0 flex flex-col;
+  @apply relative w-full shrink-0 flex flex-col min-h-0 overflow-hidden;
 
   /* Never exceed the viewport — keeps a tall (e.g. :auto height) modal fully
      on screen so its body can scroll instead of being clipped by the centered
-     overlay. */
+     overlay. The width clamp does the same horizontally: the size classes set a
+     preferred width (e.g. w-xl), but on a narrow phone screen it caps to the
+     viewport instead of overflowing and being clipped on both sides. The gutter
+     is tight on mobile to reclaim width and opens up to 2rem from sm up. */
   max-height: calc(100dvh - 2rem);
+  max-width: calc(100dvw - 1rem);
 
   box-shadow: var(--shadow-modal);
 
@@ -80,6 +84,14 @@
   transition:
     opacity var(--modal-transition-duration) ease-out,
     transform var(--modal-transition-duration) ease-out;
+}
+
+/* Open the gutter back up from sm up, where the extra breathing room reads
+   better and the clamp rarely engages anyway. */
+@media (min-width: 640px) {
+  .modal__card {
+    max-width: calc(100dvw - 2rem);
+  }
 }
 
 .modal:popover-open .modal__card {
@@ -126,19 +138,19 @@
    its wrapper fill the (capped) modal height and shrink, so the body's
    overflow-auto kicks in while the header and footer stay pinned. */
 .modal__card > .card {
-  @apply w-full flex-1 min-h-0;
+  @apply w-full flex-1 min-h-0 overflow-hidden;
 }
 
 .modal__card > .card > .card__wrapper {
-  @apply w-full flex flex-col flex-1 min-h-0;
+  @apply w-full flex flex-col flex-1 min-h-0 overflow-hidden;
 }
 
 .modal__card .card__header {
-  @apply py-3 px-4;
+  @apply py-3 px-4 shrink-0;
 }
 
 .modal__card > .card > .card__wrapper > .card__body {
-  @apply flex flex-col flex-1 gap-4 items-start pt-0 px-0 min-h-64;
+  @apply block flex-1 pt-0 px-0 min-h-0 overflow-auto border-0 rounded-none bg-transparent;
 }
 
 .modal__title {
@@ -158,7 +170,7 @@
 }
 
 .modal__body-content {
-  @apply size-full;
+  @apply w-full min-h-48 rounded-card-wrapper border border-tertiary bg-primary;
 }
 
 /* Belongs-to "Create new" embeds an edit form in the modal. Drop the nested
@@ -169,7 +181,7 @@
 }
 
 .modal__controls {
-  @apply flex items-center justify-between gap-2 py-2 px-3 w-full;
+  @apply flex items-center justify-between gap-2 py-2 px-3 w-full shrink-0;
 }
 
 /* When the controls hold only buttons, nudge the horizontal padding in so the

--- a/app/views/avo/actions/show.html.erb
+++ b/app/views/avo/actions/show.html.erb
@@ -38,7 +38,7 @@
       <%= form.hidden_field :arguments, value: params[:arguments] %>
       <%= hidden_field_tag :resource_view, params[:resource_view] %>
       <% if @fields.present? %>
-        <div class="description-list border-t border-b border-tertiary">
+        <div class="description-list border-t border-tertiary">
           <% @fields.each_with_index do |field, index| %>
             <%= render field
               .hydrate(resource: @resource, record: @resource.record, user: @resource.user, view: @view, action: @action)

--- a/spec/dummy/app/avo/actions/sub/dummy_action.rb
+++ b/spec/dummy/app/avo/actions/sub/dummy_action.rb
@@ -14,6 +14,18 @@ class Avo::Actions::Sub::DummyAction < Avo::BaseAction
 
   def fields
     field :size, as: :radio, options: {small: "Small Option", medium: "Medium Option", large: "Large Option"}, default: :medium
+
+    # Fields below are used to test the scrolling behavior of the modal.
+    # field :size_2, as: :radio, options: {small: "Small Option", medium: "Medium Option", large: "Large Option"}, default: :medium
+    # field :size_3, as: :radio, options: {small: "Small Option", medium: "Medium Option", large: "Large Option"}, default: :medium
+    # field :size_4, as: :radio, options: {small: "Small Option", medium: "Medium Option", large: "Large Option"}, default: :medium
+    # field :size_5, as: :radio, options: {small: "Small Option", medium: "Medium Option", large: "Large Option"}, default: :medium
+    # field :size_6, as: :radio, options: {small: "Small Option", medium: "Medium Option", large: "Large Option"}, default: :medium
+    # # field :size_7, as: :radio, options: {small: "Small Option", medium: "Medium Option", large: "Large Option"}, default: :medium
+    # # field :size_8, as: :radio, options: {small: "Small Option", medium: "Medium Option", large: "Large Option"}, default: :medium
+    # # field :size_9, as: :radio, options: {small: "Small Option", medium: "Medium Option", large: "Large Option"}, default: :medium
+    # # field :size_10, as: :radio, options: {small: "Small Option", medium: "Medium Option", large: "Large Option"}, default: :medium
+
     TestBuddy.hi("Dummy action fields")
     field :keep_modal_open, as: :boolean
     field :persistent_text, as: :text


### PR DESCRIPTION
## What

UI4 polish for the modal and field-wrapper layout.

### Modal (`modal.css`)
- Pin the header and footer (`shrink-0`) and let the **body scroll** within a viewport-capped card, instead of the whole card overflowing the centered overlay.
- Clamp the card **width** on mobile (`max-width: calc(100dvw - 1rem)`) so a wide modal (e.g. `w-xl`) caps to the viewport instead of being clipped on both sides; the gutter opens back up to `2rem` from `sm` up.
- Give the body content its own bordered surface (`border`, `rounded-card-wrapper`, `bg-primary`) and an `overflow-auto` scroll region.

### Field wrapper (`field-wrapper.css` + `application.css`)
- Extract the stacked layout into a reusable `field-stacked` custom variant that fires below `md`, when the page forces stacked fields (`.all-fields-stacked`), or per-field (`.field-wrapper--stacked`). Replaces the duplicated selector list.

### Action modal (`actions/show.html.erb`)
- Drop the redundant bottom border on the description list now that the modal body content carries its own border.

### Misc
- Exclude `tmp/*` dirs from Tailwind `@source` scanning in `application.css`.
- Commented-out extra fields in the dummy action for manually exercising modal scrolling.

## Testing
Manual — verify modal header/footer stay pinned while a tall body scrolls, and that a wide modal stays on-screen on narrow viewports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS and markup-only UI polish with no auth, data, or API changes; main risk is visual/layout regressions in modals and field forms.
> 
> **Overview**
> **Modal layout** now keeps header and footer fixed while the body scrolls inside a viewport-capped card, with horizontal `max-width` clamps on narrow screens and a bordered scroll surface on `.modal__body-content`.
> 
> **Field stacked layout** is centralized in a new `field-stacked` Tailwind custom variant (mobile, `.all-fields-stacked`, and `.field-wrapper--stacked`), and `field-wrapper.css` applies stacked styles through `@variant field-stacked` instead of duplicated selectors.
> 
> **Action modals** drop the extra bottom border on the fields `description-list` because the modal body supplies its own chrome. Tailwind `@source` scanning excludes several `tmp/*` paths, and the dummy action adds commented radio fields for manual scroll testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e669414a9e56aee25ddc9f239cb086f57983711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->