### PR TITLE
Remove first-link top offset in sidebar sections and groups

### DIFF
--- a/app/assets/stylesheets/css/sidebar.css
+++ b/app/assets/stylesheets/css/sidebar.css
@@ -104,11 +104,6 @@
   @apply w-full flex flex-col;
 }
 
-/* Pull the first link a bit closer to the header above it */
-.sidebar-section__items > .sidebar-link:first-child {
-  @apply -mt-2;
-}
-
 /* Remove link gap when no items in the section have icons */
 .sidebar-section__items:not(:has(.sidebar-link__icon-wrapper)) .sidebar-link {
   @apply gap-0;
@@ -135,11 +130,6 @@
 
 .sidebar-group__items {
   @apply w-full flex flex-col;
-}
-
-/* Pull the first link a bit closer to the header above it */
-.sidebar-group__items > .sidebar-link:first-child {
-  @apply -mt-2;
 }
 
 /* Remove link gap when no items in the group have icons */


### PR DESCRIPTION
Removes the two `-mt-2` rules that pulled the first link in each sidebar section and group closer to the header above it, letting links sit at their natural spacing.

---

[![Compound Engineering v2.59.0](https://img.shields.io/badge/Compound_Engineering-v2.59.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.8 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/avo-hq/codesmith/avo/pr/4579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784285928&installation_id=139851646&pr_number=4579&repository=avo-hq%2Favo&return_to=https%3A%2F%2Fgithub.com%2Favo-hq%2Favo%2Fpull%2F4579&signature=4867c84b02613ae11c966fd86a4bdde944479fddb1206c4c9b5dc0d6eb8a0510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only spacing tweak in the sidebar with no logic, auth, or data impact.
> 
> **Overview**
> **Sidebar spacing** no longer pulls the first nav link under a section or group header upward with `-mt-2`.
> 
> The rules targeting `.sidebar-section__items > .sidebar-link:first-child` and `.sidebar-group__items > .sidebar-link:first-child` are removed from `sidebar.css`, so the gap between headers and their first link follows default link/layout spacing instead of the tighter offset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a922fd92f936ebe210fbdf7e854330824ad332e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->