### PR TITLE
fix: close race in Avo.boot that corrupts the plugin registry

### DIFF
--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -55,6 +55,11 @@ module Avo
 
   class ViewTypeComponentNotFoundError < StandardError; end
 
+  # Serializes Avo.boot so concurrent code reloads (config.to_prepare fires on
+  # every reload, from every request thread) can't interleave the plugin
+  # registry reset with its repopulation. See PluginManager#begin_reload.
+  @boot_mutex = Mutex.new
+
   # Exception raised when a resource is missing
   class MissingResourceError < StandardError
     def initialize(model_class, field)
@@ -92,17 +97,20 @@ module Avo
 
     # Runs when the app boots up
     def boot
-      Turbo::Streams::TagBuilder.prepend(Avo::TurboStreamActionsHelper)
-      @logger = Avo.configuration.logger
-      @field_manager = Avo::Fields::FieldManager.build
-      @view_type_manager = nil # force re-init with defaults on next access
-      @cache_store = Avo.configuration.cache_store
-      Avo.plugin_manager.reset
-      # Run load hooks for plugins to include them in the app.
-      # This is useful for plugins that need to include modules in the app that will be used on avo_boot hook.
-      ActiveSupport.run_load_hooks(:avo_plugin_include, self)
-      ActiveSupport.run_load_hooks(:avo_boot, self)
-      eager_load_actions
+      @boot_mutex.synchronize do
+        Turbo::Streams::TagBuilder.prepend(Avo::TurboStreamActionsHelper)
+        @logger = Avo.configuration.logger
+        @field_manager = Avo::Fields::FieldManager.build
+        @view_type_manager = nil # force re-init with defaults on next access
+        @cache_store = Avo.configuration.cache_store
+        Avo.plugin_manager.begin_reload
+        # Run load hooks for plugins to include them in the app.
+        # This is useful for plugins that need to include modules in the app that will be used on avo_boot hook.
+        ActiveSupport.run_load_hooks(:avo_plugin_include, self)
+        ActiveSupport.run_load_hooks(:avo_boot, self)
+        Avo.plugin_manager.commit_reload
+        eager_load_actions
+      end
     end
 
     # Runs on each request

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -109,8 +109,8 @@ module Avo
         ActiveSupport.run_load_hooks(:avo_plugin_include, self)
         ActiveSupport.run_load_hooks(:avo_boot, self)
         Avo.plugin_manager.commit_reload
-        eager_load_actions
       end
+      eager_load_actions
     end
 
     # Runs on each request

--- a/lib/avo/plugin_manager.rb
+++ b/lib/avo/plugin_manager.rb
@@ -1,7 +1,7 @@
 module Avo
   class PluginManager
     attr_reader :plugins
-    attr_accessor :engines
+    attr_reader :engines
 
     alias_method :all, :plugins
 
@@ -10,6 +10,10 @@ module Avo
       @engines = []
     end
 
+    # Direct, immediate reset -- unlike #begin_reload/#commit_reload, this is
+    # not part of Avo.boot's lifecycle (nothing calls it in production) and
+    # offers no atomicity guarantee. Kept as a manual escape hatch for specs
+    # that want a clean manager without going through a full reload cycle.
     def reset
       @plugins = []
       @engines = []
@@ -101,6 +105,9 @@ module Avo
     end
 
     def mount_engine(klass, **options)
+      # Dedup by class so a plugin hook that (by bug) calls mount_engine
+      # twice for the same engine within one boot can't leave a duplicate
+      # entry for #commit_reload to publish.
       @building_engines.delete_if { |engine| engine[:klass] == klass }
       @building_engines << {klass:, options:}
     end

--- a/lib/avo/plugin_manager.rb
+++ b/lib/avo/plugin_manager.rb
@@ -8,15 +8,8 @@ module Avo
     def initialize
       @plugins = []
       @engines = []
