### PR TITLE
fix: record-level action visibility in index row actions_list

### DIFF
--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -126,13 +126,22 @@ class Avo::ResourceComponent < Avo::BaseComponent
   def render_actions_list(actions_list)
     return unless can_see_the_actions_button?
 
-    # `as_row_control` hydrates each action with the current record (needed for both
-    # index rows and the single-record show/edit headers).
-    as_row_control = @item.present?
-
     # Inside an index table row the hotkey must be managed by the index-row-navigator
     # (data-hotkey-original); page-level headers use a plain data-hotkey.
     as_index_row_control = row_controls_context?
+
+    # `as_row_control` hydrates each action with the current record (needed for both
+    # index rows and the single-record show/edit headers). @item is only ever set for
+    # the show/edit field-panel switcher, so it's blank for index rows -- fall back to
+    # row_controls_context? there so per-row actions_list entries get hydrated too.
+    as_row_control = @item.present? || as_index_row_control
+
+    # @actions is built once by the controller's set_actions, before any row exists
+    # (its @resource.record is nil there), so a `visible` block that inspects the
+    # record can't tell rows apart -- and since set_actions already dropped the
+    # non-visible ones, there's nothing left downstream to recover them from. Rebuild
+    # the list fresh from this row's own hydrated resource instead of reusing it.
+    actions = as_index_row_control ? row_actions : @actions
 
     # Actions button hotkey "a" on the main index, show and edit pages (non-nested,
     # not an index row). The index component doesn't carry a @view, so detect it by
@@ -143,7 +152,7 @@ class Avo::ResourceComponent < Avo::BaseComponent
     )
 
     render Avo::ActionsComponent.new(
-      actions: @actions,
+      actions:,
       resource: @resource,
       view: @view,
       exclude: actions_list.exclude,
@@ -159,6 +168,12 @@ class Avo::ResourceComponent < Avo::BaseComponent
       as_index_row_control:,
       hotkey: hotkey
     )
+  end
+
+  def row_actions
+    @resource.get_actions
+      .map { |action_bag| action_bag[:class].new(record: @resource.record, resource: @resource, view: @view, **action_bag.except(:class)) }
+      .select { |action| action.is_a?(Avo::Divider) || action.visible_in_view(parent_resource: @parent_resource) }
   end
 
   def render_delete_button(control)

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -370,7 +370,7 @@ module Avo
       @actions = @resource
         .get_actions
         .map do |action_bag|
-          action_bag.delete(:class).new(record: @record, resource: @resource, view: @view, **action_bag)
+          action_bag[:class].new(record: @record, resource: @resource, view: @view, **action_bag.except(:class))
         end
         .select do |action|
           action.is_a?(DividerComponent) || action.visible_in_view(parent_resource: @parent_resource)


### PR DESCRIPTION
## Summary
- `Avo::BaseController#set_actions` builds `@actions` once per index request, before any row/record exists (`@resource.record` is `nil` at that point in `index`), and permanently drops actions whose `visible` block evaluates falsy at that moment.
- Every row's `actions_list` dropdown (rendered via `row_controls`) reused that same, already-pruned array, so a `visible` block that inspects `resource.record` could never differentiate between rows — an action was either shown for every row or hidden for all of them. Single actions placed directly via `row_controls` (and avo-custom_controls' custom action lists) already worked correctly, since those re-resolve `visible_in_view` per row with the real record.
- Fix: `render_actions_list` now rebuilds the action list fresh per row from that row's own hydrated `@resource`, matching the pattern already used elsewhere. Also stopped `set_actions` from mutating the resource's shared action bag (`action_bag.delete(:class)` → non-destructive read), since that bag is now reused by the per-row rebuild.

Fixes #4260

## Test plan
- [x] Added a regression test in `avo-custom_controls` (companion PR in the `workspace` repo) reproducing the exact `row_controls`/`actions_list` scenario from the linked issue — fails without this fix, passes with it.
- [x] `spec/components/`, `spec/system/avo/group_1..3` action specs, `spec/requests/avo/actions_request_spec.rb`, and various index/row/control feature specs — 362 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)