### PR TITLE
Speed up Tests CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,14 +168,14 @@ jobs:
           - name: group_3
             display: Group 3
             rspec_paths: spec/system/avo/group_3
-        # Only the matrix corners (oldest and newest) run the full system suite;
-        # the cross-combos rarely surface version-specific failures the corners
-        # don't already catch. Halves this job class from 12 runs to 6.
-        exclude:
-          - ruby: '3.3'
-            rails: '8.0'
-          - ruby: '3.4'
-            rails: '7.1'
+      # Only the matrix corners (oldest and newest) run the full system suite;
+      # the cross-combos rarely surface version-specific failures the corners
+      # don't already catch. Halves this job class from 12 runs to 6.
+      exclude:
+        - ruby: '3.3'
+          rails: '8.0'
+        - ruby: '3.4'
+          rails: '7.1'
     runs-on: blacksmith-8vcpu-ubuntu-2404
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -169,14 +169,14 @@ jobs:
           - name: group_3
             display: Group 3
             rspec_paths: spec/system/avo/group_3
-      # Only the matrix corners (oldest and newest) run the full system suite;
-      # the cross-combos rarely surface version-specific failures the corners
-      # don't already catch. Halves this job class from 12 runs to 6.
-      exclude:
-        - ruby: '3.3'
-          rails: '8.0'
-        - ruby: '3.4'
-          rails: '7.1'
+        # Only the matrix corners (oldest and newest) run the full system suite;
+        # the cross-combos rarely surface version-specific failures the corners
+        # don't already catch. Halves this job class from 12 runs to 6.
+        exclude:
+          - ruby: '3.3'
+            rails: '8.0'
+          - ruby: '3.4'
+            rails: '7.1'
     runs-on: blacksmith-8vcpu-ubuntu-2404
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,30 +32,15 @@ env:
 
 jobs:
   # ----------------------------------------------------------------------------
-  # Feature and request specs
+  # Build assets once
+  #
+  # The esbuild/Tailwind output in app/assets/builds/avo is identical across the
+  # Ruby/Rails matrix, so build it a single time here and share it with every
+  # test job via an artifact. The test jobs then need no Node/yarn at all.
   # ----------------------------------------------------------------------------
-  feature:
-    name: feature (Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails }})
-    strategy:
-      matrix:
-        ruby:
-          - '3.3'
-          - '3.4'
-        rails:
-          - '7.1'
-          - '8.0'
+  build_assets:
+    name: Build assets
     runs-on: blacksmith-4vcpu-ubuntu-2404
-
-    env:
-      RAILS_VERSION: ${{ matrix.rails }}
-      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_${{ matrix.rails }}_ruby_${{ matrix.ruby }}.gemfile
-
-    services:
-      postgres:
-        image: postgres:10.8
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - uses: actions/checkout@v4
@@ -64,34 +49,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-          bundler: default
-          ruby-version: ${{ matrix.ruby }}
-
-      - name: Prepare database
-        run: |
-          # Migrate the primary database first so schema.rb is regenerated
-          # once, single-threaded. Then have parallel workers load that
-          # schema instead of running migrations concurrently, which races
-          # on schema.rb writes (see #4564).
-          bundle exec rake db:create db:migrate
-          bundle exec rake parallel:create parallel:load_schema
-
-      - name: Get yarn cache directory path
-        id: test-yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        id: test-yarn-cache
-        with:
-          path: ${{ steps.test-yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-test-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-test-yarn-${{ hashFiles('**/yarn.lock') }}
+          cache: yarn
 
       - name: Yarn install the dummy app
         run: |
@@ -108,6 +66,66 @@ jobs:
         run: |
           yarn build
           yarn build:custom-js
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: avo-assets
+          path: app/assets/builds/avo
+          retention-days: 1
+
+  # ----------------------------------------------------------------------------
+  # Feature and request specs
+  # ----------------------------------------------------------------------------
+  feature:
+    name: feature (Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails }})
+    needs: build_assets
+    strategy:
+      matrix:
+        ruby:
+          - '3.3'
+          - '3.4'
+        rails:
+          - '7.1'
+          - '8.0'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    env:
+      RAILS_VERSION: ${{ matrix.rails }}
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_${{ matrix.rails }}_ruby_${{ matrix.ruby }}.gemfile
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          bundler: default
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: Download built assets
+        uses: actions/download-artifact@v4
+        with:
+          name: avo-assets
+          path: app/assets/builds/avo
+
+      - name: Prepare database
+        run: |
+          # Migrate the primary database first so schema.rb is regenerated
+          # once, single-threaded. Then have parallel workers load that
+          # schema instead of running migrations concurrently, which races
+          # on schema.rb writes (see #4564).
+          bundle exec rake db:create db:migrate
+          bundle exec rake parallel:create parallel:load_schema
 
       - name: Run tests
         id: run_tests
