### PR TITLE
Fix standardrb lint after Avo 4 merge

### DIFF
--- a/app/components/avo/fields/tiptap_field/edit_component.rb
+++ b/app/components/avo/fields/tiptap_field/edit_component.rb
@@ -8,7 +8,7 @@ class Avo::Fields::TiptapField::EditComponent < Avo::Fields::EditComponent
     @resource_id = args[:resource_id]
     @resource_name = args[:resource_name]
 
-    super(**args)
+    super
   end
 
   def resource_name

--- a/app/components/avo/fields/trix_field/edit_component.rb
+++ b/app/components/avo/fields/trix_field/edit_component.rb
@@ -8,7 +8,7 @@ class Avo::Fields::TrixField::EditComponent < Avo::Fields::EditComponent
     @resource_id = args[:resource_id] || @resource&.record&.to_param
     @resource_name = args[:resource_name] || @resource&.singular_route_key
 
-    super(**args)
+    super
 
     @input_id = if @resource_name.present?
       "#{@field.type}_#{@resource_name}_#{@field.id}"

--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -61,8 +61,8 @@ module Avo
         search_query_undefined = error_payload(
           header: "⚠️ Warning ⚠️",
           help: "",
-          _label: "Search is disabled for #{resource}.\n To enable it please use this guide...",
-          _url: "https://docs.avohq.io/3.0/search.html#enable-search-for-a-resource"
+          label: "Search is disabled for #{resource}.\n To enable it please use this guide...",
+          url: "https://docs.avohq.io/3.0/search.html#enable-search-for-a-resource"
         )
 
         return [key, search_query_undefined]
@@ -235,8 +235,8 @@ module Avo
     end
 
     def error_payload(
-      _label:,
-      _url: "",
+      label:,
+      url: "",
       header: "🚨 An error occurred during search 🚨",
       help: "Please review and resolve the issue before deployment 🚨"
     )
@@ -244,8 +244,8 @@ module Avo
         header:,
         help:,
         results: {
-          _label:,
-          _url:,
+          _label: label,
+          _url: url,
           _error: true
         },
         count: 1

--- a/lib/avo/concerns/checks_assoc_authorization.rb
+++ b/lib/avo/concerns/checks_assoc_authorization.rb
@@ -32,7 +32,7 @@ module Avo
 
         # Use the policy methods from the parent (Post)
         service = reflection_resource.authorization
-        method_name = :"#{policy_method}_#{association_name}?".to_sym
+        method_name = :"#{policy_method}_#{association_name}?"
 
         if service.has_method?(method_name, raise_exception: false)
           service.authorize_action(method_name, record:, raise_exception: false)

--- a/lib/avo/concerns/visible_in_different_views.rb
+++ b/lib/avo/concerns/visible_in_different_views.rb
@@ -13,10 +13,10 @@ module Avo
 
       def initialize_views
         # Set defaults
-        @show_on_index = @show_on_index.nil? ? true : @show_on_index
-        @show_on_show = @show_on_show.nil? ? true : @show_on_show
-        @show_on_new = @show_on_new.nil? ? true : @show_on_new
-        @show_on_edit = @show_on_edit.nil? ? true : @show_on_edit
+        @show_on_index = @show_on_index.nil? || @show_on_index
+        @show_on_show = @show_on_show.nil? || @show_on_show
+        @show_on_new = @show_on_new.nil? || @show_on_new
+        @show_on_edit = @show_on_edit.nil? || @show_on_edit
         @show_on_preview = @show_on_preview.nil? ? false : @show_on_preview
 
         if @args.present?

--- a/lib/avo/fields/area_field.rb
+++ b/lib/avo/fields/area_field.rb
@@ -9,7 +9,7 @@ module Avo
       def initialize(id, **args, &block)
         hide_on :index
 
-        super(id, **args, &block)
+        super
 
         @geometry = args[:geometry].presence || :polygon # Accepts: `:polygon` or `:multi_polygon`
         @mapkick_options = args[:mapkick_options].presence || {}

--- a/lib/avo/fields/boolean_field.rb
+++ b/lib/avo/fields/boolean_field.rb
@@ -5,7 +5,7 @@ module Avo
       attr_reader :false_value
 
       def initialize(id, **args, &block)
-        super(id, **args, &block)
+        super
 
         @true_value = args[:true_value].present? ? args[:true_value] : true
         @false_value = args[:false_value].present? ? args[:false_value] : false

--- a/lib/avo/fields/boolean_group_field.rb
+++ b/lib/avo/fields/boolean_group_field.rb
@@ -2,7 +2,7 @@ module Avo
   module Fields
     class BooleanGroupField < BaseField
       def initialize(id, **args, &block)
-        super(id, **args, &block)
+        super
 
         @options = args[:options] || {}
       end

--- a/lib/avo/fields/code_field.rb
+++ b/lib/avo/fields/code_field.rb
@@ -16,7 +16,7 @@ module Avo
           args[:update_using] ||= -> { value.blank? ? value : JSON.parse(value) }
         end
 
-        super(id, **args, &block)
+        super
 
         @language = args[:language].present? ? args[:language].to_s : "javascript"
         @theme = args[:theme].present? ? args[:theme].to_s : "default"

--- a/lib/avo/fields/country_field.rb
+++ b/lib/avo/fields/country_field.rb
@@ -10,7 +10,7 @@ module Avo
       def initialize(id, **args, &block)
         args[:placeholder] ||= I18n.t("avo.choose_a_country")
 
-        super(id, **args, &block)
+        super
 
         @countries = begin
           ISO3166::Country.translations.sort_by { |code, name| name }.to_h

--- a/lib/avo/fields/date_field.rb
+++ b/lib/avo/fields/date_field.rb
@@ -8,7 +8,7 @@ module Avo
       attr_reader :picker_options
 
       def initialize(id, **args, &block)
-        super(id, **args, &block)
+        super
 
         add_string_prop args, :first_day_of_week, 1
         add_string_prop args, :picker_format, "Y-m-d"

--- a/lib/avo/fields/date_time_field.rb
+++ b/lib/avo/fields/date_time_field.rb
@@ -7,7 +7,7 @@ module Avo
       attr_reader :relative
 
       def initialize(id, **args, &block)
-        super(id, **args, &block)
+        super
 
         add_boolean_prop args, :time_24hr
         add_string_prop args, :picker_format, "Y-m-d H:i:S"

--- a/lib/avo/fields/easy_mde_field.rb
+++ b/lib/avo/fields/easy_mde_field.rb
@@ -4,7 +4,7 @@ module Avo
       attr_reader :options
 
       def initialize(id, **args, &block)
-        super(id, **args, &block)
+        super
 
         hide_on :index
 

--- a/lib/avo/fields/external_image_field.rb
+++ b/lib/avo/fields/external_image_field.rb
@@ -4,7 +4,7 @@ module Avo
       attr_reader :link_to_record
 
       def initialize(id, **args, &block)
-        super(id, **args, &block)
+        super
 
         @link_to_record = args[:link_to_record].present? ? args[:link_to_record] : false
 

