### PR TITLE
fix: let multi-select filters scroll to their hidden options

### DIFF
--- a/app/assets/stylesheets/css/components/input.css
+++ b/app/assets/stylesheets/css/components/input.css
@@ -203,7 +203,11 @@
     background-position: left var(--input-icon-offset) center;
   }
 
+  /* The base reset sets `overflow: hidden` on every select, which clips the
+     options past the visible rows and leaves no way to scroll to them. */
   select[multiple] {
+    @apply overflow-y-auto;
+
     background-image: none;
   }
 

--- a/spec/dummy/app/avo/filters/post_long_options_filter.rb
+++ b/spec/dummy/app/avo/filters/post_long_options_filter.rb
@@ -1,0 +1,12 @@
+class Avo::Filters::PostLongOptionsFilter < Avo::Filters::MultipleSelectFilter
+  self.name = "Long options"
+
+  # Only used to test that the options list scrolls when it overflows.
+  def apply(request, query, value)
+    query
+  end
+
+  def options
+    (1..20).index_with { |index| "Option #{index}" }
+  end
+end

--- a/spec/dummy/app/avo/resources/post.rb
+++ b/spec/dummy/app/avo/resources/post.rb
@@ -141,6 +141,7 @@ class Avo::Resources::Post < Avo::BaseResource
     filter Avo::Filters::FeaturedFilter
     filter Avo::Filters::PublishedFilter
     filter Avo::Filters::PostStatusFilter
+    filter Avo::Filters::PostLongOptionsFilter
   end
 
   def actions

--- a/spec/system/avo/group_2/filters/filters_spec.rb
+++ b/spec/system/avo/group_2/filters/filters_spec.rb
@@ -282,6 +282,29 @@ RSpec.describe "Filters", type: :system do
         expect(page).to have_text("2 records")
       end
     end
+
+    context "when the options overflow the visible rows" do
+      let(:select_id) { "avo_filters_long_options" }
+
+      it "scrolls to reach the options past the visible ones" do
+        visit url
+        open_filters_menu
+
+        expect(page).to have_select select_id
+
+        overflows = page.evaluate_script(
+          "(() => { const el = document.getElementById('#{select_id}'); return el.scrollHeight > el.clientHeight })()"
+        )
+        expect(overflows).to be(true), "expected the options to overflow the select so it needs to scroll"
+
+        overflow_y = page.evaluate_script(
+          "getComputedStyle(document.getElementById('#{select_id}')).overflowY"
+        )
+        # `overflow: hidden` still allows programmatic scrolling, so asserting on
+        # scrollTop would pass even when the user can't reach the hidden options.
+        expect(overflow_y).to be_in(%w[auto scroll])
+      end
+    end
   end
 
   describe "Text filter" do


### PR DESCRIPTION
## The problem

`Avo::Filters::MultipleSelectFilter` renders at most 4 rows — `size` is clamped to `2..4` in `_multiple_select_filter.html.erb`:

```erb
size: filter.options.size.clamp(2, 4)
```

That clamp is fine on its own: a longer list is meant to scroll. But the select has no scrollbar, so every option past the 4th is simply unreachable — you can't `CMD+click` what you can't scroll to.

## The cause

The base input reset in `css/components/input.css` applies `overflow-hidden` to **every** `select`:

```css
select, textarea, .textarea-field, input:not(...), .input-field, tags.tagify {
  @apply ... overflow-hidden text-ellipsis whitespace-nowrap ...;
}
```

A browser renders `select[multiple]` as a listbox with `overflow: auto` by default. The reset lands in `@layer base`, which outranks the UA stylesheet, so it overrides that default and clips the list. The only existing `select[multiple]` rule sets `background-image`, so nothing restored it.

Verified against the compiled CSS — with 20 options, the box is 108px tall around 508px of content, `overflow-y` computes to `hidden`, and no scrollbar is rendered.

## The fix

Restore `overflow-y: auto` for `select[multiple]`. `overflow-x` stays hidden, so long option labels keep their existing ellipsis behavior.

| | Before | After |
|---|---|---|
| `overflow-y` | `hidden` | `auto` |
| Scrollbar rendered | no | yes |
| Options reachable (of 20) | 4 | 20 |

## Testing

Added a system spec covering a filter with 20 options. It fails on `main` (`expected "hidden".in?(["auto", "scroll"])`) and passes with the fix.

One subtlety worth flagging for review: **`overflow: hidden` still allows *programmatic* scrolling** — it only blocks the user. An assertion on `scrollTop` therefore passes even with the bug present (I confirmed this: such a test went green against the unfixed CSS). The spec asserts on the computed `overflow-y` instead, since that is what actually decides whether a user can scroll.

The new `PostLongOptionsFilter` dummy filter has no `default`, so it doesn't disturb the existing `Reset filters` assertions on the Posts panel.

- New spec: fails before, passes after.
- `spec/features/avo/select_field_spec.rb` — 23 examples, 0 failures (the fix touches all `select[multiple]`, not just filters).
- `spec/system/avo/group_2/filters/` — 7 failures, all pre-existing and **identical on a clean `main`** (leftover local seed data in the dummy DB; unrelated Teams/date/persist specs). This change adds 1 example and 0 new failures.
- Verified in a real browser on the dummy app, both before and after.

## Docs

No changes needed — `docs/4.0/filters.md` doesn't document the multi-select rendering, size, or scroll behavior, and this restores intended behavior with no API or config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)