### PR TITLE
chore: add redirect from /avo to /admin in routes

### DIFF
--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -32,5 +32,7 @@ Rails.application.routes.draw do
     scope "(:locale)" do
       # mount_avo
     end
+
+    get "/avo", to: redirect("/admin")
   end
 end


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

WIP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routing-only change in the test dummy app with no auth or data-handling logic changes.
> 
> **Overview**
> Adds a **GET `/avo` → `/admin` redirect** in the dummy app routes, inside the existing admin `authenticate` block.
> 
> This gives a stable alias for the Avo mount path so old bookmarks or links to `/avo` land on the real admin UI at `/admin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 775720712d87ae279e775c982338606aa6b76c5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->