### PR TITLE
Include safelist.txt in Tailwind v4 host builds

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -22,6 +22,7 @@
 /* We couldn't find a way to implement blocklist in the CSS config */
 /* blocklist: ['bg-[#{chart_color(index)}]', 'bg-[${color}]'] */
 @source inline("break-all");
+@source "../../../safelist.txt";
 
 /* Tailwind colors */
 /* red, orange, amber, yellow, lime, green, emerald, teal, cyan, sky, blue, indigo, violet, purple, fuchsia, pink, rose */

--- a/avo.gemspec
+++ b/avo.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
 
   # NOTE: `public/` is rejected below — Avo 4 ships precompiled assets from
   # `app/assets/builds`, and a stale `public/avo-assets` dir was what bloated some builds.
-  spec.files = Dir["{bin,app,config,db,lib,public}/**/*", "Rakefile", "README.md", "avo.gemspec", "Gemfile", "Gemfile.lock", "tailwind.preset.js", "tailwind.custom.js"]
+  spec.files = Dir["{bin,app,config,db,lib,public}/**/*", "Rakefile", "README.md", "avo.gemspec", "Gemfile", "Gemfile.lock", "tailwind.preset.js", "tailwind.custom.js", "safelist.txt"]
     .reject { |f| f.start_with?("public/") }
 
   spec.add_dependency "activerecord", ">= 6.1"


### PR DESCRIPTION
## Summary
- Adds `@source "../../../safelist.txt"` to `application.css` so Tailwind v4 picks up dynamically-built utility classes (accent picker swatches, button colors, chart backgrounds, etc.)
- Ships `safelist.txt` in the gem via `avo.gemspec`

When host apps use Avo's Tailwind integration (`avo:tailwindcss:build`), classes like `bg-red-500` were missing because they're interpolated in ERB (`bg-#{accent}-500`) and can't be content-scanned. The precompiled gem CSS included them, but host rebuilds did not — causing broken accent color pickers and similar UI gaps.

## Test plan
- [ ] Enable Tailwind integration in a host app (`config.tailwindcss_integration_enabled = true`)
- [ ] Run `bin/rails avo:tailwindcss:build`
- [ ] Confirm `app/assets/builds/avo/application.css` includes `bg-red-500`, `bg-orange-500`, etc.
- [ ] Open admin → accent color picker shows all swatches with correct colors


Made with [Cursor](https://cursor.com)