### PR TITLE
Extract reusable row background color tokens

### DIFF
--- a/app/assets/stylesheets/css/table.css
+++ b/app/assets/stylesheets/css/table.css
@@ -1,6 +1,7 @@
 /* The dance we need to do to be able to have rounded corners on an HTML table */
 .table-row {
   @apply rounded-ss-lg;
+  background: var(--color-row-bg);
 
   &:first-child {
     & > td:first-child {
@@ -39,24 +40,19 @@
   }
 
   &:hover {
-    background: var(--color-table-row-hover);
+    background: var(--color-row-bg-hover);
   }
-}
-
-@theme {
-  --color-table-row-selected: color-mix(in oklab, var(--color-primary), var(--color-content) 12%);
-  --color-table-row-hover: color-mix(in oklab, var(--color-primary), var(--color-content) 5%);
 }
 
 .shift-pressed {
   & .highlighted-row {
-    background: var(--color-table-row-selected);
+    background: var(--color-row-bg-selected);
   }
 }
 
 .table-row:hover.selected-row,
 .selected-row {
-  background: var(--color-table-row-hover);
+  background: var(--color-row-bg-hover);
 }
 
 .table-row.is-keyboard-focused {
@@ -65,10 +61,10 @@
 
 /* Reorder drag placeholder (SortableJS ghostClass) — theme-aware for dark mode. */
 .table-row--ghost {
-  background: var(--color-table-row-selected);
+  background: var(--color-row-bg-selected);
 
   & > td {
-    background: var(--color-table-row-selected);
+    background: var(--color-row-bg-selected);
   }
 }
 

--- a/app/assets/stylesheets/css/variables.css
+++ b/app/assets/stylesheets/css/variables.css
@@ -69,13 +69,11 @@
      content on top. Shared knob so any surface that needs a subtle hover state
      (table rows, etc.) reads from one place and stays per-scheme since it
      references --color-primary / --color-content. */
-  --color-hover-bg: color-mix(in oklab, var(--color-primary), var(--color-content) 5%);
-
-  /* Row surfaces. Base defaults to the primary surface; hover reuses the
-     shared --color-hover-bg tint; selected is a stronger content wash. All
-     resolve per-scheme via the underlying tokens. */
+  /* Row surfaces. Base defaults to the primary surface; hover is a faint
+     content wash; selected is a stronger one. All resolve per-scheme via the
+     underlying tokens. */
   --color-row-bg: var(--color-primary);
-  --color-row-bg-hover: var(--color-hover-bg);
+  --color-row-bg-hover: color-mix(in oklab, var(--color-primary), var(--color-content) 5%);
   --color-row-bg-selected: color-mix(in oklab, var(--color-primary), var(--color-content) 12%);
 
   --color-scheme: var(--color-white);

--- a/app/assets/stylesheets/css/variables.css
+++ b/app/assets/stylesheets/css/variables.css
@@ -65,6 +65,19 @@
   --color-content: var(--color-avo-neutral-950);
   --color-content-secondary: var(--color-avo-neutral-500);
 
+  /* Generic hover surface tint: the primary surface with a faint wash of
+     content on top. Shared knob so any surface that needs a subtle hover state
+     (table rows, etc.) reads from one place and stays per-scheme since it
+     references --color-primary / --color-content. */
+  --color-hover-bg: color-mix(in oklab, var(--color-primary), var(--color-content) 5%);
+
+  /* Row surfaces. Base defaults to the primary surface; hover reuses the
+     shared --color-hover-bg tint; selected is a stronger content wash. All
+     resolve per-scheme via the underlying tokens. */
+  --color-row-bg: var(--color-primary);
+  --color-row-bg-hover: var(--color-hover-bg);
+  --color-row-bg-selected: color-mix(in oklab, var(--color-primary), var(--color-content) 12%);
+
   --color-scheme: var(--color-white);
   --color-scheme-opposite: var(--color-black);
 

--- a/lib/avo/concerns/row_controls_configuration.rb
+++ b/lib/avo/concerns/row_controls_configuration.rb
@@ -27,14 +27,14 @@ module Avo
 
       def row_controls_classes
         float_classes = "bg-primary
-          group-hover:bg-table-row-hover
+          group-hover:bg-row-bg-hover
 
           sticky inset-auto end-0
 
           before:content-[''] before:absolute before:z-10 before:inset-auto before:start-0 before:top-0 before:mt-0 before:-translate-x-full before:w-3 before:h-full
           before:bg-gradient-to-r
           before:from-transparent before:to-primary
-          group-hover:before:from-transparent group-hover:before:to-table-row-hover
+          group-hover:before:from-transparent group-hover:before:to-row-bg-hover
         "
 
         # TODO: add this to the css classes above


### PR DESCRIPTION
## Summary

Row hover/selected backgrounds were inlined as `color-mix(...)` inside `table.css`. This pulls them into named, overridable tokens in `variables.css` so the row surfaces live in one place and resolve per color-scheme (light/dark) automatically.

New tokens:

| Token | Default |
|-------|---------|
| `--color-row-bg` | `var(--color-primary)` |
| `--color-row-bg-hover` | `color-mix(in oklab, primary, content 5%)` |
| `--color-row-bg-selected` | `color-mix(in oklab, primary, content 12%)` |

`table.css` now just consumes these (base row, `:hover`, selected/highlight, and the SortableJS drag-ghost). No visual change — the base row was already the primary surface; it's now an explicit, themeable knob. The keyboard-focus row keeps its distinct accent mix.

---

[![Compound Engineering v2.59.0](https://img.shields.io/badge/Compound_Engineering-v2.59.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.8 (1M context) via [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Styling-only token rename and centralization with no logic changes; main risk is custom CSS still referencing removed `--color-table-row-*` names.
> 
> **Overview**
> Centralizes **table row surface colors** in `variables.css` as `--color-row-bg`, `--color-row-bg-hover`, and `--color-row-bg-selected`, replacing ad hoc `--color-table-row-*` definitions that lived only in `table.css`.
> 
> **`table.css`** now reads those tokens for the default row fill, hover, shift-highlight/ghost states, and drops the local `@theme` block. Keyboard-focused rows still use the separate accent `color-mix` (unchanged).
> 
> **`row_controls_configuration.rb`** updates floating row-control Tailwind classes from `bg-table-row-hover` / gradient targets to **`bg-row-bg-hover`** so sticky controls track the same hover tint as the row.
> 
> Intended as a **theming refactor** (one override point, per light/dark scheme via `--color-primary` / `--color-content`); behavior should match prior mixes unless custom installs relied on the old token names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a46640e5014b0371d87d10fdd15b094f5c567d6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->