-    end
-
-    # Direct, immediate reset -- unlike #begin_reload/#commit_reload, this is
-    # not part of Avo.boot's lifecycle (nothing calls it in production) and
-    # offers no atomicity guarantee. Kept as a manual escape hatch for specs
-    # that want a clean manager without going through a full reload cycle.
-    def reset
-      @plugins = []
-      @engines = []
+      @building_plugins = []
+      @building_engines = []
     end
 
     # Starts a re-registration cycle without touching the currently published
@@ -29,15 +22,26 @@ module Avo
       @building_engines = []
     end
 
-    # Publishes the registrations collected since #begin_reload. Each
-    # reassignment is a single atomic pointer swap, so a concurrent reader
-    # always observes either the complete old list or the complete new one,
-    # never a partially rebuilt one.
+    # Publishes the registrations collected since #begin_reload. Each of the
+    # two reassignments below is individually an atomic pointer swap, so a
+    # reader of .engines alone (or .plugins alone) always sees the complete
+    # old list or the complete new one, never a partially rebuilt one. The
+    # two fields are not published jointly -- a reader combining both in one
+    # operation could observe them from different reload generations. No
+    # current reader does that (mount_avo reads only .engines; installed?
+    # reads only .plugins).
     def commit_reload
       @plugins = @building_plugins
       @engines = @building_engines
-      @building_plugins = nil
-      @building_engines = nil
+      # Reset to fresh arrays rather than nil: register/mount_engine must
+      # stay callable even outside a begin_reload/commit_reload window --
+      # e.g. avo-permissions calls Avo.plugin_manager.register at Rails
+      # initializer time, before Avo.boot ever runs. Such a call is simply
+      # discarded by the next #begin_reload rather than raising, matching
+      # the pre-atomic-publish behavior where register/mount_engine never
+      # crashed regardless of timing.
+      @building_plugins = []
+      @building_engines = []
     end
 
     def register(name, priority: 10)

--- a/lib/avo/plugin_manager.rb
+++ b/lib/avo/plugin_manager.rb
@@ -15,13 +15,34 @@ module Avo
       @engines = []
     end
 
+    # Starts a re-registration cycle without touching the currently published
+    # @plugins/@engines, so concurrent readers (e.g. mount_avo's route-drawing
+    # loop) keep seeing the complete pre-reload list until #commit_reload
+    # publishes the new one. Called by Avo.boot inside its Mutex, so only one
+    # reload is ever building at a time.
+    def begin_reload
+      @building_plugins = []
+      @building_engines = []
+    end
+
+    # Publishes the registrations collected since #begin_reload. Each
+    # reassignment is a single atomic pointer swap, so a concurrent reader
+    # always observes either the complete old list or the complete new one,
+    # never a partially rebuilt one.
+    def commit_reload
+      @plugins = @building_plugins
+      @engines = @building_engines
+      @building_plugins = nil
+      @building_engines = nil
+    end
+
     def register(name, priority: 10)
       # Capture the file that called `register` so the plugin can later resolve
       # the gem it actually ships in. Plugins register under nicknames
       # (e.g. `:rhino` for `avo-rhino_field`), so the name alone isn't enough.
       registered_from = caller_locations(1, 1)&.first&.path
 
-      @plugins << Plugin.new(name:, priority: priority, registered_from: registered_from)
+      @building_plugins << Plugin.new(name:, priority: priority, registered_from: registered_from)
     end
 
     def register_view_type(name, component:, icon:, active_icon:, translation_key: nil)
@@ -80,7 +101,8 @@ module Avo
     end
 
     def mount_engine(klass, **options)
-      @engines << {klass:, options:}
+      @building_engines.delete_if { |engine| engine[:klass] == klass }
+      @building_engines << {klass:, options:}
     end
   end
 

--- a/spec/features/avo/lib/mount_avo_spec.rb
+++ b/spec/features/avo/lib/mount_avo_spec.rb
@@ -8,12 +8,6 @@ RSpec.describe "mount_avo" do
     Avo.configuration.mount_lookbook = original
   end
 
