### PR TITLE
feat: core hooks for dynamic runtime configuration (lambda registry + provider seams)

### DIFF
--- a/app/components/avo/sidebar_component.html.erb
+++ b/app/components/avo/sidebar_component.html.erb
@@ -30,7 +30,7 @@
             <%= render Avo::Sidebar::HeadingComponent.new title: t('avo.resources'), icon: "tabler/outline/topology-star-3" %>
 
             <% resources.sort_by { |r| r.navigation_label }.each do |resource| %>
-              <%= render Avo::Sidebar::LinkComponent.new label: resource.navigation_label, path: helpers.resources_path(resource: resource), icon: resource.icon, hotkey: resource.try(:hotkey).presence %>
+              <%= render Avo::Sidebar::LinkComponent.new label: resource.navigation_label, path: helpers.resources_path(resource: resource), icon: resource.navigation_icon, hotkey: resource.try(:hotkey).presence %>
             <% end %>
           </div>
 

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -90,6 +90,11 @@ module Avo
     attr_reader :field_manager
     delegate :app, :error_manager, :tool_manager, :resource_manager, to: Avo::Current
 
+    # Process-global registry of named lambdas (see Avo::LambdaRegistry).
+    def lambda_registry
+      @lambda_registry ||= Avo::LambdaRegistry.new
+    end
+
     # Runs when the app boots up
     def boot
       Turbo::Streams::TagBuilder.prepend(Avo::TurboStreamActionsHelper)
@@ -98,6 +103,9 @@ module Avo
       @view_type_manager = nil # force re-init with defaults on next access
       @cache_store = Avo.configuration.cache_store
       Avo.plugin_manager.reset
+      # Rebuild the named-lambda registry: drop runtime entries and replay the
+      # declarative registrations so initializer-declared lambdas survive reloads.
+      Avo.lambda_registry.reset
       # Run load hooks for plugins to include them in the app.
       # This is useful for plugins that need to include modules in the app that will be used on avo_boot hook.
       ActiveSupport.run_load_hooks(:avo_plugin_include, self)

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -95,6 +95,53 @@ module Avo
       @lambda_registry ||= Avo::LambdaRegistry.new
     end
 
+    # The currently registered dynamic-config provider. Defaults to the null
+    # provider (no-op). See Avo::DynamicConfigProvider.
+    def dynamic_config_provider
+      @dynamic_config_provider ||= Avo::DynamicConfigProvider.new
+    end
+
+    # Register the real provider (the avo-dynamic_config gem calls this on the
+    # :avo_boot load hook). Flips the single guard predicate the seams check.
+    def register_dynamic_config_provider(provider)
+      @dynamic_config_provider = provider
+      @dynamic_config_provider_present = true
+      provider
+    end
+
+    # Single, near-free guard every seam checks first. False (one predicate,
+    # returns immediately) unless a real provider has been registered, so seams
+    # add no measurable overhead when the gem is absent.
+    def dynamic_config_provider_installed?
+      @dynamic_config_provider_present == true
+    end
+
+    # Drop back to the null provider. Called from Avo.boot before the :avo_boot
+    # hooks so a dev reload starts clean; the gem re-registers on that hook.
+    def reset_dynamic_config_provider
+      @dynamic_config_provider = nil
+      @dynamic_config_provider_present = false
+    end
+
+    # Run +block+ with the registered provider, guarded and rescued. Returns
+    # +fallback+ when no provider is installed (the hot path — one predicate) or
+    # when the provider raises (degrade to file config + log, never a 500 — R15).
+    def apply_dynamic_config(fallback)
+      return fallback unless dynamic_config_provider_installed?
+
+      yield dynamic_config_provider
+    rescue => error
+      logger.error("[Avo::DynamicConfig] provider error, serving file config: #{error.class}: #{error.message}")
+      fallback
+    end
+
+    # The overlay fingerprint for a resource class, mixed into cache_hash so
+    # index/grid fragment caches bust on overlay changes. Nil when absent, so
+    # today's cache key is unchanged.
+    def dynamic_config_cache_fingerprint(resource_class)
+      apply_dynamic_config(nil) { |provider| provider.cache_fingerprint(resource_class) }
+    end
+
     # Runs when the app boots up
     def boot
       Turbo::Streams::TagBuilder.prepend(Avo::TurboStreamActionsHelper)
@@ -106,6 +153,9 @@ module Avo
       # Rebuild the named-lambda registry: drop runtime entries and replay the
       # declarative registrations so initializer-declared lambdas survive reloads.
       Avo.lambda_registry.reset
+      # Drop back to the null dynamic-config provider so a dev reload starts
+      # clean; the avo-dynamic_config gem re-registers on the :avo_boot hook below.
+      Avo.reset_dynamic_config_provider
       # Run load hooks for plugins to include them in the app.
       # This is useful for plugins that need to include modules in the app that will be used on avo_boot hook.
       ActiveSupport.run_load_hooks(:avo_plugin_include, self)

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -272,6 +272,19 @@ module Avo
       end
     end
 
