### PR TITLE
Revert avo-records_reordering to avo-record_reordering (AVO-1364)

### DIFF
--- a/app/components/avo/index/resource_controls_component.rb
+++ b/app/components/avo/index/resource_controls_component.rb
@@ -143,8 +143,8 @@ class Avo::Index::ResourceControlsComponent < Avo::ResourceComponent
   end
 
   def render_order_controls(control)
-    if Avo.plugin_manager.installed?("avo-records_reordering") && try(:can_reorder?)
-      render Avo::RecordsReordering::ButtonsComponent.new resource: @resource, reflection: @reflection, view_type: @view_type
+    if Avo.plugin_manager.installed?("avo-record_reordering") && try(:can_reorder?)
+      render Avo::RecordReordering::ButtonsComponent.new resource: @resource, reflection: @reflection, view_type: @view_type
     end
   end
 

--- a/lib/tasks/avo_tasks.rake
+++ b/lib/tasks/avo_tasks.rake
@@ -100,7 +100,7 @@ task "avo:sym_link" do
   end
 
   gem_paths = `bundle list --paths 2>/dev/null`.split("\n")
-  ["avo-advanced", "avo-pro", "avo-advanced_search", "avo-authorization", "avo-records_reordering", "avo-dynamic_filters", "avo-dashboards", "avo-menu", "avo-kanban", "avo-forms"].each do |gem|
+  ["avo-advanced", "avo-pro", "avo-advanced_search", "avo-authorization", "avo-record_reordering", "avo-dynamic_filters", "avo-dashboards", "avo-menu", "avo-kanban", "avo-forms"].each do |gem|
     path = gem_paths.find { |gem_path| gem_path.include?("/#{gem}-") }
 
     # If path is nil we check if package is defined outside of root (on release process it is)


### PR DESCRIPTION
## Summary
- Restores plugin key and ordering controls component for `avo-record_reordering`
- Restores `avo:packages` rake task gem list entry

## Test plan
- [ ] Lint and tests pass on 4-dev

Made with [Cursor](https://cursor.com)