### PR TITLE
Increase spacing between sidebar sections

### DIFF
--- a/app/assets/stylesheets/css/sidebar.css
+++ b/app/assets/stylesheets/css/sidebar.css
@@ -83,7 +83,7 @@
 /* ================================================ */
 
 .sidebar-section {
-  @apply not-first:mt-4;
+  @apply not-first:mt-5;
 }
 
 .sidebar-section__header {


### PR DESCRIPTION
Bumps the vertical gap between sidebar sections from `mt-4` to `mt-5` for a bit more breathing room between groups.

---

[![Compound Engineering v2.59.0](https://img.shields.io/badge/Compound_Engineering-v2.59.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.8 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/avo-hq/codesmith/avo/pr/4578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784284639&installation_id=139851646&pr_number=4578&repository=avo-hq%2Favo&return_to=https%3A%2F%2Fgithub.com%2Favo-hq%2Favo%2Fpull%2F4578&signature=0055d719b83dc435d5802f77242f4b82582b44aa963c8241b4ee730e83c11f7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single visual spacing tweak in sidebar CSS with no logic, data, or security impact.
> 
> **Overview**
> Increases vertical separation between stacked **sidebar sections** (`Sidebar::SectionComponent`) by changing `.sidebar-section` from `not-first:mt-4` to **`not-first:mt-5`**, so every section after the first gets a slightly larger top margin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c89b1fe4fb3b2774b5c29b57bf69ab944318ba9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->