-  def draw_mount_avo(**options)
-    routes = ActionDispatch::Routing::RouteSet.new
-    routes.draw { mount_avo(**options) }
-    routes
-  end
-
   it "defaults mount_lookbook to false" do
     draw_mount_avo
 

--- a/spec/lib/avo/boot_thread_safety_spec.rb
+++ b/spec/lib/avo/boot_thread_safety_spec.rb
@@ -54,7 +54,11 @@ RSpec.describe "Avo.boot thread safety" do
     pre_boot_engines = Avo.plugin_manager.engines
 
     boot_thread = Thread.new { Avo.boot }
-    reached_midpoint.pop # wait until the background boot has registered engine 1 but not committed
+    # Bounded wait: if a future regression makes the background boot never
+    # reach the rendezvous (e.g. it raises before mount_engine runs), fail
+    # with a clear message instead of hanging this example (and, since
+    # boot_thread would then hold the mutex forever, every later spec too).
+    raise "background boot never reached the rendezvous point" if reached_midpoint.pop(timeout: 5).nil?
 
     begin
       # Mid-boot, a concurrent reader (standing in for mount_avo's route-drawing
@@ -76,12 +80,51 @@ RSpec.describe "Avo.boot thread safety" do
     ])
   end
 
-  it "does not deadlock when Avo.boot is called sequentially, matching the two real call sites" do
+  it "does not raise when Avo.boot is called sequentially, matching the two real (non-nested) call sites" do
     allow(ActiveSupport).to receive(:run_load_hooks).and_call_original
 
     expect {
       Avo.boot
       Avo.boot
     }.not_to raise_error
+  end
+
+  it "raises ThreadError instead of deadlocking on genuine same-thread reentrancy" do
+    # Ruby's Mutex is not reentrant: locking it twice on the same thread
+    # raises immediately rather than hanging. Neither real call site
+    # (config.after_initialize, config.to_prepare) nests a call to Avo.boot,
+    # but this documents what happens if a future hook ever does.
+    allow(ActiveSupport).to receive(:run_load_hooks).and_call_original
+    allow(ActiveSupport).to receive(:run_load_hooks).with(:avo_boot, Avo) do
+      Avo.boot
+    end
+
+    expect { Avo.boot }.to raise_error(ThreadError, /deadlock/)
+  end
+
+  it "leaves the previously published registry intact and releases the mutex when a hook raises mid-boot" do
+    fake_engine = Class.new(Rails::Engine)
+    allow(ActiveSupport).to receive(:run_load_hooks).and_call_original
+    allow(ActiveSupport).to receive(:run_load_hooks).with(:avo_boot, Avo) do
+      Avo.plugin_manager.mount_engine(fake_engine, at: "/fake")
+    end
+    Avo.boot
+    published_engines = Avo.plugin_manager.engines
+
+    allow(ActiveSupport).to receive(:run_load_hooks).with(:avo_boot, Avo) do
+      Avo.plugin_manager.mount_engine(Class.new(Rails::Engine), at: "/never-published")
+      raise "boom"
+    end
+
+    expect { Avo.boot }.to raise_error("boom")
+    # commit_reload never ran, so the last successful boot's registry stands.
+    expect(Avo.plugin_manager.engines).to eq(published_engines)
+
+    # Mutex#synchronize releases the lock via ensure even on exception, so
+    # the next boot proceeds normally rather than deadlocking.
+    allow(ActiveSupport).to receive(:run_load_hooks).with(:avo_boot, Avo) do
+      Avo.plugin_manager.mount_engine(fake_engine, at: "/fake")
+    end
+    expect { Avo.boot }.not_to raise_error
   end
 end

--- a/spec/lib/avo/boot_thread_safety_spec.rb
+++ b/spec/lib/avo/boot_thread_safety_spec.rb
@@ -1,16 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Avo.boot thread safety" do
-  # Isolate this file's mutations of the global plugin manager -- Avo.boot
-  # mutates a process-wide singleton, and these specs deliberately register
-  # fake plugins/engines under it to reproduce the race, so the original
-  # (rails_helper-booted) manager must be restored for every other spec file.
-  around do |example|
-    original_manager = Avo.instance_variable_get(:@plugin_manager)
-    example.run
-  ensure
-    Avo.instance_variable_set(:@plugin_manager, original_manager)
-  end
+  include_context "with isolated plugin manager"
 
   it "populates plugin_manager as before for a normal single-threaded boot" do
     fake_engine = Class.new(Rails::Engine)

