### PR TITLE
Fix nested menu sub-items resolving their path

### DIFF
--- a/app/assets/stylesheets/css/sidebar.css
+++ b/app/assets/stylesheets/css/sidebar.css
@@ -235,6 +235,60 @@
   border-end-start-radius: 2px;
 }
 
+/* Hover preview: redraw the full connector path down to the hovered subitem,
+   mirroring the active styling. Every item above it gets a vertical line; the
+   hovered item gets the L-shape, or a T-shape when the active item sits below
+   it (so the line continues past it). The preview is faint (0.6) only when it
+   extends below the active item — at or above the active item it stays solid. */
+.sidebar-subitem:hover,
+.sidebar-subitem:has(~ .sidebar-subitem:hover) {
+  @apply relative;
+}
+
+/* Vertical line for every item above the hovered one */
+.sidebar-subitem:has(~ .sidebar-subitem:hover)::before {
+  content: '';
+  @apply absolute top-0 bottom-0;
+  inset-inline-start: -10px;
+  width: auto;
+  height: auto;
+  border-inline-start: 2px solid var(--sidebar-link-active-background);
+  border-block-end: none;
+  border-end-start-radius: 0;
+}
+
+/* L-shape: endpoint at the hovered item */
+.sidebar-subitem:hover::before {
+  content: '';
+  @apply absolute top-0;
+  inset-inline-start: -10px;
+  height: 50%;
+  width: 10px;
+  border-inline-start: 2px solid var(--sidebar-link-active-background);
+  border-block-end: 2px solid var(--sidebar-link-active-background);
+  border-end-start-radius: 2px;
+}
+
+/* T-shape: when the active item is below the hovered one, the line must
+   continue down past it — full vertical line (top + bottom) with a branch to
+   the right (three endings) instead of the L-shape endpoint. */
+.sidebar-subitem:hover:has(~ .sidebar-subitem--bar-active)::before {
+  @apply top-0 bottom-0;
+  height: auto;
+  width: auto;
+  border-block-end: none;
+  border-end-start-radius: 0;
+}
+
+.sidebar-subitem:hover:has(~ .sidebar-subitem--bar-active)::after {
+  content: '';
+  @apply absolute;
+  top: calc(50% - 1px);
+  inset-inline-start: -10px;
+  width: 10px;
+  border-block-end: 2px solid var(--sidebar-link-active-background);
+}
+
 /* ================================================ */
 /* Sidebar Profile — SidebarProfileComponent        */
 /* BEM: .sidebar-profile (block)                    */

--- a/app/components/avo/sidebar/link_component.html.erb
+++ b/app/components/avo/sidebar/link_component.html.erb
@@ -29,14 +29,16 @@
 <% if @items.present? && parent_link_active? %>
   <div class="sidebar-subitem__items">
     <% @items.each_with_index do |item, index| %>
-      <% if item.path.present? %>
-        <%= link_caller.send link_method, item.path, class: "sidebar-subitem #{subitem_bar_class(index)}", active: @active, target: item.target, data: subitem_data(item), disabled: @disabled, "aria-disabled": @disabled, **item.args do %>
+      <% path = subitem_path(item) %>
+      <% active = index == active_item_index %>
+      <% if path.present? %>
+        <%= link_caller.send link_method, path, class: "sidebar-subitem #{subitem_bar_class(index)}", active: active, target: item.try(:target), data: subitem_data(item), disabled: @disabled, "aria-disabled": @disabled, **(item.try(:args) || {}).except(:active) do %>
           <span><%= item.try(:label).presence || item.try(:name).presence %></span>
 
           <%= hotkey_badge(item.hotkey, class: "ms-auto") if item.try(:hotkey).present? %>
         <% end %>
       <% else %>
-        <%= content_tag :div, class: "sidebar-subitem #{subitem_bar_class(index)}", active: @active, target: item.target, data: subitem_data(item) do %>
+        <%= content_tag :div, class: "sidebar-subitem #{subitem_bar_class(index)}", active: active, target: item.try(:target), data: subitem_data(item) do %>
           <span><%= item.try(:label).presence || item.try(:name).presence %></span>
         <% end %>
       <% end %>