--- a/lib/avo/fields/file_field.rb
+++ b/lib/avo/fields/file_field.rb
@@ -8,13 +8,13 @@ module Avo
       attr_reader :display_filename
 
       def initialize(id, **args, &block)
-        super(id, **args, &block)
+        super
 
         @link_to_record = args[:link_to_record].present? ? args[:link_to_record] : false
         @is_avatar = args[:is_avatar].present? ? args[:is_avatar] : false
         @direct_upload = args[:direct_upload].present? ? args[:direct_upload] : false
         @accept = args[:accept].present? ? args[:accept] : nil
-        @display_filename = args[:display_filename].nil? ? true : args[:display_filename]
+        @display_filename = args[:display_filename].nil? || args[:display_filename]
       end
 
       def path

--- a/lib/avo/fields/gravatar_field.rb
+++ b/lib/avo/fields/gravatar_field.rb
@@ -12,12 +12,12 @@ module Avo
       def initialize(id, **args, &block)
         args[:name] ||= "Avatar"
 
-        super(id, **args, &block)
+        super
 
         hide_on [:edit, :new]
 
         @link_to_record = args[:link_to_record].present? ? args[:link_to_record] : false
-        @rounded = args[:rounded].nil? ? true : args[:rounded]
+        @rounded = args[:rounded].nil? || args[:rounded]
         @size = args[:size].present? ? args[:size].to_i : 32
         @default = args[:default].present? ? ERB::Util.url_encode(args[:default]).to_s : ""
       end

--- a/lib/avo/fields/has_one_field.rb
+++ b/lib/avo/fields/has_one_field.rb
@@ -21,7 +21,7 @@ module Avo
           hide_on :forms
         end
 
-        super(id, **args, &block)
+        super
 
         @placeholder ||= I18n.t "avo.choose_an_option"
         @attach_fields = args[:attach_fields]

--- a/lib/avo/fields/heading_field.rb
+++ b/lib/avo/fields/heading_field.rb
@@ -9,7 +9,7 @@ module Avo
         args[:updatable] = false
         @label = args[:label] || id.to_s.humanize
 
-        super(id, **args, &block)
+        super
 
         # this field is not used to update anything
         @for_presentation_only = true

--- a/lib/avo/fields/hidden_field.rb
+++ b/lib/avo/fields/hidden_field.rb
@@ -2,7 +2,7 @@ module Avo
   module Fields
     class HiddenField < TextField
       def initialize(id, **args, &block)
-        super(id, **args, &block)
+        super
 
         only_on :forms
       end

--- a/lib/avo/fields/number_field.rb
+++ b/lib/avo/fields/number_field.rb
@@ -6,7 +6,7 @@ module Avo
       attr_reader :step
 
       def initialize(id, **args, &block)
-        super(id, **args, &block)
+        super
 
         @min = args[:min].present? ? args[:min].to_f : nil
         @max = args[:max].present? ? args[:max].to_f : nil

--- a/lib/avo/fields/password_field.rb
+++ b/lib/avo/fields/password_field.rb
@@ -6,7 +6,7 @@ module Avo
       def initialize(id, **args, &block)
         show_on :forms
 
-        super(id, **args, &block)
+        super
 
         hide_on :index, :show
 

--- a/lib/avo/fields/select_field.rb
+++ b/lib/avo/fields/select_field.rb
@@ -8,7 +8,7 @@ module Avo
       def initialize(id, **args, &block)
         args[:placeholder] ||= I18n.t("avo.choose_an_option")
 
-        super(id, **args, &block)
+        super
 
         @options = if args[:options].is_a? Hash
           ActiveSupport::HashWithIndifferentAccess.new args[:options]

--- a/lib/avo/fields/stars_field.rb
+++ b/lib/avo/fields/stars_field.rb
@@ -4,7 +4,7 @@ module Avo
       attr_reader :max
 
       def initialize(name, **args, &block)
-        super(name, **args, &block)
+        super
 
         @max = args[:max] || 5
       end

--- a/lib/avo/fields/status_field.rb
+++ b/lib/avo/fields/status_field.rb
@@ -2,7 +2,7 @@ module Avo
   module Fields
     class StatusField < BaseField
       def initialize(id, **args, &block)
-        super(id, **args, &block)
+        super
 
         @loading_when = args[:loading_when].present? ? [args[:loading_when]].flatten.map(&:to_sym) : []
         @failed_when = args[:failed_when].present? ? [args[:failed_when]].flatten.map(&:to_sym) : []

--- a/lib/avo/fields/tags_field.rb
+++ b/lib/avo/fields/tags_field.rb
@@ -9,7 +9,7 @@ module Avo
       attr_reader :suggestions_max_items
 
       def initialize(id, **args, &block)
-        super(id, **args, &block)
+        super
 
         add_boolean_prop args, :close_on_select
         add_boolean_prop args, :enforce_suggestions

--- a/lib/avo/fields/textarea_field.rb
+++ b/lib/avo/fields/textarea_field.rb
@@ -6,7 +6,7 @@ module Avo
       def initialize(id, **args, &block)
         hide_on :index
 
-        super(id, **args, &block)
+        super
 
         @rows = args[:rows].present? ? args[:rows].to_i : 5
       end

--- a/lib/avo/fields/time_field.rb
+++ b/lib/avo/fields/time_field.rb
@@ -5,7 +5,7 @@ module Avo
       attr_reader :picker_format
 
       def initialize(id, **args, &block)
-        super(id, **args, &block)
+        super
 
         add_string_prop args, :picker_format, "H:i:S"
         add_string_prop args, :format, "TT"

--- a/lib/avo/fields/tiptap_field.rb
+++ b/lib/avo/fields/tiptap_field.rb
@@ -4,7 +4,7 @@ module Avo
       attr_reader :always_show
 
       def initialize(id, **args, &block)
-        super(id, **args, &block)
+        super
 
         hide_on :index
 

--- a/lib/avo/fields/trix_field.rb
+++ b/lib/avo/fields/trix_field.rb
@@ -8,7 +8,7 @@ module Avo
       attr_reader :hide_attachment_url
 
       def initialize(id, **args, &block)
-        super(id, **args, &block)
+        super
 
         hide_on :index
 

--- a/lib/avo/filters/date_time_filter.rb
+++ b/lib/avo/filters/date_time_filter.rb
@@ -24,7 +24,7 @@ module Avo
           defaultDate: value,
           enableTime: has_time?,
           enableSeconds: has_time?,
-          time_24hr: has_time? ? true : nil,
+          time_24hr: has_time? || nil,
           noCalendar: type == :time,
           mode: mode,
           dateFormat: picker_format,

--- a/lib/avo/item_grapher.rb
+++ b/lib/avo/item_grapher.rb
@@ -9,7 +9,7 @@ class Avo::ItemGrapher
 
   def decode_item(item)
     result = ""
-    result << "──" * (item[:level])
+    result << "──" * item[:level]
     result << "→"
     result << item[:id]
     if item[:items].present?

