### PR TITLE
fix(sidebar): stop root-path links from staying active on every page

### DIFF
--- a/app/components/avo/sidebar/link_component.html.erb
+++ b/app/components/avo/sidebar/link_component.html.erb
@@ -1,5 +1,5 @@
 <% if @path.present? %>
-  <%= link_caller.send link_method, @path, class: root_css_class, active: @active, target: @target, data: link_data, disabled: @disabled, "aria-disabled": @disabled, **@args do %>
+  <%= link_caller.send link_method, @path, class: root_css_class, active: resolved_active, target: @target, data: link_data, disabled: @disabled, "aria-disabled": @disabled, **@args do %>
     <% if show_icon? %>
       <span class="sidebar-link__icon-wrapper sidebar-icon <%= 'sidebar-link__icon-wrapper--placeholder' if link_icon.blank? %>">
         <%= helpers.svg link_icon, class: "sidebar-link__icon sidebar-icon" if link_icon.present? %>
@@ -15,7 +15,7 @@
     <% end %>
   <% end %>
 <% else %>
-  <%= content_tag :div, class: root_css_class, active: @active, target: @target, data: @data do %>
+  <%= content_tag :div, class: root_css_class, active: resolved_active, target: @target, data: @data do %>
     <% if show_icon? %>
       <span class="sidebar-link__icon-wrapper sidebar-icon <%= 'sidebar-link__icon-wrapper--placeholder' if link_icon.blank? %>">
         <%= helpers.svg link_icon, class: "sidebar-link__icon sidebar-icon" if link_icon.present? %>

--- a/app/components/avo/sidebar/link_component.rb
+++ b/app/components/avo/sidebar/link_component.rb
@@ -76,4 +76,22 @@ class Avo::Sidebar::LinkComponent < Avo::BaseComponent
   def link_icon
     @icon
   end
+
+  # A link pointing at the root path would stay active on every page under
+  # `:inclusive` matching (root is a prefix of all of them). Fall back to
+  # `:exclusive` so it only lights up on the root page itself. Only kicks in
+  # for the default mode — an explicit `active:` from the caller wins.
+  def resolved_active
+    return @active unless @active == :inclusive && root_link?
+
+    :exclusive
+  end
+
+  def root_link?
+    return false if @path.blank?
+
+    URI(@path).path.chomp("/") == helpers.root_path_without_url.chomp("/")
+  rescue URI::InvalidURIError
+    false
+  end
 end

--- a/spec/components/avo/sidebar/link_component_spec.rb
+++ b/spec/components/avo/sidebar/link_component_spec.rb
@@ -40,4 +40,26 @@ RSpec.describe Avo::Sidebar::LinkComponent, type: :component do
       expect(build(path: "http://[invalid").is_external?).to be true
     end
   end
+
+  describe "#resolved_active" do
+    def build(path:, active: :inclusive)
+      component = described_class.new(label: "Link", path: path, active: active)
+      allow(component).to receive(:helpers).and_return(double(root_path_without_url: "/avo"))
+      component
+    end
+
+    it "downgrades a default root link to :exclusive so it isn't active everywhere" do
+      expect(build(path: "/avo").resolved_active).to eq :exclusive
+      expect(build(path: "/avo/").resolved_active).to eq :exclusive
+    end
+
+    it "leaves non-root links inclusive" do
+      expect(build(path: "/avo/resources/users").resolved_active).to eq :inclusive
+    end
+
+    it "only overrides the default :inclusive mode, leaving other modes untouched" do
+      expect(build(path: "/avo", active: :exact).resolved_active).to eq :exact
+      expect(build(path: "/avo", active: true).resolved_active).to eq true
+    end
+  end
 end


### PR DESCRIPTION
## Problem

A sidebar/menu link pointing at the root path — e.g. a `link_to "Home", Avo.configuration.root_path` menu item — stayed highlighted as active on **every** page.

Every sidebar and menu link renders through `Avo::Sidebar::LinkComponent`, which defaults to `active: :inclusive` (prefix matching). The root path is a prefix of every path mounted under it, so the root link matched everywhere.

## Fix

`LinkComponent#resolved_active` downgrades the default `:inclusive` mode to `:exclusive` when the link's path *is* the root path, so it only lights up on the root page itself. An explicit `active:` passed by the caller still wins — only the default is adjusted.

One guard in the shared leaf fixes it for all callers (Home links, custom menu links, anything pointing at root), with no per-link `active:` needed.

## Demo

On a resource page, the root-pointing **Home** link is no longer highlighted — only the current resource is:

Before: Home + current resource both active. After: only the current resource.

## Tests

Added a `#resolved_active` spec block covering root, trailing-slash root, non-root, and explicit-mode cases.

https://claude.ai/code/session_01T3p3dR8Q8mMKbVQgvcGRLs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI/navigation active-state logic in one component with specs; no auth, data, or API changes.
> 
> **Overview**
> Fixes sidebar **Home** (and other Avo root) links incorrectly showing as active on every page under the mount.
> 
> `Avo::Sidebar::LinkComponent` now passes **`resolved_active`** into `active_link_to` / the non-link `div` instead of raw `@active`. When the default **`active: :inclusive`** is used and the link path matches **`root_path_without_url`** (with trailing-slash normalization), it is downgraded to **`:exclusive`** so only the root page highlights the link. Explicit **`active:`** values from callers are unchanged.
> 
> Specs cover root paths, non-root paths, and explicit active modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d94aafb0513ad677a1e113c24dfada9e877ba8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->