--- a/app/components/avo/sidebar/link_component.html.erb
+++ b/app/components/avo/sidebar/link_component.html.erb
@@ -1,6 +1,6 @@
 <% if @path.present? %>
-  <%= link_caller.send link_method, @path, class: "sidebar-link", active: parent_link_active?, target: @target, data: link_data, disabled: @disabled, "aria-disabled": @disabled, **@args do %>
-    <% if @reserve_icon_space || link_icon.present? %>
+  <%= link_caller.send link_method, @path, class: root_css_class, active: @active, target: @target, data: link_data, disabled: @disabled, "aria-disabled": @disabled, **@args do %>
+    <% if show_icon? %>
       <span class="sidebar-link__icon-wrapper sidebar-icon <%= 'sidebar-link__icon-wrapper--placeholder' if link_icon.blank? %>">
         <%= helpers.svg link_icon, class: "sidebar-link__icon sidebar-icon" if link_icon.present? %>
       </span>
@@ -15,8 +15,8 @@
     <% end %>
   <% end %>
 <% else %>
-  <%= content_tag :div, class: "sidebar-link", active: @active, target: @target, data: @data do %>
-    <% if @reserve_icon_space || link_icon.present? %>
+  <%= content_tag :div, class: root_css_class, active: @active, target: @target, data: @data do %>
+    <% if show_icon? %>
       <span class="sidebar-link__icon-wrapper sidebar-icon <%= 'sidebar-link__icon-wrapper--placeholder' if link_icon.blank? %>">
         <%= helpers.svg link_icon, class: "sidebar-link__icon sidebar-icon" if link_icon.present? %>
       </span>
@@ -24,24 +24,4 @@
 
     <span><%= @label %></span>
   <% end %>
-<% end %>
-
-<% if @items.present? && parent_link_active? %>
-  <div class="sidebar-subitem__items">
-    <% @items.each_with_index do |item, index| %>
-      <% path = subitem_path(item) %>
-      <% active = index == active_item_index %>
-      <% if path.present? %>
-        <%= link_caller.send link_method, path, class: "sidebar-subitem #{subitem_bar_class(index)}", active: active, target: item.try(:target), data: subitem_data(item), disabled: @disabled, "aria-disabled": @disabled, **(item.try(:args) || {}).except(:active) do %>
-          <span><%= item.try(:label).presence || item.try(:name).presence %></span>
-
-          <%= hotkey_badge(item.hotkey, class: "ms-auto") if item.try(:hotkey).present? %>
-        <% end %>
-      <% else %>
-        <%= content_tag :div, class: "sidebar-subitem #{subitem_bar_class(index)}", active: active, target: item.try(:target), data: subitem_data(item) do %>
-          <span><%= item.try(:label).presence || item.try(:name).presence %></span>
-        <% end %>
-      <% end %>
-    <% end %>
-  </div>
 <% end %>

--- a/app/components/avo/sidebar/link_component.html.erb
+++ b/app/components/avo/sidebar/link_component.html.erb
@@ -1,5 +1,5 @@
 <% if @path.present? %>
-  <%= link_caller.send link_method, @path, class: "sidebar-link", active: @active, target: @target, data: link_data, disabled: @disabled, "aria-disabled": @disabled, **@args do %>
+  <%= link_caller.send link_method, @path, class: "sidebar-link", active: parent_link_active?, target: @target, data: link_data, disabled: @disabled, "aria-disabled": @disabled, **@args do %>
     <% if @reserve_icon_space || link_icon.present? %>
       <span class="sidebar-link__icon-wrapper sidebar-icon <%= 'sidebar-link__icon-wrapper--placeholder' if link_icon.blank? %>">
         <%= helpers.svg link_icon, class: "sidebar-link__icon sidebar-icon" if link_icon.present? %>

--- a/app/components/avo/sidebar/link_component.rb
+++ b/app/components/avo/sidebar/link_component.rb
@@ -2,11 +2,14 @@
 
 require "view_component/version"
 
