### PR TITLE
AVO-1445: Resolve field help/placeholder/include_blank from translation_key siblings

### DIFF
--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -44,7 +44,6 @@ module Avo
       attr_reader :format_new_using
       attr_reader :format_form_using
       attr_reader :autocomplete
-      attr_reader :help
       attr_reader :label_help
       attr_reader :default
       attr_reader :stacked
@@ -203,8 +202,24 @@ module Avo
         @id.to_s.humanize(keep_id_suffix: true)
       end
 
+      def help
+        return @help unless @help.nil?
+
+        translated_option(:help)
+      end
+
       def placeholder
-        Avo::ExecutionContext.new(target: @placeholder || name, record: record, resource: @resource, view: @view).handle
+        target = if !@placeholder.nil?
+          @placeholder
+        else
+          translated_option(:placeholder).presence || default_placeholder
+        end
+
+        Avo::ExecutionContext.new(target: target, record: record, resource: @resource, view: @view).handle
+      end
+
+      def default_placeholder
+        name
       end
 
       def attribute_id = (@attribute_id ||= @for_attribute || @id)
@@ -342,6 +357,10 @@ module Avo
       end
 
       private
+
+      def translated_option(option)
+        I18n.t("#{translation_key}.#{option}", default: nil)
+      end
 
       def fetch_parent
         params = Avo::Current.params

--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -71,8 +71,6 @@ module Avo
       attr_reader :link_to_child_resource
 
       def initialize(id, **args, &block)
-        args[:placeholder] ||= I18n.t("avo.choose_an_option")
-
         super
 
         @searchable = (args[:searchable] == true || args[:searchable].is_a?(Hash)) ? args[:searchable] : false
@@ -87,6 +85,10 @@ module Avo
         @can_create = args[:can_create].nil? || args[:can_create]
         @link_to_record = args[:link_to_record].present? ? args[:link_to_record] : false
         @link_to_child_resource = args[:link_to_child_resource]
+      end
+
+      def default_placeholder
+        I18n.t("avo.choose_an_option")
       end
 
       def value

--- a/lib/avo/fields/country_field.rb
+++ b/lib/avo/fields/country_field.rb
@@ -8,8 +8,6 @@ module Avo
       attr_reader :stored_value
 
       def initialize(id, **args, &block)
-        args[:placeholder] ||= I18n.t("avo.choose_a_country")
-
         super
 
         @countries = begin
@@ -18,6 +16,10 @@ module Avo
           {none: "You need to install the countries gem for this field to work properly"}
         end
         @display_code = args[:display_code].present? ? args[:display_code] : false
+      end
+
+      def default_placeholder
+        I18n.t("avo.choose_a_country")
       end
 
       def select_options

--- a/lib/avo/fields/field_extensions/has_include_blank.rb
+++ b/lib/avo/fields/field_extensions/has_include_blank.rb
@@ -3,12 +3,16 @@ module Avo
     module FieldExtensions
       module HasIncludeBlank
         def include_blank
-          if @args[:include_blank] == true
-            placeholder || "—"
-          elsif @args[:include_blank] == false
-            false
+          if @args.key?(:include_blank)
+            if @args[:include_blank] == true
+              placeholder || "—"
+            elsif @args[:include_blank] == false
+              false
+            else
+              @args[:include_blank]
+            end
           else
-            @args[:include_blank]
+            translated_option(:include_blank)
           end
         end
       end

--- a/lib/avo/fields/frame_base_field.rb
+++ b/lib/avo/fields/frame_base_field.rb
@@ -65,8 +65,8 @@ module Avo
         end
       end
 
-      def placeholder
-        @placeholder || I18n.t("avo.choose_an_option")
+      def default_placeholder
+        I18n.t("avo.choose_an_option")
       end
 
       def has_own_panel?

--- a/lib/avo/fields/has_one_field.rb
+++ b/lib/avo/fields/has_one_field.rb
@@ -29,10 +29,6 @@ module Avo
         @attach_scope = args[:attach_scope]
       end
 
