### PR TITLE
feat: add config.associations namespace for frame loading and lookup limit

### DIFF
--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -324,18 +324,22 @@ module Avo
     end
 
     def select_options(query)
-      query.all.limit(Avo.configuration.associations_lookup_list_limit).map do |record|
+      lookup_list_limit = Avo.configuration.associations[:lookup_list_limit]
+
+      query.all.limit(lookup_list_limit).map do |record|
         [@attachment_resource.new(record: record).record_title, record.to_param]
       end.tap do |options|
-        options << t("avo.more_records_available") if options.size == Avo.configuration.associations_lookup_list_limit
+        options << t("avo.more_records_available") if options.size == lookup_list_limit
       end
     end
 
     def checkbox_list_options(query)
-      query.all.limit(Avo.configuration.associations_lookup_list_limit).map do |record|
+      lookup_list_limit = Avo.configuration.associations[:lookup_list_limit]
+
+      query.all.limit(lookup_list_limit).map do |record|
         checkbox_list_option(record)
       end.tap do |options|
-        if options.size == Avo.configuration.associations_lookup_list_limit
+        if options.size == lookup_list_limit
           options << {title: t("avo.more_records_available"), hint: true}
         end
       end

--- a/lib/avo/concerns/frame_loading_mode.rb
+++ b/lib/avo/concerns/frame_loading_mode.rb
@@ -39,7 +39,7 @@ module Avo
       # How long a manual frame remembers an opened frame when neither the field
       # nor the global config pins an explicit `auto_load_for`.
       def default_manual_auto_load_for
-        frame_loading_defaults[:auto_load_for] || 15.minutes
+        frame_loading_defaults.fetch(:auto_load_for, 15.minutes)
       end
 
       # The cold-start render mode: `:manual`, `:lazy`, or `nil` when unset.

--- a/lib/avo/concerns/frame_loading_mode.rb
+++ b/lib/avo/concerns/frame_loading_mode.rb
@@ -22,8 +22,8 @@
 #
 # When no per-call `loading:` is given, the host's `frame_loading_defaults`
 # supply the fallback. Association fields read them from
-# `Avo.configuration.associations = {frames: {load_mode:, auto_load_for:}}`
-# (default `load_mode: :lazy`); tabs have no global default and stay eager.
+# `Avo.configuration.associations = {frames: {loading:, auto_load_for:}}`
+# (default `loading: :lazy`); tabs have no global default and stay eager.
 module Avo
   module Concerns
     module FrameLoadingMode
@@ -55,7 +55,7 @@ module Avo
           elsif @loading.present?
             @loading.to_sym
           else
-            frame_loading_defaults[:load_mode]
+            frame_loading_defaults[:loading]
           end
       end
 

--- a/lib/avo/concerns/frame_loading_mode.rb
+++ b/lib/avo/concerns/frame_loading_mode.rb
@@ -2,10 +2,11 @@
 #
 # `loading:` accepts either a symbol shorthand or a Hash:
 #
-#   loading: :manual                                  # placeholder + Load button
-#   loading: {mode: :manual}                          # same as above
-#   loading: {mode: :manual, auto_load_for: 5.minutes} # + sliding auto-load memory
-#   loading: {mode: :lazy}                            # native lazy (loads on reveal)
+#   loading: :manual                                   # placeholder + Load button, 15 min memory
+#   loading: {mode: :manual}                           # same as above
+#   loading: {mode: :manual, auto_load_for: 5.minutes} # custom sliding auto-load memory
+#   loading: {mode: :manual, auto_load_for: 0}         # opt out — frame closes on next refresh
+#   loading: {mode: :lazy}                             # native lazy (loads on reveal)
 #
 # This is orthogonal to the eager/lazy string returned by
 # `Avo::Fields::Concerns::FrameLoading#turbo_frame_loading` — `manual?` is a
@@ -15,15 +16,36 @@
 # frame, a short-lived cookie (scoped per record + frame) remembers it, and the
 # server renders a real auto-loading `<turbo-frame src>` — no placeholder, no
 # Load button — on return for that duration. The window slides via the cookie's