@@ -131,6 +149,7 @@ jobs:
   # ----------------------------------------------------------------------------
   system:
     name: system (Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails }}, ${{ matrix.spec_group.display }})
+    needs: build_assets
     strategy:
       matrix:
         ruby:
@@ -149,7 +168,15 @@ jobs:
           - name: group_3
             display: Group 3
             rspec_paths: spec/system/avo/group_3
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+        # Only the matrix corners (oldest and newest) run the full system suite;
+        # the cross-combos rarely surface version-specific failures the corners
+        # don't already catch. Halves this job class from 12 runs to 6.
+        exclude:
+          - ruby: '3.3'
+            rails: '8.0'
+          - ruby: '3.4'
+            rails: '7.1'
+    runs-on: blacksmith-8vcpu-ubuntu-2404
 
     env:
       RAILS_VERSION: ${{ matrix.rails }}
@@ -157,7 +184,9 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10.8
+        image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
@@ -165,17 +194,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
           bundler: default
           ruby-version: ${{ matrix.ruby }}
+
+      - name: Download built assets
+        uses: actions/download-artifact@v4
+        with:
+          name: avo-assets
+          path: app/assets/builds/avo
 
       - name: Prepare database
         run: |
@@ -185,34 +215,6 @@ jobs:
           # on schema.rb writes (see #4564).
           bundle exec rake db:create db:migrate
           bundle exec rake parallel:create parallel:load_schema
-
-      - name: Get yarn cache directory path
-        id: test-yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        id: test-yarn-cache
-        with:
-          path: ${{ steps.test-yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-test-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-test-yarn-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Yarn install the dummy app
-        run: |
-          cd spec/dummy
-          yarn
-
-      - name: Yarn install
-        run: yarn
-
-      - name: Build assets
-        env:
-          RAILS_ENV: production
-          NODE_ENV: production
-        run: |
-          yarn build
-          yarn build:custom-js
 
       - name: Run tests
         id: run_tests
@@ -236,6 +238,7 @@ jobs:
   # ----------------------------------------------------------------------------
   components:
     name: components (Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails }})
+    needs: build_assets
     strategy:
       matrix:
         ruby:
@@ -252,71 +255,46 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10.8
+        image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: 22
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          bundler: default
+          ruby-version: ${{ matrix.ruby }}
 
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true
-        bundler: default
-        ruby-version: ${{ matrix.ruby }}
+      - name: Download built assets
+        uses: actions/download-artifact@v4
+        with:
+          name: avo-assets
+          path: app/assets/builds/avo
 
-    - name: Prepare database
-      run: |
-        bin/rails db:create db:migrate
+      - name: Prepare database
+        run: |
+          bin/rails db:create db:migrate
 
-    - name: Get yarn cache directory path
-      id: test-yarn-cache-dir-path
-      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - name: Run tests
+        id: run_tests
+        run: bundle exec rspec spec/components
 
