### PR TITLE
Fix Plugin#version to return the actual installed gem version

### DIFF
--- a/lib/avo/plugin.rb
+++ b/lib/avo/plugin.rb
@@ -4,7 +4,7 @@ module Avo
     attr_reader :priority
     attr_reader :registered_from
 
-    delegate :version, :namespace, :engine, to: :class
+    delegate :namespace, :engine, to: :class
 
     def initialize(*, name:, priority:, registered_from: nil, **, &block)
       @name = name
@@ -27,13 +27,12 @@ module Avo
       @gem_name = registered_gem&.name
     end
 
-    # The actual installed version of the gem that ships this plugin, resolved
-    # from the Bundler spec. More reliable than the class-level VERSION constant
-    # lookup because plugins are instances of Avo::Plugin (not subclasses).
-    def gem_version
-      return @gem_version if defined?(@gem_version)
+    # Installed version of this plugin's gem, resolved from the Bundler spec via
+    # the registration callsite. Falls back to the class-level VERSION constant.
+    def version
+      return @version if defined?(@version)
 
-      @gem_version = registered_gem&.version&.to_s
+      @version = registered_gem&.version&.to_s || self.class.version
     end
 
     private


### PR DESCRIPTION
## Problem

`plugin.version` was delegated to `plugin.class.version`, which resolves `"#{namespace}::VERSION"`. Because all plugins are **instances** of `Avo::Plugin` (not subclasses), `plugin.class` is always `Avo::Plugin`, so every plugin returned `Avo::VERSION` (`4.0.0`) regardless of its real version.

## Fix

Override `version` as an instance method that reads from the Bundler spec found via `registered_from` — the same mechanism used by `gem_name`. Falls back to the class-level VERSION constant if Bundler resolution fails.

```ruby
# before  =>  "4.0.0" for every plugin
# after   =>  "4.0.0.beta.23" (avo-pro), "4.0.1" (avo-licensing), etc.
plugin.version
```

This makes `plugin.version` correct everywhere it's called, including the `avo_gems` payload sent to clerk.

Related: [AVO-1403](https://linear.app/avo-hq/issue/AVO-1403)

Made with [Cursor](https://cursor.com)