-# refreshed max-age. v1 honors `auto_load_for` for `:manual` only.
+# refreshed max-age. Manual frames default to a 15-minute window; pass an
+# explicit `auto_load_for: 0` (or `nil`) to opt out. v1 honors `auto_load_for`
+# for `:manual` only.
+#
+# When no per-call `loading:` is given, the host's `frame_loading_defaults`
+# supply the fallback. Association fields read them from
+# `Avo.configuration.associations = {frames: {load_mode:, auto_load_for:}}`
+# (default `load_mode: :lazy`); tabs have no global default and stay eager.
 module Avo
   module Concerns
     module FrameLoadingMode
       extend ActiveSupport::Concern
 
+      # Global defaults this host falls back to when no per-call `loading:` is
+      # given. Tabs have none (keeping the eager-inline default); association
+      # fields override this to read `Avo.configuration.associations[:frames]`.
+      def frame_loading_defaults
+        {}
+      end
+
+      # How long a manual frame remembers an opened frame when neither the field
+      # nor the global config pins an explicit `auto_load_for`.
+      def default_manual_auto_load_for
+        frame_loading_defaults[:auto_load_for] || 15.minutes
+      end
+
       # The cold-start render mode: `:manual`, `:lazy`, or `nil` when unset.
       # A Hash without an explicit `mode:` defaults to `:manual`, so
-      # `loading: {auto_load_for: 5.minutes}` is "manual + memory".
+      # `loading: {auto_load_for: 5.minutes}` is "manual + memory". With no
+      # per-call `loading:` at all, fall back to the host's global default.
       def loading_mode
         return @loading_mode if defined?(@loading_mode)
 
@@ -32,6 +54,8 @@ module Avo
             (@loading.symbolize_keys[:mode] || :manual).to_sym
           elsif @loading.present?
             @loading.to_sym
+          else
+            frame_loading_defaults[:load_mode]
           end
       end
 
@@ -47,12 +71,29 @@ module Avo
       end
 
       # Seconds the browser should remember the opened frame and auto-load it on
-      # return (sliding window). `nil` unless a `loading: {auto_load_for: …}` Hash
-      # was given. Accepts an `ActiveSupport::Duration` or a raw integer.
+      # return (sliding window). Accepts an `ActiveSupport::Duration` or a raw
+      # integer. Returns `nil` (no memory window) when the frame isn't manual.
+      #
+      # Manual frames default to `default_manual_auto_load_for`. A developer can
+      # override the window — or opt out entirely with `auto_load_for: 0`/`nil`,
+      # which closes the frame again on the next refresh.
       def auto_load_for
-        return unless @loading.is_a?(Hash)
+        return @auto_load_for if defined?(@auto_load_for)
 
-        @loading.symbolize_keys[:auto_load_for]&.to_i
+        options = @loading.is_a?(Hash) ? @loading.symbolize_keys : {}
+
+        window =
+          if options.key?(:auto_load_for)
+            # An explicit per-field value wins, including `0`/`nil` (opt out).
+            options[:auto_load_for]
+          elsif manual?
+            # Otherwise manual frames fall back to the configured default window.
+            default_manual_auto_load_for
+          end
+
+        # `0`/`nil` (or a negative) means "no memory" — close again on refresh.
+        seconds = window&.to_i
+        @auto_load_for = (seconds if seconds&.positive?)
       end
     end
   end

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -236,7 +236,10 @@ module Avo
         lookup_list_limit: 1000,
         frames: {
           loading: :lazy,
-          auto_load_for: 15.minutes
+          # 15 minutes, in seconds. Kept as a literal (not `15.minutes`) because
+          # this constant is evaluated at require time, before ActiveSupport's
+          # `Integer#minutes` core extension is guaranteed to be loaded.
+          auto_load_for: 15 * 60
         }
       }.freeze
     end

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -228,14 +228,14 @@ module Avo
     # lookup before Avo shows the "more records available" notice.
     #
     # `frames` controls association turbo frames (has_one, has_many, habtm).
-    # `load_mode` is the cold-start render mode when a field doesn't set its own
+    # `loading` is the cold-start render mode when a field doesn't set its own
     # `loading:` — `:lazy` (loads on reveal) or `:manual` (placeholder + Load
     # button). `auto_load_for` is the manual memory window (see FrameLoadingMode).
     unless defined?(ASSOCIATIONS_DEFAULTS)
       ASSOCIATIONS_DEFAULTS = {
         lookup_list_limit: 1000,
         frames: {
-          load_mode: :lazy,
+          loading: :lazy,
           auto_load_for: 15.minutes
         }
       }.freeze

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -11,6 +11,7 @@ module Avo
     attr_writer :persistence
     attr_writer :resource_row_controls_config
     attr_writer :hotkeys
