### PR TITLE
feat(generators): add tool route inside mount_avo block

### DIFF
--- a/lib/generators/avo/tool_generator.rb
+++ b/lib/generators/avo/tool_generator.rb
@@ -35,24 +35,32 @@ module Generators
 
         # Add the route inside the `mount_avo` block so it gets the `avo.#{file_name}_path` helper.
         # If `mount_avo` is a one-liner, turn it into a block. If it's already a block, inject into it.
-        # If there's no `mount_avo` at all, fall back to a standalone Avo engine routes block.
+        # If there's no `mount_avo` (or the line can't be safely rewritten), fall back to a
+        # standalone Avo engine routes block.
         routes_path = "config/routes.rb"
         routes_content = File.read(Rails.root.join(routes_path))
         route_definition = "get \"#{file_name}\", to: \"tools##{file_name}\", as: :#{file_name}"
         mount_avo_line = routes_content.lines.find { |line| line.match?(/^[ \t]*mount_avo\b/) }
+        mount_avo = mount_avo_line && analyze_routes_line(mount_avo_line)
 
-        if mount_avo_line && mount_avo_line_is_block?(mount_avo_line)
+        if mount_avo && mount_avo[:block]
+          # `mount_avo do` is already a block → inject the route as its first line.
           indent = mount_avo_line[/^[ \t]*/] + "  "
           inject_into_file routes_path, after: /^[ \t]*mount_avo\b.*\n/ do
             "#{indent}#{route_definition}\n"
           end
-        elsif mount_avo_line
+        elsif mount_avo && mount_avo[:complete]
+          # `mount_avo` one-liner → wrap it into a block around the new route.
           indent = mount_avo_line[/^[ \t]*/]
           inner = indent + "  "
           gsub_file routes_path, /^[ \t]*mount_avo\b.*$/ do |line|
-            "#{insert_do_before_comment(line)}\n#{inner}#{route_definition}\n#{indent}end"
+            code, comment = analyze_routes_line(line).values_at(:code, :comment)
+            trailing = comment.empty? ? "" : " #{comment}"
+            "#{code.rstrip} do#{trailing}\n#{inner}#{route_definition}\n#{indent}end"
           end
         else
+          # No `mount_avo`, or a line we can't safely rewrite (multi-line call, unterminated
+          # string) → fall back to a standalone Avo engine routes block.
           append_to_file routes_path, <<~ROUTE
 
             if defined? ::Avo
@@ -84,22 +92,39 @@ module Generators
           "<code class='p-1 rounded-sm bg-gray-500 text-white text-sm'>#{text}</code>"
         end
 