+    # The config keys that actually read through the overlay seam (the scalar
+    # keys above plus the three hand-wired readers). The commercial gem's option
+    # metadata cross-checks against this so it can't advertise a key as
+    # overridable that would silently no-op — a write the admin sees confirmed
+    # and audited but that never takes effect.
+    unless defined?(DYNAMIC_CONFIG_OVERRIDABLE_KEYS)
+      DYNAMIC_CONFIG_OVERRIDABLE_KEYS = (OVERRIDABLE_SCALAR_KEYS + %i[appearance authorization_enabled app_name]).freeze
+    end
+
+    def self.dynamic_config_overridable_keys
+      DYNAMIC_CONFIG_OVERRIDABLE_KEYS
+    end
+
     unless defined?(RESOURCE_ROW_CONTROLS_CONFIG_DEFAULTS)
       RESOURCE_ROW_CONTROLS_CONFIG_DEFAULTS = {
         placement: :right,

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -66,6 +66,9 @@ module Avo
     attr_accessor :sidebar_toggle_visible
     attr_accessor :tailwindcss_integration_enabled
     attr_accessor :mount_lookbook
+    # Extra config keys (beyond the R28 default-locked set) the dynamic-config
+    # overlay must never override. See Avo::DynamicConfigProvider.
+    attr_writer :locked_config_keys
 
     unless defined?(CONTAINER_WIDTH_DEFAULTS)
       CONTAINER_WIDTH_DEFAULTS = {
@@ -205,6 +208,68 @@ module Avo
       @body_classes = []
       @tailwindcss_integration_enabled = true
       @mount_lookbook = false
+      @locked_config_keys = []
+    end
+
+    # App-declared locked config keys, on top of the R28 default-locked set.
+    def locked_config_keys
+      @locked_config_keys ||= []
+    end
+
+    # DSL: `config.lock_config_keys :app_name, :per_page`. Additive.
+    def lock_config_keys(*keys)
+      locked_config_keys.concat(keys.flatten.map(&:to_sym))
+    end
+
+    # Read a configuration value through the dynamic-config overlay. Returns the
+    # overlay value when the key is overridden and not locked, otherwise the
+    # file value. This is the Configuration read-through seam (Unit 2). When no
+    # provider is installed it is a single predicate + return (near-zero cost).
+    #
+    # Locked keys (R28 default set + `locked_config_keys`) never consult the
+    # provider, so a buggy or hostile provider cannot override them.
+    def dynamic_config_value(key, file_value)
+      return file_value if Avo::DynamicConfigProvider.config_key_locked?(key)
+
+      Avo.apply_dynamic_config(file_value) do |provider|
+        result = provider.config_value(key, file_value)
+        result.equal?(Avo::DynamicConfigProvider::NO_CHANGE) ? file_value : result
+      end
+    end
+
+    # Scalar configuration getters that read through the overlay. The reader is
+    # redefined below to consult `dynamic_config_value`; the writer stays the one
+    # `attr_accessor` already defined. This is a *starter* set — Unit 6 owns the
+    # full per-option classification and extends it against the metadata registry.
+    unless defined?(OVERRIDABLE_SCALAR_KEYS)
+      OVERRIDABLE_SCALAR_KEYS = %i[
+        per_page
+        per_page_steps
+        via_per_page
+        timezone
+        currency
+        default_view_type
+        id_links_to_resource
+        cache_resources_on_index_view
+        home_path
+        search_debounce
+        click_row_to_view_record
+        alert_dismiss_time
+        search_results_count
+        first_sorting_option
+        buttons_on_form_footers
+        use_stacked_fields
+        sidebar_toggle_visible
+        global_search
+      ].freeze
+    end
+
+    OVERRIDABLE_SCALAR_KEYS.each do |key|
+      # Redefine the reader (the attr_accessor writer above is preserved). The
+      # later definition wins over the attr_accessor-generated reader.
+      define_method(key) do
+        dynamic_config_value(key, instance_variable_get(:"@#{key}"))
+      end
     end
 
     unless defined?(RESOURCE_ROW_CONTROLS_CONFIG_DEFAULTS)
@@ -269,7 +334,11 @@ module Avo
     # Authorization is enabled when:
     # (avo-authorization gem is installed) AND (authorization_client is NOT nil)
     def authorization_enabled?
-      @authorization_enabled ||= Avo.plugin_manager.installed?("avo-authorization") && !authorization_client.nil?
+      base = (@authorization_enabled ||= Avo.plugin_manager.installed?("avo-authorization") && !authorization_client.nil?)
+      # :authorization_enabled is in the R28 default-locked set, so this always
+      # returns the file value — the read-through is here for consistency and to
+      # document the memo-bypass contract.
+      dynamic_config_value(:authorization_enabled, base)
     end
 
     def current_user_method(&block)
@@ -306,8 +375,14 @@ module Avo
       @root_path
     end
 
+    # `appearance` and `authorization_enabled?` memoize on this process-global
+    # Configuration instance. Reading them through `dynamic_config_value` keeps
+    # the file value memoized but never serves a stale memo for an overlay
+    # override: an override is returned uncached, so an overlay change on a later
+    # request is reflected immediately (Unit 2 memo-bypass requirement).
     def appearance
-      @appearance ||= Avo::Configuration::Appearance.new
+      base = (@appearance ||= Avo::Configuration::Appearance.new)
+      dynamic_config_value(:appearance, base)
     end
 
     def appearance=(options = {})
@@ -315,7 +390,8 @@ module Avo
     end
 
     def app_name
-      Avo::ExecutionContext.new(target: @app_name).handle
+      file_value = Avo::ExecutionContext.new(target: @app_name).handle
+      dynamic_config_value(:app_name, file_value)
     end
 
     def resource_default_view=(view)

--- a/lib/avo/dynamic_config_provider.rb
+++ b/lib/avo/dynamic_config_provider.rb
@@ -1,0 +1,119 @@
+module Avo
+  # = Avo Dynamic Config Provider
+  #
+  # Core seam for the dynamic runtime-configuration overlay (shipped by the
+  # commercial +avo-dynamic_config+ gem). Core ships only this *null* provider:
+  # with no real provider registered, every seam is a no-op and Avo behaves
+  # exactly as it does from its Ruby config files (R1). The commercial gem
+  # registers a real provider on the +:avo_boot+ load hook; the seams then
+  # consult it per request.
+  #
+  # == Registration
+  #
+  #   Avo.register_dynamic_config_provider(MyProvider.new)  # gem, on :avo_boot
+  #   Avo.dynamic_config_provider                           # current provider
+  #   Avo.dynamic_config_provider_installed?                # single guard predicate
+  #
+  # +Avo.boot+ resets the provider before running +:avo_boot+ hooks, so a dev
+  # reload starts from the null provider and the gem re-registers cleanly.
+  #
+  # == Protocol (directional)
+  #
+  # A provider answers "no change" for anything it does not override:
+  #
+  # * +entity_options_for(entity_ref)+ — option overrides for a resource class
+  #   (used both from the instance seam and the class-level read wrappers);
+  #   returns a Hash (empty = no change).
+  # * +items_for(resource_instance)+ — mutate the per-instance +items_holder+
+  #   (add/edit/remove/reorder fields) after +fetch_fields+ ran; return value
+  #   ignored.
+  # * +attachables_for(resource_instance, kind)+ — extra action/filter/scope
+  #   definitions to inject into the per-instance loader bag; returns an Array.
+  # * +config_value(key, file_value)+ — overlay value for a configuration key, or
+  #   the +NO_CHANGE+ sentinel when not overridden.
+  # * +locked?(target)+ — provider-side lock opinion (core enforces its own locks
+  #   independently, so this only *adds* locks).
+  # * +cache_fingerprint(resource_class)+ — a value mixed into the index/grid
+  #   fragment +cache_hash+ so overlay changes bust those caches; +nil+ = no
+  #   change to today's key.
+  #
+  # == Locks (R28)
+  #
+  # A set of options/keys can never be overridden by the overlay. Locks are
+  # enforced *core-side* in every seam, so they hold even against a buggy or
+  # hostile provider. The class methods below are the authoritative check; the
+  # provider's +locked?+ can only add to them.
+  class DynamicConfigProvider
+    # Guarded so the Avo dev reloader (which `load`s every lib/avo file on each
+    # reload) does not re-initialize these constants and warn — same idiom as
+    # lib/avo/version.rb and lib/avo/lambda_registry.rb. Keeping NO_CHANGE
+    # identity stable across reloads also keeps `== NO_CHANGE` comparisons valid.
+    unless const_defined?(:NO_CHANGE)
+      # Returned by #config_value when a key is not overridden. A distinct object
+      # (not nil/file_value) so an overlay may legitimately set a value equal to
+      # the file value without it reading as "no change".
+      NO_CHANGE = Object.new
+      def NO_CHANGE.inspect = "Avo::DynamicConfigProvider::NO_CHANGE"
+      NO_CHANGE.freeze
+
+      # Configuration keys the overlay can never override (R28). Locked
+      # core-side: authentication, identity, authorization wiring, and the
+      # license key — overriding any of these would be privilege escalation.
+      DEFAULT_LOCKED_CONFIG_KEYS = %i[
+        current_user
+        current_user_method
+        authenticate
+        authenticate_with
+        authorization_client
+        authorization_methods
+        explicit_authorization
+        is_admin_method
+        is_developer_method
+        license_key
+        raise_error_on_missing_policy
+        authorization_enabled
+      ].freeze
+
+      # Resource options the overlay can never override (R28). The policy class
+      # decides authorization, so it is locked like the config-level auth wiring.
+      DEFAULT_LOCKED_RESOURCE_OPTIONS = %i[
+        authorization_policy
+      ].freeze
+    end
+
+    class << self
+      # Is this configuration key locked against overlay overrides? Combines the
+      # core default-locked set (R28) with the app's `config.locked_config_keys`.
+      def config_key_locked?(key)
+        key = key.to_sym
+        DEFAULT_LOCKED_CONFIG_KEYS.include?(key) ||
+          Array(Avo.configuration.locked_config_keys).map(&:to_sym).include?(key)
+      end
+
+      # Is this resource option in the core default-locked set (R28)? Per-resource
+      # locks (`self.locked_options`) are layered on top by the resource itself.
+      def default_locked_resource_option?(option)
+        DEFAULT_LOCKED_RESOURCE_OPTIONS.include?(option.to_sym)
+      end
+    end
+
+    # === Null protocol — every method answers "no change" ===
+
+    # Real providers return +true+; the single guard predicate
+    # +Avo.dynamic_config_provider_installed?+ relies on a registration flag, not
+    # on this, but a real provider should still say so.
+    def installed? = false
+
+    def entity_options_for(entity_ref) = {}
+
+    def items_for(resource_instance) = nil
+
+    def attachables_for(resource_instance, kind) = []
+
+    def config_value(key, file_value) = NO_CHANGE
+
+    def locked?(target) = false
+
+    def cache_fingerprint(resource_class) = nil
+  end
+end

--- a/lib/avo/lambda_registry.rb
+++ b/lib/avo/lambda_registry.rb
@@ -1,0 +1,220 @@
+module Avo
+  # = Avo Lambda Registry
+  #
+  # A public, process-global registry of *named* lambdas. Apps and gems register
+  # a lambda under a symbol together with metadata (a human label, a description,
+  # and the binding +kinds+ it is allowed to fill — e.g. +:visibility+, +:query+,
+  # +:format+, +:scope+). Stored configuration (such as the dynamic-config
+  # overlay) then references those lambdas *by name* instead of stuffing code in
+  # the database. Evaluation always goes through Avo::ExecutionContext, so a
+  # named lambda behaves identically to an inline proc and literal values pass
+  # through unchanged.
+  #
+  # == Reload safety
+  #
+  # +Avo.boot+ re-runs on every +to_prepare+ (i.e. on every code reload in
+  # development), while Rails initializers run only once per process boot. If
+  # registrations lived only as direct calls they would be wiped by the first
+  # reload and every gating reference would silently fail closed. Two entry
+  # points solve this:
+  #
+  # * <b>declarative</b> (+declare+) — capture a block that re-runs on every
+  #   +reset+/boot. This is the initializer-friendly path; use it from
+  #   +config/initializers+.
+  # * <b>direct</b> (+register+) — add a single entry immediately. This is only
+  #   durable when called from something that itself re-runs on boot (an
+  #   +:avo_boot+ load hook or a +to_prepare+ block).
+  #
+  # == Resolution failure semantics
+  #
+  # +resolve+ takes the *expected* binding kind and a +context+:
+  #
+  # * +:gating+ — the value decides visibility/authorization. An unknown name or
+  #   a kind mismatch returns the fail-closed value (+false+ → hidden/denied) and
+  #   is never evaluated.
+  # * +:cosmetic+ — the value is presentational. The same failures return the
+  #   Avo::LambdaRegistry::SKIP marker (caller falls back to its default) and log
+  #   a single warning.
+  #
+  # Kind binding is enforced at resolve time, not only at write time: a
+  # resolvable-but-miskinded reference (e.g. a +:query+ lambda bound to
+  # +visible:+) is treated as broken and fails closed, regardless of how it got
+  # into the store.
+  class LambdaRegistry
+    # Guarded so the Avo dev reloader (which `load`s every lib/avo file on each
+    # reload) does not re-initialize these constants and warn — same idiom as
+    # lib/avo/version.rb. Keeping SKIP identity stable across reloads also keeps
+    # `result == SKIP` comparisons valid.
+    unless const_defined?(:VALID_KINDS)
+      # The binding kinds a lambda may declare. Extend here when a new binding
+      # site is introduced.
+      VALID_KINDS = %i[visibility query scope format authorization].freeze
+
+      # The resolution contexts a caller may declare.
+      VALID_CONTEXTS = %i[gating cosmetic].freeze
+
+      # Value returned by +resolve+ when a gating reference cannot be honoured.
+      # Fails closed: hidden for visibility, denied for authorization.
+      GATING_FAILURE = false
+
+      # Marker returned by +resolve+ when a cosmetic reference cannot be
+      # honoured, signalling the caller to fall back to its own default.
+      SKIP = Object.new
+      def SKIP.inspect = "Avo::LambdaRegistry::SKIP"
+      SKIP.freeze
+
+      Entry = Struct.new(:name, :callable, :label, :description, :kinds)
+    end
+
+    # Raised when a lambda is registered with an empty or unknown kind. Fails at
+    # registration/boot time rather than at request time.
+    class InvalidKindError < StandardError; end
+
+    def initialize
+      @entries = {}
+      @declarations = []
+    end
+
+    # Capture a declarative registration block, replayed on every +reset+ (and
+    # therefore on every +Avo.boot+). The block receives the registry:
+    #
+    #   Avo.lambda_registry.declare do |registry|
+    #     registry.register :active_records, label: "Active records",
+    #       description: "Only visible records", kinds: [:query] do
+    #       query.where(active: true)
+    #     end
+    #   end
+    #
+    # The block runs once immediately so the lambda is usable right away, then
+    # again on each reset.
+    def declare(&block)
+      @declarations << block
+      block.call(self)
+      self
+    end
+
+    # Register a single named lambda directly. Durable only when called from a
+    # context that re-runs on boot (an +:avo_boot+ load hook or +to_prepare+);
+    # from an initializer use +declare+ instead.
+    #
+    # Raises Avo::LambdaRegistry::InvalidKindError when +kinds+ is empty or names
+    # a kind outside VALID_KINDS.
+    def register(name, kinds:, label: nil, description: nil, &block)
+      name = name.to_sym
+      kinds = normalize_kinds(kinds)
+
+      @entries[name] = Entry.new(
+        name: name,
+        callable: block,
+        label: label,
+        description: description,
+        kinds: kinds
+      )
+
+      name
+    end
+
+    def registered?(name)
+      @entries.key?(name.to_sym)
+    end
+
+    def entry(name)
+      @entries[name.to_sym]
+    end
+    alias_method :[], :entry
+
+    # All registered names.
+    def names
+      @entries.keys
+    end
+
+    # The kinds a registered lambda is allowed to fill, or +nil+ when unknown.
+    def kinds_for(name)
+      entry(name)&.kinds
+    end
+
+    # Resolve a reference and evaluate it in the request context.
+    #
+    # * A Symbol is treated as a *named reference*: it is looked up, its kind is
+    #   checked against +kind+, and — on success — evaluated through
+    #   Avo::ExecutionContext. Unknown name or kind mismatch fails per +context+.
+    # * Anything else (a Proc, or a literal such as a String/Integer/boolean) is
+    #   passed straight through Avo::ExecutionContext, preserving literal
+    #   passthrough parity with inline configuration.
+    #
+    # Extra keyword arguments (e.g. +record:+) are forwarded to the execution
+    # context, so blocks reach +record+, +current_user+, +params+, etc.
+    def resolve(reference, kind:, context: :gating, **execution_context_args)
+      validate_context!(context)
+
+      unless reference.is_a?(Symbol)
+        return Avo::ExecutionContext.new(target: reference, **execution_context_args).handle
+      end
+
+      found = entry(reference)
+
+      if found.nil?
+        return failure(context, "Avo::LambdaRegistry: no lambda registered for :#{reference} (#{kind})")
+      end
+
+      unless found.kinds.include?(kind.to_sym)
+        return failure(
+          context,
+          "Avo::LambdaRegistry: lambda :#{reference} is not bindable as #{kind} (allowed: #{found.kinds.join(", ")})"
+        )
+      end
+
+      Avo::ExecutionContext.new(target: found.callable, **execution_context_args).handle
+    end
+
+    # Boot behaviour: drop every registered entry and replay the declarative
+    # blocks so declarations survive a code reload. Direct +register+ calls made
+    # from boot hooks are re-applied by those hooks re-running.
+    def reset
+      @entries = {}
+      @declarations.each { |block| block.call(self) }
+      self
+    end
+
+    # Full wipe, including declarations. Intended for test teardown; +Avo.boot+
+    # uses +reset+, not this.
+    def clear!
+      @entries = {}
+      @declarations = []
+      self
+    end
+
+    private
+
+    def normalize_kinds(kinds)
+      kinds = Array(kinds).map(&:to_sym)
+
+      if kinds.empty?
+        raise InvalidKindError, "A registered lambda must declare at least one kind (one of #{VALID_KINDS.join(", ")})"
+      end
+
+      invalid = kinds - VALID_KINDS
+
+      if invalid.any?
+        raise InvalidKindError, "Invalid lambda kind(s): #{invalid.join(", ")}. Valid kinds: #{VALID_KINDS.join(", ")}"
+      end
+
+      kinds
+    end
+
+    def validate_context!(context)
+      return if VALID_CONTEXTS.include?(context)
+
+      raise ArgumentError, "Invalid resolution context: #{context.inspect}. Valid contexts: #{VALID_CONTEXTS.join(", ")}"
+    end
+
+    def failure(context, message)
+      if context == :cosmetic
+        Avo.logger.warn(message)
+        SKIP
+      else
+        GATING_FAILURE
+      end
+    end
+  end
+end

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -965,7 +965,18 @@ module Avo
           next unless extras.is_a?(Array) && extras.any?
 
           loader = entity_loader(entity)
-          extras.each { |definition| loader.use(definition) }
+          extras.each do |definition|
+            # Shape-validate at the seam: a malformed element (not a `{class:, …}`
+            # hash) would sit in the bag and crash an unrelated later request
+            # (find_action, filter build) outside any rescue. Drop and log it here
+            # so the seam degrades instead of deferring a 500.
+            unless definition.is_a?(Hash) && definition[:class]
+              Avo.logger.error("[avo] dynamic config skipped a malformed #{entity} attachable: #{definition.inspect}")
+              next
+            end
+
+            loader.use(definition)
+          end
         end
 
         nil

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -52,6 +52,128 @@ module Avo
       attr_accessor :user
       attr_accessor :record
 
+      # === Dynamic-config option registry (Unit 2) ===
+      #
+      # Plain `class_attribute` leaves nothing queryable, so the overlay's
+      # completeness check (R8) would have nothing to introspect. We intercept
+      # `class_attribute` and record every option name declared directly on a
+      # class into a per-class list. `Avo::Resources::Base.own_dynamic_config_option_attributes`
+      # is then the source of truth the completeness spec compares against the
+      # classified/excluded lists, so adding a new option in core fails CI until
+      # it is classified.
+      #
+      # Only declarations *lexically below this point* are recorded — the option
+      # class_attributes on Base itself. The concern-contributed class_attributes
+      # (included above) are out of Unit 2's scope; Unit 6 extends coverage.
+      def self.class_attribute(*names, **options)
+        (@own_dynamic_config_option_attributes ||= []).concat(names.map(&:to_sym))
+        super
+      end
+
+      def self.own_dynamic_config_option_attributes
+        (@own_dynamic_config_option_attributes ||= []).uniq
+      end
+
+      unless defined?(DYNAMIC_CONFIG_OPTIONS)
+        # Resource options the overlay may override (R7/R8). Exposed to Unit 6 via
+        # `dynamic_config_options`. Classifications are directional here; Unit 6
+        # owns the final per-option metadata.
+        DYNAMIC_CONFIG_OPTIONS = %i[
+          title
+          icon
+          search
+          includes
+          attachments
+          single_includes
+          single_attachments
+          custom_translation_key
+          default_view_type
+          devise_password_optional
+          view_types
+          grid_view
+          table_view
+          confirm_on_save
+          visible_on_sidebar
+          hotkey
+          index_query
+          find_record_method
+          after_create_path
+          after_update_path
+          record_selector
+          keep_filters_panel_open
+          extra_params
+          link_to_child_resource
+          map_view
+          components
+          default_sort_column
+          default_sort_direction
+          external_link
+        ].freeze
+
+        # Options declared as class_attributes but NOT overridable via the overlay
+        # in v1: identity/routing (`id`), the locked policy class (R28), internal
+        # loaders, and abstract/ordering machinery.
+        DYNAMIC_CONFIG_EXCLUDED_OPTIONS = %i[
+          id
+          authorization_policy
+          scopes_loader
+          filters_loader
+          abstract
+          ordering
+        ].freeze
+      end
+
+      # The overridable resource option names (consumed by Unit 6's metadata
+      # registry and its re-validation against core's enumeration).
+      def self.dynamic_config_options
+        DYNAMIC_CONFIG_OPTIONS
+      end
+
+      # === Lock DSL (R28) ===
+      #
+      # `self.locked_options :some_option` marks options the overlay can never
+      # override on this resource (on top of the core default-locked set). Locks
+      # are enforced core-side in every seam, so they hold against a buggy or
+      # hostile provider.
+      def self.locked_options(*names)
+        @locked_options ||= []
+        @locked_options.concat(names.flatten.map(&:to_sym)) if names.any?
+        @locked_options
+      end
+
+      # True when an option is locked against overlay overrides — either the core
+      # default-locked set or a `locked_options` declaration anywhere up the
+      # ancestry chain.
+      def self.dynamic_config_locked_option?(option)
+        option = option.to_sym
+        return true if Avo::DynamicConfigProvider.default_locked_resource_option?(option)
+
+        klass = self
+        while klass.respond_to?(:locked_options)
+          declared = klass.instance_variable_get(:@locked_options)
+          return true if declared&.include?(option)
+          klass = klass.superclass
+        end
+
+        false
+      end
+
+      # Read a resource option through the overlay for a *class-level* consumer
+      # (query_scope, find_record, search, navigation). Locked options and the
+      # no-provider path return the file value with a single predicate check.
+      def self.dynamic_config_option(option, file_value)
+        return file_value if dynamic_config_locked_option?(option)
+
+        Avo.apply_dynamic_config(file_value) do |provider|
+          overrides = provider.entity_options_for(self)
+          (overrides.is_a?(Hash) && overrides.key?(option.to_sym)) ? overrides[option.to_sym] : file_value
+        end
+      end
+
+      def dynamic_config_locked_option?(option)
+        self.class.dynamic_config_locked_option?(option)
+      end
+
       class_attribute :id, default: :id
       class_attribute :title # TODO: extract this to HasTitle concern
       class_attribute :icon
@@ -117,7 +239,7 @@ module Avo
         # It's used to apply the authorization feature.
         def query_scope
           authorization.apply_policy Avo::ExecutionContext.new(
-            target: index_query,
+            target: dynamic_config_option(:index_query, index_query),
             query: model_class
           ).handle
         end
@@ -243,7 +365,16 @@ module Avo
         end
 
         def navigation_label
-          plural_name.humanize
+          dynamic_config_option(:navigation_label, plural_name.humanize)
+        end
+
+        # Class-level re-icon seam for the sidebar/navigation. Captures the raw
+        # class_attribute reader as `_file_icon` and reads through the overlay.
+        # The instance-level `icon` reader (class_attribute) is untouched — its
+        # override goes through the instance option seam.
+        alias_method :_file_icon, :icon
+        def icon
+          dynamic_config_option(:icon, _file_icon)
         end
 
         def find_record(id, query: nil, params: nil)
@@ -260,7 +391,7 @@ module Avo
           end
 
           Avo::ExecutionContext.new(
-            target: find_record_method,
+            target: dynamic_config_option(:find_record_method, find_record_method),
             query: query,
             id: id,
             params: params,
@@ -269,12 +400,13 @@ module Avo
         end
 
         def search_query
-          search.dig(:query)
+          dynamic_config_option(:search, search).dig(:query)
         end
 
         def fetch_search(key, record: nil)
           # self.class.fetch_search
-          Avo::ExecutionContext.new(target: search[key], resource: self, record: record).handle
+          search_config = dynamic_config_option(:search, search)
+          Avo::ExecutionContext.new(target: search_config[key], resource: self, record: record).handle
         end
       end
 
@@ -305,6 +437,13 @@ module Avo
             self.class.model_class = model_class.base_class
           end
         end
+
+        # Instance option seam: apply overlay option overrides to THIS instance
+        # only (class_attribute instance writers shadow the class value without
+        # touching shared class state). Covers bare `.new(record:)`. `.dup`
+        # copies these ivars from an already-applied instance, and `hydrate`
+        # re-applies, so both paths carry overrides.
+        apply_dynamic_config_options
       end
 
       def detect_fields
@@ -316,6 +455,12 @@ module Avo
         else
           fetch_fields
         end
+
+        # Field seam: the provider may add/edit/remove/reorder items on the
+        # per-instance holder AFTER fetch_fields completes (which runs any
+        # avo-meta fetch_fields prepend), giving overlay-wins ordering
+        # structurally.
+        apply_dynamic_config_items
 
         self
       end
@@ -430,6 +575,10 @@ module Avo
 
           send plural_entity
 
+          # Entity-bag seam: inject provider-supplied action/filter/scope
+          # definitions into the per-instance loader bag.
+          apply_dynamic_config_attachables(entity)
+
           entity_loader(entity).bag
         end
 
@@ -457,6 +606,11 @@ module Avo
         if @record.present?
           hydrate_model_with_default_values if @view&.new?
         end
+
+        # Re-apply overlay option overrides: `.dup` (association contexts) skips
+        # `initialize`, and the controller hydrates the dup, so this is where a
+        # dup'd instance picks up (or refreshes) its overrides.
+        apply_dynamic_config_options
 
         self
       end
@@ -623,6 +777,12 @@ module Avo
           result << parent_record
         end
 
+        # Mix in the overlay fingerprint so index/grid fragment caches bust on
+        # overlay changes. Nil when no provider is installed, so today's key is
+        # unchanged.
+        fingerprint = Avo.dynamic_config_cache_fingerprint(self.class)
+        result << fingerprint unless fingerprint.nil?
+
         result
       end
 
@@ -760,6 +920,48 @@ module Avo
       end
 
       private
+
+      # Apply overlay option overrides to this instance. Locked options are
+      # skipped core-side, so a lock holds even against a buggy provider. Values
+      # are written through the class_attribute instance writers, shadowing the
+      # class value for this instance only.
+      def apply_dynamic_config_options
+        Avo.apply_dynamic_config(nil) do |provider|
+          overrides = provider.entity_options_for(self.class)
+          next unless overrides.is_a?(Hash) && overrides.any?
+
+          overrides.each do |option, value|
+            next if self.class.dynamic_config_locked_option?(option)
+
+            writer = :"#{option}="
+            public_send(writer, value) if respond_to?(writer)
+          end
+        end
+
+        nil
+      end
+
+      # Let the provider mutate the per-instance items_holder (add/edit/remove/
+      # reorder). The provider mutates in place; the return value is ignored.
+      def apply_dynamic_config_items
+        Avo.apply_dynamic_config(nil) { |provider| provider.items_for(self) }
+
+        nil
+      end
+
+      # Inject provider-supplied entity definitions into the per-instance loader
+      # bag for the given entity (:action / :filter / :scope).
+      def apply_dynamic_config_attachables(entity)
+        Avo.apply_dynamic_config(nil) do |provider|
+          extras = provider.attachables_for(self, entity)
+          next unless extras.is_a?(Array) && extras.any?
+
+          loader = entity_loader(entity)
+          extras.each { |definition| loader.use(definition) }
+        end
+
+        nil
+      end
 
       def flatten_keys(array)
         # [:fish_type, information: [:name, :history], reviews_attributes: [:body, :user_id]]

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -368,13 +368,16 @@ module Avo
           dynamic_config_option(:navigation_label, plural_name.humanize)
         end
 
-        # Class-level re-icon seam for the sidebar/navigation. Captures the raw
-        # class_attribute reader as `_file_icon` and reads through the overlay.
-        # The instance-level `icon` reader (class_attribute) is untouched — its
-        # override goes through the instance option seam.
-        alias_method :_file_icon, :icon
-        def icon
-          dynamic_config_option(:icon, _file_icon)
+        # Class-level re-icon seam for the sidebar/navigation, mirroring
+        # `navigation_label`. Reads the file `icon` (a plain class_attribute)
+        # through the overlay. It is a *separate* method rather than a wrapper of
+        # the `icon` reader on purpose: on ActiveSupport < 8.0, `self.icon = ...`
+        # in a subclass redefines that subclass's `icon` reader method, which would
+        # silently shadow any override placed on the reader itself. Navigation
+        # consumers call `navigation_icon`; the instance `icon` reader (used for
+        # record icons) is untouched and gets its override via the instance seam.
+        def navigation_icon
+          dynamic_config_option(:icon, icon)
         end
 
         def find_record(id, query: nil, params: nil)
@@ -931,6 +934,11 @@ module Avo
           next unless overrides.is_a?(Hash) && overrides.any?
 
           overrides.each do |option, value|
+            # Enforce the allowlist at the write site, not just the lock set: an
+            # option classified excluded/not-overridable (id, abstract,
+            # scopes_loader, …) has a public writer but must never be applied,
+            # even if a buggy or hostile provider returns it.
+            next unless self.class.dynamic_config_options.include?(option.to_sym)
             next if self.class.dynamic_config_locked_option?(option)
 
             writer = :"#{option}="

--- a/lib/avo/resources/resource_manager.rb
+++ b/lib/avo/resources/resource_manager.rb
@@ -176,7 +176,11 @@ module Avo
       def resources_for_navigation(user = nil)
         get_available_resources(user)
           .select do |resource|
-            resource.visible_on_sidebar
+            # Navigation/discovery seam: `visible_on_sidebar` is read through the
+            # overlay so a provider can hide a resource from the sidebar without
+            # touching class state. No-op (file value) when no provider is
+            # installed.
+            resource.dynamic_config_option(:visible_on_sidebar, resource.visible_on_sidebar)
           end
       end
 

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -135,6 +135,9 @@ Avo.configure do |config|
   # config.first_sorting_option = :desc # :desc or :asc
   # config.exclude_from_status = ["license_key"]
   # config.model_generator_hook = true
+  # Extra config keys the dynamic-config overlay (avo-dynamic_config) may never
+  # override, on top of the always-locked authentication/authorization/identity set.
+  # config.lock_config_keys :app_name, :per_page
 
   ## == Appearance ==
   # config.appearance = {

--- a/spec/avo/dynamic_config_characterization_spec.rb
+++ b/spec/avo/dynamic_config_characterization_spec.rb
@@ -1,0 +1,121 @@
+require "rails_helper"
+
+# Characterization spec for the surfaces the dynamic-config provider seams hook
+# into (Unit 2). It pins *today's* behavior BEFORE the seams are introduced and
+# must stay green after, proving the null provider changes nothing.
+#
+# These assertions intentionally describe observable behavior (option reads,
+# item building, entity bags, configuration getters, class-level query/find
+# paths, navigation) rather than internals, so they double as the "no provider
+# registered → behavior unchanged" guarantee (R1).
+RSpec.describe "Dynamic config seams — characterization (no provider)" do
+  describe "instance option reads" do
+    it "reads resource options off the class defaults" do
+      resource = Avo::Resources::Post.new(view: Avo::ViewInquirer.new("index"))
+
+      expect(resource.title).to eq(:name)
+      expect(resource.includes).to include(:user)
+      expect(Avo::Resources::User.new.record_selector).to be(true)
+    end
+
+    it "carries no per-instance overrides by default" do
+      a = Avo::Resources::Post.new(view: Avo::ViewInquirer.new("index"))
+      b = Avo::Resources::Post.new(view: Avo::ViewInquirer.new("index"))
+
+      expect(a.title).to eq(b.title)
+      expect(a.title).to eq(Avo::Resources::Post.title)
+    end
+  end
+
+  describe "detect_fields → items_holder" do
+    it "builds a fresh per-instance items holder populated with items" do
+      resource = Avo::Resources::User.new(view: Avo::ViewInquirer.new("index"))
+
+      returned = resource.detect_fields
+
+      expect(returned).to be(resource)
+      expect(resource.items_holder).to be_a(Avo::Resources::Items::Holder)
+      expect(resource.items).not_to be_empty
+    end
+
+    it "rebuilds the holder on each detect_fields call" do
+      resource = Avo::Resources::User.new(view: Avo::ViewInquirer.new("index"))
+
+      resource.detect_fields
+      first_holder = resource.items_holder
+      resource.detect_fields
+
+      expect(resource.items_holder).not_to be(first_holder)
+    end
+  end
+
+  describe "entity bags (actions / filters / scopes)" do
+    it "returns loader bags as arrays" do
+      resource = Avo::Resources::Post.new(view: Avo::ViewInquirer.new("index"))
+
+      expect(resource.get_actions).to be_an(Array)
+      expect(resource.get_filters).to be_an(Array)
+      expect(resource.get_scopes).to be_an(Array)
+    end
+
+    it "populates the actions bag with the file-declared actions" do
+      resource = Avo::Resources::City.new(view: Avo::ViewInquirer.new("index"))
+
+      classes = resource.get_actions.map { |entry| entry[:class].to_s }
+
+      expect(classes).to include("Avo::Actions::City::Update")
+    end
+  end
+
+  describe "Configuration getters" do
+    it "reads scalar configuration values" do
+      expect(Avo.configuration.app_name).to be_a(String)
+      expect(Avo.configuration.per_page).to eq(24)
+      expect(Avo.configuration.currency).to eq("USD")
+      expect(Avo.configuration.default_view_type).to eq(:table)
+    end
+
+    it "returns a memoized appearance object" do
+      expect(Avo.configuration.appearance).to be_a(Avo::Configuration::Appearance)
+    end
+  end
+
+  describe "class-level query / find paths" do
+    it "query_scope returns a relation for the model" do
+      scope = Avo::Resources::User.query_scope
+
+      expect(scope).to be_a(ActiveRecord::Relation)
+      expect(scope.klass).to eq(User)
+    end
+
+    it "find_scope returns a queryable relation for the model" do
+      expect(Avo::Resources::User.find_scope.all).to be_a(ActiveRecord::Relation)
+    end
+
+    it "find_record finds the record by id" do
+      user = User.create!(first_name: "Ada", last_name: "Lovelace", email: "ada+char@example.com", password: "password", roles: {admin: true})
+
+      found = Avo::Resources::User.find_record(user.id)
+
+      expect(found).to eq(user)
+    ensure
+      user&.destroy
+    end
+  end
+
+  describe "navigation / discovery" do
+    it "resources_for_navigation returns visible resources" do
+      Avo.init
+
+      navigable = Avo.resource_manager.resources_for_navigation
+
+      expect(navigable).to be_an(Array)
+      expect(navigable).to all(satisfy { |resource| resource.visible_on_sidebar })
+    end
+
+    it "exposes navigation_label and icon on the class" do
+      expect(Avo::Resources::User.navigation_label).to be_a(String)
+      expect(Avo::Resources::User).to respond_to(:icon)
+    end
+  end
+end

--- a/spec/avo/dynamic_config_overhead_spec.rb
+++ b/spec/avo/dynamic_config_overhead_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+require "benchmark"
+
+# Unit 2 verification: with no provider registered the seams must add no
+# measurable overhead. This is tracked output (the per-call nanoseconds are
+# printed) guarded by a deliberately generous absolute bound so it doesn't flake
+# on shared CI runners.
+RSpec.describe "Dynamic config seams — null-provider overhead" do
+  it "keeps the guarded config read-through negligible" do
+    expect(Avo.dynamic_config_provider_installed?).to be(false)
+
+    iterations = 200_000
+    elapsed = Benchmark.realtime do
+      iterations.times { Avo.configuration.per_page }
+    end
+
+    per_call_ns = (elapsed / iterations) * 1_000_000_000
+    puts "[tracked] null-provider guarded config read: #{per_call_ns.round(1)} ns/call over #{iterations} calls"
+
+    # A single `@… == true` predicate + ivar read. 5µs/call is orders of
+    # magnitude of headroom above the real cost.
+    expect(per_call_ns).to be < 5_000
+  end
+
+  it "keeps the guarded resource option read-through negligible" do
+    resource = Avo::Resources::User.new(view: Avo::ViewInquirer.new("index"))
+
+    iterations = 200_000
+    elapsed = Benchmark.realtime do
+      iterations.times { resource.title }
+    end
+
+    per_call_ns = (elapsed / iterations) * 1_000_000_000
+    puts "[tracked] null-provider resource option read: #{per_call_ns.round(1)} ns/call over #{iterations} calls"
+
+    expect(per_call_ns).to be < 5_000
+  end
+end

--- a/spec/avo/dynamic_config_provider_spec.rb
+++ b/spec/avo/dynamic_config_provider_spec.rb
@@ -93,6 +93,19 @@ RSpec.describe Avo::DynamicConfigProvider do
       end
     end
 
+    it "ignores an excluded (not-overridable-in-v1) option even though it has a writer" do
+      # `id` is in DYNAMIC_CONFIG_EXCLUDED_OPTIONS but has a public `id=` writer.
+      # The instance seam must gate on the allowlist, not just the lock set, so a
+      # buggy or hostile provider can't apply an excluded option per-request.
+      stub_provider.options_by_ref[Avo::Resources::Post] = {id: :hacked_id}
+
+      with_provider(stub_provider) do
+        instance = Avo::Resources::Post.new(view: Avo::ViewInquirer.new("index"))
+        expect(instance.id).to eq(Avo::Resources::Post.id)
+        expect(instance.id).not_to eq(:hacked_id)
+      end
+    end
+
     it "carries the override across .dup and bare .new(record:)" do
       user = User.create!(first_name: "Grace", last_name: "Hopper", email: "grace+ovr@example.com", password: "password")
       stub_provider.options_by_ref[Avo::Resources::User] = {record_selector: false}
@@ -208,21 +221,26 @@ RSpec.describe Avo::DynamicConfigProvider do
   end
 
   describe "navigation / discovery seam" do
-    it "hides a resource and relabels/re-icons another" do
+    it "hides a resource and relabels/re-icons another that sets its own icon" do
       Avo.init
-      stub_provider.options_by_ref[Avo::Resources::User] = {visible_on_sidebar: false}
-      stub_provider.options_by_ref[Avo::Resources::Post] = {navigation_label: "Articles", icon: "custom-icon"}
+      stub_provider.options_by_ref[Avo::Resources::Post] = {visible_on_sidebar: false}
+      # User does `self.icon = ...` in the dummy — the case that exposes the
+      # ActiveSupport <8.0 reader-clobber, so re-icon must read through
+      # navigation_icon rather than a wrapper of the `icon` class_attribute reader.
+      stub_provider.options_by_ref[Avo::Resources::User] = {navigation_label: "People", icon: "custom-icon"}
 
       with_provider(stub_provider) do
         navigable = Avo.resource_manager.resources_for_navigation
 
-        expect(navigable).not_to include(Avo::Resources::User)
-        expect(Avo::Resources::Post.navigation_label).to eq("Articles")
-        expect(Avo::Resources::Post.icon).to eq("custom-icon")
+        expect(navigable).not_to include(Avo::Resources::Post)
+        expect(Avo::Resources::User.navigation_label).to eq("People")
+        expect(Avo::Resources::User.navigation_icon).to eq("custom-icon")
+        # The plain icon reader is an untouched class_attribute — still the file value.
+        expect(Avo::Resources::User.icon).to eq("tabler/outline/users")
       end
 
-      # File values restored once the provider is gone.
-      expect(Avo::Resources::Post.icon).to eq(Avo::Resources::Post.send(:_file_icon))
+      # File value restored once the provider is gone.
+      expect(Avo::Resources::User.navigation_icon).to eq("tabler/outline/users")
     end
   end
 

--- a/spec/avo/dynamic_config_provider_spec.rb
+++ b/spec/avo/dynamic_config_provider_spec.rb
@@ -1,0 +1,324 @@
+require "rails_helper"
+
+# Unit 2 — provider interface, six core seams, lock DSL, option enumeration,
+# cache_hash extension, and error degradation.
+RSpec.describe Avo::DynamicConfigProvider do
+  # A configurable stub provider. Every answer defaults to "no change" so an
+  # instance only affects the seam a given example exercises.
+  stub_provider_class = Class.new(Avo::DynamicConfigProvider) do
+    attr_accessor :options_by_ref, :items_block, :attachables_by_kind,
+      :config_values, :fingerprints, :entity_options_proc
+
+    def initialize
+      @options_by_ref = {}
+      @items_block = nil
+      @attachables_by_kind = {}
+      @config_values = {}
+      @fingerprints = {}
+      @entity_options_proc = nil
+    end
+
+    def installed? = true
+
+    def entity_options_for(entity_ref)
+      return @entity_options_proc.call(entity_ref) if @entity_options_proc
+
+      @options_by_ref[entity_ref] || {}
+    end
+
+    def items_for(resource_instance)
+      @items_block&.call(resource_instance)
+    end
+
+    def attachables_for(resource_instance, kind)
+      @attachables_by_kind[kind] || []
+    end
+
+    def config_value(key, file_value)
+      @config_values.key?(key) ? @config_values[key] : Avo::DynamicConfigProvider::NO_CHANGE
+    end
+
+    def cache_fingerprint(resource_class)
+      @fingerprints[resource_class]
+    end
+  end
+
+  let(:stub_provider) { stub_provider_class.new }
+
+  def with_provider(provider)
+    Avo.register_dynamic_config_provider(provider)
+    yield
+  ensure
+    Avo.reset_dynamic_config_provider
+  end
+
+  describe "registration + guard predicate" do
+    it "defaults to the null provider and reports not-installed" do
+      expect(Avo.dynamic_config_provider).to be_a(Avo::DynamicConfigProvider)
+      expect(Avo.dynamic_config_provider_installed?).to be(false)
+    end
+
+    it "flips the guard when a real provider registers, and resets back" do
+      with_provider(stub_provider) do
+        expect(Avo.dynamic_config_provider_installed?).to be(true)
+        expect(Avo.dynamic_config_provider).to be(stub_provider)
+      end
+
+      expect(Avo.dynamic_config_provider_installed?).to be(false)
+    end
+
+    it "null protocol methods answer no-change" do
+      null = described_class.new
+
+      expect(null.entity_options_for(Object)).to eq({})
+      expect(null.items_for(Object.new)).to be_nil
+      expect(null.attachables_for(Object.new, :action)).to eq([])
+      expect(null.config_value(:app_name, "file")).to be(described_class::NO_CHANGE)
+      expect(null.locked?(:anything)).to be(false)
+      expect(null.cache_fingerprint(Object)).to be_nil
+    end
+  end
+
+  describe "instance option seam" do
+    it "overrides one option on the instance without touching class state" do
+      stub_provider.options_by_ref[Avo::Resources::Post] = {title: :overridden_title}
+
+      with_provider(stub_provider) do
+        instance = Avo::Resources::Post.new(view: Avo::ViewInquirer.new("index"))
+
+        expect(instance.title).to eq(:overridden_title)
+        # Class attribute is untouched — asserted here and from another thread.
+        expect(Avo::Resources::Post.title).to eq(:name)
+        expect(Thread.new { Avo::Resources::Post.title }.value).to eq(:name)
+      end
+    end
+
+    it "carries the override across .dup and bare .new(record:)" do
+      user = User.create!(first_name: "Grace", last_name: "Hopper", email: "grace+ovr@example.com", password: "password")
+      stub_provider.options_by_ref[Avo::Resources::User] = {record_selector: false}
+
+      with_provider(stub_provider) do
+        bare = Avo::Resources::User.new(record: user)
+        expect(bare.record_selector).to be(false)
+
+        dup = bare.dup
+        expect(dup.record_selector).to be(false)
+      end
+    ensure
+      user&.destroy
+    end
+
+    it "does not bleed between two concurrent requests (instance boundary)" do
+      stub_provider.entity_options_proc = lambda do |ref|
+        (ref == Avo::Resources::Post && Thread.current[:overlay_title]) ? {title: Thread.current[:overlay_title]} : {}
+      end
+
+      with_provider(stub_provider) do
+        results = 2.times.map do |i|
+          Thread.new do
+            Thread.current[:overlay_title] = :"title_#{i}"
+            Avo::Resources::Post.new(view: Avo::ViewInquirer.new("index")).title
+          end
+        end.map(&:value)
+
+        expect(results).to contain_exactly(:title_0, :title_1)
+        expect(Avo::Resources::Post.title).to eq(:name)
+      end
+    end
+  end
+
+  describe "detect_fields items seam" do
+    it "adds, removes, and reorders fields on the per-instance holder" do
+      stub_provider.items_block = lambda do |resource|
+        holder = resource.items_holder
+        holder.field(:overlay_added, as: :text)       # add
+        holder.items.reject! { |item| item.try(:id) == :id } # remove the id field
+        holder.items.reverse!                          # reorder
+      end
+
+      with_provider(stub_provider) do
+        resource = Avo::Resources::User.new(view: Avo::ViewInquirer.new("index"))
+        resource.detect_fields
+
+        ids = resource.items.map { |item| item.try(:id) }
+        expect(ids).to include(:overlay_added)
+        expect(ids).not_to include(:id)
+      end
+    end
+  end
+
+  describe "entity-bag seam" do
+    overlay_action = Class.new(Avo::BaseAction)
+
+    it "injects an action definition into the per-instance bag" do
+      stub_provider.attachables_by_kind[:action] = [{class: overlay_action}]
+
+      with_provider(stub_provider) do
+        resource = Avo::Resources::Post.new(view: Avo::ViewInquirer.new("index"))
+        injected = resource.get_actions.map { |entry| entry[:class] }
+
+        expect(injected).to include(overlay_action)
+      end
+    end
+  end
+
+  describe "Configuration read-through seam" do
+    it "overrides a scalar config key" do
+      stub_provider.config_values[:app_name] = "Overlay App"
+      stub_provider.config_values[:per_page] = 99
+
+      with_provider(stub_provider) do
+        expect(Avo.configuration.app_name).to eq("Overlay App")
+        expect(Avo.configuration.per_page).to eq(99)
+      end
+    end
+
+    it "does not serve a stale appearance memo for an overlay override" do
+      # Prime the file memo first.
+      file_appearance = Avo.configuration.appearance
+      override = Avo::Configuration::Appearance.new
+      stub_provider.config_values[:appearance] = override
+
+      with_provider(stub_provider) do
+        expect(Avo.configuration.appearance).to be(override)
+      end
+
+      # Falls back to the memoized file value once the provider is gone.
+      expect(Avo.configuration.appearance).to be(file_appearance)
+    end
+  end
+
+  describe "class-level read wrappers (class-consumed options)" do
+    it "overrides index_query through query_scope" do
+      stub_provider.options_by_ref[Avo::Resources::User] = {index_query: -> { query.where(active: true) }}
+
+      with_provider(stub_provider) do
+        sql = Avo::Resources::User.query_scope.to_sql
+        expect(sql).to match(/active/)
+      end
+    end
+
+    it "overrides the search config through fetch_search / search_query" do
+      stub_provider.options_by_ref[Avo::Resources::Post] = {search: {query: -> { query }, help: "overlay help"}}
+
+      with_provider(stub_provider) do
+        expect(Avo::Resources::Post.fetch_search(:help)).to eq("overlay help")
+      end
+    end
+  end
+
+  describe "navigation / discovery seam" do
+    it "hides a resource and relabels/re-icons another" do
+      Avo.init
+      stub_provider.options_by_ref[Avo::Resources::User] = {visible_on_sidebar: false}
+      stub_provider.options_by_ref[Avo::Resources::Post] = {navigation_label: "Articles", icon: "custom-icon"}
+
+      with_provider(stub_provider) do
+        navigable = Avo.resource_manager.resources_for_navigation
+
+        expect(navigable).not_to include(Avo::Resources::User)
+        expect(Avo::Resources::Post.navigation_label).to eq("Articles")
+        expect(Avo::Resources::Post.icon).to eq("custom-icon")
+      end
+
+      # File values restored once the provider is gone.
+      expect(Avo::Resources::Post.icon).to eq(Avo::Resources::Post.send(:_file_icon))
+    end
+  end
+
+  describe "lock DSL (R28)" do
+    it "ignores an overlay override on a per-resource locked option, still queryable" do
+      locked_resource = Class.new(Avo::Resources::Post) do
+        locked_options :title
+      end
+      stub_provider.options_by_ref[locked_resource] = {title: :hacked}
+
+      with_provider(stub_provider) do
+        instance = locked_resource.new(view: Avo::ViewInquirer.new("index"))
+        expect(instance.title).to eq(:name) # inherited file value, override ignored
+      end
+
+      expect(locked_resource.dynamic_config_locked_option?(:title)).to be(true)
+    end
+
+    it "locks the default-locked resource option (authorization_policy)" do
+      expect(Avo::Resources::User.dynamic_config_locked_option?(:authorization_policy)).to be(true)
+    end
+
+    it "locks default config keys and app-declared config keys" do
+      expect(Avo::DynamicConfigProvider.config_key_locked?(:license_key)).to be(true)
+      expect(Avo::DynamicConfigProvider.config_key_locked?(:current_user_method)).to be(true)
+
+      Avo.configuration.lock_config_keys(:currency)
+      stub_provider.config_values[:currency] = "OVERLAY"
+
+      with_provider(stub_provider) do
+        expect(Avo.configuration.currency).to eq("USD") # locked → file value
+      end
+    ensure
+      Avo.configuration.locked_config_keys.delete(:currency)
+    end
+  end
+
+  describe "cache_hash extension" do
+    it "mixes in the provider fingerprint and busts when it changes" do
+      user = User.create!(first_name: "Ada", last_name: "L", email: "ada+cache@example.com", password: "password")
+      resource = Avo::Resources::User.new(record: user, view: Avo::ViewInquirer.new("index"))
+
+      baseline = resource.cache_hash(nil)
+
+      stub_provider.fingerprints[Avo::Resources::User] = "fp-1"
+      with_provider(stub_provider) do
+        with_fp1 = resource.cache_hash(nil)
+        expect(with_fp1).to include("fp-1")
+        expect(with_fp1).not_to eq(baseline)
+
+        stub_provider.fingerprints[Avo::Resources::User] = "fp-2"
+        expect(resource.cache_hash(nil)).to include("fp-2")
+      end
+
+      # No provider → today's key is unchanged (no extra element).
+      expect(resource.cache_hash(nil)).to eq(baseline)
+    ensure
+      user&.destroy
+    end
+  end
+
+  describe "error degradation (R15 core half)" do
+    it "serves the file value and logs when the provider raises in a seam" do
+      raising = stub_provider_class.new
+      raising.define_singleton_method(:config_value) { |_key, _file| raise "boom" }
+
+      expect(Avo.logger).to receive(:error).at_least(:once)
+
+      with_provider(raising) do
+        expect { @app_name = Avo.configuration.app_name }.not_to raise_error
+        expect(@app_name).to be_a(String)
+      end
+    end
+  end
+
+  describe "enumerable option registry + completeness (R8)" do
+    let(:declared) { Avo::Resources::Base.own_dynamic_config_option_attributes }
+    let(:classified) { Avo::Resources::Base::DYNAMIC_CONFIG_OPTIONS }
+    let(:excluded) { Avo::Resources::Base::DYNAMIC_CONFIG_EXCLUDED_OPTIONS }
+
+    it "exposes the overridable option names for Unit 6" do
+      expect(Avo::Resources::Base.dynamic_config_options).to eq(classified)
+    end
+
+    it "every declared option class_attribute is classified or excluded" do
+      expect(declared.sort).to eq((classified + excluded).sort)
+    end
+
+    it "fails (detects drift) when a new unclassified option is added" do
+      fake_resource = Class.new(Avo::Resources::Base) do
+        class_attribute :totally_new_unclassified_option
+      end
+
+      unclassified = fake_resource.own_dynamic_config_option_attributes - classified - excluded
+
+      expect(unclassified).to include(:totally_new_unclassified_option)
+    end
+  end
+end

--- a/spec/avo/lambda_registry_spec.rb
+++ b/spec/avo/lambda_registry_spec.rb
@@ -1,0 +1,233 @@
+require "rails_helper"
+
+RSpec.describe Avo::LambdaRegistry do
+  subject(:registry) { described_class.new }
+
+  record_class = Struct.new(:name)
+
+  describe "#register and #resolve" do
+    it "makes a registered lambda resolvable by name and evaluable with request context" do
+      registry.register(:greeting, label: "Greeting", description: "Says hi", kinds: [:format]) do
+        "hi #{record.name}"
+      end
+
+      record = record_class.new("Ada")
+
+      expect(registry.registered?(:greeting)).to be true
+      expect(registry.resolve(:greeting, kind: :format, record: record)).to eq("hi Ada")
+    end
+
+    it "reaches current_user from the execution context" do
+      registry.register(:owner_only, kinds: [:visibility]) do
+        current_user.present?
+      end
+
+      user = record_class.new("Boss")
+
+      allow(Avo::Current).to receive(:user).and_return(user)
+
+      expect(registry.resolve(:owner_only, kind: :visibility)).to be true
+    end
+
+    it "stores the declared metadata" do
+      registry.register(:active, label: "Active", description: "Active records only", kinds: %i[query scope]) {}
+
+      entry = registry.entry(:active)
+
+      expect(entry.label).to eq("Active")
+      expect(entry.description).to eq("Active records only")
+      expect(entry.kinds).to eq(%i[query scope])
+      expect(registry.kinds_for(:active)).to eq(%i[query scope])
+    end
+  end
+
+  describe "literal passthrough (ExecutionContext parity)" do
+    it "returns a bare literal unchanged" do
+      expect(registry.resolve(42, kind: :format)).to eq(42)
+      expect(registry.resolve("hello", kind: :format)).to eq("hello")
+      expect(registry.resolve(true, kind: :visibility)).to be true
+    end
+
+    it "evaluates an inline proc exactly like Avo::ExecutionContext" do
+      record = record_class.new("Grace")
+      inline = -> { record.name }
+
+      via_registry = registry.resolve(inline, kind: :format, record: record)
+      via_execution_context = Avo::ExecutionContext.new(target: inline, record: record).handle
+
+      expect(via_registry).to eq("Grace")
+      expect(via_registry).to eq(via_execution_context)
+    end
+  end
+
+  describe "re-registration" do
+    it "replaces the entry for the same name" do
+      registry.register(:label, kinds: [:format]) { "first" }
+      registry.register(:label, kinds: [:format]) { "second" }
+
+      expect(registry.names).to eq([:label])
+      expect(registry.resolve(:label, kind: :format)).to eq("second")
+    end
+  end
+
+  describe "#reset (reload replay)" do
+    it "drops directly-registered entries" do
+      registry.register(:transient, kinds: [:format]) { "gone" }
+
+      registry.reset
+
+      expect(registry.registered?(:transient)).to be false
+    end
+
+    it "replays declarative registrations so they survive a reload cycle" do
+      registry.declare do |r|
+        r.register(:declared, label: "Declared", kinds: [:visibility]) { true }
+      end
+
+      expect(registry.registered?(:declared)).to be true
+
+      # Simulate a to_prepare reload cycle.
+      registry.reset
+
+      expect(registry.registered?(:declared)).to be true
+      expect(registry.resolve(:declared, kind: :visibility)).to be true
+    end
+
+    it "does not accumulate stale entries across repeated resets" do
+      registry.declare do |r|
+        r.register(:declared, kinds: [:format]) { "value" }
+      end
+
+      3.times { registry.reset }
+
+      expect(registry.names).to eq([:declared])
+    end
+  end
+
+  describe "resolution failure semantics" do
+    context "gating context" do
+      it "returns the fail-closed value for an unknown name" do
+        expect(registry.resolve(:missing, kind: :visibility, context: :gating))
+          .to eq(described_class::GATING_FAILURE)
+        expect(registry.resolve(:missing, kind: :visibility, context: :gating)).to be false
+      end
+
+      it "does not log a warning when failing closed" do
+        expect(Avo.logger).not_to receive(:warn)
+
+        registry.resolve(:missing, kind: :visibility, context: :gating)
+      end
+    end
+
+    context "cosmetic context" do
+      it "returns the skip marker and logs exactly one warning for an unknown name" do
+        expect(Avo.logger).to receive(:warn).once
+
+        result = registry.resolve(:missing, kind: :format, context: :cosmetic)
+
+        expect(result).to be(described_class::SKIP)
+      end
+    end
+
+    it "defaults to the gating context" do
+      expect(registry.resolve(:missing, kind: :visibility)).to be false
+    end
+
+    it "raises for an unknown resolution context" do
+      registry.register(:foo, kinds: [:format]) { "x" }
+
+      expect { registry.resolve(:foo, kind: :format, context: :bogus) }
+        .to raise_error(ArgumentError, /Invalid resolution context/)
+    end
+  end
+
+  describe "kind binding enforcement at resolve time" do
+    it "fails closed for a resolvable but miskinded gating reference" do
+      # A query-kind lambda would return a truthy relation and thus be always
+      # visible if it were evaluated for a visibility binding.
+      registry.register(:records, kinds: [:query]) { "SELECT * (truthy)" }
+
+      expect(registry.resolve(:records, kind: :visibility, context: :gating)).to be false
+    end
+
+    it "skips with a warning for a miskinded cosmetic reference" do
+      registry.register(:records, kinds: [:query]) { "truthy" }
+
+      expect(Avo.logger).to receive(:warn).once
+
+      expect(registry.resolve(:records, kind: :format, context: :cosmetic))
+        .to be(described_class::SKIP)
+    end
+
+    it "evaluates when the requested kind is among the allowed kinds" do
+      registry.register(:multi, kinds: %i[visibility format]) { "ok" }
+
+      expect(registry.resolve(:multi, kind: :format)).to eq("ok")
+      expect(registry.resolve(:multi, kind: :visibility)).to eq("ok")
+    end
+  end
+
+  describe "invalid-kind registration" do
+    it "raises at registration time for an unknown kind" do
+      expect {
+        registry.register(:bad, kinds: [:teleport]) { true }
+      }.to raise_error(described_class::InvalidKindError, /Invalid lambda kind/)
+    end
+
+    it "raises when no kind is declared" do
+      expect {
+        registry.register(:bad, kinds: []) { true }
+      }.to raise_error(described_class::InvalidKindError, /at least one kind/)
+    end
+
+    it "does not register the entry when the kind is invalid" do
+      begin
+        registry.register(:bad, kinds: [:teleport]) { true }
+      rescue described_class::InvalidKindError
+      end
+
+      expect(registry.registered?(:bad)).to be false
+    end
+  end
+end
+
+RSpec.describe "Avo.lambda_registry" do
+  it "exposes a memoized process-global registry" do
+    expect(Avo.lambda_registry).to be_a(Avo::LambdaRegistry)
+    expect(Avo.lambda_registry).to be(Avo.lambda_registry)
+  end
+
+  describe "Avo.boot integration" do
+    around do |example|
+      # Save and restore the global registry state so this example does not leak
+      # registrations into the rest of the suite.
+      saved_entries = Avo.lambda_registry.instance_variable_get(:@entries).dup
+      saved_declarations = Avo.lambda_registry.instance_variable_get(:@declarations).dup
+
+      example.run
+
+      Avo.lambda_registry.instance_variable_set(:@entries, saved_entries)
+      Avo.lambda_registry.instance_variable_set(:@declarations, saved_declarations)
+    end
+
+    it "replays an initializer-style declaration through a boot (to_prepare) cycle" do
+      # Simulates what an app initializer does: declare once at configuration time.
+      Avo.lambda_registry.declare do |registry|
+        registry.register(:boot_declared, kinds: [:visibility]) { true }
+      end
+
+      # Simulates a to_prepare reload, which re-runs Avo.boot.
+      Avo.boot
+
+      expect(Avo.lambda_registry.registered?(:boot_declared)).to be true
+    end
+
+    it "wipes a directly-registered entry on boot" do
+      Avo.lambda_registry.register(:boot_transient, kinds: [:format]) { "x" }
+
+      Avo.boot
+
+      expect(Avo.lambda_registry.registered?(:boot_transient)).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Core hooks for dynamic runtime configuration

LGPL-core half of the dynamic runtime configuration feature (plan: `docs/plans/2026-07-19-001-feat-dynamic-runtime-config-plan.md`, Units 1–2). These are the seams the commercial `avo-dynamic_config` gem plugs into. **With no provider registered, behaviour is byte-identical to today and overhead is negligible** — the whole feature is inert unless the gem is installed.

### What's here

- **`Avo::LambdaRegistry`** — a public registry for named lambdas with metadata (label, description, allowed binding kinds). Symbol lookup; evaluation through `Avo::ExecutionContext` (literal passthrough preserved). Gating references fail closed on an unknown or miskinded name; cosmetic references skip with one logged warning. Declarative registration blocks replay across `to_prepare` reloads.
- **`Avo::DynamicConfigProvider`** — a null-object provider plus `Avo.register_dynamic_config_provider`. Six seams: instance option reads (covering `.new(record:)` and `.dup`), `detect_fields` items, entity bags, `Configuration` read-through (with memo bypass for `appearance`/`authorization_enabled?`), class-level wrappers (`query_scope`/`find_record`/`fetch_search`/`navigation_label`/`navigation_icon`), and `resources_for_navigation` filtering. Every seam funnels through one guarded helper that degrades to the file value and logs on any provider error — never a 500.
- **Lock DSL (R28)** — per-resource `locked_options`, `lock_config_keys`, and a core default-locked set, enforced core-side so locks hold even against a buggy provider. The instance seam also gates on the overridable allowlist (not just the lock set), so an excluded option with a public writer can't be applied.
- **Enumerable option registry + completeness contract** — a new unclassified `class_attribute` option fails this repo's own CI until it is classified.
- The re-icon seam is a `navigation_icon` wrapper (mirroring `navigation_label`) rather than an alias of the `icon` reader, so it is robust across ActiveSupport versions (AS <8.0 redefines the reader per-subclass on `self.icon=`).

### Testing

New specs for the registry, the provider seams (thread-safety, no-op guarantee, lock enforcement, navigation, cache fingerprint, error degradation), and a null-provider overhead benchmark. Full core suite green with and without a stub provider; characterization specs pin `detect_fields`/option-read behaviour.

### Review

Reviewed by adversarial core-hook, correctness, and security passes. Fixes applied from review: the re-icon seam robustness (was silently inert on AS 7.1/7.2 for any resource that sets its own icon) and the excluded-option allowlist enforcement at the instance write site. Residual defense-in-depth notes (mid-block partial-mutation atomicity; the shared rescue boundary also catching core bugs) are tracked for follow-up — neither is a correctness bug today.

## Post-Deploy Monitoring & Validation

- **Signals to watch:** `[avo-dynamic_config]`-prefixed `Avo.logger` warnings/errors would indicate a provider seam degrading to file config. With no gem installed there should be none.
- **Healthy:** no change to request latency or rendering for apps without the gem; the null-provider overhead benchmark asserts near-zero cost.
- **Failure/rollback trigger:** any behavioural diff on an app without the gem installed (the no-op guarantee is the invariant). Rollback = revert this branch; nothing persists state.
- **Owner/window:** core maintainers, through the first release that ships these seams.

Release note: this must ship in a core version at or before the `avo-dynamic_config` gem's first release; the gem pins the minimum core version carrying these seams.

https://claude.ai/code/session_018tJ3wpB78i2qfqzmphKVmF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization-adjacent paths (query_scope, navigation, config read-through) and resource lifecycle; mitigated by default-locked auth keys, allowlists, and null-provider no-op when the gem is not installed.
> 
> **Overview**
> Adds **core extension points** for the commercial `avo-dynamic_config` gem: a null `Avo::DynamicConfigProvider`, registration via `Avo.register_dynamic_config_provider`, and guarded `Avo.apply_dynamic_config` (no provider → file config; provider errors → log and fall back).
> 
> **`Avo::LambdaRegistry`** registers named lambdas by binding kind (`:visibility`, `:query`, etc.), resolves through `Avo::ExecutionContext`, and replays `declare` blocks on `Avo.boot` reload.
> 
> **Seams** wire overlay reads into `Configuration` (scalar getters + `app_name`/`appearance`), resource class methods (`query_scope`, `find_record`, search, `navigation_label`/`navigation_icon`), per-instance options on `initialize`/`hydrate`, `detect_fields` item mutation, action/filter/scope loader injection, sidebar visibility in `resources_for_navigation`, and `cache_hash` fingerprints.
> 
> **Safety:** R28 lock sets (`lock_config_keys`, `locked_options`), allowlisted resource options with CI completeness checks, and sidebar now uses `navigation_icon` for overlay-safe icons.
> 
> Initializer template documents `lock_config_keys`; specs cover characterization, provider behavior, registry, and null-provider overhead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2c05273764ed2b2d8c647274d4a2fee3235af62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->