+    attr_writer :associations
     # When unset, Tailwind scans Rails.root.join("app"). Each entry is an absolute path or a path relative to Rails.root.
     attr_writer :tailwindcss_content_sources
     attr_accessor :timezone
@@ -55,7 +56,6 @@ module Avo
     attr_accessor :is_developer_method
     attr_accessor :search_results_count
     attr_accessor :first_sorting_option
-    attr_accessor :associations_lookup_list_limit
     attr_accessor :column_names_mapping
     attr_accessor :column_types_mapping
     attr_accessor :model_generator_hook
@@ -187,12 +187,12 @@ module Avo
       @is_developer_method = :is_developer?
       @search_results_count = 8
       @first_sorting_option = :desc # :desc or :asc
-      @associations_lookup_list_limit = 1000
       @exclude_from_status = []
       @column_names_mapping = {}
       @column_types_mapping = {}
       @resource_row_controls_config = {}
       @hotkeys = {}
+      @associations = {}
       @global_search = {
         enabled: true,
         navigation_section: true
@@ -222,12 +222,45 @@ module Avo
       }.freeze
     end
 
+    # Global defaults for associations.
+    #
+    # `lookup_list_limit` caps how many records are listed in a belongs_to/attach
+    # lookup before Avo shows the "more records available" notice.
+    #
+    # `frames` controls association turbo frames (has_one, has_many, habtm).
+    # `load_mode` is the cold-start render mode when a field doesn't set its own
+    # `loading:` — `:lazy` (loads on reveal) or `:manual` (placeholder + Load
+    # button). `auto_load_for` is the manual memory window (see FrameLoadingMode).
+    unless defined?(ASSOCIATIONS_DEFAULTS)
+      ASSOCIATIONS_DEFAULTS = {
+        lookup_list_limit: 1000,
+        frames: {
+          load_mode: :lazy,
+          auto_load_for: 15.minutes
+        }
+      }.freeze
+    end
+
     def resource_row_controls_config
       RESOURCE_ROW_CONTROLS_CONFIG_DEFAULTS.merge @resource_row_controls_config
     end
 
     def hotkeys
       HOTKEYS_DEFAULTS.merge @hotkeys
+    end
+
+    def associations
+      ASSOCIATIONS_DEFAULTS.deep_merge(@associations)
+    end
+
+    # Backward-compatible flat accessor — the canonical home is now
+    # `config.associations[:lookup_list_limit]`.
+    def associations_lookup_list_limit
+      associations[:lookup_list_limit]
+    end
+
+    def associations_lookup_list_limit=(value)
+      @associations[:lookup_list_limit] = value
     end
 
     # Authorization is enabled when:

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -121,10 +121,12 @@ module Avo
 
         query = scoped_target_query(resource, get_record)
 
-        query.all.limit(Avo.configuration.associations_lookup_list_limit).map do |record|
+        lookup_list_limit = Avo.configuration.associations[:lookup_list_limit]
+
+        query.all.limit(lookup_list_limit).map do |record|
           [resource.new(record: record).record_title, record.to_param]
         end.tap do |options|
-          options << t("avo.more_records_available") if options.size == Avo.configuration.associations_lookup_list_limit
+          options << t("avo.more_records_available") if options.size == lookup_list_limit
         end
       end
 

--- a/lib/avo/fields/frame_base_field.rb
+++ b/lib/avo/fields/frame_base_field.rb
@@ -32,7 +32,7 @@ module Avo
           .to_s
       end
 
-      # Association frames inherit their cold-start defaults (`load_mode`,
+      # Association frames inherit their cold-start defaults (`loading`,
       # `auto_load_for`) from `config.associations = {frames: {...}}` when the
       # field itself doesn't pass `loading:`. See Avo::Concerns::FrameLoadingMode.
       def frame_loading_defaults

--- a/lib/avo/fields/frame_base_field.rb
+++ b/lib/avo/fields/frame_base_field.rb
@@ -32,6 +32,13 @@ module Avo
           .to_s
       end
 