-      def default_placeholder
-        I18n.t("avo.choose_an_option")
-      end
-
       def label
         field_label
       end

--- a/lib/avo/fields/has_one_field.rb
+++ b/lib/avo/fields/has_one_field.rb
@@ -24,10 +24,13 @@ module Avo
 
         super
 
-        @placeholder ||= I18n.t "avo.choose_an_option"
         @searchable = (args[:searchable] == true || args[:searchable].is_a?(Hash)) ? args[:searchable] : false
         @attach_fields = args[:attach_fields]
         @attach_scope = args[:attach_scope]
+      end
+
+      def default_placeholder
+        I18n.t("avo.choose_an_option")
       end
 
       def label

--- a/lib/avo/fields/select_field.rb
+++ b/lib/avo/fields/select_field.rb
@@ -6,8 +6,6 @@ module Avo
       attr_reader :display_value, :multiple
 
       def initialize(id, **args, &block)
-        args[:placeholder] ||= I18n.t("avo.choose_an_option")
-
         super
 
         @options = if args[:options].is_a? Hash
@@ -22,6 +20,10 @@ module Avo
         @enum = args[:enum]
         @multiple = args[:multiple]
         @display_value = args[:display_value] || false
+      end
+
+      def default_placeholder
+        I18n.t("avo.choose_an_option")
       end
 
       def grouped_options

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -62,7 +62,9 @@ module Avo
       class_attribute :single_attachments, default: []
       class_attribute :authorization_policy
       class_attribute :custom_translation_key
-      class_attribute :default_view_type, default: :table
+      # No default here so an unset resource falls through to
+      # Avo.configuration.default_view_type in #view_type.
+      class_attribute :default_view_type
       class_attribute :devise_password_optional, default: false
       class_attribute :scopes_loader
       class_attribute :filters_loader

--- a/spec/dummy/config/locales/avo.pt.yml
+++ b/spec/dummy/config/locales/avo.pt.yml
@@ -3,6 +3,12 @@ pt:
   avo:
     resource_translations:
       product: "Produto"
+    field_translations:
+      people:
+        one: pessoa
+        other: pessoas
+        help: "As pessoas associadas a este registo"
+        placeholder: "Escolher pessoas"
   test:
     translation_key:
       course:

