### PR TITLE
Hide license key on status page by default

### DIFF
--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -187,7 +187,7 @@ module Avo
       @is_developer_method = :is_developer?
       @search_results_count = 8
       @first_sorting_option = :desc # :desc or :asc
-      @exclude_from_status = []
+      @exclude_from_status = ["license_key"]
       @column_names_mapping = {}
       @column_types_mapping = {}
       @resource_row_controls_config = {}

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -133,7 +133,7 @@ Avo.configure do |config|
   # config.field_wrapper_layout = true
   # config.resource_parent_controller = "Avo::ResourcesController"
   # config.first_sorting_option = :desc # :desc or :asc
-  # config.exclude_from_status = [] # show the license key on the status page (hidden by default)
+  # config.exclude_from_status = ["license_key"]
   # config.model_generator_hook = true
 
   ## == Appearance ==

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -133,7 +133,7 @@ Avo.configure do |config|
   # config.field_wrapper_layout = true
   # config.resource_parent_controller = "Avo::ResourcesController"
   # config.first_sorting_option = :desc # :desc or :asc
-  # config.exclude_from_status = []
+  # config.exclude_from_status = [] # show the license key on the status page (hidden by default)
   # config.model_generator_hook = true
 
   ## == Appearance ==

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -12,7 +12,6 @@ Avo.configure do |config|
 
   ## == Licensing ==
   config.license_key = ENV["AVO_LICENSE_KEY"]
-  config.exclude_from_status = ["license_key"]
 
   ## == App context ==
   config.current_user_method = :current_user


### PR DESCRIPTION
## Summary
- Change the default `exclude_from_status` to `["license_key"]` so the license key is no longer exposed on the status page unless explicitly opted in
- Remove the redundant dummy app override now covered by the new default
- Update the generator initializer comment to document how to show the license key

Fixes [AVO-1423](https://linear.app/avo-hq/issue/AVO-1423/fix-license-key-exposed-on-status-page-by-default)

## Test plan
- [ ] Visit `/avo_private/status` as an admin and confirm the license key is not shown by default
- [ ] Set `config.exclude_from_status = []` and confirm the license key appears
- [ ] Confirm other status items (Ruby version, Rails version, etc.) still render


Made with [Cursor](https://cursor.com)