+      # Association frames inherit their cold-start defaults (`load_mode`,
+      # `auto_load_for`) from `config.associations = {frames: {...}}` when the
+      # field itself doesn't pass `loading:`. See Avo::Concerns::FrameLoadingMode.
+      def frame_loading_defaults
+        Avo.configuration.associations.fetch(:frames, {})
+      end
+
       # The value
       def field_value
         value.send(database_value)

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -68,9 +68,6 @@ Avo.configure do |config|
   ## == Number of search results to display ==
   # config.search_results_count = 8
 
-  ## == Associations lookup list limit ==
-  # config.associations_lookup_list_limit = 1000
-
   ## == Cache options ==
   ## Provide a lambda to customize the cache store used by Avo.
   ## We compute the cache store by default, this is NOT the default, just an example.
@@ -104,6 +101,19 @@ Avo.configure do |config|
   # config.hotkeys = {
   #   enabled: true,          # Master switch: set to false to disable all keyboard shortcuts
   #   show_key_badges: true   # Set to false to hide inline kbd badge elements from the UI
+  # }
+
+  ## == Associations ==
+  # config.associations = {
+  #   # Cap how many records a belongs_to/attach lookup lists before showing the
+  #   # "more records available" notice.
+  #   lookup_list_limit: 1000,
+  #   # Cold-start loading for association turbo frames (has_one, has_many, habtm),
+  #   # used when a field doesn't set its own `loading:`.
+  #   frames: {
+  #     load_mode: :lazy,           # :lazy (load on reveal) or :manual (placeholder + Load button)
+  #     auto_load_for: 15.minutes   # how long a manual frame is remembered once opened (0/nil to disable)
+  #   }
   # }
 
   ## == Customization ==

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -111,7 +111,7 @@ Avo.configure do |config|
   #   # Cold-start loading for association turbo frames (has_one, has_many, habtm),
   #   # used when a field doesn't set its own `loading:`.
   #   frames: {
-  #     load_mode: :lazy,           # :lazy (load on reveal) or :manual (placeholder + Load button)
+  #     loading: :lazy,             # :lazy (load on reveal) or :manual (placeholder + Load button)
   #     auto_load_for: 15.minutes   # how long a manual frame is remembered once opened (0/nil to disable)
   #   }
   # }

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -160,7 +160,7 @@ Avo.configure do |config|
   # and also only on test environment, in dev it works fine
   config.alert_dismiss_time = Rails.env.test? ? 10000 : 5000
   config.search_results_count = 8
-  config.associations_lookup_list_limit = 1000
+  config.associations = {lookup_list_limit: 1000}
 
   ## == Menus ==
   if Rails.env.test?

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -35,6 +35,13 @@ Avo.configure do |config|
   # Shouldn't impact on community only if custom authorization service was configured.
   config.explicit_authorization = true
 
+  # config.associations = {
+  #   frames: {
+  #     loading: :manual
+  #     # auto_load_for: 15.minutes
+  #   }
+  # }
+
   ## == Customization ==
   config.id_links_to_resource = true
   # config.container_width = :small
@@ -160,7 +167,6 @@ Avo.configure do |config|
   # and also only on test environment, in dev it works fine
   config.alert_dismiss_time = Rails.env.test? ? 10000 : 5000
   config.search_results_count = 8
-  config.associations = {lookup_list_limit: 1000}
 
   ## == Menus ==
   if Rails.env.test?

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -37,7 +37,7 @@ Avo.configure do |config|
 
   # config.associations = {
   #   frames: {
-  #     loading: :manual
+  #     loading: :manual,
   #     # auto_load_for: 15.minutes
   #   }
   # }

--- a/spec/lib/avo/concerns/frame_loading_mode_spec.rb
+++ b/spec/lib/avo/concerns/frame_loading_mode_spec.rb
@@ -23,17 +23,37 @@ RSpec.describe Avo::Concerns::FrameLoadingMode do
   describe "symbol shorthand loading: :manual" do
     subject { tab(:manual) }
 
-    it "is manual with no memory window (backward compatible)" do
+    it "is manual and defaults to a 15-minute memory window" do
       expect(subject.manual?).to be true
       expect(subject.loading_mode).to eq(:manual)
-      expect(subject.auto_load_for).to be_nil
+      expect(subject.auto_load_for).to eq(15.minutes.to_i)
     end
   end
 
   describe "hash loading: {mode: :manual}" do
     subject { tab({mode: :manual}) }
 
