### PR TITLE
fix(ui): accept optional badge/label props on tab and count components

### DIFF
--- a/app/components/avo/u_i/count_component.html.erb
+++ b/app/components/avo/u_i/count_component.html.erb
@@ -1,1 +1,1 @@
-<%= content_tag :span, @count, class: class_names("count", @classes), data: @data %>
+<%= content_tag :span, @count, class: class_names("count", @classes), data: @data, "aria-label": @label %>

--- a/app/components/avo/u_i/count_component.rb
+++ b/app/components/avo/u_i/count_component.rb
@@ -8,4 +8,7 @@ class Avo::UI::CountComponent < Avo::BaseComponent
   prop :count
   prop :classes, default: nil
   prop :data, default: -> { {} }
+  # Optional accessible name (e.g. "1,234 records") when the visible +count+ is
+  # abbreviated or purely numeric. Rendered as aria-label; omitted when nil.
+  prop :label, default: nil
 end

--- a/app/components/avo/u_i/tabs/tab_component.html.erb
+++ b/app/components/avo/u_i/tabs/tab_component.html.erb
@@ -22,6 +22,6 @@
   ) do %>
     <%= svg @icon, class: "tabs__item-icon", "aria-hidden": "true" if @icon.present? %>
     <%= tag.span @label, class: "tabs__item-label" if @label.present? %>
-    <%= @badge.respond_to?(:render_in) ? render(@badge) : @badge if @badge.present? %>
+    <%= render_badge %>
   <% end %>
 <% end %>

--- a/app/components/avo/u_i/tabs/tab_component.html.erb
+++ b/app/components/avo/u_i/tabs/tab_component.html.erb
@@ -22,5 +22,6 @@
   ) do %>
     <%= svg @icon, class: "tabs__item-icon", "aria-hidden": "true" if @icon.present? %>
     <%= tag.span @label, class: "tabs__item-label" if @label.present? %>
+    <%= @badge.respond_to?(:render_in) ? render(@badge) : @badge if @badge.present? %>
   <% end %>
 <% end %>

--- a/app/components/avo/u_i/tabs/tab_component.rb
+++ b/app/components/avo/u_i/tabs/tab_component.rb
@@ -19,6 +19,7 @@ module Avo
         prop :data, default: {}.freeze
         prop :classes
         prop :title
+        prop :badge, default: nil
       end
     end
   end

--- a/app/components/avo/u_i/tabs/tab_component.rb
+++ b/app/components/avo/u_i/tabs/tab_component.rb
@@ -20,6 +20,16 @@ module Avo
         prop :classes
         prop :title
         prop :badge, default: nil
+
+        private
+
+        # The badge may be a component instance (eager count pill) or a
+        # pre-rendered safe string (deferred counter frame); render accordingly.
+        def render_badge
+          return unless @badge.present?
+
+          @badge.respond_to?(:render_in) ? render(@badge) : @badge
+        end
       end
     end
   end

--- a/spec/components/avo/u_i/count_component_spec.rb
+++ b/spec/components/avo/u_i/count_component_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Avo::UI::CountComponent, type: :component do
   include Capybara::RSpecMatchers
 
-  def render_component(**opts)
-    render_inline(described_class.new(**opts))
+  def render_component(**)
+    render_inline(described_class.new(**))
   end
 
   describe "rendering" do

--- a/spec/components/avo/u_i/count_component_spec.rb
+++ b/spec/components/avo/u_i/count_component_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Avo::UI::CountComponent, type: :component do
+  include Capybara::RSpecMatchers
+
+  def render_component(**opts)
+    render_inline(described_class.new(**opts))
+  end
+
+  describe "rendering" do
+    it "renders the count as the visible text" do
+      render_component(count: "1,234")
+
+      expect(page).to have_css("span.count", text: "1,234")
+    end
+
+    it "forwards custom classes" do
+      render_component(count: "5", classes: "ms-1")
+
+      expect(page).to have_css("span.count.ms-1")
+    end
+
+    it "forwards data attributes" do
+      render_component(count: "5", data: {testid: "count"})
+
+      expect(page).to have_css("span.count[data-testid='count']")
+    end
+  end
+
+  describe "with a label (accessible name)" do
+    it "does not raise when passed a label keyword" do
+      expect { render_component(count: "5", label: "5 records") }.not_to raise_error
+    end
+
+    it "renders the label as the aria-label while count stays the visible text" do
+      render_component(count: "1,234", label: "1234 records")
+
+      expect(page).to have_css("span.count[aria-label='1234 records']", text: "1,234")
+    end
+
+    it "omits aria-label when no label is given" do
+      render_component(count: "5")
+
+      expect(page).not_to have_css("span.count[aria-label]")
+    end
+  end
+end