-    - uses: actions/cache@v4
-      id: test-yarn-cache
-      with:
-        path: ${{ steps.test-yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-test-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-test-yarn-${{ hashFiles('**/yarn.lock') }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage_components_${{ matrix.rails }}_ruby_${{ matrix.ruby }}
+          path: coverage/.resultset.json
 
-    - name: Yarn install the dummy app
-      run: |
-        cd spec/dummy
-        yarn
-
-    - name: Yarn install
-      run: yarn
-
-    - name: Build assets
-      env:
-        RAILS_ENV: production
-        NODE_ENV: production
-      run: |
-        yarn build
-        yarn build:custom-js
-
-    - name: Run tests
-      id: run_tests
-      run: bundle exec rspec spec/components
-
-    - uses: actions/upload-artifact@v4
-      with:
-        name: coverage_components_${{ matrix.rails }}_ruby_${{ matrix.ruby }}
-        path: coverage/.resultset.json
-
-    - uses: actions/upload-artifact@v4
-      if: always() && steps.run_tests.outcome == 'failure'
-      with:
-        name: rspec_failed_screenshots_rails_${{ matrix.rails }}_ruby_${{ matrix.ruby }}
-        path: ./spec/dummy/tmp/screenshots
+      - uses: actions/upload-artifact@v4
+        if: always() && steps.run_tests.outcome == 'failure'
+        with:
+          name: rspec_failed_screenshots_rails_${{ matrix.rails }}_ruby_${{ matrix.ruby }}
+          path: ./spec/dummy/tmp/screenshots
 
   # ----------------------------------------------------------------------------
   # i18n tests
@@ -335,40 +313,43 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10.8
+        image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true
-        bundler: default
-        ruby-version: ${{ matrix.ruby }}
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          bundler: default
+          ruby-version: ${{ matrix.ruby }}
 
-    - name: Run tests
-      id: run_tests
-      run: bundle exec rspec spec/system/avo/i18n_spec.rb
+      - name: Run tests
+        id: run_tests
+        run: bundle exec rspec spec/system/avo/i18n_spec.rb
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: coverage_system_${{ matrix.rails }}_ruby_${{ matrix.ruby }}
-        path: coverage/.resultset.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage_system_${{ matrix.rails }}_ruby_${{ matrix.ruby }}
+          path: coverage/.resultset.json
 
-    - uses: actions/upload-artifact@v4
-      if: always() && steps.run_tests.outcome == 'failure'
-      with:
-        name: rspec_failed_screenshots_rails_${{ matrix.rails }}_ruby_${{ matrix.ruby }}
-        path: ./spec/dummy/tmp/screenshots
+      - uses: actions/upload-artifact@v4
+        if: always() && steps.run_tests.outcome == 'failure'
+        with:
+          name: rspec_failed_screenshots_rails_${{ matrix.rails }}_ruby_${{ matrix.ruby }}
+          path: ./spec/dummy/tmp/screenshots
 
   # ----------------------------------------------------------------------------
   # Accessibility tests
   # ----------------------------------------------------------------------------
   accessibility:
     name: accessibility (Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails }})
+    needs: build_assets
     strategy:
       matrix:
         ruby:
@@ -383,62 +364,38 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10.8
+        image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: 22
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          bundler: default
+          ruby-version: ${{ matrix.ruby }}
 
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true
-        bundler: default
-        ruby-version: ${{ matrix.ruby }}
+      - name: Download built assets
+        uses: actions/download-artifact@v4
+        with:
+          name: avo-assets
+          path: app/assets/builds/avo
 
-    - name: Prepare database
-      run: |
-        bin/rails db:create db:migrate
+      - name: Prepare database
+        run: |
+          bin/rails db:create db:migrate
 
-    - name: Get yarn cache directory path
-      id: test-yarn-cache-dir-path
-      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - name: Run tests
+        id: run_tests
+        run: bundle exec rspec spec/a11y
 
-    - uses: actions/cache@v4
-      id: test-yarn-cache
-      with:
-        path: ${{ steps.test-yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-test-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-test-yarn-${{ hashFiles('**/yarn.lock') }}
-
-    - name: Yarn install the dummy app
-      run: |
-        cd spec/dummy
-        yarn
-
-    - name: Yarn install
-      run: yarn
-
-    - name: Build assets
-      env:
-        RAILS_ENV: production
-        NODE_ENV: production
-      run: |
-        yarn build
-
-    - name: Run tests
-      id: run_tests
-      run: bundle exec rspec spec/a11y
-
-    - uses: actions/upload-artifact@v4
-      if: always() && steps.run_tests.outcome == 'failure'
-      with:
-        name: rspec_failed_screenshots_a11y_${{ matrix.rails }}_ruby_${{ matrix.ruby }}
-        path: ./spec/dummy/tmp/screenshots
+      - uses: actions/upload-artifact@v4
+        if: always() && steps.run_tests.outcome == 'failure'
+        with:
+          name: rspec_failed_screenshots_a11y_${{ matrix.rails }}_ruby_${{ matrix.ruby }}
+          path: ./spec/dummy/tmp/screenshots

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,6 @@
 name: Tests
 
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,13 @@ jobs:
         rails:
           - '7.1'
           - '8.0'
+        # Only the matrix corners (oldest and newest) run; the cross-combos
+        # rarely surface version-specific failures the corners don't catch.
+        exclude:
+          - ruby: '3.3'
+            rails: '8.0'
+          - ruby: '3.4'
+            rails: '7.1'
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     env:
@@ -248,6 +255,13 @@ jobs:
         rails:
           - '7.1'
           - '8.0'
+        # Only the matrix corners (oldest and newest) run; the cross-combos
+        # rarely surface version-specific failures the corners don't catch.
+        exclude:
+          - ruby: '3.3'
+            rails: '8.0'
+          - ruby: '3.4'
+            rails: '7.1'
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     env:


### PR DESCRIPTION
## Why

The `Tests` workflow rebuilds identical JS/CSS assets in every one of its ~22 matrix jobs and runs a wide matrix on 4-vCPU runners. The asset output (`app/assets/builds/avo`) is purely esbuild/Tailwind and is independent of the Ruby/Rails version, so it can be built once and shared.

## What changed (`.github/workflows/tests.yml`)

1. **Build assets once → artifact.** New `build_assets` job installs Node deps and runs `yarn build && yarn build:custom-js`, uploading `app/assets/builds/avo` as the `avo-assets` artifact. `feature`, `system`, `components`, and `accessibility` now `needs: build_assets` and download the artifact instead of running `setup-node`, two `yarn` installs, and the build steps. Removes that work from ~21 job runs.
2. **Trim system matrix 12 → 6.** `exclude` drops the cross-combos (`3.3/8.0`, `3.4/7.1`), keeping the oldest and newest Ruby/Rails corners × 3 shard groups.
3. **Bigger runners for system specs.** Sharded `system` jobs now run on `blacksmith-8vcpu-ubuntu-2404` so `parallel_rspec` gets more cores.
4. **Postgres 10.8 → 16.** All services bumped, with `POSTGRES_HOST_AUTH_METHOD=trust` added to preserve the current passwordless `postgres` auth.

Also gives the yarn cache (in `build_assets`) a real `restore-keys` prefix instead of one that duplicated the exact key.

`i18n` is unchanged — it has no Node/asset steps today and passes without them.

## Verify on first run

- Confirm no asset-free test job shells out to `yarn`/`node` at runtime (Propshaft just serves the prebuilt files). `accessibility` now receives `build + build:custom-js` (a harmless superset of its previous `build`-only assets).
- Confirm Postgres 16 `trust` auth connects on the first `db:create`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/avo-hq/codesmith/avo/pr/4580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784291818&installation_id=139851646&pr_number=4580&repository=avo-hq%2Favo&return_to=https%3A%2F%2Fgithub.com%2Favo-hq%2Favo%2Fpull%2F4580&signature=a9115b343d693b23875bfdf8c98e2b28b2058763bb9a4b6604209889c9c8149e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fewer Ruby/Rails matrix combinations and shared prebuilt assets could miss version-specific failures or asset/runtime mismatches; Postgres 16 with trust auth is a CI-only change but affects every DB-backed job.
> 
> **Overview**
> **Speeds up the Tests GitHub Actions workflow** by building JS/CSS once and tightening how much CI runs.
> 
> A new **`build_assets`** job runs `yarn build` and `yarn build:custom-js`, uploads `app/assets/builds/avo`, and **`feature`**, **`system`**, **`components`**, and **`accessibility`** depend on it and download that artifact instead of setting up Node, installing yarn, and rebuilding on every matrix cell.
> 
> **Matrix coverage is reduced** on `feature`, `system`, and `components`: `exclude` drops the middle Ruby/Rails cross-combos so only the oldest/newest corners run (system goes from 12 jobs to 6). **System specs** move to **`blacksmith-8vcpu-ubuntu-2404`** runners.
> 
> **Postgres** service images are bumped from **10.8 to 16** with **`POSTGRES_HOST_AUTH_METHOD: trust`** on all jobs that use Postgres. **`i18n`** is unchanged (no asset download, still a single matrix cell).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af3a01c13481318486ee919e3b3a55a8b652fda0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->