### PR TITLE
fix: use resource_default_view in frame field default_view

### DIFF
--- a/lib/avo/fields/frame_base_field.rb
+++ b/lib/avo/fields/frame_base_field.rb
@@ -129,7 +129,7 @@ module Avo
       private
 
       def default_view
-        Avo.configuration.skip_show_view ? :edit : :show
+        Avo.configuration.resource_default_view.edit? ? :edit : :show
       end
 
       # Attributes exposed to callable descriptions. `loading_type` tells a


### PR DESCRIPTION
`Avo::Fields::FrameBaseField#default_view` called `Avo.configuration.skip_show_view`, which was removed and replaced by `resource_default_view` (a `ViewInquirer`). The old call would raise `NoMethodError`.

This maps the old behavior faithfully:

```ruby
skip_show_view ? :edit : :show  →  resource_default_view.edit? ? :edit : :show
```

Matches how `spec/system/avo/group_3/skip_show_view_spec.rb` already sets `resource_default_view = :edit`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line config API swap with equivalent behavior; no auth or data-path changes.
> 
> **Overview**
> **`Avo::Fields::FrameBaseField#default_view`** no longer calls the removed **`skip_show_view`** config (which would raise **`NoMethodError`**). It now uses **`Avo.configuration.resource_default_view.edit?`** to pick **`:edit`** vs **`:show`**, matching the old **`skip_show_view ? :edit : :show`** behavior and the same pattern used elsewhere (e.g. show authorization).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf819666a293d54e0d4b5bddaa80c79a45ba5e43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->