### PR TITLE
fix: preserve Marksmith heading sizes

### DIFF
--- a/app/assets/stylesheets/css/typography.css
+++ b/app/assets/stylesheets/css/typography.css
@@ -1,20 +1,20 @@
-h1 {
+h1:not(:where(.marksmith-rendered-body *)) {
   @apply text-4xl;
 }
 
-h2 {
+h2:not(:where(.marksmith-rendered-body *)) {
   @apply text-3xl;
 }
 
-h3 {
+h3:not(:where(.marksmith-rendered-body *)) {
   @apply text-2xl;
 }
 
-h4 {
+h4:not(:where(.marksmith-rendered-body *)) {
   @apply text-xl;
 }
 
-h5 {
+h5:not(:where(.marksmith-rendered-body *)) {
   @apply text-lg;
 }
 


### PR DESCRIPTION
# Description

I scoped Avo's global heading typography so it no longer overrides heading styles inside Marksmith-rendered Markdown. I used `:where()` for the exclusion to keep the original element-selector specificity outside Marksmith.

Fixes #4466

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (not applicable: selector-only CSS change)
- [ ] I have made corresponding changes to the documentation (not applicable: bug fix only)
- [ ] I have added tests that prove my fix is effective or that my feature works (no CSS unit-test harness is available)
- [ ] I tested the design in Light and Dark mode, and all default themes

## Screenshots & recording

The issue already includes before/after screenshots for the affected Markdown preview. This change only prevents Avo's global heading rules from overriding Marksmith's existing rendered-body typography.

## Manual review steps

1. Render Markdown containing H3 and H4 headings in a `:markdown` field preview.
2. Confirm that H3 and H4 use Marksmith's distinct heading sizes.
3. Confirm that headings outside `.marksmith-rendered-body` retain Avo's global typography.

## Validation

- `yarn install --frozen-lockfile`
- `yarn build`
- Compiled CSS assertion: H1-H5 rules exclude `.marksmith-rendered-body` descendants and no unscoped H3/H4 rule remains
- `git diff --check`

I did not run the full Rails system suite locally because Ruby is unavailable in this environment; the full matrix is deferred to CI.