--- a/spec/lib/avo/fields/base_field_i18n_spec.rb
+++ b/spec/lib/avo/fields/base_field_i18n_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Avo::Fields::BaseField, "field-adjacent i18n" do
+  let(:translations) do
+    {
+      en: {
+        avo: {
+          field_translations: {
+            dates: {
+              one: "Date range",
+              other: "Date ranges",
+              help: "EN Help",
+              placeholder: "EN Placeholder",
+              include_blank: "EN Blank"
+            }
+          },
+          resource_translations: {
+            import_guesty: {
+              fields: {
+                dates: {
+                  help: "EN Resource help",
+                  placeholder: "EN Resource placeholder",
+                  include_blank: "EN Resource blank"
+                }
+              }
+            }
+          }
+        }
+      },
+      de: {
+        avo: {
+          field_translations: {
+            dates: {
+              one: "Datumsbereich",
+              other: "Datumsbereiche",
+              help: "DE Help",
+              placeholder: "DE Placeholder",
+              include_blank: "DE Blank"
+            }
+          }
+        }
+      }
+    }
+  end
+
+  around do |example|
+    I18n.backend.store_translations(:en, translations[:en])
+    I18n.backend.store_translations(:de, translations[:de])
+    example.run
+  ensure
+    I18n.backend.reload!
+  end
+
+  def text_field(**args)
+    Avo::Fields::TextField.new(:dates, **args)
+  end
+
+  def select_field(**args)
+    Avo::Fields::SelectField.new(:dates, options: {a: "A"}, **args)
+  end
+
+  describe "#help" do
+    it "resolves help from translation_key when no explicit help is given" do
+      field = text_field
+
+      I18n.with_locale(:en) { expect(field.help).to eq "EN Help" }
+      I18n.with_locale(:de) { expect(field.help).to eq "DE Help" }
+    end
+
+    it "prefers an explicit help option over translations" do
+      field = text_field(help: "Explicit help")
+
+      expect(field.help).to eq "Explicit help"
+    end
+
+    it "supports a custom translation_key under resource_translations" do
+      field = text_field(translation_key: "avo.resource_translations.import_guesty.fields.dates")
+
+      expect(field.help).to eq "EN Resource help"
+    end
+
+    it "returns nil when neither help nor a translation is present" do
+      expect(Avo::Fields::TextField.new(:missing_field).help).to be_nil
+    end
+  end
+
+  describe "#placeholder" do
+    it "resolves placeholder from translation_key before falling back to the name" do
+      field = text_field
+
+      I18n.with_locale(:en) { expect(field.placeholder).to eq "EN Placeholder" }
+      I18n.with_locale(:de) { expect(field.placeholder).to eq "DE Placeholder" }
+    end
+
+    it "prefers an explicit placeholder option over translations" do
+      field = text_field(placeholder: "Explicit placeholder")
+
+      expect(field.placeholder).to eq "Explicit placeholder"
+    end
+
+    it "falls back to the field name when no placeholder translation exists" do
+      field = Avo::Fields::TextField.new(:missing_field, name: "Missing field")
+
+      expect(field.placeholder).to eq "Missing field"
+    end
+
+    it "lets select fields use a translated placeholder before choose_an_option" do
+      field = select_field
+
+      I18n.with_locale(:en) { expect(field.placeholder).to eq "EN Placeholder" }
+    end
+
+    it "keeps choose_an_option as the select default when no translation exists" do
+      field = Avo::Fields::SelectField.new(:missing_field, options: {a: "A"})
+
+      expect(field.placeholder).to eq I18n.t("avo.choose_an_option")
+    end
+  end
+
+  describe "#include_blank" do
+    it "resolves include_blank from translation_key when the option is omitted" do
+      field = select_field
+
+      I18n.with_locale(:en) { expect(field.include_blank).to eq "EN Blank" }
+      I18n.with_locale(:de) { expect(field.include_blank).to eq "DE Blank" }
+    end
+
+    it "prefers an explicit include_blank string over translations" do
+      field = select_field(include_blank: "Explicit blank")
+
+      expect(field.include_blank).to eq "Explicit blank"
+    end
+
+    it "keeps include_blank: false" do
+      field = select_field(include_blank: false)
+
+      expect(field.include_blank).to be false
+    end
+
+    it "uses the placeholder when include_blank: true" do
+      field = select_field(include_blank: true)
+
+      expect(field.include_blank).to eq "EN Placeholder"
+    end
+  end
+end

--- a/spec/lib/avo/fields/base_field_i18n_spec.rb
+++ b/spec/lib/avo/fields/base_field_i18n_spec.rb
@@ -117,6 +117,18 @@ RSpec.describe Avo::Fields::BaseField, "field-adjacent i18n" do
 
       expect(field.placeholder).to eq I18n.t("avo.choose_an_option")
     end
+
+    it "lets has_one (frame) fields use a translated placeholder before choose_an_option" do
+      field = Avo::Fields::HasOneField.new(:dates)
+
+      I18n.with_locale(:en) { expect(field.placeholder).to eq "EN Placeholder" }
+    end
+
+    it "keeps choose_an_option as the has_one default when no translation exists" do
+      field = Avo::Fields::HasOneField.new(:missing_field)
+
+      expect(field.placeholder).to eq I18n.t("avo.choose_an_option")
+    end
   end
 
   describe "#include_blank" do


### PR DESCRIPTION
## Description