--- a/lib/avo/media_library/configuration.rb
+++ b/lib/avo/media_library/configuration.rb
@@ -1,7 +1,6 @@
 module Avo
   module MediaLibrary
     class Configuration
-
       class_attribute :visible, default: true
       class_attribute :enabled, default: false
 

--- a/lib/avo/reloader.rb
+++ b/lib/avo/reloader.rb
@@ -28,7 +28,7 @@ class Avo::Reloader
   def files
     # we want to watch some files no matter what
     paths = [
-      Rails.root.join("config", "initializers", "avo.rb"),
+      Rails.root.join("config", "initializers", "avo.rb")
     ]
 
     # we want to watch some files only in Avo development

--- a/lib/avo/resources/controls/attach_button.rb
+++ b/lib/avo/resources/controls/attach_button.rb
@@ -3,7 +3,7 @@ module Avo
     module Controls
       class AttachButton < BaseControl
         def initialize(**args)
-          super(**args)
+          super
 
           if args[:item].present?
             @label = I18n.t("avo.attach_item", item: args[:item]) if label.nil?

--- a/lib/avo/resources/controls/back_button.rb
+++ b/lib/avo/resources/controls/back_button.rb
@@ -3,7 +3,7 @@ module Avo
     module Controls
       class BackButton < BaseControl
         def initialize(**args)
-          super(**args)
+          super
 
           @label = args[:label] || I18n.t("avo.go_back")
         end

--- a/lib/avo/resources/controls/create_button.rb
+++ b/lib/avo/resources/controls/create_button.rb
@@ -3,7 +3,7 @@ module Avo
     module Controls
       class CreateButton < BaseControl
         def initialize(**args)
-          super(**args)
+          super
 
           if args[:item].present?
             @label = I18n.t("avo.create_new_item", item: args[:item].humanize(capitalize: false)) if label.nil?

--- a/lib/avo/resources/controls/delete_button.rb
+++ b/lib/avo/resources/controls/delete_button.rb
@@ -3,7 +3,7 @@ module Avo
     module Controls
       class DeleteButton < BaseControl
         def initialize(**args)
-          super(**args)
+          super
 
           @label = args[:label] || I18n.t("avo.delete").capitalize
           if args[:item].present?

--- a/lib/avo/resources/controls/detach_button.rb
+++ b/lib/avo/resources/controls/detach_button.rb
@@ -3,7 +3,7 @@ module Avo
     module Controls
       class DetachButton < BaseControl
         def initialize(**args)
-          super(**args)
+          super
 
           if args[:item].present?
             @title = I18n.t("avo.detach_item", item: args[:item]).humanize if title.nil?

--- a/lib/avo/resources/controls/edit_button.rb
+++ b/lib/avo/resources/controls/edit_button.rb
@@ -3,7 +3,7 @@ module Avo
     module Controls
       class EditButton < BaseControl
         def initialize(**args)
-          super(**args)
+          super
 
           @label = args[:label] || I18n.t("avo.edit").capitalize
           if args[:item].present?

--- a/lib/avo/resources/controls/save_button.rb
+++ b/lib/avo/resources/controls/save_button.rb
@@ -3,7 +3,7 @@ module Avo
     module Controls
       class SaveButton < BaseControl
         def initialize(**args)
-          super(**args)
+          super
 
           @label = args[:label] || I18n.t(
             "#{args[:resource].translation_key}.save",

--- a/lib/avo/resources/controls/show_button.rb
+++ b/lib/avo/resources/controls/show_button.rb
@@ -3,7 +3,7 @@ module Avo
     module Controls
       class ShowButton < BaseControl
         def initialize(**args)
-          super(**args)
+          super
 
           if args[:item].present?
             @title = I18n.t("avo.view_item", item: args[:item]).humanize if title.nil?

--- a/lib/avo/resources/items/holder.rb
+++ b/lib/avo/resources/items/holder.rb
@@ -19,7 +19,7 @@ class Avo::Resources::Items::Holder
   def field(field_name, **args, &block)
     # If the field is paresed inside a tab group, add it to the tab
     # This will happen when the field is parsed inside a tab group from a resource method
-    if from.present? && from.class == Avo::Resources::Items::TabGroup::Builder
+    if from.present? && from.instance_of?(Avo::Resources::Items::TabGroup::Builder)
       return from.field(field_name, holder: self, **args, &block)
     end
 

--- a/lib/avo/services/telemetry_service.rb
+++ b/lib/avo/services/telemetry_service.rb
@@ -54,10 +54,10 @@ class Avo::Services::TelemetryService
         cache_operational: cache_operational?,
         **config_metadata
       }
-    # rescue => error
-    #   {
-    #     error: error.message
-    #   }
+      # rescue => error
+      #   {
+      #     error: error.message
+      #   }
     end
 
     def cache_operational?

--- a/lib/avo/services/uri_service.rb
+++ b/lib/avo/services/uri_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avo
   module Services
     class URIService
@@ -23,10 +25,10 @@ module Avo
         return self if paths.blank?
 
         # Add the intermediary forward slash
-        @uri.path = @uri.path.concat("/") unless @uri.path.ends_with? "/"
+        @uri.path.concat("/") unless @uri.path.ends_with? "/"
 
         # Add the paths to the URI
-        @uri.merge!(path: @uri.path.concat(join_paths(paths)))
+        @uri[:path] = @uri.path.concat(join_paths(paths))
 
         self
       end
@@ -44,7 +46,7 @@ module Avo
         return self if params.blank?
 
         # Add the query params to the URI
-        @uri.merge!(query: [@uri.query, *params].compact.join("&"))
+        @uri[:query] = [@uri.query, *params].compact.join("&")
 
         self
       end
@@ -65,9 +67,7 @@ module Avo
 
       # Removes the forward slash if it's present at the start of the path
       def sanitize_path(path)
-        if path.to_s.starts_with? "/"
-          path = path[1..]
-        end
+        path = path[1..] if path.to_s.starts_with? "/"
 
         ERB::Util.url_encode path
       end

--- a/lib/avo/services/uri_service.rb
+++ b/lib/avo/services/uri_service.rb
@@ -28,7 +28,7 @@ module Avo
         @uri.path.concat("/") unless @uri.path.ends_with? "/"
 
         # Add the paths to the URI
-        @uri[:path] = @uri.path.concat(join_paths(paths))
+        @uri.path = @uri.path.concat(join_paths(paths))
 
         self
       end
@@ -46,7 +46,7 @@ module Avo
         return self if params.blank?
 
         # Add the query params to the URI
-        @uri[:query] = [@uri.query, *params].compact.join("&")
+        @uri.query = [@uri.query, *params].compact.join("&")
 
         self
       end

--- a/lib/generators/avo/base_generator.rb
+++ b/lib/generators/avo/base_generator.rb
@@ -6,7 +6,7 @@ module Generators
       hide!
 
       def initialize(*args)
-        super(*args)
+        super
 
         # Don't output the version if requested so
         unless args.include?(["--skip-avo-version"])

