### PR TITLE
feat(count-component): forward data attributes

### DIFF
--- a/app/components/avo/u_i/count_component.html.erb
+++ b/app/components/avo/u_i/count_component.html.erb
@@ -1,1 +1,1 @@
-<span class="<%= class_names("count", @classes) %>"><%= @count %></span>
+<%= content_tag :span, @count, class: class_names("count", @classes), data: @data %>

--- a/app/components/avo/u_i/count_component.rb
+++ b/app/components/avo/u_i/count_component.rb
@@ -7,4 +7,5 @@
 class Avo::UI::CountComponent < Avo::BaseComponent
   prop :count
   prop :classes, default: nil
+  prop :data, default: -> { {} }
 end


### PR DESCRIPTION
## What

Add a `data` prop to `Avo::UI::CountComponent` so callers can attach `data-*` attributes (e.g. Stimulus targets) to the rendered count pill.

## Why

The avo-kanban column header wants to reuse `CountComponent` for its item counter, but the counter is updated client-side via a `data-columns-target="counter"` hook. This prop lets the shared component carry that attribute instead of forcing a bespoke markup fork.

Backwards compatible — `data` defaults to `{}`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible ViewComponent API and template change with no auth or data-handling impact.
> 
> **Overview**
> **`Avo::UI::CountComponent`** now accepts an optional **`data`** prop (default `{}`) and renders the count pill with **`content_tag`**, so callers can pass **`data-*`** attributes (e.g. Stimulus **`data-columns-target="counter"`**) without duplicating markup.
> 
> Existing usages stay the same when **`data`** is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f7365153f54c9363b0d96a53a41a9b8c05f4169. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->