--- a/spec/components/avo/u_i/tabs/tab_component_spec.rb
+++ b/spec/components/avo/u_i/tabs/tab_component_spec.rb
@@ -71,6 +71,42 @@ RSpec.describe Avo::UI::Tabs::TabComponent, type: :component do
       end
     end
 
+    context "with badge" do
+      it "renders a component badge inside the tab link" do
+        render_component(badge: Avo::UI::CountComponent.new(count: "5"))
+
+        expect(page).to have_css("a.tabs__item span.count", text: "5")
+      end
+
+      it "renders a pre-rendered safe-string badge inside the tab link" do
+        render_component(badge: %(<span class="deferred-badge">x</span>).html_safe)
+
+        expect(page).to have_css("a.tabs__item span.deferred-badge", text: "x")
+      end
+
+      it "renders the badge after the label" do
+        render_component(label: "Published", badge: Avo::UI::CountComponent.new(count: "9"))
+
+        expect(page).to have_css(".tabs__item-label + span.count")
+      end
+
+      it "omits badge markup when no badge is given" do
+        render_component
+
+        expect(page).not_to have_css("span.count")
+      end
+
+      it "omits badge markup when badge is nil" do
+        render_component(badge: nil)
+
+        expect(page).not_to have_css("span.count")
+      end
+
+      it "does not raise when passed a badge keyword" do
+        expect { render_component(badge: Avo::UI::CountComponent.new(count: "1")) }.not_to raise_error
+      end
+    end
+
     it "renders with custom attributes" do
       render_component(
         id: "custom-tab-id",


### PR DESCRIPTION
## Summary

Adding an opt-in count pill to a scope's tab crashed every scoped index page with `ArgumentError: unknown keyword :badge` (and `:label` on eager counters). `avo-scopes` passes `badge:` to `Avo::UI::Tabs::TabComponent` and `label:` to `Avo::UI::CountComponent`, but neither component ever declared those props — so `prop_initializer`'s strict constructor raised before the page could render.

Before: a scoped index with a counter-bearing scope returned a 500. After: the count pill renders next to the scope tab.

This teaches both shared components to accept the props `avo-scopes` already sends:

- **`Avo::UI::Tabs::TabComponent`** gains an optional `badge` (default `nil`), rendered after the label inside the tab link. A small private `render_badge` handles both shapes the caller sends: a component instance (the eager `CountComponent` pill) and a pre-rendered safe string (the deferred/lazy counter frame).
- **`Avo::UI::CountComponent`** gains an optional `label` (default `nil`), rendered as the span's `aria-label` — the accessible name for an abbreviated or purely numeric count.

Both props default to `nil`, so every existing call site (the filters bar's applied-count pill, tab groups) is unaffected — purely additive.

## Tests

- `spec/components/avo/u_i/tabs/tab_component_spec.rb` — new `with badge` context: component badge, pre-rendered safe-string badge, placement after the label, nil/omitted, and no-raise on the `badge:` keyword (the crash reproduction).
- `spec/components/avo/u_i/count_component_spec.rb` (new) — count/classes/data rendering plus the `label` → `aria-label` accessible-name behavior and its omission when nil.
- End-to-end regression that renders the full scopes bar lives in the paired `avo-scopes` change (avo-hq/workspace) — that repo's CI depends on this PR landing first.

Fixes AVO-1500 — https://linear.app/avo-hq/issue/AVO-1500/fix-unknown-keyword-badge

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
