### PR TITLE
fix(i18n): stop memoizing action default translations

### DIFF
--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -10,9 +10,9 @@ module Avo
 
     class_attribute :name, default: nil
     class_attribute :description, default: nil
-    class_attribute :message
-    class_attribute :confirm_button_label
-    class_attribute :cancel_button_label
+    class_attribute :message, default: -> { I18n.t("avo.are_you_sure_you_want_to_run_this_option") }
+    class_attribute :confirm_button_label, default: -> { I18n.t("avo.run") }
+    class_attribute :cancel_button_label, default: -> { I18n.t("avo.cancel") }
     class_attribute :confirmation, default: true
     class_attribute :standalone, default: false
     class_attribute :visible, default: -> {
@@ -132,9 +132,6 @@ module Avo
       ).handle.with_indifferent_access
       @query = query
       @index_query = index_query
-      self.class.message ||= I18n.t("avo.are_you_sure_you_want_to_run_this_option")
-      self.class.confirm_button_label ||= I18n.t("avo.run")
-      self.class.cancel_button_label ||= I18n.t("avo.cancel")
 
       self.items_holder = Avo::Resources::Items::Holder.new
 

--- a/spec/lib/avo/base_action_i18n_spec.rb
+++ b/spec/lib/avo/base_action_i18n_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Avo::BaseAction, "default i18n labels" do
+  let(:action_class) do
+    Class.new(Avo::BaseAction) do
+      self.name = "Locale probe"
+    end
+  end
+
+  def labels_for(locale)
+    I18n.with_locale(locale) do
+      action = action_class.new
+      {
+        message: action.get_message,
+        confirm: action.confirm_button_label,
+        cancel: action.cancel_button_label
+      }
+    end
+  end
+
+  it "resolves default message and button labels in the current locale each time" do
+    english = labels_for(:en)
+    german = labels_for(:de)
+
+    expect(english).to eq(
+      message: I18n.t("avo.are_you_sure_you_want_to_run_this_option", locale: :en),
+      confirm: I18n.t("avo.run", locale: :en),
+      cancel: I18n.t("avo.cancel", locale: :en)
+    )
+
+    expect(german).to eq(
+      message: I18n.t("avo.are_you_sure_you_want_to_run_this_option", locale: :de),
+      confirm: I18n.t("avo.run", locale: :de),
+      cancel: I18n.t("avo.cancel", locale: :de)
+    )
+
+    expect(german).not_to eq(english)
+  end
+end


### PR DESCRIPTION
## Summary
- Fixes [AVO-1441](https://linear.app/avo-hq/issue/AVO-1441/stop-memoizing-actions-translations): action default `message` / confirm / cancel labels no longer freeze in the first request's locale
- Defaults are now lazy `I18n.t` lambdas (evaluated via `Avo::ExecutionContext` at render time) instead of `||=` memoization in `initialize`
- Adds a regression spec that instantiates the same action class under `:en` then `:de`

## Test plan
- [x] `bin/test ./spec/lib/avo/base_action_i18n_spec.rb`
- [ ] Manual: open Users → Actions → Toggle inactive (English defaults)
- [ ] Visit `/admin/resources/users?set_locale=de` without restarting the server
- [ ] Open Toggle inactive again and confirm German defaults (Ausführen / Abbrechen)

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This only changes how default action confirmation strings are resolved per request locale; no schema, API, or persistence changes.


Made with [Cursor](https://cursor.com)