### PR TITLE
feat: density setting and host-agnostic index field wrappers

### DIFF
--- a/app/assets/stylesheets/css/focus.css
+++ b/app/assets/stylesheets/css/focus.css
@@ -16,7 +16,7 @@
     outline: none;
   }
 
-  a[href]:empty:not([aria-label]) {
+  a[href]:empty:not([aria-label]):not([aria-labelledby]) {
     display: none;
   }
 

--- a/app/components/avo/fields/index_component.rb
+++ b/app/components/avo/fields/index_component.rb
@@ -8,7 +8,7 @@ class Avo::Fields::IndexComponent < Avo::BaseComponent
   attr_reader :parent_resource
   attr_reader :view
 
-  def initialize(field: nil, resource: nil, reflection: nil, index: 0, parent_record: nil, parent_resource: nil, **kwargs)
+  def initialize(field: nil, resource: nil, reflection: nil, index: 0, parent_record: nil, parent_resource: nil, density: nil, field_wrapper: {}, **kwargs)
     @field = field
     @resource = resource
     @index = index
@@ -17,6 +17,8 @@ class Avo::Fields::IndexComponent < Avo::BaseComponent
     @parent_resource = parent_resource
     @view = Avo::ViewInquirer.new("index")
     @reflection = reflection
+    @density = density
+    @field_wrapper_options = field_wrapper
   end
 
   def resource_view_path
@@ -35,7 +37,9 @@ class Avo::Fields::IndexComponent < Avo::BaseComponent
   def field_wrapper_args
     {
       field: @field,
-      resource: @resource
+      resource: @resource,
+      density: @density,
+      **@field_wrapper_options
     }
   end
 end

--- a/app/components/avo/index/field_wrapper_component.html.erb
+++ b/app/components/avo/index/field_wrapper_component.html.erb
@@ -1,10 +1,10 @@
-<%= content_tag :td,
+<%= content_tag @html_tag,
   class: class_names(
     "group/clipboard px-2 leading-none whitespace-nowrap h-full text-content text-sm",
     @classes,
     @field.get_html(:classes, view: @view, element: :wrapper),
     {
-      "py-4": !@flush
+      density_padding_class => !@flush
     }
   ),
   data: {

--- a/app/components/avo/index/field_wrapper_component.rb
+++ b/app/components/avo/index/field_wrapper_component.rb
@@ -1,11 +1,23 @@
 # frozen_string_literal: true
 
 class Avo::Index::FieldWrapperComponent < Avo::BaseComponent
+  # Vertical padding for each density step. `nil` density falls back to
+  # `Avo.configuration.density`.
+  DENSITY_PADDING = {
+    tight: "py-2",
+    normal: "py-4",
+    relaxed: "py-6"
+  }.freeze
+
   prop :field
   prop :resource
   prop :dash_if_blank, default: true
   prop :center_content, default: false
   prop :flush, default: false
+  prop :density, default: nil
+  # The wrapper element. Defaults to a table cell; non-table hosts (e.g. the
+  # dashboards list card) render the same field components inside a :div.
+  prop :html_tag, default: :td
   prop :args, kind: :**, default: {}.freeze
 
   def after_initialize
@@ -30,5 +42,9 @@ class Avo::Index::FieldWrapperComponent < Avo::BaseComponent
 
   def render_dash?
     @field.value.blank? && @dash_if_blank
+  end
+
+  def density_padding_class
+    DENSITY_PADDING[(@density || Avo.configuration.density)&.to_sym] || DENSITY_PADDING[:normal]
   end
 end

--- a/app/javascript/js/controllers/table_row_controller.js
+++ b/app/javascript/js/controllers/table_row_controller.js
@@ -17,8 +17,8 @@ export default class extends Controller {
   anchor = null
 
   mouseEntered(event) {
-    const row = event.target.closest('tr')
-    const url = row.dataset.visitPath
+    const row = event.target.closest('[data-visit-path]')
+    const url = row?.dataset?.visitPath
 
     if (url) {
       this.anchor = this.createAnchor(url)
@@ -64,14 +64,14 @@ export default class extends Controller {
       return // Don't navigate if a link or button is clicked
     }
 
-    const row = event.target.closest('tr')
-    const url = row.dataset.visitPath
+    const row = event.target.closest('[data-visit-path]')
+    const url = row?.dataset?.visitPath
 
     if (!row || !url) {
       return
     }
 
-    if (event.metaKey || event.ctrlKey) {
+    if (event.metaKey || event.ctrlKey || row.dataset.visitTarget === '_blank') {
       this.#visitInNewTab(url)
     } else {
       this.#visitInSameTab(url)

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -51,6 +51,7 @@ module Avo
     attr_accessor :resource_parent_controller
     attr_accessor :default_url_options
     attr_accessor :click_row_to_view_record
+    attr_accessor :density
     attr_accessor :alert_dismiss_time
     attr_accessor :is_admin_method
     attr_accessor :is_developer_method
@@ -182,6 +183,7 @@ module Avo
       @default_url_options = []
       @pagination = {}
       @click_row_to_view_record = true
+      @density = :normal
       @alert_dismiss_time = 5000
       @is_admin_method = :is_admin?
       @is_developer_method = :is_developer?

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -118,6 +118,7 @@ Avo.configure do |config|
 
   ## == Customization ==
   config.click_row_to_view_record = true
+  # config.density = :normal # :tight, :normal, :relaxed
   # config.app_name = 'Avocadelicious'
   # config.timezone = 'UTC'
   # config.currency = 'USD'


### PR DESCRIPTION
## What

Core support for the dashboards table & list cards (avo-dashboards) rendering their cells through the real field index components, plus a global density setting.

### Density
- `config.density` — `:tight`, `:normal` (default), `:relaxed` — controls index row vertical padding (`py-2/4/6`) via `Avo::Index::FieldWrapperComponent`, documented in the initializer template.
- The index wrapper also takes a `density:` keyword (mirroring the show/edit wrapper's existing `density:` prop) so hosts can override per render; `Avo::Fields::IndexComponent` threads it through `field_wrapper_args`.

### Host-agnostic index field wrappers
- `FieldWrapperComponent` gains `prop :html_tag, default: :td` — unchanged for tables, but a non-table host can render the same field components inside `<div>` wrappers.
- `IndexComponent` accepts `field_wrapper: {html_tag:, flush:, class:}` merged into `field_wrapper_args`. Components that pass a literal `flush: true` (boolean, badge) still win over the splat.

### Row navigation
- `table-row` controller now matches `closest('[data-visit-path]')` instead of `closest('tr')`, so any row element (e.g. a list `<li>`) can use click-to-visit; null-safe when no ancestor matches.
- Honors `data-visit-target="_blank"` by routing through the existing open-in-new-tab path.

### Focus CSS
- The `a[href]:empty:not([aria-label])` guard no longer hides anchors labelled via `aria-labelledby` — used by the cards' stretched row links.

## Why

The avo-dashboards TableCard/ListCard declare `fields` and render each cell through `field.component_for_view(:index)`, so every field type behaves exactly like the resource index views. These hooks keep that reuse possible without duplicating field rendering in the gem.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and presentation-layer changes with backward-compatible defaults; row navigation behavior is slightly broader but still gated on existing data attributes.
> 
> **Overview**
> Adds **`config.density`** (`:tight`, `:normal`, `:relaxed`) so index row vertical padding is configurable globally, with per-render overrides via `density:` on `Avo::Fields::IndexComponent` and `Avo::Index::FieldWrapperComponent` (`py-2` / `py-4` / `py-6`).
> 
> Index field wrappers can render outside tables: **`html_tag`** (default `:td`) and **`field_wrapper:`** options are threaded from `IndexComponent` into the wrapper, so hosts like dashboard list cards can reuse the same index field components in `<div>` cells.
> 
> **Row navigation** in `table-row` Stimulus now finds `closest('[data-visit-path]')` instead of `tr`, uses optional chaining when no row matches, and opens a new tab when `data-visit-target="_blank"` is set.
> 
> **Focus CSS** no longer hides empty links that only have **`aria-labelledby`** (stretched row links in cards).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 779956b51978aee5f348c490db916312d683adf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->