### PR TITLE
docs(agents): document the class-as-URL-parameter (slug) pattern

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -66,6 +66,38 @@ When toggling the visibility of some html elements, use the `hidden` HTML attrib
 
 Whenever possible use the `partial:` keyword when rendering partials unless needed otherwise.
 
+### Class as a URL parameter (slug)
+
+When a class travels in a URL (a scope, filter, action, or any selectable type), encode it as a readable slug, not the raw class name, and resolve it back by matching against the objects you already registered.
+
+Never `constantize` the param. It is user input, and constantizing it means arbitrary class loading (autoload DoS, information disclosure, gadget surface). Match against a known set instead.
+
+Parameterize: derive a stable slug from the class. Keep the full namespace path; do not `demodulize`, or nested classes collide (`A::Active` and `B::Active` both become `active`). `underscore` turns `::` into `/`; map that boundary to `-` so the URL builder does not `%2F` encode a slash.
+
+```ruby
+def self.param
+  @param ||= name.underscore               # Avo::Scopes::Admin::NonAdmins => "avo/scopes/admin/non_admins"
+              .delete_prefix("avo/scopes/") # => "admin/non_admins" (strip the type's conventional root)
+              .tr("/", "-")                 # => "admin-non_admins"
+end
+```
+
+Result: `/admin/resources/users?scope=admin-non_admins`
+
+Class and module names are CamelCase, so `_` only comes from a word boundary and `-` only from a `::` boundary. `admin-non_admins` maps unambiguously to `Admin::NonAdmins`, and distinct nested classes never collide.
+
+Deparameterize: match the computed slug against the registered set and return the class. Do not rebuild the class from the string.
+
+```ruby
+scopes.find { |scope| scope.param == params[:scope] }
+```
+
+Guards:
+
+- Let `self.param` be overridden for a custom short slug (`scope=vip`), which also breaks the rare collision.
+- Assert slug uniqueness within the set at boot; raise and point the author at `self.param` on conflict.
+- During a transition, also accept the legacy value so bookmarked URLs keep working (`scope.param == p || scope.name == p`); drop the fallback a version later.
+
 ## Logging in (development & testing)
 
 The dummy app at `spec/dummy` uses Devise for authentication. Avo is mounted at `/admin` and is wrapped in an `authenticate :user, ->(user) { user.is_admin? }` block, so you need an admin user to reach it.


### PR DESCRIPTION
Adds a reusable pattern to `agents.md`: how to encode a class in a URL (scopes, filters, actions, any selectable type) as a readable, namespace-safe slug and resolve it back.

Key points captured:
- **Never `constantize` the param** - it's user input; resolve by matching against the registered set instead (avoids autoload DoS / info disclosure / gadget surface).
- **Keep the namespace** - base the slug on `name.underscore` (not `demodulize`) so nested classes like `A::Active` and `B::Active` don't collide.
- **URL-clean + reversible** - map the `::` boundary to `-` (`name.underscore.tr('/', '-')`), so `Admin::NonAdmins` becomes `admin-non_admins` (no `%2F`), a clean bijection given CamelCase class names.
- Guards: overridable `self.param`, boot-time uniqueness assertion, and a legacy-value fallback for bookmarked URLs.

Came out of the scopes URL-param discussion (`?scope=Avo%3A%3AScopes%3A%3ANonAdmins` is ugly and constantize-prone).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security behavior impact.
> 
> **Overview**
> Adds a **Ruby on Rails** subsection to `agents.md` that standardizes how selectable types (scopes, filters, actions, etc.) appear in query params.
> 
> The doc prescribes **slug encoding** from `name.underscore` with namespace preserved (no `demodulize`), `::` mapped to `-` for clean URLs, and optional stripping of a conventional root prefix. Resolution is **lookup against a registered set** via `scope.param == params[:scope]`—explicitly **not** `constantize`.
> 
> It also documents **guards**: overridable `self.param`, boot-time slug uniqueness checks, and a temporary legacy param fallback for bookmarked URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4d91538abd9ad3f3ff38b262367e826eb31c83f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->