--- a/spec/lib/avo/boot_thread_safety_spec.rb
+++ b/spec/lib/avo/boot_thread_safety_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.describe "Avo.boot thread safety" do
+  # Isolate this file's mutations of the global plugin manager -- Avo.boot
+  # mutates a process-wide singleton, and these specs deliberately register
+  # fake plugins/engines under it to reproduce the race, so the original
+  # (rails_helper-booted) manager must be restored for every other spec file.
+  around do |example|
+    original_manager = Avo.instance_variable_get(:@plugin_manager)
+    example.run
+  ensure
+    Avo.instance_variable_set(:@plugin_manager, original_manager)
+  end
+
+  it "populates plugin_manager as before for a normal single-threaded boot" do
+    fake_engine = Class.new(Rails::Engine)
+    allow(ActiveSupport).to receive(:run_load_hooks).and_call_original
+    allow(ActiveSupport).to receive(:run_load_hooks).with(:avo_boot, Avo) do
+      Avo.plugin_manager.register(:fake_plugin, priority: 5)
+      Avo.plugin_manager.mount_engine(fake_engine, at: "/fake")
+    end
+
+    Avo.boot
+
+    expect(Avo.plugin_manager.engines).to eq([{klass: fake_engine, options: {at: "/fake"}}])
+    expect(Avo.plugin_manager.plugins.map(&:name)).to eq([:fake_plugin])
+  end
+
+  it "leaves no duplicate engines or plugins when multiple threads call Avo.boot concurrently" do
+    fake_engine = Class.new(Rails::Engine)
+    allow(ActiveSupport).to receive(:run_load_hooks).and_call_original
+    allow(ActiveSupport).to receive(:run_load_hooks).with(:avo_boot, Avo) do
+      # Widen the interleaving window so, without the fix, concurrent boots
+      # reliably interleave their reset-then-repopulate sequence instead of
+      # relying on timing luck.
+      Avo.plugin_manager.register(:fake_plugin, priority: 5)
+      Thread.pass
+      Avo.plugin_manager.mount_engine(fake_engine, at: "/fake")
+      Thread.pass
+    end
+
+    threads = 8.times.map { Thread.new { Avo.boot } }
+    threads.each(&:join)
+
+    expect(Avo.plugin_manager.engines).to eq([{klass: fake_engine, options: {at: "/fake"}}])
+    expect(Avo.plugin_manager.plugins.map(&:name)).to eq([:fake_plugin])
+  end
+
+  it "never exposes a partially rebuilt engines list to a concurrent reader" do
+    fake_engine_1 = Class.new(Rails::Engine)
+    fake_engine_2 = Class.new(Rails::Engine)
+    reached_midpoint = Queue.new
+    release_midpoint = Queue.new
+
+    allow(ActiveSupport).to receive(:run_load_hooks).and_call_original
+    allow(ActiveSupport).to receive(:run_load_hooks).with(:avo_boot, Avo) do
+      Avo.plugin_manager.mount_engine(fake_engine_1, at: "/one")
+      reached_midpoint << true
+      release_midpoint.pop
+      Avo.plugin_manager.mount_engine(fake_engine_2, at: "/two")
+    end
+
+    pre_boot_engines = Avo.plugin_manager.engines
+
+    boot_thread = Thread.new { Avo.boot }
+    reached_midpoint.pop # wait until the background boot has registered engine 1 but not committed
+
+    begin
+      # Mid-boot, a concurrent reader (standing in for mount_avo's route-drawing
+      # loop) must see the complete pre-boot list, never a partial one that
+      # contains only fake_engine_1.
+      expect(Avo.plugin_manager.engines).to eq(pre_boot_engines)
+    ensure
+      # Always release the paused background thread, even if the assertion
+      # above fails -- otherwise boot_thread stays parked mid-Avo.boot,
+      # permanently holding the boot mutex and hanging every later spec in
+      # this process that calls Avo.boot.
+      release_midpoint << true
+      boot_thread.join
+    end
+
+    expect(Avo.plugin_manager.engines).to eq([
+      {klass: fake_engine_1, options: {at: "/one"}},
+      {klass: fake_engine_2, options: {at: "/two"}}
+    ])
+  end
+
+  it "does not deadlock when Avo.boot is called sequentially, matching the two real call sites" do
+    allow(ActiveSupport).to receive(:run_load_hooks).and_call_original
+
+    expect {
+      Avo.boot
+      Avo.boot
+    }.not_to raise_error
+  end
+end