--- a/lib/generators/avo/install_generator.rb
+++ b/lib/generators/avo/install_generator.rb
@@ -30,7 +30,7 @@ module Generators
         end
 
         if defined?(Account) && Account.is_a?(ActiveRecord::Base)
-          Rails::Generators.invoke("avo:resource", ["account", "-q"], {destination_root: Rails.root })
+          Rails::Generators.invoke("avo:resource", ["account", "-q"], {destination_root: Rails.root})
         end
       end
     end

--- a/lib/generators/avo/named_base_generator.rb
+++ b/lib/generators/avo/named_base_generator.rb
@@ -6,7 +6,7 @@ module Generators
       hide!
 
       def initialize(name, *options)
-        super(name, *options)
+        super
         invoke "avo:version", name, *options
       end
     end

--- a/lib/generators/avo/resource_generator.rb
+++ b/lib/generators/avo/resource_generator.rb
@@ -10,6 +10,45 @@ module Generators
 
       source_root File.expand_path("templates", __dir__)
 
+      ICON_MAP = {
+        user: "tabler/outline/users",
+        customer: "tabler/outline/user",
+        transaction: "tabler/outline/credit-card-pay",
+        post: "tabler/outline/ballpen",
+        comment: "tabler/outline/message",
+        product: "tabler/outline/package",
+        order: "tabler/outline/shopping-cart",
+        category: "tabler/outline/folder",
+        tag: "tabler/outline/tag",
+        project: "tabler/outline/building-store",
+        team: "tabler/outline/users-group",
+        company: "tabler/outline/building",
+        invoice: "tabler/outline/file-invoice",
+        payment: "tabler/outline/cash",
+        article: "tabler/outline/article",
+        event: "tabler/outline/calendar-event",
+        notification: "tabler/outline/bell",
+        message: "tabler/outline/mail",
+        setting: "heroicons/outline/cog",
+        report: "tabler/filled/chart-pie-4",
+        task: "tabler/outline/checklist",
+        review: "tabler/outline/star",
+        photo: "tabler/outline/photo",
+        image: "tabler/outline/photo",
+        video: "tabler/outline/video",
+        file: "tabler/outline/file",
+        document: "tabler/outline/file-text",
+        role: "tabler/outline/shield",
+        permission: "tabler/outline/lock",
+        subscription: "tabler/outline/credit-card",
+        plan: "tabler/outline/list",
+        address: "tabler/outline/map-pin",
+        location: "tabler/outline/map-pin",
+        country: "tabler/outline/world-map",
+        city: "tabler/outline/building-community",
+        account: "tabler/outline/user-circle"
+      }.freeze
+
       namespace "avo:resource"
 
       class_option "model-class",
@@ -321,45 +360,6 @@ module Generators
         def field(name, type)
           ::Avo::Mappings::NAMES_MAPPING[name.to_sym] || ::Avo::Mappings::FIELDS_MAPPING[type&.to_sym] || {field: "text"}
         end
-
-        ICON_MAP = {
-          user: "tabler/outline/users",
-          customer: "tabler/outline/user",
-          transaction: "tabler/outline/credit-card-pay",
-          post: "tabler/outline/ballpen",
-          comment: "tabler/outline/message",
-          product: "tabler/outline/package",
-          order: "tabler/outline/shopping-cart",
-          category: "tabler/outline/folder",
-          tag: "tabler/outline/tag",
-          project: "tabler/outline/building-store",
-          team: "tabler/outline/users-group",
-          company: "tabler/outline/building",
-          invoice: "tabler/outline/file-invoice",
-          payment: "tabler/outline/cash",
-          article: "tabler/outline/article",
-          event: "tabler/outline/calendar-event",
-          notification: "tabler/outline/bell",
-          message: "tabler/outline/mail",
-          setting: "heroicons/outline/cog",
-          report: "tabler/filled/chart-pie-4",
-          task: "tabler/outline/checklist",
-          review: "tabler/outline/star",
-          photo: "tabler/outline/photo",
-          image: "tabler/outline/photo",
-          video: "tabler/outline/video",
-          file: "tabler/outline/file",
-          document: "tabler/outline/file-text",
-          role: "tabler/outline/shield",
-          permission: "tabler/outline/lock",
-          subscription: "tabler/outline/credit-card",
-          plan: "tabler/outline/list",
-          address: "tabler/outline/map-pin",
-          location: "tabler/outline/map-pin",
-          country: "tabler/outline/world-map",
-          city: "tabler/outline/building-community",
-          account: "tabler/outline/user-circle",
-        }.freeze
 
         def icon_for_resource
           ICON_MAP[singular_name.underscore.split("/").last.downcase.to_sym]

--- a/lib/generators/model_generator.rb
+++ b/lib/generators/model_generator.rb
@@ -1,5 +1,5 @@
-require 'rails/generators'
-require 'rails/generators/rails/model/model_generator'
+require "rails/generators"
+require "rails/generators/rails/model/model_generator"
 
 module Rails
   module Generators

--- a/lib/generators/rails/avo_resource_generator.rb
+++ b/lib/generators/rails/avo_resource_generator.rb
@@ -1,4 +1,4 @@
-require 'rails/generators/active_record/model/model_generator'
+require "rails/generators/active_record/model/model_generator"
 
 module Rails
   module Generators

--- a/pluggy/lib/pluggy/fields/radio_field.rb
+++ b/pluggy/lib/pluggy/fields/radio_field.rb
@@ -6,7 +6,7 @@ module Pluggy
       attr_reader :options
 
       def initialize(id, **args, &block)
-        super(id, **args, &block)
+        super
 
         add_array_prop args, :options
       end

--- a/scripts/merge_coverage.rb
+++ b/scripts/merge_coverage.rb
@@ -1,22 +1,22 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'simplecov'
-require 'simplecov-lcov'
+require "simplecov"
+require "simplecov-lcov"
 
-puts('Merging coverage results...')
+puts("Merging coverage results...")
 
-report_path = ARGV[0] || 'coverage.lcov'
+report_path = ARGV[0] || "coverage.lcov"
 SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
 SimpleCov::Formatter::LcovFormatter.config.single_report_path = report_path
 
-SimpleCov.collate(['coverage_features/.resultset.json', 'coverage_system/.resultset.json']) do
+SimpleCov.collate(["coverage_features/.resultset.json", "coverage_system/.resultset.json"]) do
   enable_coverage :branch
   formatter SimpleCov::Formatter::LcovFormatter
 end
 
 if File.size(report_path).zero?
-  puts('Written report has 0 bytes')
+  puts("Written report has 0 bytes")
   exit 1
 end
 puts("Done! LCOV saved to #{SimpleCov::Formatter::LcovFormatter.config.single_report_path}")

--- a/spec/components/avo/base_component_hotkey_badge_spec.rb
+++ b/spec/components/avo/base_component_hotkey_badge_spec.rb
@@ -1,16 +1,16 @@
 require "rails_helper"
 
