### PR TITLE
AVO-1445: Add translation_key sibling fallbacks for field help/placeholder/include_blank

### DIFF
--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -203,8 +203,22 @@ module Avo
         @id.to_s.humanize(keep_id_suffix: true)
       end
 
+      def help
+        return @help if @args.key?(:help)
+
+        translated_field_option(:help)
+      end
+
+      def default_placeholder
+        name
+      end
+
       def placeholder
-        Avo::ExecutionContext.new(target: @placeholder || name, record: record, resource: @resource, view: @view).handle
+        target = @placeholder
+        target = translated_field_option(:placeholder) if target.nil? && !@args.key?(:placeholder)
+        target = default_placeholder if target.nil?
+
+        Avo::ExecutionContext.new(target:, record: record, resource: @resource, view: @view).handle
       end
 
       def attribute_id = (@attribute_id ||= @for_attribute || @id)
@@ -342,6 +356,10 @@ module Avo
       end
 
       private
+
+      def translated_field_option(option_name)
+        t("#{translation_key}.#{option_name}", default: nil)
+      end
 
       def fetch_parent
         params = Avo::Current.params

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -71,8 +71,6 @@ module Avo
       attr_reader :link_to_child_resource
 
       def initialize(id, **args, &block)
-        args[:placeholder] ||= I18n.t("avo.choose_an_option")
-
         super
 
         @searchable = (args[:searchable] == true || args[:searchable].is_a?(Hash)) ? args[:searchable] : false
@@ -87,6 +85,10 @@ module Avo
         @can_create = args[:can_create].nil? || args[:can_create]
         @link_to_record = args[:link_to_record].present? ? args[:link_to_record] : false
         @link_to_child_resource = args[:link_to_child_resource]
+      end
+
+      def default_placeholder
+        I18n.t("avo.choose_an_option")
       end
 
       def value

--- a/lib/avo/fields/country_field.rb
+++ b/lib/avo/fields/country_field.rb
@@ -8,8 +8,6 @@ module Avo
       attr_reader :stored_value
 
       def initialize(id, **args, &block)
-        args[:placeholder] ||= I18n.t("avo.choose_a_country")
-
         super
 
         @countries = begin
@@ -18,6 +16,10 @@ module Avo
           {none: "You need to install the countries gem for this field to work properly"}
         end
         @display_code = args[:display_code].present? ? args[:display_code] : false
+      end
+
+      def default_placeholder
+        I18n.t("avo.choose_a_country")
       end
 
       def select_options

--- a/lib/avo/fields/field_extensions/has_include_blank.rb
+++ b/lib/avo/fields/field_extensions/has_include_blank.rb
@@ -7,8 +7,10 @@ module Avo
             placeholder || "—"
           elsif @args[:include_blank] == false
             false
+          elsif @args.key?(:include_blank)
+            execute_context(@args[:include_blank])
           else
-            @args[:include_blank]
+            translated_field_option(:include_blank)
           end
         end
       end

--- a/lib/avo/fields/select_field.rb
+++ b/lib/avo/fields/select_field.rb
@@ -6,8 +6,6 @@ module Avo
       attr_reader :display_value, :multiple
 
       def initialize(id, **args, &block)
-        args[:placeholder] ||= I18n.t("avo.choose_an_option")
-
         super
 
         @options = if args[:options].is_a? Hash
@@ -22,6 +20,10 @@ module Avo
         @enum = args[:enum]
         @multiple = args[:multiple]
         @display_value = args[:display_value] || false
+      end
+
+      def default_placeholder
+        I18n.t("avo.choose_an_option")
       end
 
       def grouped_options