--- a/spec/lib/avo/plugin_manager_boot_race_spec.rb
+++ b/spec/lib/avo/plugin_manager_boot_race_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe "Avo plugin manager boot race - end-to-end regression" do
+  # Isolate this file's mutations of the global plugin manager, matching
+  # boot_thread_safety_spec.rb.
+  around do |example|
+    original_manager = Avo.instance_variable_get(:@plugin_manager)
+    example.run
+  ensure
+    Avo.instance_variable_set(:@plugin_manager, original_manager)
+  end
+
+  # Mirrors spec/features/avo/lib/mount_avo_spec.rb's pattern: draw mount_avo
+  # into a fresh, isolated RouteSet so this spec never touches the dummy
+  # app's real routes.
+  def draw_mount_avo(**options)
+    routes = ActionDispatch::Routing::RouteSet.new
+    routes.draw { mount_avo(**options) }
+    routes
+  end
+
+  def stub_pro_engine
+    stub_const("Avo::PluginManagerBootRaceSpec", Module.new)
+    stub_const("Avo::PluginManagerBootRaceSpec::Engine", Class.new(Rails::Engine) do
+      isolate_namespace Avo::PluginManagerBootRaceSpec
+
+      def self.name
+        "Avo::PluginManagerBootRaceSpec::Engine"
+      end
+    end)
+    Avo::PluginManagerBootRaceSpec::Engine
+  end
+
+  it "does not raise ArgumentError after concurrent Avo.boot calls followed by a route redraw" do
+    fake_engine = stub_pro_engine
+
+    allow(ActiveSupport).to receive(:run_load_hooks).and_call_original
+    allow(ActiveSupport).to receive(:run_load_hooks).with(:avo_boot, Avo) do
+      Avo.plugin_manager.mount_engine(fake_engine, at: "/plugin_manager_boot_race_spec")
+    end
+
+    threads = 8.times.map { Thread.new { Avo.boot } }
+    threads.each(&:join)
+
+    expect(Avo.plugin_manager.engines).to eq([{klass: fake_engine, options: {at: "/plugin_manager_boot_race_spec"}}])
+    expect { draw_mount_avo }.not_to raise_error
+  end
+
+  it "sanity check: mount_avo does raise ArgumentError when the registry actually holds a duplicate" do
+    # Proves the assertion above is a real regression guard, not vacuously
+    # green -- a corrupted registry (the pre-fix failure mode) still trips
+    # mount_avo's route-drawing loop.
+    fake_engine = stub_pro_engine
+
+    Avo.plugin_manager.begin_reload
+    Avo.plugin_manager.instance_variable_get(:@building_engines) << {klass: fake_engine, options: {at: "/one"}}
+    Avo.plugin_manager.instance_variable_get(:@building_engines) << {klass: fake_engine, options: {at: "/two"}}
+    Avo.plugin_manager.commit_reload
+
+    expect { draw_mount_avo }.to raise_error(ArgumentError, /Invalid route name, already in use/)
+  end
+end

