### PR TITLE
fix(external_link): render for non-ActiveRecord records

### DIFF
--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -726,7 +726,12 @@ module Avo
       end
 
       def get_external_link
-        return unless record&.persisted?
+        return if record.nil?
+        # Skip only on the "create" form views where there's no saved record to
+        # link to yet. Avoid `record.persisted?` here: non-ActiveRecord records
+        # (e.g. API-backed resources) report `persisted? => false` and would
+        # never render an external link.
+        return if view&.new? || view&.create?
 
         Avo::ExecutionContext.new(target: external_link, resource: self, record: record).handle
       end

--- a/spec/lib/avo/resources/get_external_link_spec.rb
+++ b/spec/lib/avo/resources/get_external_link_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Resource#get_external_link" do
+  # A record that behaves like an API-backed / non-ActiveRecord record: it has
+  # data but reports `persisted? => false`. The old guard (`return unless
+  # record&.persisted?`) hid the external link for these entirely.
+  let(:record) { Struct.new(:id) { def persisted? = false }.new(1) }
+
+  def resource_for(view)
+    Avo::Resources::Post.new(record: record, view: view).tap do |resource|
+      resource.external_link = -> { "/external/#{record.id}" }
+    end
+  end
+
+  it "renders for a non-persisted (non-ActiveRecord) record on show" do
+    expect(resource_for(:show).get_external_link).to eq "/external/1"
+  end
+
+  it "renders on edit" do
+    expect(resource_for(:edit).get_external_link).to eq "/external/1"
+  end
+
+  it "is hidden on the new form" do
+    expect(resource_for(:new).get_external_link).to be_nil
+  end
+
+  it "is hidden on the create form" do
+    expect(resource_for(:create).get_external_link).to be_nil
+  end
+
+  it "is hidden when there is no record" do
+    resource = Avo::Resources::Post.new(view: :show)
+    resource.external_link = -> { "/external" }
+    expect(resource.get_external_link).to be_nil
+  end
+end


### PR DESCRIPTION
## Problem

`Avo::Resources::Base#get_external_link` guards on `record&.persisted?`:

```ruby
def get_external_link
  return unless record&.persisted?
  Avo::ExecutionContext.new(target: external_link, resource: self, record: record).handle
end
```

Non-ActiveRecord records (API-backed / HTTP resources, POROs, service objects) report `persisted? => false`, so `self.external_link` silently never renders for them. The configured block isn't even called.

## Fix

Gate on the **view** instead of `persisted?`. The guard's real intent is "don't show an external link on the create form where there's no saved record yet" — that's a view concern, not a record-type concern.

```ruby
def get_external_link
  return if record.nil?
  return if view&.new? || view&.create?
  Avo::ExecutionContext.new(target: external_link, resource: self, record: record).handle
end
```

- ActiveRecord resources: unchanged behavior (no link on the new/create form; link on show/edit/index).
- Any other record type: `self.external_link` now works.

## Tests

Added `spec/lib/avo/resources/get_external_link_spec.rb` covering a non-persisted record rendering on show/edit, and staying hidden on new/create and when there's no record. The show/edit cases fail on the old `persisted?` guard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change in `get_external_link` with targeted specs; no auth or data-layer changes.
> 
> **Overview**
> **`get_external_link`** no longer requires `record.persisted?`, so API-backed or other records that always return `false` from `persisted?` can show the configured external link on show/edit (and similar views).
> 
> The guard now returns early when **`record` is nil** or the view is **`new` / `create`**, matching the intent to hide the link only on create forms. ActiveRecord resources should behave the same as before for those views.
> 
> Adds **`spec/lib/avo/resources/get_external_link_spec.rb`** for non-persisted records on show/edit, hidden on new/create, and nil record.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e1e3d70a1e683672079349aa11ec24ba0a1c9c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->