### PR TITLE
Add editor_url icon and link to standard filters (AVO-1096)

### DIFF
--- a/app/assets/stylesheets/css/components/filters.css
+++ b/app/assets/stylesheets/css/components/filters.css
@@ -23,7 +23,7 @@
 }
 
 .filters-section__title {
-  @apply text-sm font-medium text-foreground;
+  @apply flex items-center gap-1 text-sm font-medium text-foreground;
 }
 
 .filters-section__body {

--- a/app/components/avo/filters_component.html.erb
+++ b/app/components/avo/filters_component.html.erb
@@ -22,7 +22,20 @@
           <div class="filters-card__content">
             <div class="divide-y divide-secondary">
               <% @filters.each do |filter| %>
-                <%= render partial: filter.class.template, locals: {filter: filter} %>
+                <div class="filters-section">
+                  <div class="filters-section__title">
+                    <%= filter.name %>
+                    <% if Rails.env.development? %>
+                      <%= render Avo::DiscreetInformationComponent.new(
+                        as: :icon,
+                        url: helpers.editor_file_path(filter),
+                        icon: "tabler/outline/code",
+                        title: t("avo.open_in_your_editor")
+                      ) %>
+                    <% end %>
+                  </div>
+                  <%= render partial: filter.class.template, locals: {filter: filter} %>
+                </div>
               <% end %>
             </div>
           </div>

--- a/app/helpers/avo/resources_helper.rb
+++ b/app/helpers/avo/resources_helper.rb
@@ -28,15 +28,6 @@ module Avo
     alias_method :edit_field_wrapper, :field_wrapper
     alias_method :show_field_wrapper, :field_wrapper
 
-    def filter_wrapper(name: nil, index: nil, **args, &block)
-      render layout: "layouts/avo/filter_wrapper", locals: {
-        name: name,
-        index: index
-      } do
-        capture(&block)
-      end
-    end
-
     def item_selector_data_attributes(resource, controller: "")
       {
         resource_name: resource.model_key,

--- a/app/views/avo/base/_boolean_filter.html.erb
+++ b/app/views/avo/base/_boolean_filter.html.erb
@@ -2,8 +2,7 @@
   class="filters-section__body"
   data-controller="boolean-filter"
   data-filter-name="<%= filter.name %>"
-  data-boolean-filter-keep-filters-panel-open-value="<%= @resource.keep_filters_panel_open %>"
->
+  data-boolean-filter-keep-filters-panel-open-value="<%= @resource.keep_filters_panel_open %>">
   <div class="flex items-center">
     <% if filter.options.empty? %>
       <div class="filters-section__empty-state"><%= filter.class.empty_message %></div>
@@ -13,15 +12,14 @@
           <label class="filters-boolean-option">
             <%= check_box_tag filter.id, value, filter.selected_value(value.to_s, @applied_filters),
               id: "avo_filters_#{filter.id.parameterize.underscore}",
-              'data-filter-class': filter.class,
-              'data-boolean-filter-target': 'option',
-              'data-action': 'input->boolean-filter#changeFilter'
-            %>
+              "data-filter-class": filter.class,
+              "data-boolean-filter-target": "option",
+              "data-action": "input->boolean-filter#changeFilter" %>
             <span><%= label %></span>
           </label>
         <% end %>
       </div>
     <% end %>
-    <%= link_to 'url_redirect', request.url, data: { 'boolean-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
+    <%= link_to "url_redirect", request.url, data: {"boolean-filter-target": "urlRedirect", "turbo-frame": params[:turbo_frame]}, class: "hidden" %>
   </div>
 </div>

--- a/app/views/avo/base/_boolean_filter.html.erb
+++ b/app/views/avo/base/_boolean_filter.html.erb
@@ -1,28 +1,27 @@
 <div
+  class="filters-section__body"
   data-controller="boolean-filter"
   data-filter-name="<%= filter.name %>"
   data-boolean-filter-keep-filters-panel-open-value="<%= @resource.keep_filters_panel_open %>"
 >
-  <%= filter_wrapper name: filter.name do %>
-    <div class="flex items-center">
-      <% if filter.options.empty? %>
-        <div class="filters-section__empty-state"><%= filter.class.empty_message %></div>
-      <% else %>
-        <div class="filters-boolean-options">
-          <% filter.options.each do |value, label| %>
-            <label class="filters-boolean-option">
-              <%= check_box_tag filter.id, value, filter.selected_value(value.to_s, @applied_filters),
-                id: "avo_filters_#{filter.id.parameterize.underscore}",
-                'data-filter-class': filter.class,
-                'data-boolean-filter-target': 'option',
-                'data-action': 'input->boolean-filter#changeFilter'
-              %>
-              <span><%= label %></span>
-            </label>
-          <% end %>
-        </div>
-      <% end %>
-      <%= link_to 'url_redirect', request.url, data: { 'boolean-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
-    </div>
-  <% end %>
+  <div class="flex items-center">
+    <% if filter.options.empty? %>
+      <div class="filters-section__empty-state"><%= filter.class.empty_message %></div>
+    <% else %>
+      <div class="filters-boolean-options">
+        <% filter.options.each do |value, label| %>
+          <label class="filters-boolean-option">
+            <%= check_box_tag filter.id, value, filter.selected_value(value.to_s, @applied_filters),
+              id: "avo_filters_#{filter.id.parameterize.underscore}",
+              'data-filter-class': filter.class,
+              'data-boolean-filter-target': 'option',
+              'data-action': 'input->boolean-filter#changeFilter'
+            %>
+            <span><%= label %></span>
+          </label>
+        <% end %>
+      </div>
+    <% end %>
+    <%= link_to 'url_redirect', request.url, data: { 'boolean-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
+  </div>
 </div>

--- a/app/views/avo/base/_date_time_filter.html.erb
+++ b/app/views/avo/base/_date_time_filter.html.erb
@@ -1,17 +1,18 @@
 <%= content_tag :div, class: "filters-section__body", data: {
-    controller: "date-time-filter",
-    filter_name: filter.name,
-    date_time_filter_class_value: filter.class.to_s,
-    date_time_filter_keep_filters_panel_open_value: @resource.keep_filters_panel_open,
-    date_time_filter_picker_options_value: filter.picker_options(@applied_filters[filter.class.to_s])
-  } do %>
+      controller: "date-time-filter",
+      filter_name: filter.name,
+      date_time_filter_class_value: filter.class.to_s,
+      date_time_filter_keep_filters_panel_open_value: @resource.keep_filters_panel_open,
+      date_time_filter_picker_options_value: filter.picker_options(@applied_filters[filter.class.to_s])
+    } do %>
   <div class="filters-date-input">
     <div class="w-full" data-slot="value">
       <%= text_field_tag :value, "",
-        class: input_classes('w-full mb-0 !pe-9'),
+        class: input_classes("w-full mb-0 !pe-9"),
         placeholder: filter.class.empty_message,
+        autocomplete: "off",
         data: {
-          date_time_filter_target: "input",
+          date_time_filter_target: "input"
         } %>
     </div>
 
@@ -29,9 +30,9 @@
   </div>
 
   <div class="flex justify-end">
-    <%= a_button style: :primary, data: { action: "date-time-filter#changeFilter" }, size: :sm do %>
+    <%= a_button style: :primary, data: {action: "date-time-filter#changeFilter"}, size: :sm do %>
       <%= filter.button_label || "#{t("avo.filter_by")} #{filter.name}" %>
     <% end %>
   </div>
-  <%= link_to 'url_redirect', request.url, data: { 'date-time-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
+  <%= link_to "url_redirect", request.url, data: {"date-time-filter-target": "urlRedirect", "turbo-frame": params[:turbo_frame]}, class: "hidden" %>
 <% end %>

--- a/app/views/avo/base/_date_time_filter.html.erb
+++ b/app/views/avo/base/_date_time_filter.html.erb
@@ -1,39 +1,37 @@
-<%= content_tag :div, data: {
+<%= content_tag :div, class: "filters-section__body", data: {
     controller: "date-time-filter",
     filter_name: filter.name,
     date_time_filter_class_value: filter.class.to_s,
     date_time_filter_keep_filters_panel_open_value: @resource.keep_filters_panel_open,
     date_time_filter_picker_options_value: filter.picker_options(@applied_filters[filter.class.to_s])
   } do %>
-  <%= filter_wrapper name: filter.name do %>
-    <div class="filters-date-input">
-      <div class="w-full" data-slot="value">
-        <%= text_field_tag :value, "",
-          class: input_classes('w-full mb-0 !pe-9'),
-          placeholder: filter.class.empty_message,
-          data: {
-            date_time_filter_target: "input",
-          } %>
-      </div>
-
-      <%= content_tag :button,
-        class: "filters-date-input__action",
-        id: :reset,
-        type: :button,
-        title: t("avo.reset").capitalize,
+  <div class="filters-date-input">
+    <div class="w-full" data-slot="value">
+      <%= text_field_tag :value, "",
+        class: input_classes('w-full mb-0 !pe-9'),
+        placeholder: filter.class.empty_message,
         data: {
-          action: "click->date-time-filter#clear",
-          tippy: :tooltip
-        } do %>
-        <%= svg "tabler/outline/x", class: "filters-date-input__action-icon" %>
-      <% end %>
+          date_time_filter_target: "input",
+        } %>
     </div>
 
-    <div class="flex justify-end">
-      <%= a_button style: :primary, data: { action: "date-time-filter#changeFilter" }, size: :sm do %>
-        <%= filter.button_label || "#{t("avo.filter_by")} #{filter.name}" %>
-      <% end %>
-    </div>
-    <%= link_to 'url_redirect', request.url, data: { 'date-time-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
-  <% end %>
+    <%= content_tag :button,
+      class: "filters-date-input__action",
+      id: :reset,
+      type: :button,
+      title: t("avo.reset").capitalize,
+      data: {
+        action: "click->date-time-filter#clear",
+        tippy: :tooltip
+      } do %>
+      <%= svg "tabler/outline/x", class: "filters-date-input__action-icon" %>
+    <% end %>
+  </div>
+
+  <div class="flex justify-end">
+    <%= a_button style: :primary, data: { action: "date-time-filter#changeFilter" }, size: :sm do %>
+      <%= filter.button_label || "#{t("avo.filter_by")} #{filter.name}" %>
+    <% end %>
+  </div>
+  <%= link_to 'url_redirect', request.url, data: { 'date-time-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
 <% end %>

--- a/app/views/avo/base/_multiple_select_filter.html.erb
+++ b/app/views/avo/base/_multiple_select_filter.html.erb
@@ -1,22 +1,21 @@
 <div
+  class="filters-section__body"
   data-controller="multiple-select-filter"
   data-filter-name="<%= filter.name %>"
   data-multiple-select-filter-keep-filters-panel-open-value="<%= @resource.keep_filters_panel_open %>"
 >
-  <%= filter_wrapper name: filter.name do %>
-    <%= select_tag filter.id, options_for_select(filter.options.invert, filter.selected_value(@applied_filters)),
-      class: input_classes('filters-multi-select w-full'),
-      multiple: true,
-      size: filter.options.size.clamp(2, 4),
-      id: "avo_filters_#{filter.id.parameterize.underscore}",
-      'data-filter-class': filter.class.to_s,
-      'data-multiple-select-filter-target': 'selector' %>
+  <%= select_tag filter.id, options_for_select(filter.options.invert, filter.selected_value(@applied_filters)),
+    class: input_classes('filters-multi-select w-full'),
+    multiple: true,
+    size: filter.options.size.clamp(2, 4),
+    id: "avo_filters_#{filter.id.parameterize.underscore}",
+    'data-filter-class': filter.class.to_s,
+    'data-multiple-select-filter-target': 'selector' %>
 
-    <div class="flex justify-end">
-      <%= a_button style: :primary, size: :sm, data: { action: "multiple-select-filter#changeFilter" } do %>
-        <%= filter.button_label || "#{t("avo.filter_by")} #{filter.name}" %>
-      <% end %>
-    </div>
-    <%= link_to 'url_redirect', request.url, data: { 'multiple-select-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
-  <% end %>
+  <div class="flex justify-end">
+    <%= a_button style: :primary, size: :sm, data: { action: "multiple-select-filter#changeFilter" } do %>
+      <%= filter.button_label || "#{t("avo.filter_by")} #{filter.name}" %>
+    <% end %>
+  </div>
+  <%= link_to 'url_redirect', request.url, data: { 'multiple-select-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
 </div>

--- a/app/views/avo/base/_multiple_select_filter.html.erb
+++ b/app/views/avo/base/_multiple_select_filter.html.erb
@@ -2,20 +2,19 @@
   class="filters-section__body"
   data-controller="multiple-select-filter"
   data-filter-name="<%= filter.name %>"
-  data-multiple-select-filter-keep-filters-panel-open-value="<%= @resource.keep_filters_panel_open %>"
->
+  data-multiple-select-filter-keep-filters-panel-open-value="<%= @resource.keep_filters_panel_open %>">
   <%= select_tag filter.id, options_for_select(filter.options.invert, filter.selected_value(@applied_filters)),
-    class: input_classes('filters-multi-select w-full'),
+    class: input_classes("filters-multi-select w-full"),
     multiple: true,
     size: filter.options.size.clamp(2, 4),
     id: "avo_filters_#{filter.id.parameterize.underscore}",
-    'data-filter-class': filter.class.to_s,
-    'data-multiple-select-filter-target': 'selector' %>
+    "data-filter-class": filter.class.to_s,
+    "data-multiple-select-filter-target": "selector" %>
 
   <div class="flex justify-end">
-    <%= a_button style: :primary, size: :sm, data: { action: "multiple-select-filter#changeFilter" } do %>
+    <%= a_button style: :primary, size: :sm, data: {action: "multiple-select-filter#changeFilter"} do %>
       <%= filter.button_label || "#{t("avo.filter_by")} #{filter.name}" %>
     <% end %>
   </div>
-  <%= link_to 'url_redirect', request.url, data: { 'multiple-select-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
+  <%= link_to "url_redirect", request.url, data: {"multiple-select-filter-target": "urlRedirect", "turbo-frame": params[:turbo_frame]}, class: "hidden" %>
 </div>

--- a/app/views/avo/base/_select_filter.html.erb
+++ b/app/views/avo/base/_select_filter.html.erb
@@ -1,17 +1,16 @@
 <div
+  class="filters-section__body"
   data-controller="select-filter"
   data-filter-name="<%= filter.name %>"
   data-select-filter-keep-filters-panel-open-value="<%= @resource.keep_filters_panel_open %>"
 >
-  <%= filter_wrapper name: filter.name do %>
-    <%= select_tag filter.id, options_for_select(filter.options.invert, filter.applied_or_default_value(@applied_filters)),
-      class: input_classes('w-full mb-0'),
-      include_blank: filter.class.empty_message || '—',
-      id: "avo_filters_#{filter.id.parameterize.underscore}",
-      'data-filter-class': filter.class,
-      'data-select-filter-target': 'selector',
-      'data-action': "change->select-filter#changeFilter"
-    %>
-    <%= link_to 'url_redirect', request.url, data: { 'select-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
-  <% end %>
+  <%= select_tag filter.id, options_for_select(filter.options.invert, filter.applied_or_default_value(@applied_filters)),
+    class: input_classes('w-full mb-0'),
+    include_blank: filter.class.empty_message || '—',
+    id: "avo_filters_#{filter.id.parameterize.underscore}",
+    'data-filter-class': filter.class,
+    'data-select-filter-target': 'selector',
+    'data-action': "change->select-filter#changeFilter"
+  %>
+  <%= link_to 'url_redirect', request.url, data: { 'select-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
 </div>

--- a/app/views/avo/base/_select_filter.html.erb
+++ b/app/views/avo/base/_select_filter.html.erb
@@ -2,15 +2,13 @@
   class="filters-section__body"
   data-controller="select-filter"
   data-filter-name="<%= filter.name %>"
-  data-select-filter-keep-filters-panel-open-value="<%= @resource.keep_filters_panel_open %>"
->
+  data-select-filter-keep-filters-panel-open-value="<%= @resource.keep_filters_panel_open %>">
   <%= select_tag filter.id, options_for_select(filter.options.invert, filter.applied_or_default_value(@applied_filters)),
-    class: input_classes('w-full mb-0'),
-    include_blank: filter.class.empty_message || '—',
+    class: input_classes("w-full mb-0"),
+    include_blank: filter.class.empty_message || "—",
     id: "avo_filters_#{filter.id.parameterize.underscore}",
-    'data-filter-class': filter.class,
-    'data-select-filter-target': 'selector',
-    'data-action': "change->select-filter#changeFilter"
-  %>
-  <%= link_to 'url_redirect', request.url, data: { 'select-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
+    "data-filter-class": filter.class,
+    "data-select-filter-target": "selector",
+    "data-action": "change->select-filter#changeFilter" %>
+  <%= link_to "url_redirect", request.url, data: {"select-filter-target": "urlRedirect", "turbo-frame": params[:turbo_frame]}, class: "hidden" %>
 </div>

--- a/app/views/avo/base/_text_filter.html.erb
+++ b/app/views/avo/base/_text_filter.html.erb
@@ -1,22 +1,21 @@
 <div
+  class="filters-section__body"
   data-controller="text-filter"
   data-filter-name="<%= filter.name %>"
   data-text-filter-keep-filters-panel-open-value="<%= @resource.keep_filters_panel_open %>"
 >
-  <%= filter_wrapper name: filter.name do %>
-    <%= text_field_tag filter.id, filter.applied_or_default_value(@applied_filters),
-      class: input_classes('w-full mb-0'),
-      id: "avo_filters_#{filter.id.parameterize.underscore}",
-      placeholder: filter.class.empty_message,
-      'data-filter-class': filter.class.to_s,
-      'data-text-filter-target': 'text',
-      'data-action': 'keypress->text-filter#tryToSubmit' %>
+  <%= text_field_tag filter.id, filter.applied_or_default_value(@applied_filters),
+    class: input_classes('w-full mb-0'),
+    id: "avo_filters_#{filter.id.parameterize.underscore}",
+    placeholder: filter.class.empty_message,
+    'data-filter-class': filter.class.to_s,
+    'data-text-filter-target': 'text',
+    'data-action': 'keypress->text-filter#tryToSubmit' %>
 
-    <div class="flex justify-end">
-      <%= a_button style: :primary, data: { action: "text-filter#changeFilter" }, size: :sm do %>
-        <%= filter.button_label || "#{t("avo.filter_by")} #{filter.name}" %>
-      <% end %>
-    </div>
-    <%= link_to 'url_redirect', request.url, data: { 'text-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
-  <% end %>
+  <div class="flex justify-end">
+    <%= a_button style: :primary, data: { action: "text-filter#changeFilter" }, size: :sm do %>
+      <%= filter.button_label || "#{t("avo.filter_by")} #{filter.name}" %>
+    <% end %>
+  </div>
+  <%= link_to 'url_redirect', request.url, data: { 'text-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
 </div>

--- a/app/views/avo/base/_text_filter.html.erb
+++ b/app/views/avo/base/_text_filter.html.erb
@@ -2,20 +2,20 @@
   class="filters-section__body"
   data-controller="text-filter"
   data-filter-name="<%= filter.name %>"
-  data-text-filter-keep-filters-panel-open-value="<%= @resource.keep_filters_panel_open %>"
->
+  data-text-filter-keep-filters-panel-open-value="<%= @resource.keep_filters_panel_open %>">
   <%= text_field_tag filter.id, filter.applied_or_default_value(@applied_filters),
-    class: input_classes('w-full mb-0'),
+    class: input_classes("w-full mb-0"),
     id: "avo_filters_#{filter.id.parameterize.underscore}",
     placeholder: filter.class.empty_message,
-    'data-filter-class': filter.class.to_s,
-    'data-text-filter-target': 'text',
-    'data-action': 'keypress->text-filter#tryToSubmit' %>
+    autocomplete: "off",
+    "data-filter-class": filter.class.to_s,
+    "data-text-filter-target": "text",
+    "data-action": "keypress->text-filter#tryToSubmit" %>
 
   <div class="flex justify-end">
-    <%= a_button style: :primary, data: { action: "text-filter#changeFilter" }, size: :sm do %>
+    <%= a_button style: :primary, data: {action: "text-filter#changeFilter"}, size: :sm do %>
       <%= filter.button_label || "#{t("avo.filter_by")} #{filter.name}" %>
     <% end %>
   </div>
-  <%= link_to 'url_redirect', request.url, data: { 'text-filter-target': 'urlRedirect', 'turbo-frame': params[:turbo_frame] }, class: 'hidden' %>
+  <%= link_to "url_redirect", request.url, data: {"text-filter-target": "urlRedirect", "turbo-frame": params[:turbo_frame]}, class: "hidden" %>
 </div>

--- a/app/views/layouts/avo/_filter_wrapper.html.erb
+++ b/app/views/layouts/avo/_filter_wrapper.html.erb
@@ -1,8 +1,0 @@
-<div class="filters-section">
-  <div class="filters-section__title">
-    <%= name %>
-  </div>
-  <div class="filters-section__body">
-    <%= yield %>
-  </div>
-</div>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds a dev-only "open in your editor" icon (`</>`) next to each standard filter's title in the filters panel, matching how resources and actions already expose their source file.

Following the issue's request for a proper refactor (don't pass the filter or a prebuilt link into the generic `filter_wrapper`), the section chrome — title + editor icon — now renders in `Avo::FiltersComponent`'s loop, which already has the filter. The `filter_wrapper` helper and its `_filter_wrapper.html.erb` layout are removed, and each filter partial's controller `div` now carries the `filters-section__body` class so the input and button keep their spacing.

Fixes AVO-1096 (https://linear.app/avo-hq/issue/AVO-1096)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I tested the design in Light and Dark mode, and all default themes

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<img width="802" height="1034" alt="CleanShot 2026-07-02 at 13 51 51@2x" src="https://github.com/user-attachments/assets/f03d5574-9a7e-43fd-b29a-67c7c342d16a" />


<!-- Can the behavior touched in this PR be displayed as a screenshot or a recording. Please attach it. It makes the review easier to pass. -->

The filters panel shows a `</>` icon next to each filter title in development; clicking it opens the filter's source file in the configured editor. _Screenshot to be attached._

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. In development, open a resource index that has filters (e.g. Users) and open the Filters panel.
1. Confirm each filter title shows a `</>` icon with an "Open in your editor" tooltip; clicking it opens the filter's `.rb` source in your editor.
1. Confirm the icon is absent outside development.
1. Confirm each filter type (boolean, select, multiple-select, text, date-time) still works and the input/button spacing is intact.

Manual reviewer: please leave a comment with output from the test if that's the case.


