### PR TITLE
Fix has_one searchable hard-coded to false (AVO-1258)

### DIFF
--- a/lib/avo/fields/has_one_field.rb
+++ b/lib/avo/fields/has_one_field.rb
@@ -1,6 +1,7 @@
 module Avo
   module Fields
     class HasOneField < FrameBaseField
+      include Avo::Fields::Concerns::IsSearchable
       include Avo::Fields::Concerns::Nested
 
       attr_reader :attach_fields,
@@ -24,6 +25,7 @@ module Avo
         super
 
         @placeholder ||= I18n.t "avo.choose_an_option"
+        @searchable = (args[:searchable] == true || args[:searchable].is_a?(Hash)) ? args[:searchable] : false
         @attach_fields = args[:attach_fields]
         @attach_scope = args[:attach_scope]
       end
@@ -52,8 +54,6 @@ module Avo
 
         record
       end
-
-      def is_searchable? = false
     end
   end
 end


### PR DESCRIPTION
## Summary
- Restore `searchable:` support on `has_one` fields by including `IsSearchable` and storing `@searchable`
- Remove the hard-coded `is_searchable? = false` regression introduced during the array-adapter refactor

## Context
Part of [AVO-1258](https://linear.app/avo-hq/issue/AVO-1258/investigate-fix-has-one-searchable-hard-coded-to-false). Companion PRs:
- avo-hq/workspace — advanced_search extension hook + tests
- avo-hq/docs.avohq.io — restore `searchable` option on has_one docs

## Test plan
- [ ] `field :admin, as: :has_one, searchable: true` renders the association search picker in the attach modal (with avo-advanced_search)
- [ ] `searchable: false` / omitted still uses a plain `<select>`


Made with [Cursor](https://cursor.com)