### PR TITLE
feat(appearance): main section background image (AVO-1517)

### DIFF
--- a/app/assets/stylesheets/css/layout.css
+++ b/app/assets/stylesheets/css/layout.css
@@ -63,7 +63,15 @@
   --main-content-end-radius: 0;
   --main-content-width: var(--content-width);
 
-  @apply relative w-(--main-content-width) flex flex-col bg-(--color-main-content-background) py-2 lg:py-4 px-2 lg:px-4 border-s border-(--color-main-content-border) rounded-se-(--main-content-end-radius) rounded-ss-(--main-content-start-radius);
+  @apply relative w-(--main-content-width) flex flex-col py-2 lg:py-4 px-2 lg:px-4 border-s border-(--color-main-content-border) rounded-se-(--main-content-end-radius) rounded-ss-(--main-content-start-radius);
+
+  /* Configurable via `config.appearance = { main_content_background: ... }` which
+     sets --main-content-background at :root. Falls back to the themed color so the
+     unset state is unchanged. An image value is centered and covers by default. */
+  background: var(--main-content-background, var(--color-main-content-background));
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
 
   transition: margin 0.1s ease-in-out, width 0.1s ease-in-out;
   min-height: calc(100dvh - var(--top-navbar-height) - var(--spacing));

--- a/docs/plans/2026-07-23-001-feat-main-content-background-image-plan.md
+++ b/docs/plans/2026-07-23-001-feat-main-content-background-image-plan.md
@@ -1,0 +1,207 @@
+---
+title: "feat: Enable main section background image"
+type: feat
+status: completed
+date: 2026-07-23
+origin: https://linear.app/avo-hq/issue/AVO-1517/enable-main-section-background-image
+---
+
+# feat: Enable main section background image
+
+## Overview
+
+Give users a first-class way to set the main content section (`<main id="main-content">`) background to an image (or gradient / any CSS background value), configured through the existing `config.appearance` pipeline rather than requiring hand-written CSS overrides.
+
+## Problem Frame
+
+AVO-1517: *"Users should be able to change the main section background to an image. It may already be possible with CSS, but that needs to be tested and confirmed."*
+
+**Confirmed during research:** it is **partially** possible today, but not clean.
+- `.main-content` currently applies its background via `@apply ... bg-(--color-main-content-background)` (`app/assets/stylesheets/css/layout.css:66`), which compiles to `background-color: var(--color-main-content-background)`.
+- A `background-color` cannot hold a `url(...)`, so setting the existing var to an image does nothing. Users can override `.main-content { background-image: url(...) }` via `avo-overrides.css` or the `_head` partial, but there is **no config knob** and the color/image layering is left to the user to get right.
+
+This plan adds a dedicated `appearance.main_content_background` option that plugs into the already-established `brand_css_overrides` → `_appearance_overrides.html.erb` pipeline (the same one that powers `neutral_colors` / `accent_colors`).
+
+## Requirements Trace
+
+- R1. A user can configure the main content section background to an image via `config.appearance` — no manual CSS override required.
+- R2. The value is flexible enough to accept an image (`url(...)`), a gradient, or any CSS `background` value.
+- R3. When unset, the main content background is visually **unchanged** (still the themed `--color-main-content-background` color, correct in light and dark mode).
+- R4. The configured background survives the theme picker (light/dark, accent/neutral switches) the same way brand color overrides do.
+
+## Scope Boundaries
+
+- **Non-goal:** a UI control in the appearance picker to set the background image at runtime. This is initializer-config only, matching `logo`/`chart_colors`.
+- **Non-goal:** per-resource or per-page backgrounds. One app-wide setting.
+- **Non-goal:** Rails asset-pipeline resolution of a bare asset name (e.g. `"bg.png"` → `image_url`). The value is passed through as raw CSS; users reference assets with `url('/...')` or a full URL. (Deferred — see Open Questions.)
+- **Non-goal:** changing the breadcrumbs bar, which also reads `--color-main-content-background` (`css/components/breadcrumbs.css`). It stays color-based and untouched.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Main section element:** `app/views/layouts/avo/application.html.erb:68` — `<main id="main-content" class="main-content">`.
+- **Background rule to change:** `app/assets/stylesheets/css/layout.css:61-66` — `.main-content { @apply ... bg-(--color-main-content-background) ... }`.
+- **Default var:** `app/assets/stylesheets/css/variables.css:111-115` — `--color-main-content-background: var(--color-primary);` (resolves per-scheme via `--color-primary`).
+- **Config option home:** `lib/avo/configuration/appearance.rb` — attrs, `DEFAULTS`, `initialize`, and `brand_css_overrides` / `brand_declarations` (lines 123-161) that build the `@layer base { :root { ... } }` inline style.
+- **Config → CSS injection:** `app/views/avo/partials/_appearance_overrides.html.erb` — emits the `<style>` tag with a CSP nonce, rendered last in `<head>` (`application.html.erb:44`).
+- **Config reader:** `lib/avo/configuration.rb:311-316` — `appearance` accessor.
+
+### Institutional Learnings
+
+- **Follow the brand-color-overrides feature exactly** (origin: `external/avo/docs/plans/2026-05-06-001-feat-brand-color-overrides-plan.md`). It established the pattern: appearance attr → `brand_declarations` emits `--var: value;` → wrapped in `@layer base { :root {} }` so it beats Avo defaults but still loses to a user-selected `.accent-theme-*` (later layer). Reuse this so R4 comes for free.
+
+### Layering Note (why `@layer base` matters — from appearance.rb:110-122)
+
+`theme < base < components` ordering guarantees the `:root` override beats Avo's default `:root`/`.dark` palette while a later-layer theme class still wins. Emitting the new var in the same `@layer base { :root {} }` block keeps that guarantee.
+
+## Key Technical Decisions
+
+- **Raw CSS value, single var, `background` shorthand.** The `.main-content` rule switches from the color-only `bg-(--color-main-content-background)` to `background: var(--main-content-background, var(--color-main-content-background))`. When the option is unset the fallback resolves to the existing themed color (R3). When set, `brand_css_overrides` emits `--main-content-background: <value>` at `:root`. **Do not** declare `--main-content-background` locally on `.main-content` — a local default would shadow the `:root` override and break the feature.
+  - *Rationale:* one var, background shorthand accepts color/image/gradient/full shorthand (R2), and the `var(..., fallback)` keeps unset behavior identical (R3). Accepting raw CSS avoids needing asset-pipeline access inside the pure-string `Appearance` class.
+- **Trigger the style tag on this option too.** `brand_css_overrides` currently returns `nil` unless `neutral_colors`/`accent_colors` is set. Extend the guard so a set `main_content_background` also emits the block.
+- **Keep `--color-main-content-background` as the fallback layer.** Users who want an image *with* a color behind it (for load/transparency) can write `url('/bg.png') center/cover no-repeat, var(--color-main-content-background)` themselves. No extra knobs — YAGNI.
+
+## Open Questions
+
+### Resolved During Planning
+
+- *Is it already possible with CSS?* — Partially (manual `.main-content` override); not via config and not cleanly, because the current rule is `background-color`. This plan makes it first-class. (Answers the ticket's "test and confirm".)
+- *Which var / rule carries it?* — New `--main-content-background`, consumed by a `background` shorthand on `.main-content`, fallback to `--color-main-content-background`.
+
+### Deferred to Implementation
+
+- Whether to also set sensible default `background-size`/`background-position`/`background-repeat` on `.main-content` so a bare `url(...)` value looks reasonable without the user specifying them. Decide when implementing by eyeballing a bare-`url()` value in the browser; if it tiles/misaligns, add `background-size: cover; background-position: center; background-repeat: no-repeat;` as declared (non-shorthand) properties on `.main-content` — they don't fight the `background` shorthand only if placed *after* it, so order matters. Verify in-browser.
+- Asset-name convenience resolution (`"bg.png"` → `image_url`) — deferred as a possible follow-up; would require passing view/asset context into the override generation, a larger change than this ticket warrants.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add the `main_content_background` appearance option and emit its CSS var**
+
+**Goal:** Users can set `config.appearance = { main_content_background: "..." }` and have it emitted as a `--main-content-background` declaration through the existing override pipeline.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `lib/avo/configuration/appearance.rb`
+- Test: `spec/lib/avo/configuration/appearance_spec.rb`
+
+**Approach:**
+- Add `:main_content_background` to the `attr_reader` list and assign it in `initialize` from `config[:main_content_background]` (default `nil`; no `DEFAULTS` entry needed since nil = unchanged).
+- In `brand_css_overrides`, change the early-return guard to also stay when `main_content_background` is present: return `nil` only if `neutral_colors.nil? && accent_colors.nil? && main_content_background.nil?`.
+- In `brand_declarations`, append `"  --main-content-background: #{main_content_background};"` when `main_content_background` is set. It sits in the same `@layer base { :root {} }` block as the color overrides.
+- No new validation required (freeform CSS string); mirror how `logo` (a freeform string) is handled — no validator.
+
+**Patterns to follow:**
+- `neutral_colors` / `accent_colors` handling in `initialize`, `brand_css_overrides`, `brand_declarations` (appearance.rb:63-64, 123-161).
+
+**Test scenarios:**
+- Happy path: `Appearance.new(main_content_background: "url('/bg.png') center/cover no-repeat")` → `brand_css_overrides` includes `--main-content-background: url('/bg.png') center/cover no-repeat;` inside `@layer base { :root {` .
+- Happy path: value works for a gradient too, e.g. `"linear-gradient(...)"` is emitted verbatim.
+- Edge case: `main_content_background` unset **and** no neutral/accent colors → `brand_css_overrides` returns `nil` (no `<style>` emitted).
+- Edge case: `main_content_background` set while `neutral_colors`/`accent_colors` unset → override string is still produced and contains only the `--main-content-background` line (proves the guard change).
+- Integration: `main_content_background` set **together with** `accent_colors` → both `--main-content-background` and `--color-accent` appear in the same emitted block.
+
+**Verification:** `appearance_spec.rb` passes; the emitted string is wrapped in `@layer base { :root { ... } }`.
+
+- [ ] **Unit 2: Make `.main-content` render the configurable background**
+
+**Goal:** `.main-content` uses the new var with the themed color as fallback, so an unset config is visually identical and a set config paints the background.
+
+**Requirements:** R2, R3
+
+**Dependencies:** Unit 1 (var name must match)
+
+**Files:**
+- Modify: `app/assets/stylesheets/css/layout.css` (the `.main-content` rule, ~line 66)
+
+**Approach:**
+- Replace `bg-(--color-main-content-background)` inside the `@apply` with a plain declaration `background: var(--main-content-background, var(--color-main-content-background));` (either as a Tailwind arbitrary `bg-[...]` utility or a raw CSS property outside `@apply` — prefer raw CSS property for readability of the nested `var()` fallback; place it right after the `@apply` line).
+- Do **not** declare `--main-content-background` on `.main-content` (would shadow the `:root` override).
+- Leave `--color-main-content-border` and every other utility in the rule unchanged.
+- Leave `breadcrumbs.css` untouched (still reads `--color-main-content-background`).
+
+**Execution note:** This is a CSS/visual change — verify in the browser (see Verification), not just via unit test.
+
+**Patterns to follow:**
+- Existing arbitrary-value background usage in the same rule; `var(..., fallback)` pattern used elsewhere in `variables.css`.
+
+**Test scenarios:**
+- Test expectation: none (CSS-only) for a unit test. Covered by the browser/visual verification below and by Unit 3's request spec proving the var reaches the page.
+
+**Verification:**
+- With no `main_content_background` configured, the main panel background looks identical to before in both light and dark mode.
+- With `config.appearance = { main_content_background: "url('/some-image.png') center/cover no-repeat" }` set in the dummy app, the image renders across the main content panel; toggling light/dark and switching accent themes does not remove it (R4).
+
+- [ ] **Unit 3: Prove the option renders into the page `<head>`**
+
+**Goal:** End-to-end coverage that a configured `main_content_background` reaches the rendered `_appearance_overrides` `<style>` tag.
+
+**Requirements:** R1
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `spec/requests/avo/appearance_overrides_request_spec.rb`
+
+**Approach:**
+- Add a context that stubs `Avo.configuration.appearance.brand_css_overrides` to return a block containing `--main-content-background: url('/bg.png') ...;` (mirror the existing stubbed-overrides context) and asserts the response body includes the declaration inside a `<style>` tag. This mirrors the existing neutral/accent override request spec exactly.
+
+**Patterns to follow:**
+- `spec/requests/avo/appearance_overrides_request_spec.rb:22-52` (the "when overrides are configured" context).
+
+**Test scenarios:**
+- Integration: request to an Avo page with `brand_css_overrides` returning a `--main-content-background` block → response body contains `--main-content-background:` within a `<style>` tag.
+
+**Verification:** request spec passes.
+
+- [ ] **Unit 4: Document the option and update the initializer template**
+
+**Goal:** Users discover the option in the initializer and docs.
+
+**Requirements:** R1
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `lib/generators/avo/templates/initializer/avo.tt` (the `config.appearance` block, ~line 141-159)
+- Modify: `docs/docs/4.0/branding.md` (workspace docs site — the branding/appearance page)
+
+**Approach:**
+- Add a commented `#   main_content_background: "url('/my-background.png') center/cover no-repeat",` line to the appearance block in `avo.tt` (per the project's configuration rule: every `config.something` value must appear in the initializer template).
+- In `branding.md`, add a short subsection under the appearance/branding options explaining `main_content_background`: that it accepts any CSS `background` value (image, gradient, shorthand), that images use `url(...)`, and that it layers over the themed color (include the `..., var(--color-main-content-background)` fallback tip). Include a light/dark note (single value applies to both, like brand colors).
+
+**Test scenarios:**
+- Test expectation: none — docs and initializer template comment, no behavioral code.
+
+**Verification:** `avo.tt` shows the new commented option; `branding.md` renders the new subsection (optionally `npx vitepress build docs`).
+
+## System-Wide Impact
+
+- **Interaction graph:** Only `.main-content` background rendering and the `_appearance_overrides` `<style>` output change. Breadcrumbs bar (shares `--color-main-content-background`) is deliberately untouched and unaffected.
+- **API surface parity:** `main_content_background` is a new optional key on the same `config.appearance` hash — additive, no breaking change. Existing configs (no key) behave identically (R3).
+- **State lifecycle risks:** None — pure config-to-CSS, no persistence or runtime state. (The `persistence: :database` appearance path stores scheme/neutral/accent selections, not this static option; no change there.)
+- **Unchanged invariants:** `--color-main-content-background` and its default (`variables.css:115`) are unchanged; it remains the fallback and the breadcrumbs color source. The theme-picker layering behavior is preserved by reusing the `@layer base { :root {} }` mechanism.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Local `--main-content-background` default on `.main-content` would shadow the `:root` override and silently break the feature. | Explicitly do NOT declare it locally; use `var(--main-content-background, var(--color-main-content-background))` fallback only. Called out in Unit 2. |
+| A bare `url(...)` value tiles or misaligns without size/position. | Deferred decision in Open Questions — add `background-size/position/repeat` defaults after eyeballing; keep them as declared props ordered after the shorthand. |
+| Freeform CSS value is injected into an inline `<style>`. | Same trust model as existing `neutral_colors`/`accent_colors`/`logo` — values come from the app's own initializer (developer-controlled), emitted with a CSP nonce. No new user-facing input surface. |
+| `background` shorthand resets `background-color`. | Intended — the shorthand's own `var()` fallback supplies the themed color, so unset state is unchanged; verified in the browser. |
+
+## Documentation / Operational Notes
+
+- Docs: `docs/docs/4.0/branding.md` updated (Unit 4). Confirmed the relevant page exists (`appearance.md`, `appearance-api.md`, `branding.md` under `docs/docs/4.0/`); place the option with the other appearance branding options.
+- No migration, rollout, or monitoring concerns.
+
+## Sources & References
+
+- **Origin issue:** [AVO-1517](https://linear.app/avo-hq/issue/AVO-1517/enable-main-section-background-image)
+- Pattern reference: `external/avo/docs/plans/2026-05-06-001-feat-brand-color-overrides-plan.md`
+- Code: `lib/avo/configuration/appearance.rb`, `app/assets/stylesheets/css/layout.css:61-66`, `app/assets/stylesheets/css/variables.css:111-115`, `app/views/avo/partials/_appearance_overrides.html.erb`
+- Tests: `spec/lib/avo/configuration/appearance_spec.rb`, `spec/requests/avo/appearance_overrides_request_spec.rb`

--- a/lib/avo/configuration/appearance.rb
+++ b/lib/avo/configuration/appearance.rb
@@ -4,6 +4,7 @@ class Avo::Configuration::Appearance
     :accent,  # Symbol — default accent selection (e.g. :blue, :brand)
     :neutral_colors, # Hash{ 25 => ..., 50 => ..., ..., 950 => ... } — full 12-shade brand override (single palette, applied in both light and dark mode)
     :accent_colors,  # Hash{ color:, content:, foreground: } — three-token brand override (single palette, applied in both light and dark mode)
+    :main_content_background, # String — any CSS `background` value (image url(), gradient, color, or shorthand) for the main content section; nil leaves the themed default
     :neutrals, # Array[String] — available neutral theme names
     :accents, # Array[String] — available accent color names
     :lock, # Array[Symbol] — subset of [:scheme, :neutral, :accent]
@@ -62,6 +63,7 @@ class Avo::Configuration::Appearance
     @accent = config[:accent]
     @neutral_colors = config[:neutral_colors]
     @accent_colors = config[:accent_colors]
+    @main_content_background = config[:main_content_background]
     @neutrals = Array(config[:neutrals]).map(&:to_s).freeze
     @accents = Array(config[:accents]).map(&:to_s).freeze
     @lock = Array(config[:lock]).map(&:to_sym).freeze
@@ -121,7 +123,7 @@ class Avo::Configuration::Appearance
   # Without an `@layer` wrapper, the unlayered inline style would beat every
   # layered rule regardless of specificity, silently breaking theme selection.
   def brand_css_overrides
-    return nil if neutral_colors.nil? && accent_colors.nil?
+    return nil if neutral_colors.nil? && accent_colors.nil? && main_content_background.nil?
 
     [
       "@layer base {",
@@ -155,6 +157,12 @@ class Avo::Configuration::Appearance
       # never set this var, so the swatch keeps showing the configured brand
       # accent even while another accent is hovered or selected.
       declarations << "  --color-brand-accent: #{accent_colors[:color]};"
+    end
+
+    if main_content_background
+      # Consumed by `.main-content { background: var(--main-content-background, ...) }`.
+      # Accepts any CSS background value (url(), gradient, color, or shorthand).
+      declarations << "  --main-content-background: #{main_content_background};"
     end
 
     declarations

--- a/lib/avo/configuration/appearance.rb
+++ b/lib/avo/configuration/appearance.rb
@@ -101,9 +101,12 @@ class Avo::Configuration::Appearance
   # Returns the accent name for the data attribute (nil when accent is unset)
   def accent_css_class = accent&.to_s
 
-  # Returns the inline CSS string that overrides brand vars at :root when
-  # neutral_colors / accent_colors are configured. Returns nil when neither is
-  # set so the layout can skip emitting the <style> tag entirely.
+  # Returns the inline CSS string that overrides appearance vars at :root when
+  # any of neutral_colors / accent_colors / main_content_background are
+  # configured. Despite the "brand" name this is the single appearance CSS
+  # override pipeline, so it also emits non-brand layout vars like
+  # --main-content-background. Returns nil when none are set so the layout can
+  # skip emitting the <style> tag entirely.
   #
   # Brand palettes are single-toned — one set of values applied in both light
   # and dark mode (matching how the built-in `.neutral-theme-*` /
@@ -123,7 +126,7 @@ class Avo::Configuration::Appearance
   # Without an `@layer` wrapper, the unlayered inline style would beat every
   # layered rule regardless of specificity, silently breaking theme selection.
   def brand_css_overrides
-    return nil if neutral_colors.nil? && accent_colors.nil? && main_content_background.nil?
+    return nil if neutral_colors.nil? && accent_colors.nil? && main_content_background.blank?
 
     [
       "@layer base {",
@@ -159,9 +162,10 @@ class Avo::Configuration::Appearance
       declarations << "  --color-brand-accent: #{accent_colors[:color]};"
     end
 
-    if main_content_background
+    if main_content_background.present?
       # Consumed by `.main-content { background: var(--main-content-background, ...) }`.
       # Accepts any CSS background value (url(), gradient, color, or shorthand).
+      # Blank is treated as unset so we never emit an empty declaration.
       declarations << "  --main-content-background: #{main_content_background};"
     end
 

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -155,6 +155,7 @@ Avo.configure do |config|
   #   persistence: :database,
   #   placeholder: "avo/placeholder.svg",
   #   chart_colors: ["#0B8AE2", "#34C683", "#2AB1EE", "#34C6A8"],
+  #   main_content_background: "url('/my-background.png') center/cover no-repeat",
   #   load_settings: -> { current_user&.avo_preferences&.dig("appearance")&.symbolize_keys || {} },
   # }
 

--- a/spec/lib/avo/configuration/appearance_spec.rb
+++ b/spec/lib/avo/configuration/appearance_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe Avo::Configuration::Appearance do
       expect(appearance.accent_colors).to be_nil
     end
 
+    it "defaults main_content_background to nil" do
+      expect(appearance.main_content_background).to be_nil
+    end
+
     it "defaults lock to an empty array" do
       expect(appearance.lock).to eq([])
     end
@@ -298,6 +302,52 @@ RSpec.describe Avo::Configuration::Appearance do
           expect(css).not_to include(".dark {")
           expect(css).to include("--color-avo-neutral-25: oklch(0.99 0.01 240);")
           expect(css).to include("--color-accent-foreground: oklch(1 0 0);")
+        end
+      end
+
+      context "when only main_content_background is configured" do
+        let(:options) { {main_content_background: "url('/bg.png') center/cover no-repeat"} }
+
+        it "emits the --main-content-background declaration inside @layer base :root" do
+          css = appearance.brand_css_overrides
+
+          expect(css).to start_with("@layer base {")
+          expect(css.scan(":root {").size).to eq(1)
+          expect(css).to include("--main-content-background: url('/bg.png') center/cover no-repeat;")
+        end
+
+        it "emits the block even though neutral_colors / accent_colors are unset" do
+          expect(appearance.brand_css_overrides).not_to be_nil
+        end
+
+        it "does not emit neutral or accent declarations" do
+          css = appearance.brand_css_overrides
+
+          expect(css).not_to include("--color-avo-neutral-")
+          expect(css).not_to include("--color-accent")
+        end
+      end
+
+      context "when main_content_background is a gradient" do
+        let(:options) { {main_content_background: "linear-gradient(to bottom, #fff, #eee)"} }
+
+        it "emits the gradient value verbatim" do
+          expect(appearance.brand_css_overrides)
+            .to include("--main-content-background: linear-gradient(to bottom, #fff, #eee);")
+        end
+      end
+
+      context "when main_content_background is combined with accent_colors" do
+        let(:options) do
+          {accent_colors: complete_accent, main_content_background: "url('/bg.png')"}
+        end
+
+        it "emits both the accent tokens and the main content background in one :root block" do
+          css = appearance.brand_css_overrides
+
+          expect(css.scan(":root {").size).to eq(1)
+          expect(css).to include("--color-accent: oklch(0.6 0.2 260);")
+          expect(css).to include("--main-content-background: url('/bg.png');")
         end
       end
     end

--- a/spec/lib/avo/configuration/appearance_spec.rb
+++ b/spec/lib/avo/configuration/appearance_spec.rb
@@ -328,6 +328,14 @@ RSpec.describe Avo::Configuration::Appearance do
         end
       end
 
+      context "when main_content_background is blank" do
+        let(:options) { {main_content_background: ""} }
+
+        it "treats it as unset and returns nil (emits no empty declaration)" do
+          expect(appearance.brand_css_overrides).to be_nil
+        end
+      end
+
       context "when main_content_background is a gradient" do
         let(:options) { {main_content_background: "linear-gradient(to bottom, #fff, #eee)"} }
 
@@ -347,6 +355,20 @@ RSpec.describe Avo::Configuration::Appearance do
 
           expect(css.scan(":root {").size).to eq(1)
           expect(css).to include("--color-accent: oklch(0.6 0.2 260);")
+          expect(css).to include("--main-content-background: url('/bg.png');")
+        end
+      end
+
+      context "when main_content_background is combined with neutral_colors" do
+        let(:options) do
+          {neutral_colors: complete_neutral, main_content_background: "url('/bg.png')"}
+        end
+
+        it "emits both the neutral shades and the main content background in one :root block" do
+          css = appearance.brand_css_overrides
+
+          expect(css.scan(":root {").size).to eq(1)
+          expect(css).to include("--color-avo-neutral-25: oklch(0.99 0.01 240);")
           expect(css).to include("--main-content-background: url('/bg.png');")
         end
       end

--- a/spec/requests/avo/appearance_overrides_request_spec.rb
+++ b/spec/requests/avo/appearance_overrides_request_spec.rb
@@ -50,4 +50,28 @@ RSpec.describe "Appearance overrides", type: :request do
       expect(response.body).to include('rel="icon"')
     end
   end
+
+  context "when a main content background is configured" do
+    let(:overrides_css) do
+      <<~CSS
+        @layer base {
+          :root {
+            --main-content-background: url('/bg.png') center/cover no-repeat;
+          }
+        }
+      CSS
+    end
+
+    before do
+      allow(Avo.configuration.appearance).to receive(:brand_css_overrides).and_return(overrides_css)
+    end
+
+    it "emits the --main-content-background declaration inside a style tag" do
+      get "/admin/failed_to_load"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("--main-content-background: url('/bg.png') center/cover no-repeat;")
+      expect(response.body).to match(%r{<style\b[^>]*>.*--main-content-background.*</style>}m)
+    end
+  end
 end


### PR DESCRIPTION
## What & why

AVO-1517 asks to let users set the **main content section background to an image**. Research confirmed it was only *partially* possible today: `.main-content` painted its background with `background-color` (`bg-(--color-main-content-background)`), which can't hold a `url(...)`, so the existing color knob couldn't take an image. Users could hand-write a `.main-content` CSS override, but there was no config option.

This adds a first-class `config.appearance` option — `main_content_background` — that plugs into the same override pipeline already used by `neutral_colors` / `accent_colors`.

```ruby
config.appearance = {
  main_content_background: "url('/my-background.png') center/cover no-repeat"
  # …or a gradient, a color, or any CSS `background` shorthand
}
```

## How it works

- **`Avo::Configuration::Appearance`** gains a `main_content_background` option. When set, `brand_css_overrides` emits `--main-content-background: <value>` inside the existing `@layer base { :root { … } }` block (so it wins over Avo defaults but still loses to a user-selected theme class — same layering guarantee as the brand color overrides).
- **`.main-content`** now uses `background: var(--main-content-background, var(--color-main-content-background))`. When unset, the fallback resolves to the existing themed color, so **the default look is unchanged in both light and dark mode**. Images default to `cover` / centered / no-repeat.
- The breadcrumbs bar (which also reads `--color-main-content-background`) is deliberately untouched.

## Scope

- Initializer-config only (like `logo` / `chart_colors`) — no runtime picker control.
- App-wide, not per-resource.
- Value is passed through as raw CSS; reference assets with `url('/...')` or a full URL (no asset-name auto-resolution — noted as a possible follow-up).

## Testing

- `spec/lib/avo/configuration/appearance_spec.rb` — default nil, single emission, gradient value, guard fires when only this option is set, combined with `accent_colors`. **49 examples, 0 failures.**
- `spec/requests/avo/appearance_overrides_request_spec.rb` — the declaration renders into an inline `<style>` tag in `<head>`. **4 examples, 0 failures.**
- `standardrb` clean on all changed Ruby files.
- CSS compiles cleanly via `yarn build:css`; the new `var()` chain is present in the built `application.css`.

Browser before/after verification follows via the pipeline's browser-QA + feature-video steps.

## Docs

- `docs/docs/4.0/appearance-api.md` (docs.avohq.io repo) gains a `main_content_background` `<Option>` entry — committed separately in the docs repo.
- Initializer template `avo.tt` lists the new commented option.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is a purely additive, opt-in CSS/config change with no runtime, data, or migration impact. Existing configs (without the key) render byte-for-byte identically. Validation is visual: with the option set, the main panel shows the configured background; unset, it matches the prior themed color.

Plan: `docs/plans/2026-07-23-001-feat-main-content-background-image-plan.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, opt-in appearance/CSS config with no auth, data, or migration impact; unset configs behave as before.
> 
> **Overview**
> Adds **`config.appearance.main_content_background`** so apps can set the main panel background (image, gradient, or any CSS `background` value) without custom CSS overrides.
> 
> The value is emitted as **`--main-content-background`** through the existing `brand_css_overrides` → inline `<style>` pipeline (same `@layer base { :root }` layering as brand colors). **`.main-content`** now uses `background: var(--main-content-background, var(--color-main-content-background))` with default **cover / center / no-repeat** for bare `url()` values; when unset, the themed color fallback keeps the default look unchanged.
> 
> Includes unit/request specs, a commented option in the **`avo.tt`** initializer template, and an implementation plan doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3abcae56fe2879b5123f6ff5e04b5fa75bcae16b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Demo

Verified in the dummy app on the projects index. Configured with a test gradient
`main_content_background: "linear-gradient(135deg, #dbeafe 0%, #fce7f3 100%)"`.

**Before** — default themed panel (unchanged when the option is unset):

![before – default main content background](https://raw.githubusercontent.com/avo-hq/avo/media/avo-1517-main-content-bg/avo-1517/before-default.png)

**After** — the gradient renders on `.main-content` only; the sidebar and top navbar are untouched:

![after – gradient in light mode](https://raw.githubusercontent.com/avo-hq/avo/media/avo-1517-main-content-bg/avo-1517/after-gradient-light.png)

**Dark mode** — a single value applies in both schemes (same behavior as brand colors):

![after – gradient in dark mode](https://raw.githubusercontent.com/avo-hq/avo/media/avo-1517-main-content-bg/avo-1517/after-gradient-dark.png)

▶️ **[Watch the 6s before → after → dark walkthrough (MP4)](https://raw.githubusercontent.com/avo-hq/avo/media/avo-1517-main-content-bg/avo-1517/feature-demo.mp4)**

<sub>Media hosted on the `media/avo-1517-main-content-bg` branch. An image/gradient behaves the same way — the value is any CSS `background`.</sub>