--- a/spec/lib/avo/plugin_manager_boot_race_spec.rb
+++ b/spec/lib/avo/plugin_manager_boot_race_spec.rb
@@ -1,23 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Avo plugin manager boot race - end-to-end regression" do
-  # Isolate this file's mutations of the global plugin manager, matching
-  # boot_thread_safety_spec.rb.
-  around do |example|
-    original_manager = Avo.instance_variable_get(:@plugin_manager)
-    example.run
-  ensure
-    Avo.instance_variable_set(:@plugin_manager, original_manager)
-  end
-
-  # Mirrors spec/features/avo/lib/mount_avo_spec.rb's pattern: draw mount_avo
-  # into a fresh, isolated RouteSet so this spec never touches the dummy
-  # app's real routes.
-  def draw_mount_avo(**options)
-    routes = ActionDispatch::Routing::RouteSet.new
-    routes.draw { mount_avo(**options) }
-    routes
-  end
+  include_context "with isolated plugin manager"
 
   def stub_pro_engine
     stub_const("Avo::PluginManagerBootRaceSpec", Module.new)

--- a/spec/lib/avo/plugin_manager_spec.rb
+++ b/spec/lib/avo/plugin_manager_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe Avo::PluginManager do
+  subject(:manager) { described_class.new }
+
+  let(:engine_a) { Class.new(Rails::Engine) }
+  let(:engine_b) { Class.new(Rails::Engine) }
+
+  describe "#mount_engine" do
+    context "happy path" do
+      it "appends exactly one entry with the given options after a reload cycle" do
+        manager.begin_reload
+        manager.mount_engine(engine_a, at: "/a")
+        manager.commit_reload
+
+        expect(manager.engines).to eq([{klass: engine_a, options: {at: "/a"}}])
+      end
+    end
+
+    context "duplicate call for the same class" do
+      it "leaves exactly one entry reflecting the most recent options" do
+        manager.begin_reload
+        manager.mount_engine(engine_a, at: "/old")
+        manager.mount_engine(engine_a, at: "/new")
+        manager.commit_reload
+
+        expect(manager.engines).to eq([{klass: engine_a, options: {at: "/new"}}])
+      end
+    end
+
+    context "distinct classes" do
+      it "appends two distinct entries in insertion order" do
+        manager.begin_reload
+        manager.mount_engine(engine_a, at: "/a")
+        manager.mount_engine(engine_b, at: "/b")
+        manager.commit_reload
+
+        expect(manager.engines).to eq([
+          {klass: engine_a, options: {at: "/a"}},
+          {klass: engine_b, options: {at: "/b"}}
+        ])
+      end
+    end
+  end
+
+  describe "reader isolation before #commit_reload" do
+    it "does not change .engines or .plugins until commit_reload publishes them" do
+      manager.begin_reload
+      manager.mount_engine(engine_a, at: "/a")
+      manager.register(:some_plugin, priority: 5)
+
+      expect(manager.engines).to eq([])
+      expect(manager.plugins).to eq([])
+
+      manager.commit_reload
+
+      expect(manager.engines).to eq([{klass: engine_a, options: {at: "/a"}}])
+      expect(manager.plugins.map(&:name)).to eq([:some_plugin])
+    end
+
+    it "preserves a previously published list across a new begin_reload until commit_reload" do
+      manager.begin_reload
+      manager.mount_engine(engine_a, at: "/a")
+      manager.commit_reload
+
+      manager.begin_reload
+      manager.mount_engine(engine_b, at: "/b")
+
+      expect(manager.engines).to eq([{klass: engine_a, options: {at: "/a"}}])
+
+      manager.commit_reload
+
+      expect(manager.engines).to eq([{klass: engine_b, options: {at: "/b"}}])
+    end
+  end
+
+  describe "#reset" do
+    it "clears both plugins and engines directly, independent of begin_reload/commit_reload" do
+      manager.begin_reload
+      manager.mount_engine(engine_a, at: "/a")
+      manager.commit_reload
+      expect(manager.engines).not_to be_empty
+
+      manager.reset
+
+      expect(manager.engines).to eq([])
+      expect(manager.plugins).to eq([])
+    end
+  end
+end

