### PR TITLE
Localize Luxon date tokens on show/index (AVO-1434)

### DIFF
--- a/app/javascript/js/controllers/fields/date_field_controller.js
+++ b/app/javascript/js/controllers/fields/date_field_controller.js
@@ -86,6 +86,12 @@ export default class extends Controller {
     return this.timezoneValue || this.browserZone
   }
 
+  // Locale from the <html lang> attribute so Luxon tokens like `cccc` translate.
+  // Luxon reads locale data from the browser's native Intl API, so no locale files are bundled.
+  get locale() {
+    return document.documentElement.lang || 'en'
+  }
+
   connect() {
     // Cache the initial value so we can fill it back on disconnection.
     // We do that so the JS parser will continue to work when the user hits the back button to return on this page.
@@ -125,7 +131,7 @@ export default class extends Controller {
       }
     }
 
-    this.context.element.innerText = value.toFormat(this.formatValue)
+    this.context.element.innerText = value.toFormat(this.formatValue, { locale: this.locale })
   }
 
   initEdit() {


### PR DESCRIPTION
## What

Date/time fields displayed with Luxon format tokens like `cccc` (weekday name, e.g. `Wednesday`) always rendered in English, ignoring the app's locale.

## Why

In `date_field_controller.js`, the show/index display called `value.toFormat(this.formatValue)` with no locale, so Luxon fell back to the system locale rather than Avo's `I18n.locale`.

## Fix

Read the locale from the `<html lang>` attribute (already set to `I18n.locale` in the layout) and pass it to `toFormat`.

Luxon reads locale data from the browser's native `Intl` API — every modern browser ships full language support — so no locale files need to be bundled.

Fixes AVO-1434.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single display-path change in the date field Stimulus controller; no auth, data, or API impact.
> 
> **Overview**
> Show and index date/time display now passes the app locale into Luxon’s `toFormat`, so format tokens like `cccc` (weekday names) follow **Avo’s `I18n.locale`** instead of defaulting to English.
> 
> A new `locale` getter reads `document.documentElement.lang` (already set from `I18n.locale` in the layout), with `'en'` as fallback. **Edit** flatpickr behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb09c1cf800283e1cf858c3be070438dd3060894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->