### PR TITLE
fix: enforce attach authorization on association create (GHSA-8fq9-273g-6mrg)

### DIFF
--- a/app/controllers/avo/associations_controller.rb
+++ b/app/controllers/avo/associations_controller.rb
@@ -14,7 +14,7 @@ module Avo
     before_action :set_attachment_record, only: [:create, :destroy]
     before_action :set_attach_fields, only: [:new, :create]
     before_action :authorize_index_action, only: :index
-    before_action :authorize_attach_action, only: :new
+    before_action :authorize_attach_action, only: [:new, :create]
     before_action :authorize_detach_action, only: :destroy
 
     layout :choose_layout


### PR DESCRIPTION
## Summary

- Enforce `attach_<association>?` authorization on `AssociationsController#create`, not only on `new`
- Closes the authorization bypass reported in [GHSA-8fq9-273g-6mrg](https://github.com/avo-hq/avo/security/advisories/GHSA-8fq9-273g-6mrg) where authenticated users could attach related records via direct POST while the attach form was policy-denied

## Details

`authorize_attach_action` was bound only to `new`, but the actual mutation happens in `create`. Detach was already protected on `destroy`; this aligns attach with that pattern.

## Test plan

- [x] Regression spec added in avo-pro: https://github.com/avo-hq/avo-pro/pull/178
- [x] Spec fails before this change (POST attaches despite denied `attach_team_members?`)
- [x] Spec passes after this change

```bash
cd avo-pro
bundle exec rspec spec/features/avo_pro/association_attach_bypass_spec.rb
```