--- a/spec/lib/avo/plugin_manager_spec.rb
+++ b/spec/lib/avo/plugin_manager_spec.rb
@@ -74,17 +74,33 @@ RSpec.describe Avo::PluginManager do
     end
   end
 
-  describe "#reset" do
-    it "clears both plugins and engines directly, independent of begin_reload/commit_reload" do
-      manager.begin_reload
+  describe "register/mount_engine called outside a begin_reload/commit_reload window" do
+    # Mirrors a real call pattern: gems/avo-permissions registers its plugin
+    # name directly inside a Rails initializer (not inside
+    # ActiveSupport.on_load(:avo_boot)), which runs before Avo.boot ever
+    # calls #begin_reload for the first time.
+    it "does not raise when called on a freshly-initialized manager" do
+      expect { manager.register(:avo_permissions, priority: 5) }.not_to raise_error
+      expect { manager.mount_engine(engine_a, at: "/a") }.not_to raise_error
+    end
+
+    it "discards a pre-begin_reload registration on the next begin_reload, matching pre-atomic-publish behavior" do
+      manager.register(:avo_permissions, priority: 5)
       manager.mount_engine(engine_a, at: "/a")
+
+      manager.begin_reload
       manager.commit_reload
-      expect(manager.engines).not_to be_empty
 
-      manager.reset
-
-      expect(manager.engines).to eq([])
       expect(manager.plugins).to eq([])
+      expect(manager.engines).to eq([])
+    end
+
+    it "does not raise when called again after a commit_reload, between reload cycles" do
+      manager.begin_reload
+      manager.commit_reload
+
+      expect { manager.register(:late_plugin, priority: 5) }.not_to raise_error
+      expect { manager.mount_engine(engine_b, at: "/b") }.not_to raise_error
     end
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -33,9 +33,9 @@ end
 # Draws mount_avo into a fresh, isolated RouteSet so specs exercising route
 # drawing (e.g. mount_lookbook config, plugin-engine mounting) never touch
 # the dummy app's real routes.
-def draw_mount_avo(**options)
+def draw_mount_avo(**)
   routes = ActionDispatch::Routing::RouteSet.new
-  routes.draw { mount_avo(**options) }
+  routes.draw { mount_avo(**) }
   routes
 end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -30,6 +30,15 @@ def json_headers
   {"Content-Type" => "application/json"}
 end
 
+# Draws mount_avo into a fresh, isolated RouteSet so specs exercising route
+# drawing (e.g. mount_lookbook config, plugin-engine mounting) never touch
+# the dummy app's real routes.
+def draw_mount_avo(**options)
+  routes = ActionDispatch::Routing::RouteSet.new
+  routes.draw { mount_avo(**options) }
+  routes
+end
+
 class DummyRequest
   attr_accessor :ip
   attr_accessor :host

--- a/spec/support/shared_contexts.rb
+++ b/spec/support/shared_contexts.rb
@@ -1,3 +1,20 @@
+shared_context "with isolated plugin manager" do
+  # Avo.boot mutates a process-wide singleton (Avo.plugin_manager). Specs that
+  # call Avo.boot directly to exercise its concurrency behavior register fake
+  # plugins/engines under it. Swap in a throwaway manager for the example so
+  # Avo.boot's begin_reload/commit_reload mutate *that* instance instead of
+  # the real (rails_helper-booted) one -- reassigning the ivar back to the
+  # same original object would not undo the mutation, since commit_reload
+  # changes that object's own @plugins/@engines in place.
+  around do |example|
+    original_manager = Avo.instance_variable_get(:@plugin_manager)
+    Avo.instance_variable_set(:@plugin_manager, Avo::PluginManager.new)
+    example.run
+  ensure
+    Avo.instance_variable_set(:@plugin_manager, original_manager)
+  end
+end
+
 shared_context "has_admin_user" do
   let(:admin) { create :user, roles: {admin: true} }
 