--- a/spec/lib/avo/fields/base_field_translation_options_spec.rb
+++ b/spec/lib/avo/fields/base_field_translation_options_spec.rb
@@ -1,0 +1,129 @@
+require "rails_helper"
+
+RSpec.describe "Field translation_key sibling options", type: :model do
+  let(:view) { Avo::ViewInquirer.new(:new) }
+  let(:base_translation_key) { "avo.resource_translations.import_guesty.fields" }
+
+  before do
+    I18n.backend.store_translations(:en, {
+      avo: {
+        resource_translations: {
+          import_guesty: {
+            fields: {
+              dates: {
+                help: "Optional. Standard period: 1 week ago to present.",
+                placeholder: "Select date range"
+              },
+              status: {
+                include_blank: "No status selected",
+                placeholder: "Pick a status"
+              },
+              country: {
+                placeholder: "Select a country"
+              },
+              author: {
+                placeholder: "Pick an author"
+              }
+            }
+          }
+        }
+      }
+    })
+  end
+
+  describe Avo::Fields::TextField do
+    it "falls back to sibling placeholder translation when placeholder is not provided" do
+      field = described_class.new(:dates, translation_key: "#{base_translation_key}.dates")
+        .hydrate(view:)
+
+      expect(field.placeholder).to eq "Select date range"
+    end
+
+    it "falls back to sibling help translation when help is not provided" do
+      field = described_class.new(:dates, translation_key: "#{base_translation_key}.dates")
+
+      expect(field.help).to eq "Optional. Standard period: 1 week ago to present."
+    end
+
+    it "keeps explicit placeholder over sibling translation" do
+      field = described_class.new(
+        :dates,
+        translation_key: "#{base_translation_key}.dates",
+        placeholder: "Custom placeholder"
+      ).hydrate(view:)
+
+      expect(field.placeholder).to eq "Custom placeholder"
+    end
+
+    it "keeps explicit help over sibling translation" do
+      field = described_class.new(
+        :dates,
+        translation_key: "#{base_translation_key}.dates",
+        help: "Custom help"
+      )
+
+      expect(field.help).to eq "Custom help"
+    end
+  end
+
+  describe Avo::Fields::SelectField do
+    it "falls back to sibling placeholder translation when placeholder is not provided" do
+      field = described_class.new(
+        :status,
+        options: {Draft: "draft"},
+        translation_key: "#{base_translation_key}.status"
+      ).hydrate(view:)
+
+      expect(field.placeholder).to eq "Pick a status"
+    end
+
+    it "keeps the field default placeholder when sibling translation is missing" do
+      field = described_class.new(
+        :status,
+        options: {Draft: "draft"},
+        translation_key: "#{base_translation_key}.missing_status"
+      ).hydrate(view:)
+
+      expect(field.placeholder).to eq "Choose an option"
+    end
+
+    it "falls back to sibling include_blank translation when include_blank is not provided" do
+      field = described_class.new(
+        :status,
+        options: {Draft: "draft"},
+        translation_key: "#{base_translation_key}.status"
+      ).hydrate(view:)
+
+      expect(field.include_blank).to eq "No status selected"
+    end
+
+    it "evaluates callable include_blank values in field execution context" do
+      field = described_class.new(
+        :status,
+        options: {Draft: "draft"},
+        translation_key: "#{base_translation_key}.status",
+        include_blank: -> { "Any status" }
+      ).hydrate(view:)
+
+      expect(field.include_blank).to eq "Any status"
+    end
+  end
+
+  describe Avo::Fields::CountryField do
+    it "falls back to sibling placeholder translation when placeholder is not provided" do
+      field = described_class.new(:country, translation_key: "#{base_translation_key}.country")
+        .hydrate(view:)
+
+      expect(field.placeholder).to eq "Select a country"
+    end
+  end
+
+  describe Avo::Fields::BelongsToField do
+    it "falls back to sibling placeholder translation when placeholder is not provided" do
+      field = described_class.new(:author, translation_key: "#{base_translation_key}.author")
+        .hydrate(view:)
+
+      expect(field.placeholder).to eq "Pick an author"
+    end
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
Adds sibling i18n fallback support for field-adjacent strings using the existing `translation_key` hierarchy.

Implemented behavior:
- `help` now resolves `#{translation_key}.help` when no explicit `help:` is given.
- `placeholder` now resolves `#{translation_key}.placeholder` when no explicit `placeholder:` is given.
- `include_blank` now resolves `#{translation_key}.include_blank` when no explicit `include_blank:` is given.
- Existing explicit options still take precedence.

Also refactored default placeholder behavior for fields with custom defaults (`SelectField`, `CountryField`, `BelongsToField`) so translation sibling lookup can apply before their built-in default placeholder strings.

Added focused specs in `spec/lib/avo/fields/base_field_translation_options_spec.rb` to cover:
- placeholder/help fallback and explicit override precedence
- include_blank fallback
- callable include_blank evaluation
- select fallback to default placeholder when sibling translation is missing

Fixes # AVO-1445

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I tested the design in Light and Dark mode, and all default themes

## Screenshots & recording
N/A (backend/i18n behavior change)

## Manual review steps
1. Add translations under a field key, e.g.:
   ```yml
   avo:
     resource_translations:
       import_guesty:
         fields:
           dates:
             help: Optional. Standard period: 1 week ago to present.
             placeholder: Select date range
           status:
             include_blank: No status selected
   ```
2. Configure fields with that `translation_key` and omit explicit `help:`, `placeholder:`, and `include_blank:`.
3. Verify forms render the translated help/placeholder/include_blank values.
4. Verify explicit `help:`, `placeholder:`, or `include_blank:` still override translation fallback.
5. Run:
   ```bash
   /workspace/bin/rspec spec/lib/avo/fields/base_field_translation_options_spec.rb
   ```

Manual reviewer: please leave a comment with output from the test if that's the case.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0962bfc-3012-4e0b-896e-e6572a90de18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0962bfc-3012-4e0b-896e-e6572a90de18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