-RSpec.describe "Avo::BaseComponent#hotkey_badge", type: :component do
-  class HotkeyBadgeTestComponent < Avo::BaseComponent
-    def initialize(hotkey:)
-      @hotkey = hotkey
-    end
-
-    def call
-      hotkey_badge(@hotkey)
-    end
+class HotkeyBadgeTestComponent < Avo::BaseComponent
+  def initialize(hotkey:)
+    @hotkey = hotkey
   end
 
+  def call
+    hotkey_badge(@hotkey)
+  end
+end
+
+RSpec.describe "Avo::BaseComponent#hotkey_badge", type: :component do
   around do |example|
     original = Avo.configuration.hotkeys
     Avo.configuration.hotkeys = {enabled: true, show_key_badges: true}
@@ -68,4 +68,3 @@ RSpec.describe "Avo::BaseComponent#hotkey_badge", type: :component do
     end
   end
 end
-

--- a/spec/dummy/app/avo/actions/show_current_time.rb
+++ b/spec/dummy/app/avo/actions/show_current_time.rb
@@ -29,7 +29,7 @@ class Avo::Actions::ShowCurrentTime < Avo::BaseAction
     timezone_id = Course.timezones.find { |_, cities| cities.include?(city) }&.first
 
     if timezone_id
-      formatted_current_time = TZInfo::Timezone.get(timezone_id).now.strftime('%H:%M:%S')
+      formatted_current_time = TZInfo::Timezone.get(timezone_id).now.strftime("%H:%M:%S")
 
       succeed "In #{city} it's now #{formatted_current_time}."
     else

--- a/spec/dummy/app/avo/fields/color_picker_field.rb
+++ b/spec/dummy/app/avo/fields/color_picker_field.rb
@@ -1,6 +1,6 @@
 class Avo::Fields::ColorPickerField < Avo::Fields::BaseField
   def initialize(id, **args, &block)
-    super(id, **args, &block)
+    super
 
     @allow_non_colors = args[:allow_non_colors]
   end

--- a/spec/dummy/app/avo/filters/dummy_multiple_select_filter.rb
+++ b/spec/dummy/app/avo/filters/dummy_multiple_select_filter.rb
@@ -7,12 +7,12 @@ class Avo::Filters::DummyMultipleSelectFilter < Avo::Filters::MultipleSelectFilt
 
   def options
     {
-      'yes': 'Yes',
-      'no': 'No',
+      yes: "Yes",
+      no: "No"
     }
   end
 
   def default
-    ['yes']
+    ["yes"]
   end
 end

--- a/spec/dummy/app/avo/filters/featured_filter.rb
+++ b/spec/dummy/app/avo/filters/featured_filter.rb
@@ -2,11 +2,11 @@ class Avo::Filters::FeaturedFilter < Avo::Filters::BooleanFilter
   self.name = "Featured status"
 
   def apply(request, query, values)
-    return query if values['is_featured'] && values['is_unfeatured']
+    return query if values["is_featured"] && values["is_unfeatured"]
 
-    if values['is_featured']
+    if values["is_featured"]
       query = query.where(is_featured: true)
-    elsif values['is_unfeatured']
+    elsif values["is_unfeatured"]
       query = query.where(is_featured: false)
     end
 

--- a/spec/dummy/app/avo/filters/is_admin.rb
+++ b/spec/dummy/app/avo/filters/is_admin.rb
@@ -2,11 +2,11 @@ class Avo::Filters::IsAdmin < Avo::Filters::MultipleSelectFilter
   self.name = "Is admin"
 
   def apply(request, query, value)
-    if value.include? 'admins'
+    if value.include? "admins"
       query = query.admins
     end
 
-    if value.include? 'non_admins'
+    if value.include? "non_admins"
       query = query.non_admins
     end
 
@@ -16,7 +16,7 @@ class Avo::Filters::IsAdmin < Avo::Filters::MultipleSelectFilter
   def options
     {
       admins: "Admins",
-      non_admins: "Non admins",
+      non_admins: "Non admins"
     }
   end
 

--- a/spec/dummy/app/avo/filters/members_filter.rb
+++ b/spec/dummy/app/avo/filters/members_filter.rb
@@ -2,14 +2,14 @@ class Avo::Filters::MembersFilter < Avo::Filters::BooleanFilter
   self.name = "Members filter"
 
   def apply(request, query, value)
-    return query.where(id: Team.joins(:memberships).group("teams.id").count.keys) if value['has_members']
+    return query.where(id: Team.joins(:memberships).group("teams.id").count.keys) if value["has_members"]
 
     query
   end
 
   def options
     {
-      'has_members': "Has Members"
+      has_members: "Has Members"
     }
   end
 

--- a/spec/dummy/app/avo/filters/people_2_filter.rb
+++ b/spec/dummy/app/avo/filters/people_2_filter.rb
@@ -2,10 +2,10 @@ class Avo::Filters::People2Filter < Avo::Filters::BooleanFilter
   self.name = "People 2 status (temporary)"
 
   def apply(request, query, value = {})
-    if value['a_lot']
+    if value["a_lot"]
       query = query.where("users_required > ?", 30)
     end
-    if value['few']
+    if value["few"]
       query = query.where("users_required <= ?", 30)
     end
 
@@ -14,8 +14,8 @@ class Avo::Filters::People2Filter < Avo::Filters::BooleanFilter
 
   def options
     {
-      'a_lot': "A lot",
-      'few': "Few (< 30)"
+      a_lot: "A lot",
+      few: "Few (< 30)"
     }
   end
 

--- a/spec/dummy/app/avo/filters/people_filter.rb
+++ b/spec/dummy/app/avo/filters/people_filter.rb
@@ -14,8 +14,8 @@ class Avo::Filters::PeopleFilter < Avo::Filters::SelectFilter
 
   def options
     {
-      'a_lot': "A lot",
-      'few': "Few (< 30)"
+      a_lot: "A lot",
+      few: "Few (< 30)"
     }
   end
 

--- a/spec/dummy/app/avo/resource_tools/sidebar_tool.rb
+++ b/spec/dummy/app/avo/resource_tools/sidebar_tool.rb
@@ -4,7 +4,7 @@ class Avo::ResourceTools::SidebarTool < Avo::BaseResourceTool
   def initialize(**args)
     @render_panel = args[:render_panel]
 
-    super(**args)
+    super
   end
 
   self.name = "Sidebar tool"

--- a/spec/dummy/app/avo/resources/sibling.rb
+++ b/spec/dummy/app/avo/resources/sibling.rb
@@ -1,5 +1,5 @@
 class Avo::Resources::Sibling < Avo::BaseResource
