### PR TITLE
AVO-930: Reference avo-scopes gem in core

### DIFF
--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -143,7 +143,7 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
   end
 
   def scopes_list
-    Avo::ResourceScopes::Scopes::ListComponent.new(
+    Avo::Scopes::ListComponent.new(
       scopes: @scopes,
       resource: @resource,
       turbo_frame: @turbo_frame,
@@ -155,7 +155,7 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
   end
 
   def can_render_scopes?
-    Avo.plugin_manager.installed?("avo-resource_scopes") && @scopes.present?
+    Avo.plugin_manager.installed?("avo-scopes") && @scopes.present?
   end
 
   def back_path

--- a/lib/generators/avo/templates/scope.tt
+++ b/lib/generators/avo/templates/scope.tt
@@ -1,4 +1,4 @@
-class Avo::Scopes::<%= class_name.camelize %> < Avo::ResourceScopes::Scopes::BaseScope
+class Avo::Scopes::<%= class_name.camelize %> < Avo::Scopes::BaseScope
   self.name = "<%= name.underscore.humanize %>"
   # self.description = "<%= name.underscore.humanize %> description."
   self.scope = -> { query.all }

--- a/spec/components/avo/views/resource_index_component_spec.rb
+++ b/spec/components/avo/views/resource_index_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Avo::Views::ResourceIndexComponent, type: :component do
   describe "#can_render_scopes?" do
     before do
       allow(Avo.plugin_manager).to receive(:installed?).and_call_original
-      allow(Avo.plugin_manager).to receive(:installed?).with("avo-resource_scopes").and_return(true)
+      allow(Avo.plugin_manager).to receive(:installed?).with("avo-scopes").and_return(true)
     end
 
     it "returns false when there are no scopes" do


### PR DESCRIPTION
## Summary
- Check `installed?("avo-scopes")` instead of `avo-resource_scopes`
- Use `Avo::Scopes::ListComponent` from the avo-scopes gem
- Scope generator template inherits from `Avo::Scopes::BaseScope`

Follow-up to merged #4560 after gem rename to `avo-scopes`.

## Test plan
- [ ] Resource index component spec passes with avo-scopes stubbed
- [ ] Scope generator produces correct base class


Made with [Cursor](https://cursor.com)