### PR TITLE
Add PluginManager#register_menu_item DSL

### DIFF
--- a/lib/avo/plugin_manager.rb
+++ b/lib/avo/plugin_manager.rb
@@ -33,6 +33,18 @@ module Avo
       Avo.field_manager.load_field method_name, klass
     end
 
+    # Register a custom menu DSL method (e.g. `form`) contributed by a plugin,
+    # so it can be used inside `config.main_menu` and friends. Delegates to
+    # avo-menu's builder when it's installed; a no-op otherwise, so plugins can
+    # register unconditionally. The block is evaluated in the menu builder's
+    # context, so it can call `link`, `resource`, etc. See
+    # Avo::Menu::Builder.register_item.
+    def register_menu_item(name, &block)
+      return unless defined?(Avo::Menu::Builder)
+
+      Avo::Menu::Builder.register_item(name, &block)
+    end
+
     def register_resource_tool
     end
 


### PR DESCRIPTION
## What

Adds `Avo::PluginManager#register_menu_item`, letting plugins register a custom menu DSL method (e.g. `form`) that can then be used inside `config.main_menu` and friends.

## How it works

- Delegates to `Avo::Menu::Builder.register_item` when avo-menu is installed.
- No-op when avo-menu is absent, so plugins can call it unconditionally.
- The block is evaluated in the menu builder's context, so it can call `link`, `resource`, etc.

## Changes

- `lib/avo/plugin_manager.rb` — new `register_menu_item(name, &block)` method.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/avo-hq/codesmith/avo/pr/4571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784110977&installation_id=139851646&pr_number=4571&repository=avo-hq%2Favo&return_to=https%3A%2F%2Fgithub.com%2Favo-hq%2Favo%2Fpull%2F4571&signature=a656b8622950cd08489539a2d76aebb2b1d67bede1d84806676fbe19ae131b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single optional delegation hook in plugin registration with a defined? guard; no changes to core auth, data, or menu rendering paths in this diff.
> 
> **Overview**
> Adds **`Avo::PluginManager#register_menu_item(name, &block)`** so plugins can expose custom menu DSL methods (e.g. `form`) inside `config.main_menu` and related blocks.
> 
> When **avo-menu** is loaded, registration forwards to **`Avo::Menu::Builder.register_item`**; if the menu builder is not defined, the call is a **no-op**, so plugins can register without checking for the gem. The supplied block runs in the menu builder context and can use existing helpers like `link` and `resource`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a105a91af421b43d92c95bc25ed952a9db189375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->