-    it "is manual with no memory window" do
+    it "is manual and defaults to a 15-minute memory window" do
+      expect(subject.manual?).to be true
+      expect(subject.loading_mode).to eq(:manual)
+      expect(subject.auto_load_for).to eq(15.minutes.to_i)
+    end
+  end
+
+  describe "hash loading: {mode: :manual, auto_load_for: 0}" do
+    subject { tab({mode: :manual, auto_load_for: 0}) }
+
+    it "is manual but opts out of the memory window" do
+      expect(subject.manual?).to be true
+      expect(subject.loading_mode).to eq(:manual)
+      expect(subject.auto_load_for).to be_nil
+    end
+  end
+
+  describe "hash loading: {mode: :manual, auto_load_for: nil}" do
+    subject { tab({mode: :manual, auto_load_for: nil}) }
+
+    it "is manual but opts out of the memory window" do
       expect(subject.manual?).to be true
       expect(subject.loading_mode).to eq(:manual)
       expect(subject.auto_load_for).to be_nil

--- a/spec/lib/avo/fields/frame_base_field_spec.rb
+++ b/spec/lib/avo/fields/frame_base_field_spec.rb
@@ -1,6 +1,15 @@
 require "rails_helper"
 
 RSpec.describe Avo::Fields::FrameBaseField, type: :model do
+  # Pin the global association defaults so these specs assert field-level
+  # behavior regardless of what the dummy app configures. Contexts that need a
+  # different global config re-stub `associations` below.
+  before do
+    allow(Avo.configuration).to receive(:associations).and_return(
+      {lookup_list_limit: 1000, frames: {loading: :lazy, auto_load_for: 15.minutes}}
+    )
+  end
+
   describe "#manual?" do
     # has_many, has_one and habtm all inherit FrameBaseField, so they share the
     # `loading:` capture and the `manual?` predicate.
@@ -44,7 +53,7 @@ RSpec.describe Avo::Fields::FrameBaseField, type: :model do
       Avo::Fields::HasManyField.new(:comments)
     end
 
-    context "with the default config (load_mode: :lazy)" do
+    context "with the default config (loading: :lazy)" do
       it "renders the association lazily, not manually, with no memory window" do
         field = field_without_loading
 
@@ -55,10 +64,10 @@ RSpec.describe Avo::Fields::FrameBaseField, type: :model do
       end
     end
 
-    context "when load_mode is globally set to :manual" do
+    context "when loading is globally set to :manual" do
       before do
         allow(Avo.configuration).to receive(:associations).and_return(
-          {frames: {load_mode: :manual, auto_load_for: 15.minutes}}
+          {frames: {loading: :manual, auto_load_for: 15.minutes}}
         )
       end
 
@@ -80,7 +89,7 @@ RSpec.describe Avo::Fields::FrameBaseField, type: :model do
     context "when auto_load_for is globally set to 0 (opt out)" do
       before do
         allow(Avo.configuration).to receive(:associations).and_return(
-          {frames: {load_mode: :manual, auto_load_for: 0}}
+          {frames: {loading: :manual, auto_load_for: 0}}
         )
       end
 

--- a/spec/lib/avo/fields/frame_base_field_spec.rb
+++ b/spec/lib/avo/fields/frame_base_field_spec.rb
@@ -36,4 +36,60 @@ RSpec.describe Avo::Fields::FrameBaseField, type: :model do
       end
     end
   end
+
+  # Association frames fall back to `config.associations = {frames: {...}}` when
+  # the field doesn't pass its own `loading:`. A per-field `loading:` always wins.
+  describe "global config fallback (config.associations.frames)" do
+    def field_without_loading
+      Avo::Fields::HasManyField.new(:comments)
+    end
+
+    context "with the default config (load_mode: :lazy)" do
+      it "renders the association lazily, not manually, with no memory window" do
+        field = field_without_loading
+
+        expect(field.loading_mode).to eq(:lazy)
+        expect(field.lazy_loading_mode?).to be true
+        expect(field.manual?).to be false
+        expect(field.auto_load_for).to be_nil
+      end
+    end
+
+    context "when load_mode is globally set to :manual" do
+      before do
+        allow(Avo.configuration).to receive(:associations).and_return(
+          {frames: {load_mode: :manual, auto_load_for: 15.minutes}}
+        )
+      end
+
+      it "makes un-annotated associations manual with the configured window" do
+        field = field_without_loading
+
+        expect(field.manual?).to be true
+        expect(field.auto_load_for).to eq(15.minutes.to_i)
+      end
+
+      it "still lets a per-field loading: override the global default" do
+        field = Avo::Fields::HasManyField.new(:comments, loading: {mode: :lazy})
+
+        expect(field.manual?).to be false
+        expect(field.lazy_loading_mode?).to be true
+      end
+    end
+
+    context "when auto_load_for is globally set to 0 (opt out)" do
+      before do
+        allow(Avo.configuration).to receive(:associations).and_return(
+          {frames: {load_mode: :manual, auto_load_for: 0}}
+        )
+      end
+
+      it "is manual but carries no memory window" do
+        field = field_without_loading
+
+        expect(field.manual?).to be true
+        expect(field.auto_load_for).to be_nil
+      end
+    end
+  end
 end