+# A single sidebar link (leaf). `variant: :default` or `:subitem`. Knows nothing
+# about menus; callers pass the path, label and resolved `active` (a match mode
+# like :inclusive, or a boolean to force it).
 class Avo::Sidebar::LinkComponent < Avo::BaseComponent
   prop :label
   prop :path
   prop :active, default: :inclusive do |value|
-    value&.to_sym
+    value.is_a?(String) ? value.to_sym : value
   end
   prop :target do |value|
     value&.to_sym
@@ -15,30 +18,31 @@ class Avo::Sidebar::LinkComponent < Avo::BaseComponent
   prop :icon
   prop :reserve_icon_space, default: false
   prop :args, kind: :**, default: {}.freeze
-  prop :items
   prop :hotkey, default: nil
+  prop :variant, default: :default
+  prop :bar_class, default: ""
+
+  def subitem?
+    @variant == :subitem
+  end
+
+  def root_css_class
+    return "sidebar-link" unless subitem?
+
+    ["sidebar-subitem", @bar_class].reject(&:blank?).join(" ")
+  end
+
+  # Sub-items don't show icons (for now); top-level links do.
+  def show_icon?
+    return false if subitem?
+
+    @reserve_icon_space || link_icon.present?
+  end
 
   def link_data
-    build_link_data(@data, @hotkey)
-  end
+    return @data if @hotkey.blank?
 
-  def subitem_data(item)
-    build_link_data(item.data, item.hotkey)
-  end
-
-  # Resolve a sub-item's URL. A Link carries its own stored `path`; the other
-  # types (resource, dashboard, board, page) don't, so we derive the URL from the
-  # item type the same way ItemSwitcherComponent does for top-level items.
-  def subitem_path(item)
-    return item.path if item.try(:path).present?
-
-    case item
-    when Avo::Menu::Resource then helpers.resources_path(resource: item.parsed_resource, **item.fetch_params)
-    when Avo::Menu::Dashboard then helpers.avo_dashboards.dashboard_path(item.parsed_dashboard)
-    when Avo::Menu::Board then helpers.avo_kanban.board_path(item.record)
-    when Avo::Menu::Page then item.navigation_path
-    when Avo::Menu::Action then item.navigation_path(helpers)
-    end
+    @data.merge(hotkey: @hotkey)
   end
 
   def is_external?
@@ -62,48 +66,7 @@ class Avo::Sidebar::LinkComponent < Avo::BaseComponent
     end
   end
 
-  def parent_link_active?
-    return false if @path.blank?
-    # Keep the parent expanded when it is active itself, or when one of its
-    # sub-items is active (e.g. a nested resource that lives at a sibling path).
-    helpers.is_active_link?(@path, @active) || active_item_index.present?
-  end
-
   def link_icon
     @icon
-  end
-
-  def active_item_index
-    return @active_item_index if defined?(@active_item_index)
-
-    active = @items.to_a.each_with_index.filter_map do |item, index|
-      path = subitem_path(item)
-      [index, path.length] if path.present? && helpers.is_active_link?(path, @active)
-    end
-
-    # Favor the most specific match (longest path) so a record sub-item wins the
-    # indicator over the resource index it lives under, instead of the first match.
-    @active_item_index = active.max_by(&:last)&.first
-  end
-
-  def subitem_bar_class(index)
-    active_idx = active_item_index
-    return "" if active_idx.nil?
-
-    if index == active_idx
-      "sidebar-subitem--bar-active"
-    elsif index < active_idx
-      "sidebar-subitem--bar-pass"
-    else
-      ""
-    end
-  end
-
-  private
-
-  def build_link_data(data, hotkey)
-    return data if hotkey.blank?
-
-    data.merge(hotkey: hotkey)
   end
 end

--- a/app/components/avo/sidebar/link_component.rb
+++ b/app/components/avo/sidebar/link_component.rb
@@ -26,6 +26,20 @@ class Avo::Sidebar::LinkComponent < Avo::BaseComponent
     build_link_data(item.data, item.hotkey)
   end
 
