### PR TITLE
Avo-1368 Dynamic filters dropdown tweaks

### DIFF
--- a/app/assets/stylesheets/css/components/ui/dropdown.css
+++ b/app/assets/stylesheets/css/components/ui/dropdown.css
@@ -60,9 +60,13 @@
   @apply flex flex-col items-start self-stretch px-1;
 }
 
+/* The `a`/`button` selectors style real menu items, but a dropdown can also host
+   a `.dropdown-card` (see the `:has(.dropdown-card)` block above). Controls inside
+   that card — e.g. a footer action button — are not menu items, so exclude them and
+   let their own `.button` styles apply. */
 .dropdown-menu__item,
-.dropdown-menu__list a,
-.dropdown-menu__list button {
+.dropdown-menu__list a:not(.dropdown-card *),
+.dropdown-menu__list button:not(.dropdown-card *) {
   @apply flex items-center w-full justify-start gap-1.5 px-2 py-1.5 min-h-8 rounded-md border-none bg-transparent overflow-hidden text-ellipsis whitespace-nowrap text-content font-medium text-sm cursor-pointer leading-5;
 
   &.dropdown-menu__item--disabled {

--- a/app/javascript/js/controllers/dropdown_menu_controller.js
+++ b/app/javascript/js/controllers/dropdown_menu_controller.js
@@ -8,6 +8,9 @@ export default class extends Controller {
     // One may want to have elements that are exempt from triggering the click outside event
     exemptionContainers: Array,
     logger: Boolean,
+    // Opt-in: re-align a left-aligned panel to the right when it would overflow the
+    // viewport, so it opens leftward instead of being clipped at the right edge.
+    flip: Boolean,
   }
 
   get exemptionContainerTargets() {
@@ -53,6 +56,7 @@ export default class extends Controller {
 
   open() {
     this.menuTarget.show()
+    this.maybeFlip()
     this.element.addEventListener('keydown', this.boundHandleKeydown)
     document.body.classList.add('dropdown-open')
     this.dispatch('open', { bubbles: true })
@@ -71,6 +75,23 @@ export default class extends Controller {
     this.menuTarget.close()
     this.element.removeEventListener('keydown', this.boundHandleKeydown)
     document.body.classList.remove('dropdown-open')
+  }
+
+  // Re-align the panel when `flip` is enabled. We always re-measure from the
+  // default left-aligned position (start-0), then switch to right-aligned (end-0)
+  // only if the panel would spill past the right edge of the viewport — so it
+  // opens leftward instead of being clipped. Dropdowns that don't opt in are
+  // untouched. Assumes the opted-in panel is left-aligned by default.
+  maybeFlip() {
+    if (!this.flipValue || !this.hasMenuTarget) return
+
+    this.menuTarget.classList.remove('start-auto', 'end-0')
+    this.menuTarget.classList.add('start-0', 'end-auto')
+
+    if (this.menuTarget.getBoundingClientRect().right > document.documentElement.clientWidth) {
+      this.menuTarget.classList.remove('start-0', 'end-auto')
+      this.menuTarget.classList.add('start-auto', 'end-0')
+    }
   }
 
   handleKeydown(event) {

--- a/lib/avo/version.rb
+++ b/lib/avo/version.rb
@@ -1,3 +1,3 @@
 module Avo
-  VERSION = "4.0.0" unless const_defined?(:VERSION)
+  VERSION = '4.0.0.beta.58' unless const_defined?(:VERSION)
 end


### PR DESCRIPTION
# Description
Tweaks to the dropdown used by dynamic filters:

- **JS:** add an opt-in `flip` value to the `dropdown_menu` controller. When enabled, a left-aligned panel re-measures on open and switches to right-alignment only if it would overflow the viewport's right edge — so it opens leftward instead of being clipped. Dropdowns that don't opt in are untouched.
- **CSS:** exclude controls inside a `.dropdown-card` (e.g. a footer action button) from the menu-item styling, so their own `.button` styles apply.
- Bump version in `lib/avo/version.rb`.

## Test plan

- Open a dropdown near the right edge of the viewport with `flip` enabled → it opens leftward without clipping.
- Confirm regular dropdowns (no `flip`) are unchanged.
- Confirm action buttons inside a `.dropdown-card` keep their button styling.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots & recording
<img width="868" height="594" alt="CleanShot 2026-06-29 at 09 57 02@2x" src="https://github.com/user-attachments/assets/ac91942f-53fc-4158-b578-535b20a937c2" />
