### PR TITLE
Set up cloud dev environment + clarify ESLint caveat

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -169,10 +169,16 @@ never reached). Do not "fix" `bin/dev` for this.
 
 ### Lint
 ```
-bundle exec standardrb        # Ruby (StandardRB)
+bundle exec standardrb        # Ruby (StandardRB) -- note: .standard.yml sets `fix: true`, so this auto-fixes files
 bundle exec erb_lint --lint-all   # ERB
-yarn eslint app/javascript        # JS
+yarn eslint app/javascript        # JS -- see caveat below
 ```
+The JS lint config (`.eslintrc.json`) is the legacy eslintrc format and only works
+with old ESLint. `package.json` pins ESLint v9, which (a) defaults to flat config
+and (b) is incompatible with the `sort-imports-es6-autofix` plugin, so
+`yarn eslint app/javascript` fails locally out of the box. CI works around this by
+installing `eslint@6.8.0` (plus matching plugins) at job time before linting
+(see `.github/workflows/lint.yml`). Do not "fix" this by changing the pinned version.
 
 ### Tests
 Tests run against `RAILS_ENV=test` with `AVO_LICENSE_KEY=license_123`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Set up the Cursor Cloud development environment for the Avo Rails engine and verified it end to end (lint, tests, running the dummy app). The only code change is a small `agents.md` documentation fix.

## Environment setup (captured via update script + snapshot)

- Ruby `3.3.1` via `rbenv` + `ruby-build` (compiled with jemalloc)
- PostgreSQL 16 installed, started, and `pg_hba.conf` set to `trust` for `127.0.0.1`/`::1`
- `bundler 4.0.10`, `overmind`, `foreman`, `tmux`
- `bundle install`, root `yarn install`, and `spec/dummy` `yarn install`
- Created/migrated/seeded dev DB and loaded test DB schema; built JS/CSS/custom-js assets

The update script only refreshes dependencies (`bundle install` + `yarn install` in root and `spec/dummy`). Toolchain and Postgres live in the VM snapshot.

## Docs change

`agents.md`: corrected the lint section. `yarn eslint app/javascript` does not work locally because `package.json` pins ESLint v9 while the repo uses a legacy `.eslintrc.json` + a plugin incompatible with v9. CI installs `eslint@6.8.0` at job time as a workaround. Also noted that `standardrb` auto-fixes (`.standard.yml` has `fix: true`).

## Verification

- `bin/dev` serves the dummy app at `http://localhost:3030` (`/` -> `/admin`)
- Logged in as `hi@avohq.io` and created a "Hello World Team" record through the Avo admin CRUD
- Ran request, component, and system (headless Chrome) specs successfully

[avo_login_create_team.mp4](https://cursor.com/agents/bc-646a8f40-38cc-4da0-9c4c-893577b6c47b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Favo_login_create_team.mp4)

[Hello World Team created](https://cursor.com/agents/bc-646a8f40-38cc-4da0-9c4c-893577b6c47b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fteam_created.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-646a8f40-38cc-4da0-9c4c-893577b6c47b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-646a8f40-38cc-4da0-9c4c-893577b6c47b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

