### PR TITLE
Add gem_version to Plugin using Bundler spec resolution

### DIFF
--- a/lib/avo/plugin.rb
+++ b/lib/avo/plugin.rb
@@ -27,6 +27,15 @@ module Avo
       @gem_name = registered_gem&.name
     end
 
+    # The actual installed version of the gem that ships this plugin, resolved
+    # from the Bundler spec. More reliable than the class-level VERSION constant
+    # lookup because plugins are instances of Avo::Plugin (not subclasses).
+    def gem_version
+      return @gem_version if defined?(@gem_version)
+
+      @gem_version = registered_gem&.version&.to_s
+    end
+
     private
 
     def registered_gem


### PR DESCRIPTION
## Problem

`plugin.version` delegates to `plugin.class.version`, which calls `"#{namespace}::VERSION".safe_constantize`. Since all plugins are **instances** of `Avo::Plugin` (not subclasses), `plugin.class` is always `Avo::Plugin`, so `namespace` is always `"Avo"` and every plugin returns `Avo::VERSION` (`4.0.0`).

## Fix

Add a public `gem_version` instance method that reads the version from the Bundler spec found via `registered_from` path — the same mechanism already used by `gem_name`. This correctly resolves e.g. `avo-pro 4.0.0.beta.23`, `avo-licensing 4.0.1`.

## Usage

```ruby
plugin.gem_version  # => "4.0.0.beta.23"  (avo-pro)
plugin.gem_version  # => "4.0.1"          (avo-licensing)
```

Related: [AVO-1403](https://linear.app/avo-hq/issue/AVO-1403)

Made with [Cursor](https://cursor.com)