### PR TITLE
fix(i18n): key search JSON groups by route_key

### DIFF
--- a/app/controllers/avo/search_controller.rb
+++ b/app/controllers/avo/search_controller.rb
@@ -52,7 +52,7 @@ module Avo
     end
 
     def search_resource(resource)
-      key = resource.name.pluralize.downcase
+      key = resource.route_key
 
       # If search query is not defined return error in dev and nil otwherwise.
       if resource.search_query.blank?

--- a/spec/features/avo/search_json_locale_keys_spec.rb
+++ b/spec/features/avo/search_json_locale_keys_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature Avo::SearchController, type: :controller do
+  describe "search JSON group keys" do
+    let!(:user) { create :user, first_name: "Ada", last_name: "Lovelace" }
+
+    around do |example|
+      I18n.backend.store_translations(:de, {
+        avo: {
+          resource_translations: {
+            user: {
+              one: "Benutzer",
+              other: "Benutzer"
+            }
+          }
+        }
+      })
+
+      example.run
+    ensure
+      I18n.backend.reload!
+    end
+
+    it "keys groups by the stable route_key across locales" do
+      english_payload = search_payload_for(locale: :en)
+      german_payload = search_payload_for(locale: :de)
+
+      expect(english_payload.keys).to include("users")
+      expect(german_payload.keys).to include("users")
+      expect(german_payload.keys).not_to include("benutzers")
+      expect(german_payload.keys).to eq(english_payload.keys)
+    end
+
+    it "ships the translated plural label in the header value" do
+      payload = search_payload_for(locale: :de)
+
+      expect(payload.fetch("users").fetch("header")).to start_with("Benutzer")
+    end
+
+    def search_payload_for(locale:)
+      get :show, params: {resource_name: "users", q: "Ada", force_locale: locale}
+
+      expect(response).to have_http_status(:ok)
+      JSON.parse(response.body)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Search JSON groups from `/avo_api/<resources>/search` were keyed by the translated resource name (`resource.name.pluralize.downcase`), so keys changed by locale and broke stable JS lookups
- Key groups by `resource.route_key` instead; keep the translated plural label in `header`
- Add a locale regression spec covering English vs German payloads

Fixes AVO-1442

## Test plan
- [x] `bin/test ./spec/features/avo/search_json_locale_keys_spec.rb`
- [x] `bin/test ./spec/features/avo/search_with_q_unstripped_controller_spec.rb`
- [ ] Spot-check searchable field search JSON in a non-English locale and confirm the group key stays the route key while `header` is translated


Made with [Cursor](https://cursor.com)