### PR TITLE
Fix reorder drag placeholder background in dark mode

### DIFF
--- a/app/assets/stylesheets/css/table.css
+++ b/app/assets/stylesheets/css/table.css
@@ -63,6 +63,15 @@
   background: color-mix(in oklab, var(--color-primary), var(--color-accent) 10%);
 }
 
+/* Reorder drag placeholder (SortableJS ghostClass) — theme-aware for dark mode. */
+.table-row--ghost {
+  background: var(--color-table-row-selected);
+
+  & > td {
+    background: var(--color-table-row-selected);
+  }
+}
+
 table[role="grid"] {
   @apply outline-none;
 }


### PR DESCRIPTION
# Description
The row-reorder drag placeholder showed a hardcoded light-gray background, which looked wrong in dark mode.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording

https://github.com/user-attachments/assets/96018962-5a88-4a87-9b04-bacdae1a8dbd