### PR DESCRIPTION
In development, a code change followed by a few concurrent requests could wedge the whole dev server: it would crash on the next request with `ArgumentError: Invalid route name, already in use: 'avo_<some_pro_gem>'`, and stay crashed until a manual restart, because the failed reload never reached the code that would have fixed it. This is common in the Avo admin, where a single page load fires many parallel turbo-frame requests, each of which can trigger its own reload.

## What changed

`Avo.boot` runs on every reload (`config.to_prepare`) and once at startup. It reset the plugin/engine registry and then repopulated it from every pro gem's `on_load(:avo_boot)` hook, with no synchronization. Two threads reloading at once could interleave that reset-then-repopulate sequence and leave each pro gem's engine registered twice, which is what `mount_avo` then choked on while drawing routes.

The fix has two parts:

- `Avo.boot` is now wrapped in a `Mutex`, so concurrent reloads fully serialize instead of interleaving.
- `PluginManager` builds registrations into a staging buffer during a boot and publishes them to the live, publicly-read state via one atomic reassignment only once every hook has finished. This closes the original duplicate-registration bug, and also a second, related race: without it, a route redraw running on another thread while a boot was mid-flight could still observe a half-rebuilt registry and silently mount only some of the installed pro gems.

A plain mutex around the old reset-in-place code would have closed the first race but not the second — a redraw racing an in-flight boot could still see a torn registry, just without a crash to signal it. The staging-buffer/atomic-publish design closes both with the same mechanism.

We also considered building into a fresh `PluginManager` instance and swapping the global reference, but every pro gem registers by calling the *global* `Avo.plugin_manager` accessor directly from its own `on_load(:avo_boot)` hook — swapping the instance mid-boot would just relocate the race to whichever manager happened to be current at that moment.

## Also fixed: a boot-time crash the above change would have introduced

Review caught that `avo-permissions` registers itself directly inside a Rails initializer, not inside `on_load(:avo_boot)` like every other pro gem — so it always runs before `Avo.boot`'s first reload cycle. The initial version of this fix would have made that call raise `NoMethodError` on every boot of any app with `avo-permissions` installed. `PluginManager#register`/`#mount_engine` are now safe to call at any time again, matching the pre-fix behavior where an out-of-cycle call was silently discarded rather than crashing.

## Test plan

Three new spec files reproduce both races directly and prove the fix holds:

- `spec/lib/avo/boot_thread_safety_spec.rb` — concurrent `Avo.boot` calls leave no duplicate registrations; a reader mid-boot never observes a partially rebuilt registry; a hook exception mid-boot leaves the last-good registry intact and still releases the mutex; genuine same-thread reentrancy raises `ThreadError` rather than hanging.
- `spec/lib/avo/plugin_manager_spec.rb` — `PluginManager`'s staging-buffer/publish behavior in isolation, including `register`/`mount_engine` called outside a boot cycle.
- `spec/lib/avo/plugin_manager_boot_race_spec.rb` — the exact end-to-end reported symptom: concurrent boots followed by a real route redraw, with a sanity check proving the same setup *does* raise the reported error against a deliberately corrupted registry.

Before finalizing, I verified the new specs actually catch the regressions they claim to by reverting the fix piece by piece and confirming each test fails for the right reason (the concurrency test fails without the mutex; the reader-consistency test fails against a naive mutex-only design that doesn't also fix the staging buffer). Full `external/avo` suite passes; the two Ruby files touched are `standardrb`-clean.

## Known trade-off, left as-is

Wrapping the whole boot body in one mutex means concurrent reloads that previously ran in parallel (racily) now queue behind each other, including whatever work each pro gem's `on_load(:avo_boot)` hook does. This is accepted: the prior "parallelism" was never a supported guarantee, and a wedged dev server is worse than added reload latency. Not addressed here, and out of scope: a separate, pre-existing leak where `ActiveSupport.run_load_hooks(:avo_boot, ...)` grows unboundedly across reloads, causing late-registered `on_load(:avo_boot)` blocks to fire once per historical boot.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Sonnet_5-D97757?logo=claude&logoColor=white)