--- a/spec/lib/avo/fields/frame_base_field_spec.rb
+++ b/spec/lib/avo/fields/frame_base_field_spec.rb
@@ -100,5 +100,20 @@ RSpec.describe Avo::Fields::FrameBaseField, type: :model do
         expect(field.auto_load_for).to be_nil
       end
     end
+
+    context "when auto_load_for is globally set to nil (opt out)" do
+      before do
+        allow(Avo.configuration).to receive(:associations).and_return(
+          {frames: {loading: :manual, auto_load_for: nil}}
+        )
+      end
+
+      it "is manual but carries no memory window" do
+        field = field_without_loading
+
+        expect(field.manual?).to be true
+        expect(field.auto_load_for).to be_nil
+      end
+    end
   end
 end

--- a/spec/system/avo/group_1/manual_loading_memory_spec.rb
+++ b/spec/system/avo/group_1/manual_loading_memory_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe "Manual loading memory (auto_load_for)", type: :system do
     end
   end
 
-  describe "loading: :manual (no memory window)" do
-    it "shows the Load button again on every visit" do
+  describe "loading: :manual (defaults to a 15-minute memory window)" do
+    it "server-renders a real auto-loading frame (no Load button) on a return visit" do
       Avo::Resources::User.with_temporary_items do
         field :first_name, as: :text
         field :comments, as: :has_many, loading: :manual
@@ -60,7 +60,33 @@ RSpec.describe "Manual loading memory (auto_load_for)", type: :system do
       wait_for_loaded
       expect(page).to have_selector("turbo-frame[id='has_many_field_show_comments'] [data-resource-name='comments'][data-resource-id='#{comment.id}']")
 
-      # No window -> no memory. The placeholder returns on the next visit.
+      # The default window remembers the opened frame: the next visit auto-loads
+      # it directly (a real `<turbo-frame src>`), with no Load button.
+      visit avo.resources_user_path(user)
+      wait_for_loaded
+
+      reloaded = find('turbo-frame[id="has_many_field_show_comments"]', visible: :all)
+      expect(reloaded[:src]).to be_present
+      expect(reloaded["data-manual-frame"]).to be_nil
+      expect(page).not_to have_button("Load Comments")
+    ensure
+      Avo::Resources::User.restore_items_from_backup
+    end
+  end
+
+  describe "loading: {mode: :manual, auto_load_for: 0} (opt out of memory)" do
+    it "shows the Load button again on every visit" do
+      Avo::Resources::User.with_temporary_items do
+        field :first_name, as: :text
+        field :comments, as: :has_many, loading: {mode: :manual, auto_load_for: 0}
+      end
+
+      visit avo.resources_user_path(user)
+      within('turbo-frame[id="has_many_field_show_comments"]') { click_on "Load Comments" }
+      wait_for_loaded
+      expect(page).to have_selector("turbo-frame[id='has_many_field_show_comments'] [data-resource-name='comments'][data-resource-id='#{comment.id}']")
+
+      # Opted out -> no memory. The placeholder returns on the next visit.
       visit avo.resources_user_path(user)
 
       frame = find('turbo-frame[id="has_many_field_show_comments"]')


### PR DESCRIPTION
## What

Introduces a `config.associations` namespace in the Avo initializer and refactors how association turbo frames resolve their loading behavior.

### Manual frame memory window

