### PR TITLE
Add resource-scoped translations for tab and panel titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ For more up-to-date info check out our 🗺 [Roadmap](https://github.com/orgs/av
 
 Use this RailsBytes template to get started quick `rails app:template LOCATION='https://avohq.io/app-template'`. If you need a more detailed guide, follow [this page](https://docs.avohq.io/4.0/installation.html).
 
+# Localization
+
+Tab and panel titles use the resource's translation key with the title parameterized as the final segment:
+
+```yaml
+en:
+  avo:
+    resource_translations:
+      user:
+        tabs:
+          activity: Activity
+        panels:
+          contact_information: Contact information
+```
+
+For `tab title: "Activity"` and `panel title: "Contact information"`, Avo looks up `avo.resource_translations.user.tabs.activity` and `avo.resource_translations.user.panels.contact_information`. The configured title remains the fallback. Pass a full `translation_key:` to either item when the generated key is not suitable.
+
+See the [localization documentation](https://docs.avohq.io/4.0/i18n.html) for the other available conventions.
+
 # Contributing
 
 Please read [CONTRIBUTING.MD](./CONTRIBUTING.MD)

--- a/lib/avo/concerns/has_translatable_title.rb
+++ b/lib/avo/concerns/has_translatable_title.rb
@@ -1,0 +1,38 @@
+module Avo
+  module Concerns
+    module HasTranslatableTitle
+      def title
+        default = resolved_default_title
+        key = translation_key(default:)
+
+        return default if key.blank?
+
+        I18n.t(key, default:)
+      end
+
+      def translation_key(default: resolved_default_title)
+        @translation_key.presence || resource_translation_key(default)
+      end
+
+      private
+
+      def resolved_default_title
+        Avo::ExecutionContext.new(
+          target: @title,
+          resource:,
+          record: resource&.record,
+          view:
+        ).handle
+      end
+
+      def resource_translation_key(default)
+        return if resource.blank? || default.blank?
+
+        key = default.to_s.parameterize(separator: "_")
+        return if key.blank?
+
+        "#{resource.translation_key}.#{title_translation_scope}.#{key}"
+      end
+    end
+  end
+end

--- a/lib/avo/resources/items/item_group.rb
+++ b/lib/avo/resources/items/item_group.rb
@@ -12,10 +12,11 @@ class Avo::Resources::Items::ItemGroup
 
   delegate :items, :add_item, to: :items_holder
 
-  def initialize(title: nil, description: nil, view: nil, **args)
+  def initialize(title: nil, description: nil, translation_key: nil, view: nil, **args)
     @title = title
     @view = Avo::ViewInquirer.new view
     @description = description
+    @translation_key = translation_key
     @items_holder = Avo::Resources::Items::Holder.new
     @args = args
     @visible = args[:visible]

--- a/lib/avo/resources/items/panel.rb
+++ b/lib/avo/resources/items/panel.rb
@@ -1,5 +1,13 @@
 class Avo::Resources::Items::Panel < Avo::Resources::Items::ItemGroup
+  include Avo::Concerns::HasTranslatableTitle
+
   def get_items
     items_with_standalone_fields_wrapped_in_cards
+  end
+
+  private
+
+  def title_translation_scope
+    "panels"
   end
 end

--- a/lib/avo/resources/items/tab.rb
+++ b/lib/avo/resources/items/tab.rb
@@ -7,6 +7,7 @@ class Avo::Resources::Items::Tab
   include Avo::Concerns::IsVisible
   include Avo::Concerns::VisibleInDifferentViews
   include Avo::Concerns::FrameLoadingMode
+  include Avo::Concerns::HasTranslatableTitle
 
   delegate :items, :add_item, to: :items_holder
 
@@ -14,9 +15,10 @@ class Avo::Resources::Items::Tab
   attr_reader :lazy_load
   attr_reader :loading
 
-  def initialize(title: nil, description: nil, view: nil, **args)
+  def initialize(title: nil, description: nil, translation_key: nil, view: nil, **args)
     @title = title
     @description = description
+    @translation_key = translation_key
     @items_holder = Avo::Resources::Items::Holder.new
     @view = Avo::ViewInquirer.new view
     @args = args
@@ -25,10 +27,6 @@ class Avo::Resources::Items::Tab
     @loading = args[:loading]
 
     post_initialize if respond_to?(:post_initialize)
-  end
-
-  def title
-    Avo::ExecutionContext.new(target: @title).handle
   end
 
   def id
@@ -46,6 +44,12 @@ class Avo::Resources::Items::Tab
 
   def get_items
     items_with_standalone_fields_wrapped_in_cards
+  end
+
+  private
+
+  def title_translation_scope
+    "tabs"
   end
 
   class Builder

--- a/spec/lib/avo/resources/items/has_translatable_title_spec.rb
+++ b/spec/lib/avo/resources/items/has_translatable_title_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Avo::Concerns::HasTranslatableTitle, type: :model do
     it "trusts the translated title casing and punctuation" do
       item = build_item(item_class, title: "Localized fallback")
 
-      expect(item.title).to eq(scope == "tabs" ? "VAT & API history" : "VAT & API details")
+      expect(item.title).to eq((scope == "tabs") ? "VAT & API history" : "VAT & API details")
     end
 
     it "supports a full translation_key override" do

--- a/spec/lib/avo/resources/items/has_translatable_title_spec.rb
+++ b/spec/lib/avo/resources/items/has_translatable_title_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+RSpec.describe Avo::Concerns::HasTranslatableTitle, type: :model do
+  let(:record) { Struct.new(:name).new("Invoice 123") }
+  let(:resource) { double(translation_key: "avo.resource_translations.invoice", record:) }
+
+  around do |example|
+    I18n.backend.store_translations(
+      :en,
+      {
+        avo: {
+          resource_translations: {
+            invoice: {
+              tabs: {
+                payment_history: "Payment history",
+                localized_fallback: "VAT & API history"
+              },
+              panels: {
+                payment_history: "Payment details",
+                localized_fallback: "VAT & API details"
+              }
+            }
+          }
+        },
+        custom: {
+          layout_title: "Custom layout title"
+        }
+      }
+    )
+    I18n.backend.store_translations(
+      :pt,
+      {
+        avo: {
+          resource_translations: {
+            invoice: {
+              tabs: {
+                payment_history: "Histórico de pagamentos"
+              },
+              panels: {
+                payment_history: "Detalhes do pagamento"
+              }
+            }
+          }
+        }
+      }
+    )
+
+    I18n.with_locale(:en) { example.run }
+  ensure
+    I18n.backend.reload!
+  end
+
+  shared_examples "a resource-translated title" do |item_class, scope, english_title, portuguese_title|
+    def build_item(item_class, **args)
+      item_class.new(**args).hydrate(resource:, view: :show)
+    end
+
+    it "derives a predictable key from the resource and fallback title" do
+      item = build_item(item_class, title: "Payment history")
+
+      expect(item.translation_key).to eq "avo.resource_translations.invoice.#{scope}.payment_history"
+    end
+
+    it "resolves the title in the current request locale" do
+      item = build_item(item_class, title: "Payment history")
+
+      expect(I18n.with_locale(:en) { item.title }).to eq english_title
+      expect(I18n.with_locale(:pt) { item.title }).to eq portuguese_title
+    end
+
+    it "uses the configured title when the generated key is missing" do
+      item = build_item(item_class, title: "Untranslated title")
+
+      expect(item.title).to eq "Untranslated title"
+    end
+
+    it "trusts the translated title casing and punctuation" do
+      item = build_item(item_class, title: "Localized fallback")
+
+      expect(item.title).to eq(scope == "tabs" ? "VAT & API history" : "VAT & API details")
+    end
+
+    it "supports a full translation_key override" do
+      item = build_item(item_class, title: "Fallback title", translation_key: "custom.layout_title")
+
+      expect(item.translation_key).to eq "custom.layout_title"
+      expect(item.title).to eq "Custom layout title"
+    end
+
+    it "evaluates callable fallbacks with the hydrated resource context" do
+      item = build_item(item_class, title: -> { resource.record.name })
+
+      expect(item.title).to eq "Invoice 123"
+    end
+  end
+
+  include_examples(
+    "a resource-translated title",
+    Avo::Resources::Items::Tab,
+    "tabs",
+    "Payment history",
+    "Histórico de pagamentos"
+  )
+
+  include_examples(
+    "a resource-translated title",
+    Avo::Resources::Items::Panel,
+    "panels",
+    "Payment details",
+    "Detalhes do pagamento"
+  )
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

Adds predictable, request-localized title keys for resource tabs and panels:

- `#{resource.translation_key}.tabs.<parameterized_title>`
- `#{resource.translation_key}.panels.<parameterized_title>`

Configured titles remain fallbacks, and callers can provide a full `translation_key:` override. Callable titles now receive the hydrated resource context consistently. The convention is documented in the README.

Resolves Linear issue AVO-1463.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I tested the design in Light and Dark mode, and all default themes

## Screenshots & recording

Not applicable. This changes title resolution without changing the layout.

## Manual review steps

1. Define `panel title: "Contact information"` or `tab title: "Activity"` on a resource.
2. Add the corresponding key below the resource translation key.
3. Change locales and verify the rendered title follows the request locale while missing keys retain the configured title.

## Validation

- 17 focused item examples passed
- 7 related i18n and layout feature examples passed
- StandardRB passed for all changed Ruby files
- Ruby syntax checks passed
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AVO-1463](https://linear.app/avo-hq/issue/AVO-1463/add-a-translation-key-convention-for-tab-and-panel-titles)

<div><a href="https://cursor.com/agents/bc-4f064183-5c08-40b8-b510-98cacf466bc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f064183-5c08-40b8-b510-98cacf466bc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

