### PR TITLE
Render flatpickr calendars and tippy tooltips above top-layer modals

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -12,6 +12,7 @@ import tippy from 'tippy.js'
 
 import { LocalStorageService } from './js/local-storage-service'
 import { attachHotkeyFeedback, installGlobalHotkeys } from './js/global_hotkeys'
+import nearestTopLayer from './js/helpers/top_layer'
 
 import './js/active-storage'
 import './js/controllers'
@@ -37,6 +38,9 @@ function initTippy() {
   tippy('[data-tippy="tooltip"]', {
     theme: 'basic',
     allowHTML: true,
+    // Default is <body>; a tooltip whose trigger lives in a top-layer modal
+    // would then paint under it, so append into the modal (see helpers/top_layer).
+    appendTo: (reference) => nearestTopLayer(reference) ?? document.body,
     // Hover-only. Default 'mouseenter focus' fires when something else (e.g. a
     // dropdown menu auto-focusing its active item on open) puts focus on the
     // trigger — which would surface the tooltip without user intent.

--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -1,3 +1,4 @@
+import '../../helpers/flatpickr_top_layer'
 import { Controller } from '@hotwired/stimulus'
 import { DateTime } from 'luxon'
 import flatpickr from 'flatpickr'
@@ -226,7 +227,7 @@ export default class extends Controller {
 
   onClose(selectedDates, dateStr, instance) {
     if (instance.config.allowInput && instance.altInput.value) {
-      const value = instance.altInput.value
+      const { value } = instance.altInput
       if (value) {
         instance.setDate(value, true, instance.config.altFormat)
       } else {

--- a/app/javascript/js/controllers/tippy_controller.js
+++ b/app/javascript/js/controllers/tippy_controller.js
@@ -1,6 +1,8 @@
 import { Controller } from '@hotwired/stimulus'
 import tippy from 'tippy.js'
 
+import nearestTopLayer from '../helpers/top_layer'
+
 export default class extends Controller {
   static targets = ['source', 'content']
 
@@ -9,6 +11,9 @@ export default class extends Controller {
       content: this.contentTarget.innerHTML,
       allowHTML: true,
       theme: 'basic',
+      // Default is <body>; append into a top-layer modal when the trigger is
+      // inside one, otherwise it paints underneath (see helpers/top_layer).
+      appendTo: (reference) => nearestTopLayer(reference) ?? document.body,
     })
   }
 

--- a/app/javascript/js/helpers/flatpickr_top_layer.js
+++ b/app/javascript/js/helpers/flatpickr_top_layer.js
@@ -1,0 +1,46 @@
+import flatpickr from 'flatpickr'
+
+import nearestTopLayer from './top_layer'
+
+// Flatpickr appends its calendar to <body>, so a calendar opened from inside a
+// top-layer modal renders underneath it (see ./top_layer for the why).
+//
+// Importing this module installs the fix as a flatpickr default, so every
+// picker in the app (date fields, filters, anything added later) cooperates
+// with top-layer modals automatically — there's nothing to remember per field.
+// When the input lives inside a popover/dialog we move the calendar into that
+// top-layer element so it shares the layer, then correct flatpickr's
+// positioning for the popover's fixed, viewport-anchored containing block.
+
+function moveCalendarIntoTopLayer(selectedDates, dateStr, instance) {
+  const topLayer = nearestTopLayer(instance.element)
+
+  if (topLayer) topLayer.appendChild(instance.calendarContainer)
+}
+
+function repositionInTopLayer(selectedDates, dateStr, instance) {
+  if (!nearestTopLayer(instance.element)) return
+
+  // Flatpickr positions the calendar *after* onOpen, in document coordinates:
+  // the input's viewport position plus the page's scroll offset. Inside a fixed
+  // popover the containing block is the viewport itself (the modal locks body
+  // scroll but keeps pageYOffset), so we wait for that positioning to land, then
+  // strip the scroll offset back out. requestAnimationFrame runs after
+  // flatpickr's synchronous positioning but before the next paint, so the
+  // calendar never visibly jumps.
+  requestAnimationFrame(() => {
+    const { calendarContainer } = instance
+
+    if (calendarContainer.style.top && calendarContainer.style.top !== 'auto') {
+      calendarContainer.style.top = `${parseFloat(calendarContainer.style.top) - window.pageYOffset}px`
+    }
+    if (calendarContainer.style.left && calendarContainer.style.left !== 'auto') {
+      calendarContainer.style.left = `${parseFloat(calendarContainer.style.left) - window.pageXOffset}px`
+    }
+  })
+}
+
+flatpickr.setDefaults({
+  onReady: [moveCalendarIntoTopLayer],
+  onOpen: [repositionInTopLayer],
+})

--- a/app/javascript/js/helpers/top_layer.js
+++ b/app/javascript/js/helpers/top_layer.js
@@ -1,0 +1,12 @@
+// Native popovers and dialogs (e.g. Avo's action modal, dropdown menus) render
+// in the browser's "top layer", which paints above everything in the normal
+// layer regardless of z-index. Any floating UI a library appends to <body>
+// (flatpickr calendars, Tagify dropdowns, tippy tooltips, ...) therefore renders
+// *underneath* a modal it was opened from, and no z-index can lift it out.
+//
+// The fix for every such library is the same: append the floating element into
+// the nearest top-layer ancestor instead of <body>, so it shares the layer.
+// This is the single source of truth for "what counts as a top-layer ancestor".
+export default function nearestTopLayer(element) {
+  return element?.closest('[popover], dialog') ?? null
+}

--- a/spec/dummy/app/avo/actions/sub/dummy_action.rb
+++ b/spec/dummy/app/avo/actions/sub/dummy_action.rb
@@ -14,6 +14,8 @@ class Avo::Actions::Sub::DummyAction < Avo::BaseAction
 
   def fields
     field :size, as: :radio, options: {small: "Small Option", medium: "Medium Option", large: "Large Option"}, default: :medium
+    # Used to test that JS overlays are visible over the popup
+    # field :date, as: :date, help: "<span title='hey' data-tippy='tooltip'>hey</span>"
 
     # Fields below are used to test the scrolling behavior of the modal.
     # field :size_2, as: :radio, options: {small: "Small Option", medium: "Medium Option", large: "Large Option"}, default: :medium


### PR DESCRIPTION
## What

Avo's modal is a native popover (`popover="manual"`) that renders in the browser **top layer**, which paints above the normal layer regardless of `z-index`. Floating UI that libraries append to `<body>` — flatpickr calendars, tippy tooltips — therefore rendered **underneath** a modal it was opened from (e.g. the date picker in an action modal), and no `z-index` could lift it out.

## How

Adds a shared `nearestTopLayer(element)` helper (`app/javascript/js/helpers/top_layer.js`) — the single source of truth for the `[popover], dialog` selector — and uses it in two places:

- **flatpickr** (`helpers/flatpickr_top_layer.js`, installed once via `flatpickr.setDefaults`): when a picker lives inside a popover, move the calendar into that top-layer element so it shares the layer, then correct positioning for the popover's fixed, viewport-anchored containing block. flatpickr fires `onOpen` *before* it positions the calendar and uses document coordinates (input viewport position + page scroll), so the correction runs in a `requestAnimationFrame` (after positioning, before paint — no flicker) and strips the scroll offset back out.
- **tippy** (`application.js` global init + `tippy_controller.js`): set `appendTo` to the nearest top-layer ancestor. Popper positions correctly against a fixed container, so no manual offset math is needed.

Outside modals both paths are a no-op (`nearestTopLayer` returns `null` → falls back to `<body>`), so normal behavior is unchanged.

## Verification

Tested in the dummy app with the page scrolled (the real failure condition):

- **Date picker in an action modal** now opens snug under the input and floats above the modal content; positioned correctly despite the page scroll offset.
- **Tippy tooltip inside a modal** mounts into the modal and renders above it, placed next to its trigger.
- **Regression**: on a normal edit page the calendar still appends to `<body>` and behaves exactly as before.

## Notes / follow-ups

- The **tags field** (Tagify) has the same root cause but is *not* fixed here — Tagify's own offset-chain positioning fights the modal's nested `fixed`/`relative`/`transform` contexts (pointing its dropdown at the modal mis-positions it vertically), so it needs a dedicated fix that fully owns positioning. Tracked separately.
- **Combobox** (`avo-combobox_field`) and **searchable belongs_to** (`avo-advanced`) live in other gems and should be checked there with the same lens.
- Code/EasyMDE editors are inline (no body-appended popups); native `<select>`/country render in the top layer already — all safe.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/avo-hq/codesmith/avo/pr/4565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783866828&installation_id=139851646&pr_number=4565&repository=avo-hq%2Favo&return_to=https%3A%2F%2Fgithub.com%2Favo-hq%2Favo%2Fpull%2F4565&signature=78e8fc0136e780db277d0c2fc0e811f91ffd29d3d906f2ac8eb573618b0815a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped front-end overlay mounting with body fallback; flatpickr positioning tweak only runs inside top-layer ancestors.
> 
> **Overview**
> Fixes floating UI (flatpickr calendars and tippy tooltips) painting **under** native top-layer modals (`popover` / `dialog`) when libraries append to `<body>`.
> 
> Introduces **`nearestTopLayer`** as the shared `[popover], dialog` lookup. **Tippy** (global `initTippy` and the Stimulus `tippy` controller) now uses `appendTo` to mount into that ancestor when present, otherwise `<body>`. **Flatpickr** gets a one-time **`flatpickr.setDefaults`** hook (loaded via `date_field_controller`): move the calendar into the top-layer container on ready, then on open adjust top/left in a `requestAnimationFrame` to drop page scroll offset so placement stays correct inside fixed modals.
> 
> Outside modals behavior is unchanged (`null` → body). Dummy action adds a commented date/tippy field for manual overlay testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0841416ecfa8d0d2d8e3014da481be8375fc09b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->