### PR TITLE
Fix Tailwind CSS integration for tailwindcss-rails < 4

### DIFF
--- a/lib/avo/tailwind_builder.rb
+++ b/lib/avo/tailwind_builder.rb
@@ -19,7 +19,19 @@ module Avo
     end
 
     def self.enabled?
-      Avo.configuration.tailwindcss_integration_enabled && tailwindcss_available?
+      Avo.configuration.tailwindcss_integration_enabled && tailwindcss_available? && tailwindcss_rails_version_supported?
+    end
+
+    # tailwindcss-rails depends on tailwindcss-ruby at every major version, so requiring
+    # "tailwindcss/ruby" succeeds even when the host app is pinned to tailwindcss-rails 3.x
+    # (Tailwind CSS v3). Avo's build pipeline emits Tailwind v4-only syntax, so we only enable
+    # the integration when tailwindcss-rails (if bundled at all) is >= 4.0.0. Apps that manage
+    # tailwindcss-ruby directly (no tailwindcss-rails) are unaffected by this check.
+    def self.tailwindcss_rails_version_supported?
+      spec = Gem.loaded_specs["tailwindcss-rails"]
+      return true unless spec
+
+      Gem::Version.new(spec.version) >= Gem::Version.new("4.0.0")
     end
 
     def build

--- a/spec/features/avo/lib/tailwind_builder_spec.rb
+++ b/spec/features/avo/lib/tailwind_builder_spec.rb
@@ -11,6 +11,39 @@ RSpec.describe Avo::TailwindBuilder do
     config.instance_variable_set(:@tailwindcss_content_sources, previous)
   end
 
+  describe ".enabled?" do
+    def stub_tailwindcss_rails_version(version)
+      fake_spec = Gem::Specification.new { |s|
+        s.name = "tailwindcss-rails"
+        s.version = version
+      }
+      allow(Gem).to receive(:loaded_specs).and_return(Gem.loaded_specs.merge("tailwindcss-rails" => fake_spec))
+    end
+
+    before do
+      allow(config).to receive(:tailwindcss_integration_enabled).and_return(true)
+      allow(described_class).to receive(:tailwindcss_available?).and_return(true)
+    end
+
+    it "is disabled when the host app bundles tailwindcss-rails below version 4" do
+      stub_tailwindcss_rails_version("3.0.0")
+
+      expect(described_class.enabled?).to be false
+    end
+
+    it "is enabled when the host app bundles tailwindcss-rails 4 or higher" do
+      stub_tailwindcss_rails_version("4.0.0")
+
+      expect(described_class.enabled?).to be true
+    end
+
+    it "is enabled when tailwindcss-rails is not bundled at all" do
+      allow(Gem).to receive(:loaded_specs).and_return(Gem.loaded_specs.except("tailwindcss-rails"))
+
+      expect(described_class.enabled?).to be true
+    end
+  end
+
   describe "#generate_input_file" do
     after do
       FileUtils.rm_f(input_path)


### PR DESCRIPTION
## Summary

- `Avo::TailwindBuilder.enabled?` only checked `Avo.configuration.tailwindcss_integration_enabled && tailwindcss_available?`, where `tailwindcss_available?` just probes `require "tailwindcss/ruby"`.
- `tailwindcss-rails` depends on `tailwindcss-ruby` at every major version (verified: `tailwindcss-rails` 3.0.0 depends on `tailwindcss-ruby >= 0`; 4.x depends on `tailwindcss-ruby ~> 4.0`), so that require succeeds even when the host app is pinned to `tailwindcss-rails` 3.x (Tailwind CSS v3).
- Avo's build pipeline (`generate_input_file`) emits Tailwind v4-only CSS syntax (`@source`, `@import` directives), which breaks when the underlying `tailwindcss` binary is actually v3.
- Added `Avo::TailwindBuilder.tailwindcss_rails_version_supported?`, which checks the resolved `tailwindcss-rails` gem version (via `Gem.loaded_specs`) and requires `>= 4.0.0` when that gem is bundled. Apps that manage `tailwindcss-ruby` directly (without `tailwindcss-rails`) are unaffected.
- Wired the new check into `enabled?` alongside the existing conditions.

Fixes [AVO-1438](https://linear.app/avo-hq/issue/AVO-1438/fix-tailwind-css-integration).

## Test plan

- [x] Added `spec/features/avo/lib/tailwind_builder_spec.rb` `.enabled?` cases covering: tailwindcss-rails < 4 (disabled), tailwindcss-rails >= 4 (enabled), tailwindcss-rails absent (enabled, unaffected)
- [x] Confirmed the new "below version 4" spec fails against the old code (reproduces the bug) before the fix
- [x] `bundle exec rspec spec/features/avo/lib/tailwind_builder_spec.rb spec/features/avo/lib/configuration/tailwindcss_content_sources_spec.rb` — 10 examples, 0 failures
- [x] `bundle exec standardrb lib/avo/tailwind_builder.rb spec/features/avo/lib/tailwind_builder_spec.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)