### PR TITLE
fix(ui): make card body padding an opt-in modifier

### DIFF
--- a/app/assets/stylesheets/css/components/ui/card.css
+++ b/app/assets/stylesheets/css/components/ui/card.css
@@ -35,6 +35,16 @@
   @apply w-full;
 }
 
+/* Padded variant. `.card__body` ships unpadded so wide content (tables,
+   scrollers) can sit flush to the card edge. Add `card--padded` to a card whose
+   body holds free-form content (custom tools, forms, prose) that should get the
+   standard card padding. Usage: `panel.with_card(class: "card--padded")`. */
+.card--padded {
+  .card__body {
+    @apply p-4;
+  }
+}
+
 /* Card wrapper */
 .card__wrapper {
   @apply flex flex-col items-start self-stretch w-full;

--- a/app/components/avo/u_i/card_component.html.erb
+++ b/app/components/avo/u_i/card_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div class: class_names("card", @class), data: {**@data, item_index: @index} do %>
+<%= tag.div class: class_names("card", @class, "card--padded" => @padded), data: {**@data, item_index: @index} do %>
   <%= tag.div class: class_names("card__wrapper", @wrapper_class) do %>
     <% if header? %>
       <div class="card__header"><%= header %></div>

--- a/app/components/avo/u_i/card_component.rb
+++ b/app/components/avo/u_i/card_component.rb
@@ -5,7 +5,9 @@ class Avo::UI::CardComponent < Avo::BaseComponent
   prop :description
   prop :class
   prop :wrapper_class
-  prop :with_padding, default: -> { true }
+  # Opt-in body padding via the `.card--padded` modifier. Defaults to false so
+  # cards holding wide content (index tables, scrollers) stay flush to the edge.
+  prop :padded, default: -> { false }
   prop :variant, default: -> { :default }
   prop :options, kind: :**
   prop :data, default: -> { {}.freeze }
@@ -25,41 +27,4 @@ class Avo::UI::CardComponent < Avo::BaseComponent
       end
     end
   end
-
-  private
-
-  # def panel_classes
-  #   base_classes = "panel"
-  #   variant_classes = case variant
-  #                    when :compact
-  #                      "panel--compact"
-  #                    when :full_width
-  #                      "panel--full-width"
-  #                    else
-  #                      "panel--default"
-  #                    end
-  #   padding_classes = with_padding ? "panel--with-padding" : ""
-
-  #   [base_classes, variant_classes, padding_classes].compact.join(" ")
-  # end
-
-  # def compact?
-  #   variant == :compact
-  # end
-
-  # def full_width?
-  #   variant == :full_width
-  # end
-
-  # def with_padding?
-  #   with_padding
-  # end
-
-  # def header_classes
-  #   "panel__header"
-  # end
-
-  # def body_classes
-  #   "panel__body"
-  # end
 end


### PR DESCRIPTION
## What

The `CardComponent`'s padding prop was **effectively dead**: the template never bound a padding class, so passing it had no effect and card bodies always rendered flush.

This adds a `padded` prop wired to a new `.card--padded` modifier, defaulting to `false`. The prop name matches the CSS modifier so there's one concept to reason about.

## Why

Cards intentionally ship **unpadded** so wide content (index tables, horizontal scrollers) can sit flush to the card edge. Free-form content (custom tools, forms, prose) wants the standard `p-4` body padding — now it's a clean opt-in:

```erb
panel.with_card(padded: true)   # or ui.card(padded: true)
```

## Changes

- `card.css` — new `.card--padded { .card__body { @apply p-4; } }`
- `card_component.rb` — new `padded` prop, default `false`; also removed a block of commented-out scaffolding methods
- `card_component.html.erb` — bind `card--padded` when `padded`

## Blast radius

Additive. No caller in avo core set the old prop, and since it was a no-op, existing cards are visually unchanged. The only behavioral difference: `padded: true` now actually applies padding.