### PR TITLE
Fix theme switcher i18n fallbacks for missing appearance keys (AVO-1407)

### DIFF
--- a/app/helpers/avo/application_helper.rb
+++ b/app/helpers/avo/application_helper.rb
@@ -270,6 +270,20 @@ module Avo
       })
     end
 
+    # Translates appearance UI strings with English fallback when the active locale
+    # omits Avo 4 appearance keys. Returns plain text safe for HTML attributes.
+    def avo_appearance_t(key, **options)
+      full_key = "avo.appearance.#{key}"
+      defaults = []
+      defaults << I18n.t(full_key, locale: :en, raise: false) if I18n.locale != :en
+      defaults << options[:default] if options.key?(:default)
+      I18n.t(full_key, **options.except(:default), default: defaults.presence)
+    end
+
+    def appearance_neutral_labels(neutrals)
+      neutrals.index_with { |theme| avo_appearance_t("neutrals_list.#{theme}", default: theme.capitalize) }
+    end
+
     private
 
     # The signed_id is what Active Storage uses to locate the blob; the filename

--- a/app/javascript/js/controllers/appearance_controller.js
+++ b/app/javascript/js/controllers/appearance_controller.js
@@ -5,6 +5,8 @@ import Cookies from 'js-cookie'
 export default class extends Controller {
   static targets = ['button', 'accentOption', 'themeLabel', 'themeOption']
 
+  static values = { themeLabels: Object }
+
   connect() {
     this.appearance = window.Avo?.configuration?.appearance || {}
     this.lockedNeutral = this.appearance.neutralLocked ? this.appearance.neutral : null
@@ -323,7 +325,9 @@ export default class extends Controller {
   updateThemeLabelText(theme) {
     if (!this.hasThemeLabelTarget) return
 
-    this.themeLabelTarget.textContent = theme.charAt(0).toUpperCase() + theme.slice(1)
+    const labels = this.hasThemeLabelsValue ? this.themeLabelsValue : {}
+    const label = labels[theme] || theme.charAt(0).toUpperCase() + theme.slice(1)
+    this.themeLabelTarget.textContent = label
   }
 
   // Mirrors the Shift+K hotkey in global_hotkeys.js. CSS handles the active

--- a/app/views/avo/partials/_color_scheme_switcher.html.erb
+++ b/app/views/avo/partials/_color_scheme_switcher.html.erb
@@ -11,7 +11,8 @@
      show_scheme_picker: show_scheme_picker,
      show_key_badges_toggle: show_key_badges_toggle,
      active_neutral: current_neutral,
-     active_accent: current_accent
+     active_accent: current_accent,
+     neutral_labels: appearance_neutral_labels(appearance.neutrals)
    } %>
 
 <%# :inline renders BOTH the desktop pill (lg:+) and the compact dropdown trigger (mobile fallback). %>

--- a/app/views/avo/partials/_switcher_dropdown.html.erb
+++ b/app/views/avo/partials/_switcher_dropdown.html.erb
@@ -1,15 +1,16 @@
 <div class="<%= class_names("color-scheme-switcher color-scheme-switcher--compact", "lg:hidden": appearance.picker_layout == :inline) %>"
-     data-controller="appearance">
+     data-controller="appearance"
+     data-appearance-theme-labels-value="<%= neutral_labels.to_json %>">
   <%= render Avo::UI::DropdownComponent.new do |component| %>
     <% component.with_trigger do %>
       <button type="button"
               data-action="<%= component.action %>"
               data-tippy="tooltip"
               class="color-scheme-switcher__compact-trigger"
-              title="<%= t("avo.appearance.title") %>">
+              title="<%= avo_appearance_t("title") %>">
         <%= svg "tabler/outline/palette", class: "color-scheme-switcher__icon" %>
         <%= svg "tabler/outline/chevron-down", class: "color-scheme-switcher__chevron" %>
-        <span class="sr-only"><%= t("avo.appearance.title") %></span>
+        <span class="sr-only"><%= avo_appearance_t("title") %></span>
       </button>
     <% end %>
     <% component.with_items do %>
@@ -17,7 +18,7 @@
         <% card.with_body do %>
           <% if show_neutral_picker %>
             <div class="color-scheme-switcher__section">
-              <div class="color-scheme-switcher__section-label"><%= t("avo.appearance.neutrals") %></div>
+              <div class="color-scheme-switcher__section-label"><%= avo_appearance_t("neutrals") %></div>
               <div class="color-scheme-switcher__theme-options"
                    data-action="mouseleave->appearance#revertTheme"
                    data-leftover="<%= appearance.neutrals.size % 3 %>">
@@ -28,7 +29,7 @@
                           data-appearance-target="themeOption"
                           class="<%= class_names("color-scheme-switcher__theme-option", "color-scheme-switcher__theme-option--brand": theme == "brand", "color-scheme-switcher__theme-option--active": theme == active_neutral) %>">
                     <span class="color-scheme-switcher__theme-preview color-scheme-switcher__theme-preview--<%= theme %>"></span>
-                    <span class="color-scheme-switcher__theme-option-label"><%= t("avo.appearance.neutrals_list.#{theme}", default: theme.capitalize) %></span>
+                    <span class="color-scheme-switcher__theme-option-label"><%= avo_appearance_t("neutrals_list.#{theme}", default: theme.capitalize) %></span>
                   </button>
                 <% end %>
               </div>
@@ -37,7 +38,7 @@
 
           <% if show_accent_picker %>
             <div class="color-scheme-switcher__section">
-              <div class="color-scheme-switcher__section-label"><%= t("avo.appearance.accents") %></div>
+              <div class="color-scheme-switcher__section-label"><%= avo_appearance_t("accents") %></div>
               <div class="color-scheme-switcher__accent-options"
                    data-action="mouseleave->appearance#revertAccent">
                 <% appearance.accents.each do |accent| %>
@@ -47,7 +48,7 @@
                     else
                       "color-scheme-switcher__accent-preview bg-#{accent}-500"
                     end
-                    accent_label = t("avo.appearance.accents_list.#{accent}", default: accent.capitalize)
+                    accent_label = avo_appearance_t("accents_list.#{accent}", default: accent.capitalize)
                   %>
                   <button type="button"
                           title="<%= accent_label %>"
@@ -66,34 +67,34 @@
 
           <% if show_scheme_picker %>
             <div class="color-scheme-switcher__section">
-              <div class="color-scheme-switcher__section-label"><%= t("avo.appearance.schemes") %></div>
+              <div class="color-scheme-switcher__section-label"><%= avo_appearance_t("schemes") %></div>
               <div class="color-scheme-switcher__scheme-row">
                 <button type="button"
                         data-action="click->appearance#setScheme"
                         data-scheme="auto"
                         data-tippy="tooltip"
                         class="color-scheme-switcher__scheme-button"
-                        title="<%= t("avo.appearance.auto_tooltip") %>">
+                        title="<%= avo_appearance_t("auto_tooltip") %>">
                   <%= svg "tabler/outline/device-desktop", class: "color-scheme-switcher__icon" %>
-                  <span class="color-scheme-switcher__scheme-label"><%= t("avo.appearance.auto") %></span>
+                  <span class="color-scheme-switcher__scheme-label"><%= avo_appearance_t("auto") %></span>
                 </button>
                 <button type="button"
                         data-action="click->appearance#setScheme"
                         data-scheme="light"
                         data-tippy="tooltip"
                         class="color-scheme-switcher__scheme-button"
-                        title="<%= t("avo.appearance.light_tooltip") %>">
+                        title="<%= avo_appearance_t("light_tooltip") %>">
                   <%= svg "tabler/outline/sun", class: "color-scheme-switcher__icon" %>
-                  <span class="color-scheme-switcher__scheme-label"><%= t("avo.appearance.light") %></span>
+                  <span class="color-scheme-switcher__scheme-label"><%= avo_appearance_t("light") %></span>
                 </button>
                 <button type="button"
                         data-action="click->appearance#setScheme"
                         data-scheme="dark"
                         data-tippy="tooltip"
                         class="color-scheme-switcher__scheme-button"
-                        title="<%= t("avo.appearance.dark_tooltip") %>">
+                        title="<%= avo_appearance_t("dark_tooltip") %>">
                   <%= svg "tabler/outline/moon", class: "color-scheme-switcher__icon" %>
-                  <span class="color-scheme-switcher__scheme-label"><%= t("avo.appearance.dark") %></span>
+                  <span class="color-scheme-switcher__scheme-label"><%= avo_appearance_t("dark") %></span>
                 </button>
               </div>
             </div>
@@ -101,25 +102,25 @@
 
           <% if show_key_badges_toggle %>
             <div class="color-scheme-switcher__section">
-              <div class="color-scheme-switcher__section-label"><%= t("avo.appearance.shortcut_badges") %></div>
+              <div class="color-scheme-switcher__section-label"><%= avo_appearance_t("shortcut_badges") %></div>
               <div class="color-scheme-switcher__scheme-row">
                 <button type="button"
                         data-action="click->appearance#setKeyBadges"
                         data-key-badges="show"
                         data-tippy="tooltip"
                         class="color-scheme-switcher__scheme-button"
-                        title="<%= t("avo.appearance.shortcut_badges_show_tooltip") %>">
+                        title="<%= avo_appearance_t("shortcut_badges_show_tooltip") %>">
                   <%= svg "tabler/outline/eye", class: "color-scheme-switcher__icon" %>
-                  <span class="color-scheme-switcher__scheme-label"><%= t("avo.appearance.show") %></span>
+                  <span class="color-scheme-switcher__scheme-label"><%= avo_appearance_t("show") %></span>
                 </button>
                 <button type="button"
                         data-action="click->appearance#setKeyBadges"
                         data-key-badges="hide"
                         data-tippy="tooltip"
                         class="color-scheme-switcher__scheme-button"
-                        title="<%= t("avo.appearance.shortcut_badges_hide_tooltip") %>">
+                        title="<%= avo_appearance_t("shortcut_badges_hide_tooltip") %>">
                   <%= svg "tabler/outline/eye-off", class: "color-scheme-switcher__icon" %>
-                  <span class="color-scheme-switcher__scheme-label"><%= t("avo.appearance.hide") %></span>
+                  <span class="color-scheme-switcher__scheme-label"><%= avo_appearance_t("hide") %></span>
                 </button>
               </div>
             </div>

--- a/app/views/avo/partials/_switcher_inline.html.erb
+++ b/app/views/avo/partials/_switcher_inline.html.erb
@@ -1,5 +1,6 @@
 <div class="color-scheme-switcher color-scheme-switcher--inline hidden lg:inline-flex"
-     data-controller="appearance">
+     data-controller="appearance"
+     data-appearance-theme-labels-value="<%= neutral_labels.to_json %>">
   <% if show_neutral_picker %>
     <%= render Avo::UI::DropdownComponent.new(
       classes: "color-scheme-switcher__theme-popover"
@@ -9,8 +10,8 @@
                 data-action="<%= component.action %>"
                 data-tippy="tooltip"
                 class="color-scheme-switcher__button color-scheme-switcher__button--theme"
-                title="<%= t("avo.appearance.neutrals_picker") %>">
-          <span class="color-scheme-switcher__text" data-appearance-target="themeLabel"><%= t("avo.appearance.neutrals_list.#{active_neutral}", default: active_neutral.capitalize) %></span>
+                title="<%= avo_appearance_t("neutrals_picker") %>">
+          <span class="color-scheme-switcher__text" data-appearance-target="themeLabel"><%= avo_appearance_t("neutrals_list.#{active_neutral}", default: active_neutral.capitalize) %></span>
         </button>
       <% end %>
       <% component.with_items do %>
@@ -25,7 +26,7 @@
                         data-appearance-target="themeOption"
                         class="<%= class_names("color-scheme-switcher__theme-option", "color-scheme-switcher__theme-option--active": theme == active_neutral) %>">
                   <span class="color-scheme-switcher__theme-preview color-scheme-switcher__theme-preview--<%= theme %>"></span>
-                  <span class="color-scheme-switcher__theme-option-label"><%= t("avo.appearance.neutrals_list.#{theme}", default: theme.capitalize) %></span>
+                  <span class="color-scheme-switcher__theme-option-label"><%= avo_appearance_t("neutrals_list.#{theme}", default: theme.capitalize) %></span>
                 </button>
               <% end %>
             </div>
@@ -45,14 +46,14 @@
                 data-action="<%= component.action %>"
                 data-tippy="tooltip"
                 class="color-scheme-switcher__button color-scheme-switcher__button--accent"
-                title="<%= t("avo.appearance.accent_picker") %>">
+                title="<%= avo_appearance_t("accent_picker") %>">
           <%= svg "tabler/outline/color-swatch", class: "color-scheme-switcher__icon" %>
           <span class="color-scheme-switcher__accent-badge">
             <% appearance.accents.each do |accent| %>
               <span class="color-scheme-switcher__accent-badge-preview color-scheme-switcher__accent-badge-preview--<%= accent %> bg-<%= accent %>-500"></span>
             <% end %>
           </span>
-          <span class="sr-only"><%= t("avo.appearance.accent_picker") %></span>
+          <span class="sr-only"><%= avo_appearance_t("accent_picker") %></span>
         </button>
       <% end %>
       <% component.with_items do %>
@@ -67,7 +68,7 @@
                   else
                     "color-scheme-switcher__accent-preview bg-#{accent}-500"
                   end
-                  accent_label = t("avo.appearance.accents_list.#{accent}", default: accent.capitalize)
+                  accent_label = avo_appearance_t("accents_list.#{accent}", default: accent.capitalize)
                 %>
                 <button type="button"
                         title="<%= accent_label %>"
@@ -94,9 +95,9 @@
             data-scheme="auto"
             data-tippy="tooltip"
             class="color-scheme-switcher__button"
-            title="<%= t("avo.appearance.auto_tooltip") %>">
+            title="<%= avo_appearance_t("auto_tooltip") %>">
       <%= svg "tabler/outline/device-desktop", class: "color-scheme-switcher__icon" %>
-      <span class="sr-only"><%= t("avo.appearance.auto") %></span>
+      <span class="sr-only"><%= avo_appearance_t("auto") %></span>
     </button>
     <button type="button"
             data-appearance-target="button"
@@ -104,9 +105,9 @@
             data-scheme="light"
             data-tippy="tooltip"
             class="color-scheme-switcher__button"
-            title="<%= t("avo.appearance.light_tooltip") %>">
+            title="<%= avo_appearance_t("light_tooltip") %>">
       <%= svg "tabler/outline/sun", class: "color-scheme-switcher__icon" %>
-      <span class="sr-only"><%= t("avo.appearance.light") %></span>
+      <span class="sr-only"><%= avo_appearance_t("light") %></span>
     </button>
     <button type="button"
             data-appearance-target="button"
@@ -114,9 +115,9 @@
             data-scheme="dark"
             data-tippy="tooltip"
             class="color-scheme-switcher__button"
-            title="<%= t("avo.appearance.dark_tooltip") %>">
+            title="<%= avo_appearance_t("dark_tooltip") %>">
       <%= svg "tabler/outline/moon", class: "color-scheme-switcher__icon" %>
-      <span class="sr-only"><%= t("avo.appearance.dark") %></span>
+      <span class="sr-only"><%= avo_appearance_t("dark") %></span>
     </button>
   <% end %>
 </div>

--- a/lib/generators/avo/templates/locales/avo.ar.yml
+++ b/lib/generators/avo/templates/locales/avo.ar.yml
@@ -9,24 +9,24 @@ ar:
       accent_picker: لون مميز
       accents: اللون المميز
       accents_list:
-        amber: Amber
-        blue: Blue
-        brand: Brand
-        cyan: Cyan
-        emerald: Emerald
-        fuchsia: Fuchsia
-        green: Green
-        indigo: Indigo
-        lime: Lime
-        orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
-        rose: Rose
-        sky: Sky
-        teal: Teal
-        violet: Violet
-        yellow: Yellow
+        amber: كهرماني
+        blue: أزرق
+        brand: العلامة
+        cyan: سماوي
+        emerald: زمردي
+        fuchsia: فوشيا
+        green: أخضر
+        indigo: نيلي
+        lime: ليموني
+        orange: برتقالي
+        pink: وردي
+        purple: أرجواني
+        red: أحمر
+        rose: زهري
+        sky: سماوي
+        teal: تركواز
+        violet: بنفسجي
+        yellow: أصفر
       auto: تلقائي
       auto_tooltip: تلقائي (تفضيل النظام)
       dark: داكن
@@ -36,16 +36,16 @@ ar:
       light_tooltip: وضع الفاتح
       neutrals: السمة
       neutrals_list:
-        brand: Brand
-        gray: Gray
-        mauve: Mauve
-        mist: Mist
-        neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
-        taupe: Taupe
-        zinc: Zinc
+        brand: العلامة
+        gray: رمادي
+        mauve: بنفسجي فاتح
+        mist: ضباب
+        neutral: محايد
+        olive: زيتوني
+        slate: أردوازي
+        stone: حجري
+        taupe: رمادي بني
+        zinc: زنك
       neutrals_picker: سمة الألوان المحايدة
       schemes: المظهر
       shortcut_badges: شارات الاختصار

--- a/lib/generators/avo/templates/locales/avo.ar.yml
+++ b/lib/generators/avo/templates/locales/avo.ar.yml
@@ -8,6 +8,25 @@ ar:
     appearance:
       accent_picker: لون مميز
       accents: اللون المميز
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: تلقائي
       auto_tooltip: تلقائي (تفضيل النظام)
       dark: داكن
@@ -16,6 +35,17 @@ ar:
       light: فاتح
       light_tooltip: وضع الفاتح
       neutrals: السمة
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: سمة الألوان المحايدة
       schemes: المظهر
       shortcut_badges: شارات الاختصار

--- a/lib/generators/avo/templates/locales/avo.de.yml
+++ b/lib/generators/avo/templates/locales/avo.de.yml
@@ -9,24 +9,24 @@ de:
       accent_picker: Akzentfarbe
       accents: Akzent
       accents_list:
-        amber: Amber
-        blue: Blue
-        brand: Brand
+        amber: Bernstein
+        blue: Blau
+        brand: Marke
         cyan: Cyan
-        emerald: Emerald
+        emerald: Smaragd
         fuchsia: Fuchsia
-        green: Green
+        green: Grün
         indigo: Indigo
-        lime: Lime
+        lime: Limette
         orange: Orange
         pink: Pink
-        purple: Purple
-        red: Red
+        purple: Lila
+        red: Rot
         rose: Rose
-        sky: Sky
-        teal: Teal
-        violet: Violet
-        yellow: Yellow
+        sky: Himmelblau
+        teal: Blaugrün
+        violet: Violett
+        yellow: Gelb
       auto: Automatisch
       auto_tooltip: Automatisch (Systemeinstellung)
       dark: Dunkel
@@ -36,16 +36,16 @@ de:
       light_tooltip: Heller Modus
       neutrals: Thema
       neutrals_list:
-        brand: Brand
-        gray: Gray
-        mauve: Mauve
-        mist: Mist
+        brand: Marke
+        gray: Grau
+        mauve: Malve
+        mist: Nebel
         neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
+        olive: Oliv
+        slate: Schiefer
+        stone: Stein
         taupe: Taupe
-        zinc: Zinc
+        zinc: Zink
       neutrals_picker: Neutrale Themen
       schemes: Erscheinungsbild
       shortcut_badges: Verknüpfungssymbole

--- a/lib/generators/avo/templates/locales/avo.de.yml
+++ b/lib/generators/avo/templates/locales/avo.de.yml
@@ -8,6 +8,25 @@ de:
     appearance:
       accent_picker: Akzentfarbe
       accents: Akzent
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: Automatisch
       auto_tooltip: Automatisch (Systemeinstellung)
       dark: Dunkel
@@ -16,6 +35,17 @@ de:
       light: Hell
       light_tooltip: Heller Modus
       neutrals: Thema
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: Neutrale Themen
       schemes: Erscheinungsbild
       shortcut_badges: Verknüpfungssymbole

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -16,7 +16,37 @@ en:
       light: Light
       light_tooltip: Light mode
       neutrals: Theme
+      neutrals_list:
+        brand: Brand
+        slate: Slate
+        stone: Stone
+        gray: Gray
+        zinc: Zinc
+        neutral: Neutral
+        taupe: Taupe
+        mauve: Mauve
+        mist: Mist
+        olive: Olive
       neutrals_picker: Select neutral color
+      accents_list:
+        brand: Brand
+        red: Red
+        orange: Orange
+        amber: Amber
+        yellow: Yellow
+        lime: Lime
+        green: Green
+        emerald: Emerald
+        teal: Teal
+        cyan: Cyan
+        sky: Sky
+        blue: Blue
+        indigo: Indigo
+        violet: Violet
+        purple: Purple
+        fuchsia: Fuchsia
+        pink: Pink
+        rose: Rose
       schemes: Appearance
       shortcut_badges: Shortcut badges
       shortcut_badges_hide_tooltip: Hide keyboard shortcut badges

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -8,6 +8,25 @@ en:
     appearance:
       accent_picker: Select accent color
       accents: Accent
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: Auto
       auto_tooltip: Auto (system preference)
       dark: Dark
@@ -18,35 +37,16 @@ en:
       neutrals: Theme
       neutrals_list:
         brand: Brand
-        slate: Slate
-        stone: Stone
         gray: Gray
-        zinc: Zinc
-        neutral: Neutral
-        taupe: Taupe
         mauve: Mauve
         mist: Mist
+        neutral: Neutral
         olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: Select neutral color
-      accents_list:
-        brand: Brand
-        red: Red
-        orange: Orange
-        amber: Amber
-        yellow: Yellow
-        lime: Lime
-        green: Green
-        emerald: Emerald
-        teal: Teal
-        cyan: Cyan
-        sky: Sky
-        blue: Blue
-        indigo: Indigo
-        violet: Violet
-        purple: Purple
-        fuchsia: Fuchsia
-        pink: Pink
-        rose: Rose
       schemes: Appearance
       shortcut_badges: Shortcut badges
       shortcut_badges_hide_tooltip: Hide keyboard shortcut badges

--- a/lib/generators/avo/templates/locales/avo.es.yml
+++ b/lib/generators/avo/templates/locales/avo.es.yml
@@ -8,6 +8,25 @@ es:
     appearance:
       accent_picker: Color de acento
       accents: Acento
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: Automático
       auto_tooltip: Automático (preferencia del sistema)
       dark: Oscuro
@@ -16,6 +35,17 @@ es:
       light: Claro
       light_tooltip: Modo claro
       neutrals: Tema
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: Tema neutro
       schemes: Apariencia
       shortcut_badges: Insignias de atajo

--- a/lib/generators/avo/templates/locales/avo.es.yml
+++ b/lib/generators/avo/templates/locales/avo.es.yml
@@ -9,24 +9,24 @@ es:
       accent_picker: Color de acento
       accents: Acento
       accents_list:
-        amber: Amber
-        blue: Blue
-        brand: Brand
-        cyan: Cyan
-        emerald: Emerald
-        fuchsia: Fuchsia
-        green: Green
-        indigo: Indigo
-        lime: Lime
-        orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
-        rose: Rose
-        sky: Sky
-        teal: Teal
-        violet: Violet
-        yellow: Yellow
+        amber: Ámbar
+        blue: Azul
+        brand: Marca
+        cyan: Cian
+        emerald: Esmeralda
+        fuchsia: Fucsia
+        green: Verde
+        indigo: Índigo
+        lime: Lima
+        orange: Naranja
+        pink: Rosa
+        purple: Púrpura
+        red: Rojo
+        rose: Rosado
+        sky: Cielo
+        teal: Verde azulado
+        violet: Violeta
+        yellow: Amarillo
       auto: Automático
       auto_tooltip: Automático (preferencia del sistema)
       dark: Oscuro
@@ -36,15 +36,15 @@ es:
       light_tooltip: Modo claro
       neutrals: Tema
       neutrals_list:
-        brand: Brand
-        gray: Gray
-        mauve: Mauve
-        mist: Mist
+        brand: Marca
+        gray: Gris
+        mauve: Malva
+        mist: Niebla
         neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
-        taupe: Taupe
+        olive: Oliva
+        slate: Pizarra
+        stone: Piedra
+        taupe: Topo
         zinc: Zinc
       neutrals_picker: Tema neutro
       schemes: Apariencia

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -9,24 +9,24 @@ fr:
       accent_picker: Couleur d'accent
       accents: Accent
       accents_list:
-        amber: Amber
-        blue: Blue
-        brand: Brand
+        amber: Ambre
+        blue: Bleu
+        brand: Marque
         cyan: Cyan
-        emerald: Emerald
+        emerald: Émeraude
         fuchsia: Fuchsia
-        green: Green
+        green: Vert
         indigo: Indigo
-        lime: Lime
+        lime: Citron vert
         orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
-        rose: Rose
-        sky: Sky
-        teal: Teal
+        pink: Rose
+        purple: Violet
+        red: Rouge
+        rose: Rosé
+        sky: Ciel
+        teal: Sarcelle
         violet: Violet
-        yellow: Yellow
+        yellow: Jaune
       auto: Automatique
       auto_tooltip: Automatique (préférence système)
       dark: Sombre
@@ -36,14 +36,14 @@ fr:
       light_tooltip: Mode clair
       neutrals: Thème
       neutrals_list:
-        brand: Brand
-        gray: Gray
+        brand: Marque
+        gray: Gris
         mauve: Mauve
-        mist: Mist
-        neutral: Neutral
+        mist: Brume
+        neutral: Neutre
         olive: Olive
-        slate: Slate
-        stone: Stone
+        slate: Ardoise
+        stone: Pierre
         taupe: Taupe
         zinc: Zinc
       neutrals_picker: Thème neutre

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -8,6 +8,25 @@ fr:
     appearance:
       accent_picker: Couleur d'accent
       accents: Accent
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: Automatique
       auto_tooltip: Automatique (préférence système)
       dark: Sombre
@@ -16,6 +35,17 @@ fr:
       light: Clair
       light_tooltip: Mode clair
       neutrals: Thème
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: Thème neutre
       schemes: Apparence
       shortcut_badges: Badges de raccourci

--- a/lib/generators/avo/templates/locales/avo.it.yml
+++ b/lib/generators/avo/templates/locales/avo.it.yml
@@ -8,6 +8,25 @@ it:
     appearance:
       accent_picker: Colore accento
       accents: Accento
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: Automatico
       auto_tooltip: Automatico (preferenza di sistema)
       dark: Scuro
@@ -16,6 +35,17 @@ it:
       light: Chiaro
       light_tooltip: Modalità chiara
       neutrals: Tema
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: Tema neutro
       schemes: Aspetto
       shortcut_badges: Badge di scorciatoia

--- a/lib/generators/avo/templates/locales/avo.it.yml
+++ b/lib/generators/avo/templates/locales/avo.it.yml
@@ -9,24 +9,24 @@ it:
       accent_picker: Colore accento
       accents: Accento
       accents_list:
-        amber: Amber
-        blue: Blue
-        brand: Brand
-        cyan: Cyan
-        emerald: Emerald
-        fuchsia: Fuchsia
-        green: Green
+        amber: Ambra
+        blue: Blu
+        brand: Marchio
+        cyan: Ciano
+        emerald: Smeraldo
+        fuchsia: Fucsia
+        green: Verde
         indigo: Indigo
         lime: Lime
-        orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
-        rose: Rose
-        sky: Sky
-        teal: Teal
-        violet: Violet
-        yellow: Yellow
+        orange: Arancione
+        pink: Rosa
+        purple: Viola
+        red: Rosso
+        rose: Rosato
+        sky: Cielo
+        teal: Verde acqua
+        violet: Violetto
+        yellow: Giallo
       auto: Automatico
       auto_tooltip: Automatico (preferenza di sistema)
       dark: Scuro
@@ -36,16 +36,16 @@ it:
       light_tooltip: Modalità chiara
       neutrals: Tema
       neutrals_list:
-        brand: Brand
-        gray: Gray
-        mauve: Mauve
-        mist: Mist
-        neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
+        brand: Marchio
+        gray: Grigio
+        mauve: Malva
+        mist: Nebbia
+        neutral: Neutro
+        olive: Oliva
+        slate: Ardesia
+        stone: Pietra
         taupe: Taupe
-        zinc: Zinc
+        zinc: Zinco
       neutrals_picker: Tema neutro
       schemes: Aspetto
       shortcut_badges: Badge di scorciatoia

--- a/lib/generators/avo/templates/locales/avo.ja.yml
+++ b/lib/generators/avo/templates/locales/avo.ja.yml
@@ -8,6 +8,25 @@ ja:
     appearance:
       accent_picker: アクセントカラー
       accents: アクセント
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: 自動
       auto_tooltip: 自動（システム設定）
       dark: ダーク
@@ -16,6 +35,17 @@ ja:
       light: ライト
       light_tooltip: ライトモード
       neutrals: テーマ
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: ニュートラルテーマ
       schemes: 外観
       shortcut_badges: ショートカットバッジ

--- a/lib/generators/avo/templates/locales/avo.ja.yml
+++ b/lib/generators/avo/templates/locales/avo.ja.yml
@@ -9,24 +9,24 @@ ja:
       accent_picker: アクセントカラー
       accents: アクセント
       accents_list:
-        amber: Amber
-        blue: Blue
-        brand: Brand
-        cyan: Cyan
-        emerald: Emerald
-        fuchsia: Fuchsia
-        green: Green
-        indigo: Indigo
-        lime: Lime
-        orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
-        rose: Rose
-        sky: Sky
-        teal: Teal
-        violet: Violet
-        yellow: Yellow
+        amber: アンバー
+        blue: ブルー
+        brand: ブランド
+        cyan: シアン
+        emerald: エメラルド
+        fuchsia: フクシア
+        green: グリーン
+        indigo: インディゴ
+        lime: ライム
+        orange: オレンジ
+        pink: ピンク
+        purple: パープル
+        red: レッド
+        rose: ローズ
+        sky: スカイ
+        teal: ティール
+        violet: バイオレット
+        yellow: イエロー
       auto: 自動
       auto_tooltip: 自動（システム設定）
       dark: ダーク
@@ -36,16 +36,16 @@ ja:
       light_tooltip: ライトモード
       neutrals: テーマ
       neutrals_list:
-        brand: Brand
-        gray: Gray
-        mauve: Mauve
-        mist: Mist
-        neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
-        taupe: Taupe
-        zinc: Zinc
+        brand: ブランド
+        gray: グレー
+        mauve: モーブ
+        mist: ミスト
+        neutral: ニュートラル
+        olive: オリーブ
+        slate: スレート
+        stone: ストーン
+        taupe: トープ
+        zinc: ジンク
       neutrals_picker: ニュートラルテーマ
       schemes: 外観
       shortcut_badges: ショートカットバッジ

--- a/lib/generators/avo/templates/locales/avo.nb.yml
+++ b/lib/generators/avo/templates/locales/avo.nb.yml
@@ -9,24 +9,24 @@ nb:
       accent_picker: Aksentfarge
       accents: Aksent
       accents_list:
-        amber: Amber
-        blue: Blue
-        brand: Brand
+        amber: Rav
+        blue: Blå
+        brand: Merke
         cyan: Cyan
-        emerald: Emerald
+        emerald: Smaragd
         fuchsia: Fuchsia
-        green: Green
+        green: Grønn
         indigo: Indigo
         lime: Lime
-        orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
+        orange: Oransje
+        pink: Rosa
+        purple: Lilla
+        red: Rød
         rose: Rose
-        sky: Sky
-        teal: Teal
-        violet: Violet
-        yellow: Yellow
+        sky: Himmelblå
+        teal: Blågrønn
+        violet: Fiolett
+        yellow: Gul
       auto: Auto
       auto_tooltip: Auto (systempreferanse)
       dark: Mørk
@@ -36,16 +36,16 @@ nb:
       light_tooltip: Lys modus
       neutrals: Tema
       neutrals_list:
-        brand: Brand
-        gray: Gray
+        brand: Merke
+        gray: Grå
         mauve: Mauve
-        mist: Mist
-        neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
+        mist: Tåke
+        neutral: Nøytral
+        olive: Oliven
+        slate: Skifer
+        stone: Stein
         taupe: Taupe
-        zinc: Zinc
+        zinc: Sink
       neutrals_picker: Nøytralt tema
       schemes: Utseende
       shortcut_badges: Snarveisknapper

--- a/lib/generators/avo/templates/locales/avo.nb.yml
+++ b/lib/generators/avo/templates/locales/avo.nb.yml
@@ -8,6 +8,25 @@ nb:
     appearance:
       accent_picker: Aksentfarge
       accents: Aksent
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: Auto
       auto_tooltip: Auto (systempreferanse)
       dark: Mørk
@@ -16,6 +35,17 @@ nb:
       light: Lys
       light_tooltip: Lys modus
       neutrals: Tema
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: Nøytralt tema
       schemes: Utseende
       shortcut_badges: Snarveisknapper

--- a/lib/generators/avo/templates/locales/avo.nl.yml
+++ b/lib/generators/avo/templates/locales/avo.nl.yml
@@ -10,23 +10,23 @@ nl:
       accents: Accent
       accents_list:
         amber: Amber
-        blue: Blue
-        brand: Brand
-        cyan: Cyan
-        emerald: Emerald
+        blue: Blauw
+        brand: Merk
+        cyan: Cyaan
+        emerald: Smaragd
         fuchsia: Fuchsia
-        green: Green
+        green: Groen
         indigo: Indigo
-        lime: Lime
-        orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
-        rose: Rose
-        sky: Sky
-        teal: Teal
+        lime: Limoen
+        orange: Oranje
+        pink: Roze
+        purple: Paars
+        red: Rood
+        rose: Roos
+        sky: Hemelblauw
+        teal: Blauwgroen
         violet: Violet
-        yellow: Yellow
+        yellow: Geel
       auto: Automatisch
       auto_tooltip: Automatisch (systeemvoorkeur)
       dark: Donker
@@ -36,16 +36,16 @@ nl:
       light_tooltip: Lichtmodus
       neutrals: Thema
       neutrals_list:
-        brand: Brand
-        gray: Gray
+        brand: Merk
+        gray: Grijs
         mauve: Mauve
         mist: Mist
-        neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
+        neutral: Neutraal
+        olive: Olijf
+        slate: Leisteen
+        stone: Steen
         taupe: Taupe
-        zinc: Zinc
+        zinc: Zink
       neutrals_picker: Neutrale thema
       schemes: Uiterlijk
       shortcut_badges: Sneltoets badges

--- a/lib/generators/avo/templates/locales/avo.nl.yml
+++ b/lib/generators/avo/templates/locales/avo.nl.yml
@@ -8,6 +8,25 @@ nl:
     appearance:
       accent_picker: Accentkleur
       accents: Accent
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: Automatisch
       auto_tooltip: Automatisch (systeemvoorkeur)
       dark: Donker
@@ -16,6 +35,17 @@ nl:
       light: Licht
       light_tooltip: Lichtmodus
       neutrals: Thema
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: Neutrale thema
       schemes: Uiterlijk
       shortcut_badges: Sneltoets badges

--- a/lib/generators/avo/templates/locales/avo.nn.yml
+++ b/lib/generators/avo/templates/locales/avo.nn.yml
@@ -9,24 +9,24 @@ nn:
       accent_picker: Aksentfarge
       accents: Aksent
       accents_list:
-        amber: Amber
-        blue: Blue
-        brand: Brand
+        amber: Rav
+        blue: Blå
+        brand: Merke
         cyan: Cyan
-        emerald: Emerald
+        emerald: Smaragd
         fuchsia: Fuchsia
-        green: Green
+        green: Grøn
         indigo: Indigo
         lime: Lime
-        orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
+        orange: Oransje
+        pink: Rosa
+        purple: Lilla
+        red: Raud
         rose: Rose
-        sky: Sky
-        teal: Teal
-        violet: Violet
-        yellow: Yellow
+        sky: Himmelblå
+        teal: Blågrøn
+        violet: Fiolett
+        yellow: Gul
       auto: Auto
       auto_tooltip: Auto (systempreferanse)
       dark: Mørk
@@ -36,16 +36,16 @@ nn:
       light_tooltip: Lysmodus
       neutrals: Tema
       neutrals_list:
-        brand: Brand
-        gray: Gray
+        brand: Merke
+        gray: Grå
         mauve: Mauve
-        mist: Mist
-        neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
+        mist: Tåke
+        neutral: Nøytral
+        olive: Oliven
+        slate: Skifer
+        stone: Stein
         taupe: Taupe
-        zinc: Zinc
+        zinc: Sink
       neutrals_picker: Nøytrale tema
       schemes: Utseende
       shortcut_badges: Snarveiknappar

--- a/lib/generators/avo/templates/locales/avo.nn.yml
+++ b/lib/generators/avo/templates/locales/avo.nn.yml
@@ -8,6 +8,25 @@ nn:
     appearance:
       accent_picker: Aksentfarge
       accents: Aksent
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: Auto
       auto_tooltip: Auto (systempreferanse)
       dark: Mørk
@@ -16,6 +35,17 @@ nn:
       light: Lys
       light_tooltip: Lysmodus
       neutrals: Tema
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: Nøytrale tema
       schemes: Utseende
       shortcut_badges: Snarveiknappar

--- a/lib/generators/avo/templates/locales/avo.pl.yml
+++ b/lib/generators/avo/templates/locales/avo.pl.yml
@@ -8,6 +8,25 @@ pl:
     appearance:
       accent_picker: Kolor akcentu
       accents: Akcent
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: Automatycznie
       auto_tooltip: Automatycznie (preferencje systemowe)
       dark: Ciemny
@@ -16,6 +35,17 @@ pl:
       light: Jasny
       light_tooltip: Tryb jasny
       neutrals: Motyw
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: Motyw neutralny
       schemes: Wygląd
       shortcut_badges: Ikony skrótów

--- a/lib/generators/avo/templates/locales/avo.pl.yml
+++ b/lib/generators/avo/templates/locales/avo.pl.yml
@@ -9,24 +9,24 @@ pl:
       accent_picker: Kolor akcentu
       accents: Akcent
       accents_list:
-        amber: Amber
-        blue: Blue
-        brand: Brand
-        cyan: Cyan
-        emerald: Emerald
-        fuchsia: Fuchsia
-        green: Green
-        indigo: Indigo
-        lime: Lime
-        orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
-        rose: Rose
-        sky: Sky
-        teal: Teal
-        violet: Violet
-        yellow: Yellow
+        amber: Bursztyn
+        blue: Niebieski
+        brand: Marka
+        cyan: Cyjan
+        emerald: Szmaragd
+        fuchsia: Fuksja
+        green: Zielony
+        indigo: Indygo
+        lime: Limonka
+        orange: Pomarańczowy
+        pink: Różowy
+        purple: Fioletowy
+        red: Czerwony
+        rose: Różany
+        sky: Błękit
+        teal: Morski
+        violet: Fiolet
+        yellow: Żółty
       auto: Automatycznie
       auto_tooltip: Automatycznie (preferencje systemowe)
       dark: Ciemny
@@ -36,16 +36,16 @@ pl:
       light_tooltip: Tryb jasny
       neutrals: Motyw
       neutrals_list:
-        brand: Brand
-        gray: Gray
+        brand: Marka
+        gray: Szary
         mauve: Mauve
-        mist: Mist
-        neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
+        mist: Mgła
+        neutral: Neutralny
+        olive: Oliwkowy
+        slate: Łupkowy
+        stone: Kamienny
         taupe: Taupe
-        zinc: Zinc
+        zinc: Cynk
       neutrals_picker: Motyw neutralny
       schemes: Wygląd
       shortcut_badges: Ikony skrótów

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -9,24 +9,24 @@ pt-BR:
       accent_picker: Cor de Acento
       accents: Acento
       accents_list:
-        amber: Amber
-        blue: Blue
-        brand: Brand
-        cyan: Cyan
-        emerald: Emerald
-        fuchsia: Fuchsia
-        green: Green
-        indigo: Indigo
-        lime: Lime
-        orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
-        rose: Rose
-        sky: Sky
-        teal: Teal
-        violet: Violet
-        yellow: Yellow
+        amber: Âmbar
+        blue: Azul
+        brand: Marca
+        cyan: Ciano
+        emerald: Esmeralda
+        fuchsia: Fúcsia
+        green: Verde
+        indigo: Índigo
+        lime: Limão
+        orange: Laranja
+        pink: Rosa
+        purple: Roxo
+        red: Vermelho
+        rose: Rosé
+        sky: Céu
+        teal: Verde-azulado
+        violet: Violeta
+        yellow: Amarelo
       auto: Automático
       auto_tooltip: Automático (preferência do sistema)
       dark: Escuro
@@ -36,16 +36,16 @@ pt-BR:
       light_tooltip: Modo Claro
       neutrals: Tema
       neutrals_list:
-        brand: Brand
-        gray: Gray
-        mauve: Mauve
-        mist: Mist
-        neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
+        brand: Marca
+        gray: Cinza
+        mauve: Malva
+        mist: Névoa
+        neutral: Neutro
+        olive: Oliva
+        slate: Ardósia
+        stone: Pedra
         taupe: Taupe
-        zinc: Zinc
+        zinc: Zinco
       neutrals_picker: Tema Neutro
       schemes: Aparência
       shortcut_badges: Badges de atalho

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -8,6 +8,25 @@ pt-BR:
     appearance:
       accent_picker: Cor de Acento
       accents: Acento
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: Automático
       auto_tooltip: Automático (preferência do sistema)
       dark: Escuro
@@ -16,6 +35,17 @@ pt-BR:
       light: Claro
       light_tooltip: Modo Claro
       neutrals: Tema
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: Tema Neutro
       schemes: Aparência
       shortcut_badges: Badges de atalho

--- a/lib/generators/avo/templates/locales/avo.pt.yml
+++ b/lib/generators/avo/templates/locales/avo.pt.yml
@@ -8,6 +8,25 @@ pt:
     appearance:
       accent_picker: Cor de Acento
       accents: Acento
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: Automático
       auto_tooltip: Automático (preferência do sistema)
       dark: Escuro
@@ -16,6 +35,17 @@ pt:
       light: Claro
       light_tooltip: Modo Claro
       neutrals: Tema
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: Tema Neutro
       schemes: Aparência
       shortcut_badges: Insígnias de atalho

--- a/lib/generators/avo/templates/locales/avo.pt.yml
+++ b/lib/generators/avo/templates/locales/avo.pt.yml
@@ -9,24 +9,24 @@ pt:
       accent_picker: Cor de Acento
       accents: Acento
       accents_list:
-        amber: Amber
-        blue: Blue
-        brand: Brand
-        cyan: Cyan
-        emerald: Emerald
-        fuchsia: Fuchsia
-        green: Green
-        indigo: Indigo
-        lime: Lime
-        orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
-        rose: Rose
-        sky: Sky
-        teal: Teal
-        violet: Violet
-        yellow: Yellow
+        amber: Âmbar
+        blue: Azul
+        brand: Marca
+        cyan: Ciano
+        emerald: Esmeralda
+        fuchsia: Fúcsia
+        green: Verde
+        indigo: Índigo
+        lime: Lima
+        orange: Laranja
+        pink: Rosa
+        purple: Roxo
+        red: Vermelho
+        rose: Rosé
+        sky: Céu
+        teal: Verde-azulado
+        violet: Violeta
+        yellow: Amarelo
       auto: Automático
       auto_tooltip: Automático (preferência do sistema)
       dark: Escuro
@@ -36,16 +36,16 @@ pt:
       light_tooltip: Modo Claro
       neutrals: Tema
       neutrals_list:
-        brand: Brand
-        gray: Gray
-        mauve: Mauve
-        mist: Mist
-        neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
+        brand: Marca
+        gray: Cinzento
+        mauve: Malva
+        mist: Névoa
+        neutral: Neutro
+        olive: Oliva
+        slate: Ardósia
+        stone: Pedra
         taupe: Taupe
-        zinc: Zinc
+        zinc: Zinco
       neutrals_picker: Tema Neutro
       schemes: Aparência
       shortcut_badges: Insígnias de atalho

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -8,6 +8,25 @@ ro:
     appearance:
       accent_picker: Culoare accent
       accents: Accent
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: Automat
       auto_tooltip: Automat (preferința sistemului)
       dark: Întunecat
@@ -16,6 +35,17 @@ ro:
       light: Deschis
       light_tooltip: Mod deschis
       neutrals: Temă
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: Temă neutre
       schemes: Aspect
       shortcut_badges: Insignele scurtăturilor

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -9,24 +9,24 @@ ro:
       accent_picker: Culoare accent
       accents: Accent
       accents_list:
-        amber: Amber
-        blue: Blue
+        amber: Chihlimbar
+        blue: Albastru
         brand: Brand
         cyan: Cyan
-        emerald: Emerald
-        fuchsia: Fuchsia
-        green: Green
+        emerald: Smarald
+        fuchsia: Fucsia
+        green: Verde
         indigo: Indigo
         lime: Lime
-        orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
-        rose: Rose
-        sky: Sky
-        teal: Teal
+        orange: Portocaliu
+        pink: Roz
+        purple: Mov
+        red: Roșu
+        rose: Trandafiriu
+        sky: Cer
+        teal: Turcoaz
         violet: Violet
-        yellow: Yellow
+        yellow: Galben
       auto: Automat
       auto_tooltip: Automat (preferința sistemului)
       dark: Întunecat
@@ -37,13 +37,13 @@ ro:
       neutrals: Temă
       neutrals_list:
         brand: Brand
-        gray: Gray
-        mauve: Mauve
-        mist: Mist
-        neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
+        gray: Gri
+        mauve: Mov deschis
+        mist: Ceață
+        neutral: Neutru
+        olive: Măsliniu
+        slate: Ardezie
+        stone: Piatră
         taupe: Taupe
         zinc: Zinc
       neutrals_picker: Temă neutre

--- a/lib/generators/avo/templates/locales/avo.ru.yml
+++ b/lib/generators/avo/templates/locales/avo.ru.yml
@@ -9,24 +9,24 @@ ru:
       accent_picker: Цвет акцента
       accents: Акцент
       accents_list:
-        amber: Amber
-        blue: Blue
-        brand: Brand
-        cyan: Cyan
-        emerald: Emerald
-        fuchsia: Fuchsia
-        green: Green
-        indigo: Indigo
-        lime: Lime
-        orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
-        rose: Rose
-        sky: Sky
-        teal: Teal
-        violet: Violet
-        yellow: Yellow
+        amber: Янтарный
+        blue: Синий
+        brand: Бренд
+        cyan: Бирюзовый
+        emerald: Изумрудный
+        fuchsia: Фуксия
+        green: Зелёный
+        indigo: Индиго
+        lime: Лайм
+        orange: Оранжевый
+        pink: Розовый
+        purple: Фиолетовый
+        red: Красный
+        rose: Розовый
+        sky: Небесный
+        teal: Бирюзовый
+        violet: Фиолетовый
+        yellow: Жёлтый
       auto: Авто
       auto_tooltip: Авто (системные предпочтения)
       dark: Темный
@@ -36,16 +36,16 @@ ru:
       light_tooltip: Светлый режим
       neutrals: Тема
       neutrals_list:
-        brand: Brand
-        gray: Gray
-        mauve: Mauve
-        mist: Mist
-        neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
-        taupe: Taupe
-        zinc: Zinc
+        brand: Бренд
+        gray: Серый
+        mauve: Лиловый
+        mist: Туман
+        neutral: Нейтральный
+        olive: Оливковый
+        slate: Шифер
+        stone: Каменный
+        taupe: Тауп
+        zinc: Цинк
       neutrals_picker: Нейтральная тема
       schemes: Внешний вид
       shortcut_badges: Значки ярлыков

--- a/lib/generators/avo/templates/locales/avo.ru.yml
+++ b/lib/generators/avo/templates/locales/avo.ru.yml
@@ -8,6 +8,25 @@ ru:
     appearance:
       accent_picker: Цвет акцента
       accents: Акцент
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: Авто
       auto_tooltip: Авто (системные предпочтения)
       dark: Темный
@@ -16,6 +35,17 @@ ru:
       light: Светлый
       light_tooltip: Светлый режим
       neutrals: Тема
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: Нейтральная тема
       schemes: Внешний вид
       shortcut_badges: Значки ярлыков

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -8,6 +8,25 @@ tr:
     appearance:
       accent_picker: Vurgu rengi
       accents: Vurgu
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: Otomatik
       auto_tooltip: Otomatik (sistem tercihi)
       dark: Koyu
@@ -16,6 +35,17 @@ tr:
       light: Açık
       light_tooltip: Açık mod
       neutrals: Tema
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: Nötr tema
       schemes: Görünüm
       shortcut_badges: Kısayol rozetleri

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -9,24 +9,24 @@ tr:
       accent_picker: Vurgu rengi
       accents: Vurgu
       accents_list:
-        amber: Amber
-        blue: Blue
-        brand: Brand
-        cyan: Cyan
-        emerald: Emerald
-        fuchsia: Fuchsia
-        green: Green
-        indigo: Indigo
-        lime: Lime
-        orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
-        rose: Rose
-        sky: Sky
-        teal: Teal
-        violet: Violet
-        yellow: Yellow
+        amber: Kehribar
+        blue: Mavi
+        brand: Marka
+        cyan: Camgöbeği
+        emerald: Zümrüt
+        fuchsia: Fuşya
+        green: Yeşil
+        indigo: İndigo
+        lime: Limon
+        orange: Turuncu
+        pink: Pembe
+        purple: Mor
+        red: Kırmızı
+        rose: Gül
+        sky: Gök
+        teal: Deniz mavisi
+        violet: Menekşe
+        yellow: Sarı
       auto: Otomatik
       auto_tooltip: Otomatik (sistem tercihi)
       dark: Koyu
@@ -36,16 +36,16 @@ tr:
       light_tooltip: Açık mod
       neutrals: Tema
       neutrals_list:
-        brand: Brand
-        gray: Gray
-        mauve: Mauve
-        mist: Mist
-        neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
+        brand: Marka
+        gray: Gri
+        mauve: Eflatun
+        mist: Sis
+        neutral: Nötr
+        olive: Zeytin
+        slate: Arduvaz
+        stone: Taş
         taupe: Taupe
-        zinc: Zinc
+        zinc: Çinko
       neutrals_picker: Nötr tema
       schemes: Görünüm
       shortcut_badges: Kısayol rozetleri

--- a/lib/generators/avo/templates/locales/avo.ua.yml
+++ b/lib/generators/avo/templates/locales/avo.ua.yml
@@ -8,6 +8,25 @@ ua:
     appearance:
       accent_picker: Колір акценту
       accents: Акцент
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: Авто
       auto_tooltip: Авто (системні налаштування)
       dark: Темний
@@ -16,6 +35,17 @@ ua:
       light: Світлий
       light_tooltip: Світлий режим
       neutrals: Тема
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: Нейтральна тема
       schemes: Зовнішній вигляд
       shortcut_badges: Значки ярликів

--- a/lib/generators/avo/templates/locales/avo.ua.yml
+++ b/lib/generators/avo/templates/locales/avo.ua.yml
@@ -9,24 +9,24 @@ ua:
       accent_picker: Колір акценту
       accents: Акцент
       accents_list:
-        amber: Amber
-        blue: Blue
-        brand: Brand
-        cyan: Cyan
-        emerald: Emerald
-        fuchsia: Fuchsia
-        green: Green
-        indigo: Indigo
-        lime: Lime
-        orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
-        rose: Rose
-        sky: Sky
-        teal: Teal
-        violet: Violet
-        yellow: Yellow
+        amber: Бурштиновий
+        blue: Синій
+        brand: Бренд
+        cyan: Блакитний
+        emerald: Смарагдовий
+        fuchsia: Фуксія
+        green: Зелений
+        indigo: Індиго
+        lime: Лайм
+        orange: Помаранчевий
+        pink: Рожевий
+        purple: Фіолетовий
+        red: Червоний
+        rose: Трояндовий
+        sky: Небесний
+        teal: Бірюзовий
+        violet: Фіолетовий
+        yellow: Жовтий
       auto: Авто
       auto_tooltip: Авто (системні налаштування)
       dark: Темний
@@ -36,16 +36,16 @@ ua:
       light_tooltip: Світлий режим
       neutrals: Тема
       neutrals_list:
-        brand: Brand
-        gray: Gray
-        mauve: Mauve
-        mist: Mist
-        neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
+        brand: Бренд
+        gray: Сірий
+        mauve: Ліловий
+        mist: Туман
+        neutral: Нейтральний
+        olive: Оливковий
+        slate: Шифер
+        stone: Кам'яний
         taupe: Taupe
-        zinc: Zinc
+        zinc: Цинк
       neutrals_picker: Нейтральна тема
       schemes: Зовнішній вигляд
       shortcut_badges: Значки ярликів

--- a/lib/generators/avo/templates/locales/avo.zh-TW.yml
+++ b/lib/generators/avo/templates/locales/avo.zh-TW.yml
@@ -8,6 +8,25 @@ zh-TW:
     appearance:
       accent_picker: 重點顏色
       accents: 重點色
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: 自動
       auto_tooltip: 自動（系統偏好）
       dark: 深色
@@ -16,6 +35,17 @@ zh-TW:
       light: 淺色
       light_tooltip: 淺色模式
       neutrals: 主題
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: 中性色主題
       schemes: 外觀
       shortcut_badges: 快捷鍵徽章

--- a/lib/generators/avo/templates/locales/avo.zh-TW.yml
+++ b/lib/generators/avo/templates/locales/avo.zh-TW.yml
@@ -9,24 +9,24 @@ zh-TW:
       accent_picker: 重點顏色
       accents: 重點色
       accents_list:
-        amber: Amber
-        blue: Blue
-        brand: Brand
-        cyan: Cyan
-        emerald: Emerald
-        fuchsia: Fuchsia
-        green: Green
-        indigo: Indigo
-        lime: Lime
-        orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
-        rose: Rose
-        sky: Sky
-        teal: Teal
-        violet: Violet
-        yellow: Yellow
+        amber: 琥珀
+        blue: 藍色
+        brand: 品牌
+        cyan: 青色
+        emerald: 祖母綠
+        fuchsia: 品紅
+        green: 綠色
+        indigo: 靛藍
+        lime: 青檸
+        orange: 橙色
+        pink: 粉色
+        purple: 紫色
+        red: 紅色
+        rose: 玫瑰
+        sky: 天藍
+        teal: 藍綠
+        violet: 紫羅蘭
+        yellow: 黃色
       auto: 自動
       auto_tooltip: 自動（系統偏好）
       dark: 深色
@@ -36,16 +36,16 @@ zh-TW:
       light_tooltip: 淺色模式
       neutrals: 主題
       neutrals_list:
-        brand: Brand
-        gray: Gray
-        mauve: Mauve
-        mist: Mist
-        neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
-        taupe: Taupe
-        zinc: Zinc
+        brand: 品牌
+        gray: 灰色
+        mauve: 淡紫
+        mist: 薄霧
+        neutral: 中性
+        olive: 橄欖
+        slate: 石板
+        stone: 石色
+        taupe: 灰褐
+        zinc: 鋅色
       neutrals_picker: 中性色主題
       schemes: 外觀
       shortcut_badges: 快捷鍵徽章

--- a/lib/generators/avo/templates/locales/avo.zh.yml
+++ b/lib/generators/avo/templates/locales/avo.zh.yml
@@ -9,24 +9,24 @@ zh:
       accent_picker: 强调色
       accents: 强调色
       accents_list:
-        amber: Amber
-        blue: Blue
-        brand: Brand
-        cyan: Cyan
-        emerald: Emerald
-        fuchsia: Fuchsia
-        green: Green
-        indigo: Indigo
-        lime: Lime
-        orange: Orange
-        pink: Pink
-        purple: Purple
-        red: Red
-        rose: Rose
-        sky: Sky
-        teal: Teal
-        violet: Violet
-        yellow: Yellow
+        amber: 琥珀
+        blue: 蓝色
+        brand: 品牌
+        cyan: 青色
+        emerald: 祖母绿
+        fuchsia: 品红
+        green: 绿色
+        indigo: 靛蓝
+        lime: 青柠
+        orange: 橙色
+        pink: 粉色
+        purple: 紫色
+        red: 红色
+        rose: 玫瑰
+        sky: 天蓝
+        teal: 蓝绿
+        violet: 紫罗兰
+        yellow: 黄色
       auto: 自动
       auto_tooltip: 自动（系统偏好）
       dark: 深色
@@ -36,16 +36,16 @@ zh:
       light_tooltip: 浅色模式
       neutrals: 主题
       neutrals_list:
-        brand: Brand
-        gray: Gray
-        mauve: Mauve
-        mist: Mist
-        neutral: Neutral
-        olive: Olive
-        slate: Slate
-        stone: Stone
-        taupe: Taupe
-        zinc: Zinc
+        brand: 品牌
+        gray: 灰色
+        mauve: 淡紫
+        mist: 薄雾
+        neutral: 中性
+        olive: 橄榄
+        slate: 石板
+        stone: 石色
+        taupe: 灰褐
+        zinc: 锌色
       neutrals_picker: 中性色主题
       schemes: 外观
       shortcut_badges: 快捷键徽章

--- a/lib/generators/avo/templates/locales/avo.zh.yml
+++ b/lib/generators/avo/templates/locales/avo.zh.yml
@@ -8,6 +8,25 @@ zh:
     appearance:
       accent_picker: 强调色
       accents: 强调色
+      accents_list:
+        amber: Amber
+        blue: Blue
+        brand: Brand
+        cyan: Cyan
+        emerald: Emerald
+        fuchsia: Fuchsia
+        green: Green
+        indigo: Indigo
+        lime: Lime
+        orange: Orange
+        pink: Pink
+        purple: Purple
+        red: Red
+        rose: Rose
+        sky: Sky
+        teal: Teal
+        violet: Violet
+        yellow: Yellow
       auto: 自动
       auto_tooltip: 自动（系统偏好）
       dark: 深色
@@ -16,6 +35,17 @@ zh:
       light: 浅色
       light_tooltip: 浅色模式
       neutrals: 主题
+      neutrals_list:
+        brand: Brand
+        gray: Gray
+        mauve: Mauve
+        mist: Mist
+        neutral: Neutral
+        olive: Olive
+        slate: Slate
+        stone: Stone
+        taupe: Taupe
+        zinc: Zinc
       neutrals_picker: 中性色主题
       schemes: 外观
       shortcut_badges: 快捷键徽章

--- a/spec/helpers/avo/application_helper_spec.rb
+++ b/spec/helpers/avo/application_helper_spec.rb
@@ -67,6 +67,38 @@ RSpec.describe Avo::ApplicationHelper do
     end
   end
 
+  describe "#avo_appearance_t" do
+    before do
+      I18n.backend.store_translations(:en, avo: {appearance: {test_fallback_key: "English only"}})
+    end
+
+    it "falls back to English when the active locale omits appearance keys" do
+      I18n.with_locale(:de) do
+        expect(helper.avo_appearance_t("test_fallback_key")).to eq("English only")
+      end
+    end
+
+    it "returns plain text safe for HTML attributes" do
+      result = helper.avo_appearance_t("auto_tooltip")
+
+      expect(result).not_to include("<")
+      expect(result).not_to include("translation_missing")
+      expect(result).not_to include('">')
+    end
+
+    it "uses the explicit default when the key is missing in both locales" do
+      expect(helper.avo_appearance_t("neutrals_list.unknown", default: "Fallback")).to eq("Fallback")
+    end
+  end
+
+  describe "#appearance_neutral_labels" do
+    it "returns a label map keyed by neutral theme name" do
+      labels = helper.appearance_neutral_labels(%w[brand slate])
+
+      expect(labels).to eq({"brand" => "Brand", "slate" => "Slate"})
+    end
+  end
+
   describe "#chart_color" do
     it "returns a color from the list of configured chart_colors" do
       expect(helper.chart_color(0)).to eq(Avo.configuration.appearance.chart_colors[0])


### PR DESCRIPTION
## Summary

- Adds `avo_appearance_t` helper that falls back to English when the active locale omits Avo 4 `avo.appearance.*` keys, preventing Rails' HTML `translation_missing` spans from breaking `title` attributes and leaking visible `">` artifacts on theme switcher labels.
- Updates inline and dropdown theme switcher partials to use the helper for all appearance strings.
- Passes translated neutral theme labels to the appearance Stimulus controller via `data-appearance-theme-labels-value`, so the inline theme label stays i18n-aware after theme changes and keyboard cycling.
- Adds `neutrals_list` and `accents_list` entries to the English locale template.

Fixes [AVO-1407](https://linear.app/avo-hq/issue/AVO-1407/bugavo-401-theme-switcher-buttons-leak-unclosed-html-tags-on-ui-labels) / #4596

## Test plan

- [x] `bundle exec rspec spec/helpers/avo/application_helper_spec.rb -e "avo_appearance_t" -e "appearance_neutral_labels"`
- [ ] Upgrade an app with a stale non-English `avo.*.yml` missing appearance keys and confirm theme switcher labels render without `">` artifacts
- [ ] Change neutral theme via inline picker and keyboard shortcut; confirm label updates with translated text (or English fallback)
- [ ] Confirm tooltips and section labels still render correctly when appearance keys exist in the active locale


Made with [Cursor](https://cursor.com)