### PR TITLE
AVO-931: wire avo core to extracted pro gems

### DIFF
--- a/app/components/avo/fields/belongs_to_field/edit_component.html.erb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.html.erb
@@ -35,7 +35,7 @@
           <div data-polymorphic-type="<%= type %>">
             <%= field_wrapper(**field_wrapper_args.merge!(data: reload_data), label: Avo.resource_manager.get_resource_by_model_class(type.to_s).name, class: "!w-full") do %>
               <% if @field.is_searchable? %>
-                <%= render Avo::Pro::AssociationSearch::ContainerComponent.new(
+                <%= render Avo::AdvancedSearch::Association::ContainerComponent.new(
                       form: @form,
                       field: @field,
                       polymorphic_type: type
@@ -86,7 +86,7 @@
 <% else %>
   <%= field_wrapper(**field_wrapper_args.merge!(data: reload_data)) do %>
     <% if @field.is_searchable? %>
-      <%= render Avo::Pro::AssociationSearch::ContainerComponent.new(form: @form, field: @field) %>
+      <%= render Avo::AdvancedSearch::Association::ContainerComponent.new(form: @form, field: @field) %>
     <% else %>
       <%= @form.select @field.id_input_foreign_key,
         options_for_select(@field.options, selected: @field.value.to_param, disabled: t("avo.more_records_available")),

--- a/app/components/avo/index/resource_controls_component.rb
+++ b/app/components/avo/index/resource_controls_component.rb
@@ -143,8 +143,8 @@ class Avo::Index::ResourceControlsComponent < Avo::ResourceComponent
   end
 
   def render_order_controls(control)
-    if try(:can_reorder?)
-      render Avo::Pro::Ordering::ButtonsComponent.new resource: @resource, reflection: @reflection, view_type: @view_type
+    if Avo.plugin_manager.installed?("avo-record_reordering") && try(:can_reorder?)
+      render Avo::RecordReordering::ButtonsComponent.new resource: @resource, reflection: @reflection, view_type: @view_type
     end
   end
 

--- a/app/views/avo/associations/new.html.erb
+++ b/app/views/avo/associations/new.html.erb
@@ -22,7 +22,7 @@
                 resource: @resource,
                 label_for: 'related_id',
                 label: @field.name.singularize do %>
-                <%= render Avo::Pro::AssociationSearch::ContainerComponent.new(
+                <%= render Avo::AdvancedSearch::Association::ContainerComponent.new(
                       form: form,
                       field: @field,
                       attach: true

--- a/app/views/avo/partials/_navbar.html.erb
+++ b/app/views/avo/partials/_navbar.html.erb
@@ -30,8 +30,8 @@
   </div>
 
   <div class="top-navbar__center">
-    <% if defined?(Avo::Pro::GlobalSearch::InputComponent) %>
-      <%= render Avo::Pro::GlobalSearch::InputComponent.new(resource: @resource) %>
+    <% if Avo.plugin_manager.installed?("avo-advanced_search") %>
+      <%= render Avo::AdvancedSearch::Global::InputComponent.new(resource: @resource) %>
     <% end %>
   </div>
 

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -1,4 +1,5 @@
 require_relative "avo/engine_dsl"
+require_relative "avo/railtie_dsl"
 
 require "zeitwerk"
 require "net/http"
@@ -13,10 +14,14 @@ loader.inflector.inflect(
   "html" => "HTML",
   "uri_service" => "URIService",
   "has_html_attributes" => "HasHTMLAttributes",
-  "engine_dsl" => "EngineDSL"
+  "engine_dsl" => "EngineDSL",
+  "plugin_dsl" => "PluginDSL",
+  "railtie_dsl" => "RailtieDSL"
 )
 loader.ignore("#{__dir__}/generators")
 loader.ignore("#{__dir__}/avo/engine_dsl.rb")
+loader.ignore("#{__dir__}/avo/plugin_dsl.rb")
+loader.ignore("#{__dir__}/avo/railtie_dsl.rb")
 loader.setup
 
 module Avo

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -231,9 +231,9 @@ module Avo
     end
 
     # Authorization is enabled when:
-    # (avo-pro gem is installed) AND (authorization_client is NOT nil)
+    # (avo-authorization gem is installed) AND (authorization_client is NOT nil)
     def authorization_enabled?
-      @authorization_enabled ||= Avo.plugin_manager.installed?("avo-pro") && !authorization_client.nil?
+      @authorization_enabled ||= Avo.plugin_manager.installed?("avo-authorization") && !authorization_client.nil?
     end
 
     def current_user_method(&block)

--- a/lib/avo/plugin_dsl.rb
+++ b/lib/avo/plugin_dsl.rb
@@ -1,0 +1,8 @@
+module Avo
+  module PluginDSL
+    def avo_plugin(handler_class, handler_name:)
+      handler_class ||= "#{name.deconstantize}::#{handler_name}".constantize
+      instance_exec(&handler_class.handle)
+    end
+  end
+end

--- a/lib/avo/railtie_dsl.rb
+++ b/lib/avo/railtie_dsl.rb
@@ -1,15 +1,15 @@
 require_relative "plugin_dsl"
 
 module Avo
-  module EngineDSL
+  module RailtieDSL
     extend PluginDSL
 
     def self.extended(base)
       base.extend(PluginDSL)
     end
 
-    def avo_engine(handler_class = nil)
-      avo_plugin(handler_class, handler_name: "EngineHandler")
+    def avo_railtie(handler_class = nil)
+      avo_plugin(handler_class, handler_name: "RailtieHandler")
     end
   end
 end

--- a/lib/tasks/avo_tasks.rake
+++ b/lib/tasks/avo_tasks.rake
@@ -92,7 +92,7 @@ task "avo:sym_link" do
   end
 
   gem_paths = `bundle list --paths 2>/dev/null`.split("\n")
-  ["avo-advanced", "avo-pro", "avo-dynamic_filters", "avo-dashboards", "avo-menu", "avo-kanban", "avo-forms"].each do |gem|
+  ["avo-advanced", "avo-pro", "avo-advanced_search", "avo-authorization", "avo-record_reordering", "avo-dynamic_filters", "avo-dashboards", "avo-menu", "avo-kanban", "avo-forms"].each do |gem|
     path = gem_paths.find { |gem_path| gem_path.include?("/#{gem}-") }
 
     # If path is nil we check if package is defined outside of root (on release process it is)

--- a/spec/lib/avo/railtie_dsl_spec.rb
+++ b/spec/lib/avo/railtie_dsl_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe "Avo::RailtieDSL load order" do
+  it "is available via standalone require without full avo boot" do
+    expect(Avo::RailtieDSL).to be_a(Module)
+    expect(Avo::RailtieDSL.instance_methods).to include(:avo_railtie)
+  end
+end
+
+RSpec.describe Avo::RailtieDSL do
+  before do
+    stub_const("Avo::RailtieDSLSpec", Module.new)
+
+    stub_const("Avo::RailtieDSLSpec::RailtieHandler", Class.new do
+      def self.handle
+        -> {
+          initializer "avo-railtie-dsl-spec.init" do
+          end
+        }
+      end
+    end)
+
+    stub_const("Avo::RailtieDSLSpec::Railtie", Class.new(Rails::Railtie) do
+      extend Avo::RailtieDSL
+      avo_railtie
+    end)
+  end
+
+  let(:railtie) { Avo::RailtieDSLSpec::Railtie }
+
+  it "registers initializers from the handler proc" do
+    expect(railtie.initializers.map(&:name)).to include("avo-railtie-dsl-spec.init")
+  end
+
+  it "accepts an explicit handler class" do
+    stub_const("Avo::RailtieDSLSpec::CustomHandler", Class.new do
+      def self.handle
+        -> {
+          initializer "avo-railtie-dsl-spec.custom" do
+          end
+        }
+      end
+    end)
+
+    railtie_class = Class.new(Rails::Railtie) do
+      def self.name
+        "Avo::RailtieDSLSpec::CustomRailtie"
+      end
+
+      extend Avo::RailtieDSL
+      avo_railtie Avo::RailtieDSLSpec::CustomHandler
+    end
+
+    expect(railtie_class.initializers.map(&:name)).to include("avo-railtie-dsl-spec.custom")
+  end
+end


### PR DESCRIPTION
## Summary

- Add `Avo::RailtieDSL` and `Avo::PluginDSL` for extracted gem integration
- Point navbar, belongs-to, associations, and resource controls at `avo-advanced_search`, `avo-authorization`, and `avo-record_reordering`
- Gate authorization via `installed?("avo-authorization")`

## Test plan

- [ ] `bundle exec rspec spec/lib/avo/railtie_dsl_spec.rb`
- [ ] Boot Avo with `avo-pro` and confirm global search, authorization, and reorder controls render when gems are installed