-  self.description = "Demo resource to illustrate Avo\'s Single Table Inheritance support (Sibling < Person)"
+  self.description = "Demo resource to illustrate Avo's Single Table Inheritance support (Sibling < Person)"
   self.model_class = ::Sibling
   self.search = {
     query: -> { query.ransack(id_eq: params[:q], name_cont: params[:q], m: "or").result(distinct: false) }

--- a/spec/dummy/app/avo/resources/spouse.rb
+++ b/spec/dummy/app/avo/resources/spouse.rb
@@ -1,5 +1,5 @@
 class Avo::Resources::Spouse < Avo::BaseResource
-  self.description = "Demo resource to illustrate Avo\'s Single Table Inheritance support (Spouse < Person)"
+  self.description = "Demo resource to illustrate Avo's Single Table Inheritance support (Spouse < Person)"
   self.model_class = ::Spouse
   self.search = {
     query: -> { query.ransack(id_eq: params[:q], name_cont: params[:q], m: "or").result(distinct: false) }

--- a/spec/dummy/bin/spring
+++ b/spec/dummy/bin/spring
@@ -4,14 +4,14 @@
 # It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)
-  require 'rubygems'
-  require 'bundler'
+  require "rubygems"
+  require "bundler"
 
   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
-  spring = lockfile.specs.detect { |spec| spec.name == 'spring' }
+  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
   if spring
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-    gem 'spring', spring.version
-    require 'spring/binstub'
+    gem "spring", spring.version
+    require "spring/binstub"
   end
 end

--- a/spec/dummy/config/initializers/friendly_id.rb
+++ b/spec/dummy/config/initializers/friendly_id.rb
@@ -16,8 +16,8 @@ FriendlyId.defaults do |config|
   # undesirable to allow as slugs. Edit this list as needed for your app.
   config.use :reserved
 
-  config.reserved_words = %w(new edit index session login logout users admin
-    stylesheets assets javascripts images)
+  config.reserved_words = %w[new edit index session login logout users admin
+    stylesheets assets javascripts images]
 
   # This adds an option to treat reserved words as conflicts rather than exceptions.
   # When there is no good candidate, a UUID will be appended, matching the existing

--- a/spec/dummy/db/migrate/20210603100520_create_active_storage_variant_records.active_storage.rb
+++ b/spec/dummy/db/migrate/20210603100520_create_active_storage_variant_records.active_storage.rb
@@ -6,7 +6,7 @@ class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
         t.belongs_to :blob, null: false, index: false
         t.string :variation_digest, null: false
 
-        t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+        t.index %i[blob_id variation_digest], name: "index_active_storage_variant_records_uniqueness", unique: true
         t.foreign_key :active_storage_blobs, column: :blob_id
       end
     end

--- a/spec/dummy/db/migrate/20220414174420_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/spec/dummy/db/migrate/20220414174420_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This migration comes from acts_as_taggable_on_engine (originally 1)
 
 class ActsAsTaggableOnMigration < ActiveRecord::Migration[6.0]
@@ -9,7 +10,7 @@ class ActsAsTaggableOnMigration < ActiveRecord::Migration[6.0]
     end
 
     create_table ActsAsTaggableOn.taggings_table do |t|
-      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+      t.references :tag, foreign_key: {to_table: ActsAsTaggableOn.tags_table}
 
       # You should make sure that the column created is
       # long enough to store the required class names.
@@ -24,7 +25,7 @@ class ActsAsTaggableOnMigration < ActiveRecord::Migration[6.0]
     end
 
     add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
-              name: 'taggings_taggable_context_idx'
+      name: "taggings_taggable_context_idx"
   end
 
   def self.down

--- a/spec/dummy/db/migrate/20220414174421_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/spec/dummy/db/migrate/20220414174421_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This migration comes from acts_as_taggable_on_engine (originally 2)
 
 class AddMissingUniqueIndices < ActiveRecord::Migration[6.0]
@@ -6,19 +7,19 @@ class AddMissingUniqueIndices < ActiveRecord::Migration[6.0]
     add_index ActsAsTaggableOn.tags_table, :name, unique: true
 
     remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
-    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    remove_index ActsAsTaggableOn.taggings_table, name: "taggings_taggable_context_idx"
     add_index ActsAsTaggableOn.taggings_table,
-              %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
-              unique: true, name: 'taggings_idx'
+      %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
+      unique: true, name: "taggings_idx"
   end
 
   def self.down
     remove_index ActsAsTaggableOn.tags_table, :name
 
-    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+    remove_index ActsAsTaggableOn.taggings_table, name: "taggings_idx"
 
     add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
     add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
-              name: 'taggings_taggable_context_idx'
+      name: "taggings_taggable_context_idx"
   end
 end

--- a/spec/dummy/db/migrate/20220414174422_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/spec/dummy/db/migrate/20220414174422_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This migration comes from acts_as_taggable_on_engine (originally 3)
 
 class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[6.0]

--- a/spec/dummy/db/migrate/20220414174423_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/spec/dummy/db/migrate/20220414174423_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
+
 # This migration comes from acts_as_taggable_on_engine (originally 4)
 
 class AddMissingTaggableIndex < ActiveRecord::Migration[6.0]
   def self.up
     add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
-              name: 'taggings_taggable_context_idx'
+      name: "taggings_taggable_context_idx"
   end
 
   def self.down
-    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    remove_index ActsAsTaggableOn.taggings_table, name: "taggings_taggable_context_idx"
   end
 end

--- a/spec/dummy/db/migrate/20220414174424_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/spec/dummy/db/migrate/20220414174424_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This migration comes from acts_as_taggable_on_engine (originally 5)
 
 # This migration is added to circumvent issue #623 and have special characters

--- a/spec/dummy/db/migrate/20220414174425_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/spec/dummy/db/migrate/20220414174425_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
+
 # This migration comes from acts_as_taggable_on_engine (originally 6)
 
 class AddMissingIndexesOnTaggings < ActiveRecord::Migration[6.0]
   def change
     add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
     add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table,
-                                                                                 :taggable_id
+      :taggable_id
     add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table,
-                                                                                   :taggable_type
+      :taggable_type
     add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table,
-                                                                               :tagger_id
+      :tagger_id
     add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
 
     unless index_exists? ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
@@ -17,9 +18,9 @@ class AddMissingIndexesOnTaggings < ActiveRecord::Migration[6.0]
     end
 
     unless index_exists? ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
-                         name: 'taggings_idy'
+      name: "taggings_idy"
       add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
-                name: 'taggings_idy'
+        name: "taggings_idy"
     end
   end
 end

--- a/spec/dummy/db/migrate/20220414174426_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
+++ b/spec/dummy/db/migrate/20220414174426_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This migration comes from acts_as_taggable_on_engine (originally 7)
 
 class AddTenantToTaggings < ActiveRecord::Migration[6.0]

--- a/spec/dummy/test/components/previews/u_i/count_component_preview.rb
+++ b/spec/dummy/test/components/previews/u_i/count_component_preview.rb
@@ -9,7 +9,7 @@ module UI
     def default(count: 3)
       render_with_template(
         template: "u_i/count_component_preview/default",
-        locals: { count: count }
+        locals: {count: count}
       )
     end
   end

--- a/spec/features/avo/controller_action_spec.rb
+++ b/spec/features/avo/controller_action_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Avo::UsersController, type: :controller do
-  let!(:user) { create :user}
+  let!(:user) { create :user }
 
   describe "@view instance variable" do
     it "assigns the @widget" do

--- a/spec/features/avo/country_field_spec.rb
+++ b/spec/features/avo/country_field_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "CountryField", type: :feature do
       it "displays the placeholder" do
         visit url
 
-        expect(page).to have_select "project_country", selected: nil, options: ['No country', *countries]
+        expect(page).to have_select "project_country", selected: nil, options: ["No country", *countries]
       end
     end
   end
@@ -59,7 +59,7 @@ RSpec.describe "CountryField", type: :feature do
     context "edit" do
       let!(:url) { "/admin/resources/projects/#{project.id}/edit" }
 
-      it { is_expected.to have_select "project_country", selected: country_name, options: ['No country', *countries] }
+      it { is_expected.to have_select "project_country", selected: country_name, options: ["No country", *countries] }
 
       it "changes the country" do
         visit url

--- a/spec/features/avo/fields_methods_for_views_spec.rb
+++ b/spec/features/avo/fields_methods_for_views_spec.rb
@@ -114,7 +114,6 @@ RSpec.feature "Fields methods for each view", type: :feature do
       expect(page).not_to have_css "[data-field-id='city']"
       expect(page).not_to have_selector 'turbo-frame[id="has_many_field_show_links"]'
 
-
       # Restore the original method
       Avo::Resources::Course.class_eval do
         define_method(:show_fields, original_show_fields)

--- a/spec/features/avo/generators/field_generator_spec.rb
+++ b/spec/features/avo/generators/field_generator_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "field generator", type: :feature, acquire_lock: :generator do
       Rails.root.join("app", "components", "avo", "fields", "cats_field", "index_component.rb").to_s,
       Rails.root.join("app", "components", "avo", "fields", "cats_field", "index_component.html.erb").to_s,
       Rails.root.join("app", "components", "avo", "fields", "cats_field", "show_component.rb").to_s,
-      Rails.root.join("app", "components", "avo", "fields", "cats_field", "show_component.html.erb").to_s,
+      Rails.root.join("app", "components", "avo", "fields", "cats_field", "show_component.html.erb").to_s
     ]
 
     Rails::Generators.invoke("avo:field", ["cats", "-q"], {destination_root: Rails.root})

--- a/spec/features/avo/has_many_attach_scope_spec.rb
+++ b/spec/features/avo/has_many_attach_scope_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.feature "HasManyAttachScopes", type: :feature do
   let!(:user) { create :user }
-  let!(:post) { create :post, user_id: user.id}
-  let!(:post_2) { create :post}
+  let!(:post) { create :post, user_id: user.id }
+  let!(:post_2) { create :post }
 
   it "filters out the current selection" do
     visit "/admin/resources/users/#{user.id}/posts/new"

--- a/spec/features/avo/multiple_resources_spec.rb
+++ b/spec/features/avo/multiple_resources_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Multiple resources on same model", type: :feature do
   let(:user) { create :user }
 
-  describe 'each resource' do
+  describe "each resource" do
     it "returns to parent resource when cancel creation" do
       visit "admin/resources/compact_users/#{user.to_param}/posts?turbo_frame=has_many_field_show_posts"
       expect(current_path).to eql "/admin/resources/compact_users/#{user.to_param}/posts"

--- a/spec/features/avo/native_fields_spec.rb
+++ b/spec/features/avo/native_fields_spec.rb
@@ -6,30 +6,30 @@ RSpec.feature "NativeFields", type: :feature do
   it "has the fields prefilled" do
     visit avo.edit_resources_city_path(city, show_native_fields: 1)
 
-    expect(find_field('Name').value).to eq city.name
-    expect(find_field('Population').value).to eq city.population.to_s
-    expect(find_field('Is capital').value).to eq "1"
-    expect(find_field('Features').value).to eq "\"#{city.features}\""
+    expect(find_field("Name").value).to eq city.name
+    expect(find_field("Population").value).to eq city.population.to_s
+    expect(find_field("Is capital").value).to eq "1"
+    expect(find_field("Features").value).to eq "\"#{city.features}\""
 
     expect(page).to have_css 'img[src="https://images.unsplash.com/photo-1660061993776-098c0ee403ac?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8fHx8fHx8MTY2MDMxMzc4NA&ixlib=rb-1.2.1&q=80&w=1080"]'
-    expect(find_field('Image url').value).to eq city.image_url
+    expect(find_field("Image url").value).to eq city.image_url
 
-    expect(page).to have_css 'trix-editor'
-    expect(find_field('city[description]', visible: false).value).to include city.description.to_plain_text
+    expect(page).to have_css "trix-editor"
+    expect(find_field("city[description]", visible: false).value).to include city.description.to_plain_text
 
     expect(page).to have_css 'div[data-controller="code-field"]'
-    expect(find_field('city[tiny_description]', visible: false).value).to eq city.tiny_description
+    expect(find_field("city[tiny_description]", visible: false).value).to eq city.tiny_description
 
-    expect(page).to have_select 'city[status]', options: ["Open", "Closed", "Quarantine"], selected: city.status
+    expect(page).to have_select "city[status]", options: ["Open", "Closed", "Quarantine"], selected: city.status
   end
 
   it "updates the record through the custom fields" do
     visit avo.edit_resources_city_path(city)
 
-    fill_in 'city[name]', with: "Bucharest"
-    fill_in 'city[population]', with: 101
+    fill_in "city[name]", with: "Bucharest"
+    fill_in "city[population]", with: 101
     find('[name="city[is_capital]"]').set(false)
-    fill_in 'city[features]', with: "{\"hey\": \"features\"}"
+    fill_in "city[features]", with: "{\"hey\": \"features\"}"
 
     save
 

--- a/spec/features/avo/number_spec.rb
+++ b/spec/features/avo/number_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "number", type: :feature do
       it "clears the users_required" do
         is_expected.to have_xpath "//input[@id='project_users_required'][@type='number'][@placeholder='Users required'][@min='10.0'][@max='1000000.0'][@step='1.0'][@value='#{users_required}']"
 
-        fill_in "project_users_required", with: 'nil'
+        fill_in "project_users_required", with: "nil"
 
         save
 

--- a/spec/features/avo/resource_name_urls_spec.rb
+++ b/spec/features/avo/resource_name_urls_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
 RSpec.feature "ResourceNameUrls", type: :feature do
-  let!(:user) { create :user, first_name: 'John MMM' }
-  let!(:team) { create :team, name: 'Apple XXX' }
+  let!(:user) { create :user, first_name: "John MMM" }
+  let!(:team) { create :team, name: "Apple XXX" }
   let!(:team_membership) { team.team_members << user }
 
   it "loads the model configuration in the resource URL" do
     visit "/admin/resources/memberships/#{team.memberships.first.id}"
 
-    expect(find_field_value_element(:user)).to have_text 'John MMM'
-    expect(find_field_value_element(:team)).to have_text 'Apple XXX'
+    expect(find_field_value_element(:user)).to have_text "John MMM"
+    expect(find_field_value_element(:team)).to have_text "Apple XXX"
   end
 end

--- a/spec/features/avo/select_field_spec.rb
+++ b/spec/features/avo/select_field_spec.rb
@@ -1,5 +1,14 @@
 require "rails_helper"
 
+HASH_OPTIONS = {
+  Zero: 0,
+  Low: 50000,
+  Medium: 100000,
+  High: 250000
+}
+
+ARRAY_OPTIONS = ["Baia Mare", "București", "Coimbra", "Porto"]
+
 RSpec.feature "Select", type: :feature do
   let(:project) { create :project }
   let(:placeholder) { "Choose an option" }
@@ -50,13 +59,6 @@ RSpec.feature "Select", type: :feature do
   end
 
   describe "when options are a hash" do
-    HASH_OPTIONS = {
-      'Zero': 0,
-      'Low': 50000,
-      'Medium': 100000,
-      'High': 250000,
-    }
-
     def test_hash
       visit avo.new_resources_city_path
       expect(page).to have_select "city_population", selected: nil, options: ["Zero", "Low", "Medium", "High"]
@@ -113,8 +115,6 @@ RSpec.feature "Select", type: :feature do
   end
 
   describe "when options are an array" do
-    ARRAY_OPTIONS =  ["Baia Mare", "București", "Coimbra", "Porto"]
-
     def test_array
       visit avo.new_resources_city_path
       expect(page).to have_select "city_name", selected: nil, options: ["Baia Mare", "București", "Coimbra", "Porto"]
@@ -159,7 +159,6 @@ RSpec.feature "Select", type: :feature do
         test_array
       end
     end
-
   end
 
   describe "when options are enum array" do

--- a/spec/system/avo/group_1/date_time_utc_spec.rb
+++ b/spec/system/avo/group_1/date_time_utc_spec.rb
@@ -56,9 +56,9 @@ RSpec.describe "Date field", type: :system do
         # Open the picker.
         text_input.click
         find('.flatpickr-day[aria-label="February 11, 1988"]').click
-        find('.flatpickr-hour').set(17)
-        find('.flatpickr-minute').set(17)
-        find('.flatpickr-second').set(17)
+        find(".flatpickr-hour").set(17)
+        find(".flatpickr-minute").set(17)
+        find(".flatpickr-second").set(17)
 
         # Close the picker.
         find_field_value_element("body").trigger("click")

--- a/spec/system/avo/group_1/stimulus_spec.rb
+++ b/spec/system/avo/group_1/stimulus_spec.rb
@@ -40,34 +40,34 @@ RSpec.describe "StimulusJS", type: :system do
   end
 
   describe "city-in-country#onCountryChange (attached to ShowCurrentTime Action)" do
-  it "filters cities based on a given country" do
-    visit "/admin/resources/courses"
+    it "filters cities based on a given country" do
+      visit "/admin/resources/courses"
 
-    click_on "Actions"
-    click_on "Show current time"
+      click_on "Actions"
+      click_on "Show current time"
 
-    expect(page).to have_css "[data-field-id='country']"
-    expect(page).to have_css "[data-field-id='city']"
-    expect(page).to have_select "fields_country"
+      expect(page).to have_css "[data-field-id='country']"
+      expect(page).to have_css "[data-field-id='city']"
+      expect(page).to have_select "fields_country"
 
-    select "Spain", from: "fields_country"
+      select "Spain", from: "fields_country"
 
-    expect(page).to have_select "fields_country", selected: "Spain"
-    expect(page).to have_select "fields_city", selected: "Choose an option", options: ["Choose an option", "Madrid", "Valencia", "Barcelona"]
+      expect(page).to have_select "fields_country", selected: "Spain"
+      expect(page).to have_select "fields_city", selected: "Choose an option", options: ["Choose an option", "Madrid", "Valencia", "Barcelona"]
 
-    select "Thailand", from: "fields_country"
+      select "Thailand", from: "fields_country"
 
-    expect(page).to have_select "fields_country", selected: "Thailand"
-    expect(page).to have_select "fields_city", selected: "Choose an option", options: ["Choose an option", "Chiang Mai", "Bangkok", "Phuket"]
+      expect(page).to have_select "fields_country", selected: "Thailand"
+      expect(page).to have_select "fields_city", selected: "Choose an option", options: ["Choose an option", "Chiang Mai", "Bangkok", "Phuket"]
 
-    select "Japan", from: "fields_country"
-    expect(page).to have_select "fields_country", selected: "Japan"
-    select "Kyoto", from: "fields_city"
-    expect(page).to have_select "fields_city", selected: "Kyoto", options: ["Choose an option", "Tokyo", "Osaka", "Kyoto", "Hiroshima", "Yokohama", "Nagoya", "Kobe"]
+      select "Japan", from: "fields_country"
+      expect(page).to have_select "fields_country", selected: "Japan"
+      select "Kyoto", from: "fields_city"
+      expect(page).to have_select "fields_city", selected: "Kyoto", options: ["Choose an option", "Tokyo", "Osaka", "Kyoto", "Hiroshima", "Yokohama", "Nagoya", "Kobe"]
 
-    click_on "Run"
+      click_on "Run"
 
-    expect(page).to have_text(/In Kyoto it's now \d\d:\d\d:\d\d./)
+      expect(page).to have_text(/In Kyoto it's now \d\d:\d\d:\d\d./)
+    end
   end
-end
 end

--- a/spec/system/avo/group_2/tags_spec.rb
+++ b/spec/system/avo/group_2/tags_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "Tags", type: :system do
     end
   end
 
-  describe 'without acts_as_taggable' do
+  describe "without acts_as_taggable" do
     let(:course) { create :course, skills: [] }
     let(:path) { "/admin/resources/courses/#{course.id}/edit" }
     let(:tag_input) { tags_element(find_field_value_element("skills")) }

--- a/spec/system/avo/i18n_spec.rb
+++ b/spec/system/avo/i18n_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'i18n/tasks'
+require "i18n/tasks"
 
 RSpec.describe I18n do
   let(:i18n) { I18n::Tasks::BaseTask.new }
@@ -13,7 +13,7 @@ RSpec.describe I18n do
   # a separate job.
   it "does not have missing keys", i18n: true do
     expect(missing_keys).to be_empty,
-                            "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+      "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
   end
 
   # it 'does not have unused keys' do


### PR DESCRIPTION
## Summary

- Applies `standardrb --fix` across the codebase to resolve ~180 style offenses introduced with the Avo 4 merge (#4601)
- Manually fixes remaining warnings: search error payload keyword args, `URIService` redundant merges, `TabGroup::Builder` type check, generator `ICON_MAP` constant placement, and spec constant definitions

## Context

The `runner / standardrb` check failed on #4601. This PR gets `main` back to green for lint.

## Test plan

- [x] `bundle exec standardrb` passes locally (990 files, 0 offenses)
- [ ] CI `runner / standardrb` passes

Made with [Cursor](https://cursor.com)