### PR TITLE
feat(ui): add badge prop to TabComponent + aria-label to CountComponent

### DIFF
--- a/app/components/avo/u_i/count_component.html.erb
+++ b/app/components/avo/u_i/count_component.html.erb
@@ -1,1 +1,1 @@
-<span class="<%= class_names("count", @classes) %>"><%= @count %></span>
+<%= tag.span @count, class: class_names("count", @classes), "aria-label": @label %>

--- a/app/components/avo/u_i/count_component.rb
+++ b/app/components/avo/u_i/count_component.rb
@@ -7,4 +7,8 @@
 class Avo::UI::CountComponent < Avo::BaseComponent
   prop :count
   prop :classes, default: nil
+  # Optional accessible name. When set, it becomes the pill's aria-label so a
+  # screen reader announces something meaningful (e.g. "42 records") instead of
+  # a bare number. Visible text is unchanged.
+  prop :label, default: nil
 end

--- a/app/components/avo/u_i/tabs/tab_component.html.erb
+++ b/app/components/avo/u_i/tabs/tab_component.html.erb
@@ -22,5 +22,6 @@
   ) do %>
     <%= svg @icon, class: "tabs__item-icon", "aria-hidden": "true" if @icon.present? %>
     <%= tag.span @label, class: "tabs__item-label" if @label.present? %>
+    <% if @badge %><%= @badge.respond_to?(:render_in) ? render(@badge) : @badge %><% end %>
   <% end %>
 <% end %>

--- a/app/components/avo/u_i/tabs/tab_component.rb
+++ b/app/components/avo/u_i/tabs/tab_component.rb
@@ -19,6 +19,10 @@ module Avo
         prop :data, default: {}.freeze
         prop :classes
         prop :title
+        # Optional trailing renderable (a component instance or html_safe string)
+        # shown after the label — e.g. a count pill. Kept generic so this
+        # component stays unaware of what the badge represents.
+        prop :badge, default: nil
       end
     end
   end

--- a/lib/generators/avo/templates/scope.tt
+++ b/lib/generators/avo/templates/scope.tt
@@ -3,4 +3,10 @@ class Avo::Scopes::<%= class_name.camelize %> < Avo::Scopes::BaseScope
   # self.description = "<%= name.underscore.humanize %> description."
   self.scope = -> { query.all }
   self.visible = -> { true }
+  # Show a record-count pill next to the label. Opt-in; off by default.
+  #   true / :eager  -> count during render (blocks paint; cheap counts)
+  #   :lazy          -> count after paint via an async Turbo Frame (recommended)
+  #   :hover         -> count on first hover (degrades to :lazy on touch)
+  #   { loading: :lazy, count: -> { query.count } } -> custom/cheaper count
+  # self.counter = :lazy
 end

--- a/spec/components/avo/u_i/tabs/tab_component_spec.rb
+++ b/spec/components/avo/u_i/tabs/tab_component_spec.rb
@@ -86,6 +86,28 @@ RSpec.describe Avo::UI::Tabs::TabComponent, type: :component do
     end
   end
 
+  describe "badge" do
+    it "renders an html_safe string badge after the label" do
+      render_component(badge: "<span class='count'>42</span>".html_safe)
+
+      expect(page).to have_css("span.tabs__item-label", text: "Tab")
+      expect(page).to have_css("span.count", text: "42")
+    end
+
+    it "renders a component badge after the label" do
+      render_component(badge: Avo::UI::CountComponent.new(count: 7, label: "7 records"))
+
+      expect(page).to have_css("span.count", text: "7")
+      expect(page).to have_css("span.count[aria-label='7 records']")
+    end
+
+    it "renders no badge markup when badge is nil (regression)" do
+      render_component
+
+      expect(page).not_to have_css("span.count")
+    end
+  end
+
   describe "disabled state" do
     it "applies disabled attributes to link" do
       render_component(disabled: true)


### PR DESCRIPTION
## What

Adds a small, generic UI seam that the **avo-scopes** scope-counters feature builds on:

- `Avo::UI::Tabs::TabComponent` gains an optional **`prop :badge`** — a renderable (component instance or `html_safe` string) rendered after the label. The component stays agnostic of what the badge represents; when no badge is passed the output is byte-for-byte identical to before.
- `Avo::UI::CountComponent` gains an optional **`prop :label`** that sets the pill's `aria-label`, so a count pill announces e.g. "42 records" instead of a bare number. Visible output is unchanged when unset.
- The scope generator template documents the new `self.counter` option.

## Why

avo-scopes renders a record-count pill next to a scope's tab label. `TabComponent` previously exposed no way to attach trailing content (label is a plain string prop, no slots), so a generic `badge` seam is the minimal, reusable way to support this without teaching core about "counts".

## Prerequisite

This is the core half of the scope-counters feature. avo-scopes pins `avo >= #{Avo::VERSION}` dynamically, so its badge dependency is satisfied once this ships. **Release this before the avo-scopes counter release.**

## Testing

- `TabComponent` spec: badge renders after the label (string + component forms); **no-badge output is unchanged** (regression); `CountComponent` `aria-label` is applied.
- Full `tab_component_spec.rb` green (24 examples).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — purely additive optional props on two view components with no behavior change when unused.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely additive optional ViewComponent props and template/docs changes; no behavior change when `badge` and `label` are unset.
> 
> **Overview**
> Adds optional UI hooks for **avo-scopes** scope tab counters without changing default tab or count rendering when the new props are omitted.
> 
> **`Avo::UI::Tabs::TabComponent`** accepts an optional **`badge`** (ViewComponent instance or `html_safe` string) rendered after the tab label, so trailing pills or counts can sit on scope tabs without hard-coding “count” into the tab component.
> 
> **`Avo::UI::CountComponent`** accepts an optional **`label`** that becomes the pill’s **`aria-label`** (e.g. “42 records”) while the visible number stays the same; the template now uses `tag.span` for that attribute.
> 
> The **scope generator** template documents opt-in **`self.counter`** modes (`:lazy`, `:eager`, `:hover`, custom hash). **Tab component specs** cover string and component badges, `aria-label` on count badges, and a no-badge regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5578e6908172345ded074b2f43597d13dfd3692b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->