### PR TITLE
fix(hotkeys): ignore hotkeys on stale detached elements

### DIFF
--- a/app/javascript/js/global_hotkeys.js
+++ b/app/javascript/js/global_hotkeys.js
@@ -164,6 +164,16 @@ const TYPING_SELECTOR = 'input, textarea, select, [contenteditable]'
 // so it never reaches a document-level listener. Must be registered on each element.
 function hotkeyFireHandler(event) {
   const el = event.currentTarget
+
+  // Stale element left behind after a Turbo body replacement (e.g. clicking a
+  // broken resource renders Rails' error page). @github/hotkey keeps its
+  // reference, so without this guard pressing "p" would .click() the detached
+  // sidebar link and navigate. Cancel so hotkeys are inert on non-Avo pages.
+  if (!el.isConnected) {
+    event.preventDefault()
+    return
+  }
+
   const hotkey = el.getAttribute('data-hotkey')
 
   // Apply feedback to ALL elements sharing this hotkey (e.g. desktop + mobile sidebar).


### PR DESCRIPTION
## Problem

Click a broken resource in Avo → Turbo fetches it, gets Rails' 500 error page, and replaces the body. `@github/hotkey` keeps strong references to the *old* sidebar link elements, and nothing uninstalls them. Pressing a hotkey like `p` on the error screen then fires `hotkey-fire` on the detached Posts `<a>`; since it's no longer in the DOM there's no `<kbd>` to animate, so `hotkeyFireHandler` early-returns **without** `preventDefault()`, `@github/hotkey` runs its default action and `.click()`s the stale link, and you get navigated to Posts.

This makes it impossible to type in web-console (or anywhere) on the Rails error page.

## Fix

Guard `hotkeyFireHandler` on `el.isConnected` and cancel the event when the element is detached. Hotkeys become inert on non-Avo pages. Root-cause and doesn't depend on which Turbo event fires.

The `DIRECT_HOTKEYS` listener (`i`, `/`, `j`, `k`, Shift-combos) was already inert on the error page since each self-guards on finding an Avo element that isn't there — only the per-element `@github/hotkey` bindings leaked.

## Test

1. Open a resource that raises on show/index.
2. On the red error page, press `p` (or any sidebar hotkey) → nothing happens; you can type freely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-side guard in hotkey feedback only; no auth, data, or server behavior changes.
> 
> **Overview**
> After Turbo replaces the page with a Rails error screen, `@github/hotkey` can still fire on **detached** sidebar `[data-hotkey]` nodes. `hotkeyFireHandler` used to bail early when no `<kbd>` was found **without** `preventDefault()`, so the library’s default `.click()` still ran and hijacked keys like `p`.
> 
> **`hotkeyFireHandler`** now checks `el.isConnected` at the start; detached targets get `preventDefault()` and return, so element-bound hotkeys stay inert on non-Avo pages (e.g. web-console on the error page).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17e9a819ff4f60e2dde3204c93a0ea0df718330b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->