### PR TITLE
Show Avo Status sidebar link for users who can access private status

### DIFF
--- a/app/components/avo/sidebar_component.html.erb
+++ b/app/components/avo/sidebar_component.html.erb
@@ -63,13 +63,12 @@
       </div>
     </div>
     <div class="sidebar__footer">
-      <% if Rails.env.development? %>
+      <% if can_access_private_status? %>
         <div class="sidebar-status">
           <%= link_to helpers.avo.avo_private_status_path, class: "sidebar-status__link" do %>
             <span>Avo Status</span>
             <span><div class="sidebar-status__indicator <%= Avo.app_status ? "sidebar-status__indicator--ok" : "sidebar-status__indicator--error" %>"></div></span>
           <% end %>
-          <div class="sidebar-status__hint">👆Visible only in development👆</div>
         </div>
       <% end %>
       <%= render Avo::SidebarProfileComponent.new user: helpers._current_user %>

--- a/app/components/avo/sidebar_component.rb
+++ b/app/components/avo/sidebar_component.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Avo::SidebarComponent < Avo::BaseComponent
+  include Avo::Concerns::PrivateAccess
+
   prop :sidebar_open, default: false
   prop :for_mobile, default: false
 

--- a/app/controllers/avo/base_application_controller.rb
+++ b/app/controllers/avo/base_application_controller.rb
@@ -12,6 +12,7 @@ module Avo
     include Avo::UrlHelpers
     include Avo::Concerns::Breadcrumbs
     include Avo::Concerns::FindAssociationField
+    include Avo::Concerns::PrivateAccess
 
     protect_from_forgery with: :exception
     before_action :decode_params
@@ -300,13 +301,6 @@ module Avo
       else
         "avo/application"
       end
-    end
-
-    def authenticate_developer_or_admin!
-      # We don't care about this in development
-      return if Rails.env.development?
-
-      raise_404 unless Avo::Current.user_is_developer? || Avo::Current.user_is_admin?
     end
 
     def raise_404

--- a/lib/avo/concerns/private_access.rb
+++ b/lib/avo/concerns/private_access.rb
@@ -1,0 +1,17 @@
+module Avo
+  module Concerns
+    module PrivateAccess
+      extend ActiveSupport::Concern
+
+      def can_access_private_status?
+        return true if Rails.env.development?
+
+        Avo::Current.user_is_developer? || Avo::Current.user_is_admin?
+      end
+
+      def authenticate_developer_or_admin!
+        raise_404 unless can_access_private_status?
+      end
+    end
+  end
+end

--- a/spec/lib/avo/concerns/private_access_spec.rb
+++ b/spec/lib/avo/concerns/private_access_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe Avo::Concerns::PrivateAccess do
+  let(:host) do
+    Class.new do
+      include Avo::Concerns::PrivateAccess
+
+      def raise_404
+        raise ActionController::RoutingError, "No route matches"
+      end
+    end.new
+  end
+
+  describe "#can_access_private_status?" do
+    it "returns true in development" do
+      allow(Rails.env).to receive(:development?).and_return(true)
+      allow(Avo::Current).to receive(:user_is_developer?).and_return(false)
+      allow(Avo::Current).to receive(:user_is_admin?).and_return(false)
+
+      expect(host.can_access_private_status?).to be true
+    end
+
+    it "returns true in production for developer users" do
+      allow(Rails.env).to receive(:development?).and_return(false)
+      allow(Avo::Current).to receive(:user_is_developer?).and_return(true)
+      allow(Avo::Current).to receive(:user_is_admin?).and_return(false)
+
+      expect(host.can_access_private_status?).to be true
+    end
+
+    it "returns true in production for admin users" do
+      allow(Rails.env).to receive(:development?).and_return(false)
+      allow(Avo::Current).to receive(:user_is_developer?).and_return(false)
+      allow(Avo::Current).to receive(:user_is_admin?).and_return(true)
+
+      expect(host.can_access_private_status?).to be true
+    end
+
+    it "returns false in production for other users" do
+      allow(Rails.env).to receive(:development?).and_return(false)
+      allow(Avo::Current).to receive(:user_is_developer?).and_return(false)
+      allow(Avo::Current).to receive(:user_is_admin?).and_return(false)
+
+      expect(host.can_access_private_status?).to be false
+    end
+  end
+
+  describe "#authenticate_developer_or_admin!" do
+    it "does not raise in development" do
+      allow(Rails.env).to receive(:development?).and_return(true)
+
+      expect { host.authenticate_developer_or_admin! }.not_to raise_error
+    end
+
+    it "raises when the user cannot access private status in production" do
+      allow(Rails.env).to receive(:development?).and_return(false)
+      allow(Avo::Current).to receive(:user_is_developer?).and_return(false)
+      allow(Avo::Current).to receive(:user_is_admin?).and_return(false)
+
+      expect { host.authenticate_developer_or_admin! }.to raise_error(ActionController::RoutingError)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Extract `Avo::Concerns::PrivateAccess` so `/avo_private/status` and the sidebar status link share the same access check
- Show the Avo Status sidebar link in production for developer and admin users (not only in development)
- Add specs for the shared concern

Linear: https://linear.app/avo-hq/issue/AVO-1223/add-avo-privatestatus-on-production-for-developer-users
Docs PR: https://github.com/avo-hq/docs.avohq.io/pull/549

## Test plan
- [x] `bundle exec rspec spec/lib/avo/concerns/private_access_spec.rb`
- [ ] In development, confirm Avo Status link is visible in the sidebar for any signed-in user
- [ ] In production/staging, confirm developer users see the Avo Status link
- [ ] In production/staging, confirm admin users see the Avo Status link
- [ ] In production/staging, confirm regular users do not see the link and get 404 on `/avo_private/status`