+  # Resolve a sub-item's URL. A Link carries its own stored `path`; the other
+  # types (resource, dashboard, board, page) don't, so we derive the URL from the
+  # item type the same way ItemSwitcherComponent does for top-level items.
+  def subitem_path(item)
+    return item.path if item.try(:path).present?
+
+    case item
+    when Avo::Menu::Resource then helpers.resources_path(resource: item.parsed_resource, **item.fetch_params)
+    when Avo::Menu::Dashboard then helpers.avo_dashboards.dashboard_path(item.parsed_dashboard)
+    when Avo::Menu::Board then helpers.avo_kanban.board_path(item.record)
+    when Avo::Menu::Page then item.navigation_path
+    end
+  end
+
   def is_external?
     # If the path contains the scheme, check if it includes the root path or not
     return !@path.include?(helpers.mount_path) if URI(@path).scheme.present?
@@ -49,7 +63,9 @@ class Avo::Sidebar::LinkComponent < Avo::BaseComponent
 
   def parent_link_active?
     return false if @path.blank?
-    helpers.is_active_link?(@path, @active)
+    # Keep the parent expanded when it is active itself, or when one of its
+    # sub-items is active (e.g. a nested resource that lives at a sibling path).
+    helpers.is_active_link?(@path, @active) || active_item_index.present?
   end
 
   def link_icon
@@ -59,9 +75,14 @@ class Avo::Sidebar::LinkComponent < Avo::BaseComponent
   def active_item_index
     return @active_item_index if defined?(@active_item_index)
 
-    @active_item_index = @items&.index do |item|
-      item.path.present? && helpers.is_active_link?(item.path, @active)
+    active = @items.to_a.each_with_index.filter_map do |item, index|
+      path = subitem_path(item)
+      [index, path.length] if path.present? && helpers.is_active_link?(path, @active)
     end
+
+    # Favor the most specific match (longest path) so a record sub-item wins the
+    # indicator over the resource index it lives under, instead of the first match.
+    @active_item_index = active.max_by(&:last)&.first
   end
 
   def subitem_bar_class(index)

--- a/app/components/avo/sidebar/link_component.rb
+++ b/app/components/avo/sidebar/link_component.rb
@@ -37,6 +37,7 @@ class Avo::Sidebar::LinkComponent < Avo::BaseComponent
     when Avo::Menu::Dashboard then helpers.avo_dashboards.dashboard_path(item.parsed_dashboard)
     when Avo::Menu::Board then helpers.avo_kanban.board_path(item.record)
     when Avo::Menu::Page then item.navigation_path
+    when Avo::Menu::Action then item.navigation_path(helpers)
     end
   end
 


### PR DESCRIPTION
 # Description
  Menu sub-items were rendered assuming every child was a `link` with a stored
  `path`, so nesting a `resource` (or dashboard/board/page/action) under another
  item raised `undefined method 'path' for an instance of Avo::Menu::Resource`.

  Fixing that properly meant sub-item rendering needed per-type knowledge — which
  doesn't belong in core, since it would make `LinkComponent` depend on
  `Avo::Menu::*` types (an inverted dependency on avo-menu). So this PR makes
  `Sidebar::LinkComponent` a **pure, reusable leaf**, and the sub-item rendering
  and fixes live in the paired **avo-menu** PR.

  ## What changed
  - `Sidebar::LinkComponent` is now a single-link leaf — removed sub-item list
    rendering (`items`, `subitem_path`, `parent_link_active?`, active-index/bar
    logic) and all `Avo::Menu::*` references.
  - Added a `:subitem` variant (sub-item styling, no icon); callers pass the
    resolved `active` state — a match mode (`:inclusive`) or a boolean to force it
    (e.g. a parent that highlights when a nested child is active).
# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<img width="262" height="364" alt="Screenshot 2026-06-15 at 11 25 22" src="https://github.com/user-attachments/assets/ef7fc327-e541-4741-b5b7-d89178afbd62" />


