### PR TITLE
Give first menu item more space when it's a link

### DIFF
--- a/app/assets/stylesheets/css/sidebar.css
+++ b/app/assets/stylesheets/css/sidebar.css
@@ -152,6 +152,12 @@
   @apply py-1.5 my-px;
 }
 
+/* When the first menu item is a link (not a section), give it a bit more
+   breathing room from the top so it doesn't hug the sidebar's edge. */
+.sidebar__body-content > .sidebar-link:first-child {
+  @apply mt-3;
+}
+
 .sidebar-link:hover {
   color: var(--sidebar-content);
   background-color: var(--sidebar-link-hover-background);


### PR DESCRIPTION
## What

When the first item in the sidebar is a **link** (rather than a section), it sat flush against the top of the sidebar. Sections already get top spacing via `.sidebar-section { not-first:mt-4 }`, but a leading `.sidebar-link` only had `my-px`.

This adds a bit of top margin to a link that is the first child of the sidebar body, so it gets some breathing room from the edge.

## Where

`app/assets/stylesheets/css/sidebar.css`

```css
/* When the first menu item is a link (not a section), give it a bit more
   breathing room from the top so it doesn't hug the sidebar's edge. */
.sidebar__body-content > .sidebar-link:first-child {
  @apply mt-3;
}
```

Affects cases like the dev-only "Get started" link, "Media Library", or a custom sidebar whose first item is a link. Sections are untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/avo-hq/codesmith/avo/pr/4574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784145470&installation_id=139851646&pr_number=4574&repository=avo-hq%2Favo&return_to=https%3A%2F%2Fgithub.com%2Favo-hq%2Favo%2Fpull%2F4574&signature=4126e896ccb93986be7f02e18e68ba4fbed06871df51a3796cc18edf069fa9cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS spacing rule with a narrow selector; no behavior or security impact.
> 
> **Overview**
> Adds **`mt-3`** on `.sidebar__body-content > .sidebar-link:first-child` so a top-level link (not inside a section) isn’t flush with the top of the sidebar.
> 
> Sections already get spacing via `.sidebar-section { not-first:mt-4 }`; this only affects menus that start with a bare link (e.g. dev “Get started”, Media Library, or custom sidebars).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9db0340817256904c05333fd697d572247a2015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->