-        # Code before a trailing `#` comment (so `do` inside comments is ignored).
-        def code_before_comment(line)
-          line.to_s.sub(/[ \t]*#.*$/, "")
-        end
-
-        def mount_avo_line_is_block?(line)
-          code_before_comment(line).match?(/\bdo\b/)
-        end
-
-        # Insert ` do` before any trailing `#` comment so Ruby still opens the block.
-        def insert_do_before_comment(line)
-          if (match = line.match(/\A(.*?)([ \t]*#.*)\z/))
-            "#{match[1]} do#{match[2]}"
-          else
-            "#{line} do"
+        # Splits a routes.rb line into its `code` and trailing `comment` parts while
+        # respecting string literals, and reports whether the line already opens a `do`
+        # block (`block`) and whether it's a complete single-line statement we can rewrite
+        # (`complete`). Returns nil when the line has an unterminated string — i.e. a
+        # multi-line call — so callers fall back to a standalone routes block instead of
+        # corrupting the file. Blanking string *contents* means a `#` or `do` inside a
+        # string is never mistaken for a comment or a block opener.
+        def analyze_routes_line(line)
+          masked = +"" # code with string contents blanked and the comment dropped
+          comment_at = nil # index of the `#` that starts a real (non-string) comment
+          quote = nil
+          line.chars.each_with_index do |char, index|
+            if quote
+              masked << ((char == quote) ? char : " ")
+              quote = nil if char == quote
+            elsif char == "\"" || char == "'"
+              quote = char
+              masked << char
+            elsif char == "#"
+              comment_at = index
+              break
+            else
+              masked << char
+            end
           end
+          return nil if quote # unterminated string → multi-line statement
+
+          {
+            code: comment_at ? line[0...comment_at] : line,
+            comment: comment_at ? line[comment_at..].strip : "",
+            block: masked.match?(/\bdo\b\s*(\|[^|]*\|)?\s*\z/),
+            complete: !masked.rstrip.end_with?(",")
+          }
         end
       end
     end

--- a/lib/generators/avo/tool_generator.rb
+++ b/lib/generators/avo/tool_generator.rb
@@ -39,17 +39,18 @@ module Generators
         routes_path = "config/routes.rb"
         routes_content = File.read(Rails.root.join(routes_path))
         route_definition = "get \"#{file_name}\", to: \"tools##{file_name}\", as: :#{file_name}"
+        mount_avo_line = routes_content.lines.find { |line| line.match?(/^[ \t]*mount_avo\b/) }
 
-        if (match = routes_content.match(/^([ \t]*)mount_avo\b.*\bdo\b.*$/))
-          indent = match[1] + "  "
-          inject_into_file routes_path, after: /^[ \t]*mount_avo\b.*\bdo\b.*\n/ do
+        if mount_avo_line && mount_avo_line_is_block?(mount_avo_line)
+          indent = mount_avo_line[/^[ \t]*/] + "  "
+          inject_into_file routes_path, after: /^[ \t]*mount_avo\b.*\n/ do
             "#{indent}#{route_definition}\n"
           end
-        elsif (match = routes_content.match(/^([ \t]*)mount_avo\b.*$/))
-          indent = match[1]
+        elsif mount_avo_line
+          indent = mount_avo_line[/^[ \t]*/]
           inner = indent + "  "
           gsub_file routes_path, /^[ \t]*mount_avo\b.*$/ do |line|
-            "#{line} do\n#{inner}#{route_definition}\n#{indent}end"
+            "#{insert_do_before_comment(line)}\n#{inner}#{route_definition}\n#{indent}end"
           end
         else
           append_to_file routes_path, <<~ROUTE
@@ -81,6 +82,24 @@ module Generators
 
         def in_code(text)
           "<code class='p-1 rounded-sm bg-gray-500 text-white text-sm'>#{text}</code>"
+        end
+
+        # Code before a trailing `#` comment (so `do` inside comments is ignored).
+        def code_before_comment(line)
+          line.to_s.sub(/[ \t]*#.*$/, "")
+        end
+
+        def mount_avo_line_is_block?(line)
+          code_before_comment(line).match?(/\bdo\b/)
+        end
+
+        # Insert ` do` before any trailing `#` comment so Ruby still opens the block.
+        def insert_do_before_comment(line)
+          if (match = line.match(/\A(.*?)([ \t]*#.*)\z/))
+            "#{match[1]} do#{match[2]}"
+          else
+            "#{line} do"
+          end
         end
       end
     end

--- a/lib/generators/avo/tool_generator.rb
+++ b/lib/generators/avo/tool_generator.rb
@@ -33,23 +33,34 @@ module Generators
         # Add view file
         template "tool/view.tt", "app/views/avo/tools/#{file_name}.html.erb"
 
-        # Add the route in the `routes.rb` file.
-        # The route should be defined inside the Avo engine.
-        # The new tool has a dedicated path helper.
-        # EX:
-        #   bin/rails generate avo:tool lolo
-        #   will generate the avo.lolo_path helper
-        # THe fact that it will always generate the definded? and Avo::Engine.routes.draw wraps is unfortunate. We'd love a PR to fix that.
-        route_contents = <<~ROUTE
+        # Add the route inside the `mount_avo` block so it gets the `avo.#{file_name}_path` helper.
+        # If `mount_avo` is a one-liner, turn it into a block. If it's already a block, inject into it.
+        # If there's no `mount_avo` at all, fall back to a standalone Avo engine routes block.
+        routes_path = "config/routes.rb"
+        routes_content = File.read(Rails.root.join(routes_path))
+        route_definition = "get \"#{file_name}\", to: \"tools##{file_name}\", as: :#{file_name}"
 
-          if defined? ::Avo
-            Avo::Engine.routes.draw do
-              # This route is not protected, secure it with authentication if needed.
-              get "#{file_name}", to: "tools##{file_name}", as: :#{file_name}
-            end
+        if (match = routes_content.match(/^([ \t]*)mount_avo\b.*\bdo\b.*$/))
+          indent = match[1] + "  "
+          inject_into_file routes_path, after: /^[ \t]*mount_avo\b.*\bdo\b.*\n/ do
+            "#{indent}#{route_definition}\n"
           end
-        ROUTE
-        append_to_file "config/routes.rb", route_contents
+        elsif (match = routes_content.match(/^([ \t]*)mount_avo\b.*$/))
+          indent = match[1]
+          inner = indent + "  "
+          gsub_file routes_path, /^[ \t]*mount_avo\b.*$/ do |line|
+            "#{line} do\n#{inner}#{route_definition}\n#{indent}end"
+          end
+        else
+          append_to_file routes_path, <<~ROUTE
+
+            if defined? ::Avo
+              Avo::Engine.routes.draw do
+                #{route_definition}
+              end
+            end
+          ROUTE
+        end
 
         # Restart the server so the new routes go into effect.
         Rails::Command.invoke "restart"

--- a/spec/features/avo/generators/tool_generator_spec.rb
+++ b/spec/features/avo/generators/tool_generator_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+require "rails/generators"
+
+RSpec.feature "tool generator", type: :feature, acquire_lock: :generator do
+  let(:routes_path) { Rails.root.join("config/routes.rb") }
+  let(:generated_files) do
+    [
+      Rails.root.join("app/views/avo/sidebar/items/_lolo.html.erb").to_s,
+      Rails.root.join("app/views/avo/tools/lolo.html.erb").to_s
+    ]
+  end
+
+  around do |example|
+    original_routes = File.read(routes_path)
+
+    example.run
+  ensure
+    File.write(routes_path, original_routes)
+    delete_files(generated_files)
+
+    controller_path = Rails.root.join("app/controllers/avo/tools_controller.rb")
+    if File.exist?(controller_path)
+      content = File.read(controller_path)
+      cleaned = content.gsub(/\n  def lolo\n.*?  end\n/m, "\n")
+      File.write(controller_path, cleaned)
+    end
+  end
+
+  before do
+    allow(Rails::Command).to receive(:invoke).with("restart")
+  end
+
+  def invoke_tool_generator
+    Rails::Generators.invoke("avo:tool", ["lolo", "-q"], {destination_root: Rails.root})
+  end
+
+  it "converts a one-line mount_avo with an inline comment into a block without commenting out do/end" do
+    File.write(routes_path, <<~RUBY)
+      Rails.application.routes.draw do
+        mount_avo mount_lookbook: true # admin panel
+      end
+    RUBY
+
+    invoke_tool_generator
+
+    routes = File.read(routes_path)
+
+    # <<~ strips common indent; re-indent so we assert the 2-space routes nesting.
+    expect(routes).to include(<<~RUBY.indent(2))
+      mount_avo mount_lookbook: true do # admin panel
+        get "lolo", to: "tools#lolo", as: :lolo
+      end
+    RUBY
+    expect(routes).not_to match(/# admin panel do/)
+  end
+
+  it "converts a one-line mount_avo without a comment into a block" do
+    File.write(routes_path, <<~RUBY)
+      Rails.application.routes.draw do
+        mount_avo
+      end
+    RUBY
+
+    invoke_tool_generator
+
+    expect(File.read(routes_path)).to include(<<~RUBY.indent(2))
+      mount_avo do
+        get "lolo", to: "tools#lolo", as: :lolo
+      end
+    RUBY
+  end
+
+  it "does not treat a comment that contains do as an existing mount_avo block" do
+    File.write(routes_path, <<~RUBY)
+      Rails.application.routes.draw do
+        mount_avo # do not enable lookbook
+      end
+    RUBY
+
+    invoke_tool_generator
+
+    routes = File.read(routes_path)
+
+    expect(routes).to include(<<~RUBY.indent(2))
+      mount_avo do # do not enable lookbook
+        get "lolo", to: "tools#lolo", as: :lolo
+      end
+    RUBY
+  end
+end

--- a/spec/features/avo/generators/tool_generator_spec.rb
+++ b/spec/features/avo/generators/tool_generator_spec.rb
@@ -87,4 +87,41 @@ RSpec.feature "tool generator", type: :feature, acquire_lock: :generator do
       end
     RUBY
   end
+
+  it "converts a one-line mount_avo with mount_lookbook into a block" do
+    File.write(routes_path, <<~RUBY)
+      Rails.application.routes.draw do
+        mount_avo mount_lookbook: true
+      end
+    RUBY
+
+    invoke_tool_generator
+
+    expect(File.read(routes_path)).to include(<<~RUBY.indent(2))
+      mount_avo mount_lookbook: true do
+        get "lolo", to: "tools#lolo", as: :lolo
+      end
+    RUBY
+  end
+
+  it "injects the route into an existing mount_avo block, keeping a comment after do" do
+    File.write(routes_path, <<~RUBY)
+      Rails.application.routes.draw do
+        mount_avo mount_lookbook: true do # admin panel
+        end
+      end
+    RUBY
+
+    invoke_tool_generator
+
+    routes = File.read(routes_path)
+
+    expect(routes).to include(<<~RUBY.indent(2))
+      mount_avo mount_lookbook: true do # admin panel
+        get "lolo", to: "tools#lolo", as: :lolo
+      end
+    RUBY
+    # The `do` line is left untouched — no second `do` appended to it.
+    expect(routes).not_to match(/# admin panel do/)
+  end
 end


### PR DESCRIPTION
## What

The `avo:tool` generator used to append a standalone `Avo::Engine.routes.draw` block to `config/routes.rb`. Now it inserts the tool route inside the existing `mount_avo` block.

## Behavior

- **`mount_avo` one-liner** (e.g. `mount_avo` or `mount_avo at: "avo"`) → converted to block form with the route inside.
- **Existing `mount_avo do ... end` block** → route injected into it.
- **No `mount_avo` present** → falls back to the old standalone `Avo::Engine.routes.draw` block.

Indentation is preserved, including when `mount_avo` is nested (e.g. inside an `authenticate` block).

### Result

```ruby
Rails.application.routes.draw do
  authenticate :user, ->(user) { user.is_admin? } do
    mount_avo do
      get "hey", to: "tools#hey", as: :hey
    end
  end
end
```

## Note

Because the route now lives inside `mount_avo`, it inherits whatever authentication wraps it. The previous `# This route is not protected...` comment is dropped since it no longer applies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Generator edits `config/routes.rb` with string rewriting; mistakes could break routing, though fallbacks and new specs reduce that risk. Tool routes now inherit `mount_avo` auth wrapping, which changes exposure vs the previous standalone block.
> 
> **Overview**
> The **`avo:tool` generator** no longer appends a standalone `Avo::Engine.routes.draw` block. It registers the tool route **inside** the app’s existing **`mount_avo`** block so helpers like `avo.<tool>_path` match how Avo is mounted and any wrapping auth applies to the tool.
> 
> **Routing behavior:** inject into an existing `mount_avo do` block; rewrite a one-line `mount_avo` into a block with the new `get`; or fall back to the old engine `routes.draw` when `mount_avo` is missing or the line can’t be safely rewritten (e.g. multi-line / unterminated strings). Indentation and trailing comments are preserved via a new **`analyze_routes_line`** parser that ignores `#` and `do` inside strings.
> 
> The old “route is not protected” comment is dropped. **Feature specs** cover one-liners, inline comments, `mount_lookbook`, and existing blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbc6c1c795848688c0fbb77b525985c6e103d31b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->