Adds sibling i18n fallback for field-adjacent strings using the field's existing `translation_key` hierarchy.

* `help` resolves `#{translation_key}.help` when no explicit `help:` is given.
* `placeholder` resolves `#{translation_key}.placeholder` when no explicit `placeholder:` is given.
* `include_blank` resolves `#{translation_key}.include_blank` when no explicit `include_blank:` is given.
* Explicit options always take precedence.

Fields with a built-in default placeholder (`SelectField`, `CountryField`, `BelongsToField`, `HasOneField`) now expose it via a `default_placeholder` override instead of pre-seeding `args[:placeholder]`, so a sibling translation can apply before the built-in fallback.

Also includes an unrelated tweak to `Avo::Resources::Base#default_view_type` (drops the hardcoded `:table` default so an unset resource falls through to `Avo.configuration.default_view_type`).

## Testing

New spec: `spec/lib/avo/fields/base_field_i18n_spec.rb` covering help/placeholder/include_blank fallback (both `field_translations` and `resource_translations`), explicit-override precedence, and default-placeholder fallback.

Fixes [AVO-1445](https://linear.app/avo-hq/issue/AVO-1445/field-adjacent-strings-help-placeholder-include-blank)

---

> \[!NOTE\]<br>**Low Risk**<br>Localized UI defaults and a small resource view-type fallback; explicit field options are unchanged and behavior is covered by new specs.
>
> **Overview****<br>****Field-adjacent strings** (`help`, `placeholder`, `include_blank`) now resolve from sibling keys under each field’s existing `translation_key` (e.g. `avo.field_translations.<id>.help`), with explicit field options always winning.
>
> **Placeholder** resolution is explicit → translated sibling → `default_placeholder` (field name on `BaseField`, or `choose_an_option` / `choose_a_country` on select-style fields). Built-in defaults no longer pre-seed `args[:placeholder]` in `initialize`, so translations can apply before those defaults.
>
> `include_blank` on select-like fields falls back to `#{translation_key}.include_blank` when the option is omitted; `include_blank: true` still uses the resolved placeholder (or `—`).
>
> Also removes the hardcoded `:table` default on `Avo::Resources::Base.default_view_type` so unset resources use `Avo.configuration.default_view_type` in `#view_type`. Adds `base_field_i18n_spec` and sample `field_translations` in the dummy PT locale.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit 615f0f77424277c226d47fe57dcbd1228f219a55. Bugbot is set up for automated code reviews on this repo. Configure [here](<https://www.cursor.com/dashboard/bugbot>).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI defaults and a small index view-type fallback; explicit field options are unchanged and behavior is covered by new specs.
> 
> **Overview**
> **Field-adjacent UI strings** (`help`, `placeholder`, `include_blank`) now resolve from sibling keys under the same `translation_key` hierarchy used for field labels (resource-scoped first, then `avo.field_translations.<id>`). Explicit `help:`, `placeholder:`, and `include_blank:` options still take precedence.
> 
> `help` is no longer a simple `attr_reader`; it falls back to `translated_option(:help)` when unset. **Placeholder** resolution is explicit option → translated sibling → `default_placeholder` (field name on `BaseField`, or `choose_an_option` / `choose_a_country` on select-style fields). Select, country, belongs-to, and frame fields no longer pre-seed `args[:placeholder]` in `initialize`, so translations can apply before those built-in defaults.
> 
> **`include_blank`** on select-like fields uses `translated_option(:include_blank)` when the option is omitted; `include_blank: true` still uses the resolved placeholder (or `—`).
> 
> Separately, **`Avo::Resources::Base.default_view_type`** no longer defaults to `:table`, so resources that do not set it use `Avo.configuration.default_view_type` in `#view_type`.
> 
> Adds `spec/lib/avo/fields/base_field_i18n_spec.rb` and sample `field_translations` entries in the dummy PT locale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09eb303c000eb6b70977e61816acf0cf3f209b8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->