`loading: :manual` now defaults to a **15-minute auto-load memory window**. Once the user opens a manual frame, a short-lived per-record cookie remembers it and the server renders a real auto-loading `<turbo-frame src>` on return (no placeholder, no Load button) for that window.

Opt out explicitly:

```ruby
field :comments, as: :has_many, loading: {mode: :manual, auto_load_for: 0} # or nil
```

`0`/`nil` closes the frame again on the next refresh (the previous default).

### Global config

```ruby
config.associations = {
  lookup_list_limit: 1000,
  frames: {
    load_mode: :lazy,         # :lazy (load on reveal) or :manual (placeholder + Load button)
    auto_load_for: 15.minutes # manual memory window (0/nil to disable)
  }
}
```

- **`frames.load_mode`** is the cold-start render mode for association fields (`has_one`/`has_many`/`habtm`) that don't set their own `loading:`. Per-field `loading:` always wins. Tabs keep their eager-inline default (they're not associations).
- **`frames.auto_load_for`** is the global default manual memory window.
- **`lookup_list_limit`** is the former `config.associations_lookup_list_limit`, now folded into this namespace.

## Behavior changes

> [!IMPORTANT]
> The default `load_mode: :lazy` flips **top-level association fields from eager to lazy**. Associations inside tabs were already lazy. If we'd rather keep eager as the out-of-the-box default, change `ASSOCIATIONS_DEFAULTS[:frames][:load_mode]` to `:eager`.

- `loading: :manual` previously had **no** memory window; it now defaults to 15 minutes. The old behavior is `auto_load_for: 0`.
- `config.associations_lookup_list_limit` is kept as a backward-compatible delegating accessor, so existing initializers keep working. Canonical home is `config.associations[:lookup_list_limit]`.

## How it works

- `Avo::Concerns::FrameLoadingMode` gained a `frame_loading_defaults` hook (empty for tabs). `loading_mode` falls back to it; `auto_load_for` applies a positivity gate to both the explicit and the default branches so a `0`/`nil` (per-field or global) disables the window.
- `Avo::Fields::FrameBaseField#frame_loading_defaults` reads `Avo.configuration.associations[:frames]`.
- `Avo::Configuration#associations` deep-merges user overrides onto `ASSOCIATIONS_DEFAULTS` (mirrors the existing `hotkeys` pattern).
- Internal lookup-limit readers (`belongs_to_field`, `associations_controller`) use the namespaced key.

## Tests

- Unit: manual default window, `auto_load_for: 0`/`nil` opt-out, and the global config fallback (default lazy, global `:manual`, per-field override, global `0`).
- System: updated the manual-loading memory spec to the new default; verified `has_many`/`has_one`/manual-loading and the lookup-limit specs (`associations_using_fields_api`, `checkbox_list_attach_modal`, `create_via_belongs_to`) stay green.
- Standard clean.

## Docs

Initializer template documents the new namespace. The docs site (separate repo) still needs a page for `config.associations` — happy to follow up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/avo-hq/codesmith/avo/pr/4566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783891370&installation_id=139851646&pr_number=4566&repository=avo-hq%2Favo&return_to=https%3A%2F%2Fgithub.com%2Favo-hq%2Favo%2Fpull%2F4566&signature=bf7fff12bd7069ad3b23156cef3cd661699e865cf4304486a47d40746a69a77a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default association frame loading flips to lazy and manual frames gain a 15-minute memory window, which changes show-page behavior for existing apps without explicit `loading:` settings.
> 
> **Overview**
> Introduces **`config.associations`** so belongs_to/attach lookups and association turbo frames (`has_one` / `has_many` / `habtm`) share one initializer namespace. **`lookup_list_limit`** replaces the old flat setting (the legacy accessor still delegates). **`frames.loading`** and **`frames.auto_load_for`** apply when a field omits its own `loading:`.
> 
> **Notable default shifts:** association fields without `loading:` now cold-start as **`:lazy`** instead of eager inline. **`loading: :manual`** gains a **15-minute** “remember opened frame” window (cookie-backed auto `<turbo-frame src>` on return); the prior no-memory behavior is **`auto_load_for: 0`** or **`nil`**.
> 
> `FrameLoadingMode` falls back through `frame_loading_defaults`; association fields pull that from `config.associations[:frames]`. Docs in the generator initializer template; specs cover defaults, opt-out, and global overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43f64a126261352aeb91d58821d5687b857de716. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->