### PR TITLE
refactor(assets): remove the gem CSS @source scan and avo:sym_link

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -6,17 +6,14 @@
 @source not "*/tmp/screenshots";
 @source not "*/tmp/storage";
 
-/* TODO: Figure out a way to add those dynamically */
-/* Find a long term solution for this. */
-/* Basically this is a hack to make sure that we dont have specificity issues with the packages stylesheets. */
-/* However if we do this the packages builds are kinda irrelevant. */
-/* And we also need to release a new version of avo anytime that a package stylesheet changes. */
-@source "../../../tmp/avo/build-assets/packages/avo-advanced";
+/* Scans gem sources so their utilities compile into this build, which loads
+   after the gems' own stylesheets and would otherwise override them. Being
+   removed: gems now ship BEM component classes that core cannot clobber, so
+   they no longer need core to compile their utilities. Entries leave as each
+   gem migrates; the block and avo:sym_link go with the last one.
+   See .claude/rules/gem-css.md in the workspace. */
 @source "../../../tmp/avo/build-assets/packages/avo-dashboards";
-@source "../../../tmp/avo/build-assets/packages/avo-dynamic_filters";
 @source "../../../tmp/avo/build-assets/packages/avo-kanban";
-@source "../../../tmp/avo/build-assets/packages/avo-menu";
-@source "../../../tmp/avo/build-assets/packages/avo-pro";
 @source "../../../tmp/avo/build-assets/packages/avo-forms";
 
 /* We couldn't find a way to implement blocklist in the CSS config */

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -6,15 +6,6 @@
 @source not "*/tmp/screenshots";
 @source not "*/tmp/storage";
 
-/* Scans gem sources so their utilities compile into this build, which loads
-   after the gems' own stylesheets and would otherwise override them. Being
-   removed: gems now ship BEM component classes that core cannot clobber, so
-   they no longer need core to compile their utilities. Entries leave as each
-   gem migrates; the block and avo:sym_link go with the last one.
-   See .claude/rules/gem-css.md in the workspace. */
-@source "../../../tmp/avo/build-assets/packages/avo-kanban";
-@source "../../../tmp/avo/build-assets/packages/avo-forms";
-
 /* We couldn't find a way to implement blocklist in the CSS config */
 /* blocklist: ['bg-[#{chart_color(index)}]', 'bg-[${color}]'] */
 @source inline("break-all");

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,7 +12,6 @@
    they no longer need core to compile their utilities. Entries leave as each
    gem migrates; the block and avo:sym_link go with the last one.
    See .claude/rules/gem-css.md in the workspace. */
-@source "../../../tmp/avo/build-assets/packages/avo-dashboards";
 @source "../../../tmp/avo/build-assets/packages/avo-kanban";
 @source "../../../tmp/avo/build-assets/packages/avo-forms";
 

--- a/lib/tasks/avo_tasks.rake
+++ b/lib/tasks/avo_tasks.rake
@@ -105,7 +105,14 @@ task "avo:sym_link" do
   end
 
   gem_paths = `bundle list --paths 2>/dev/null`.split("\n")
-  ["avo-advanced", "avo-pro", "avo-advanced_search", "avo-authorization", "avo-record_reordering", "avo-dynamic_filters", "avo-dashboards", "avo-menu", "avo-kanban", "avo-forms"].each do |gem|
+  # Must stay in step with the @source entries in app/assets/stylesheets/application.css —
+  # symlinking a gem core no longer scans just creates an unread directory. Both
+  # lists lose entries as gems migrate to BEM component classes, and this task
+  # is removed with the last one.
+  #
+  # Keep prose here free of bare Tailwind utility names: this file is inside
+  # core's automatic content detection, so a stray word emits a CSS rule.
+  ["avo-dashboards", "avo-kanban", "avo-forms"].each do |gem|
     path = gem_paths.find { |gem_path| gem_path.include?("/#{gem}-") }
 
     # If path is nil we check if package is defined outside of root (on release process it is)

--- a/lib/tasks/avo_tasks.rake
+++ b/lib/tasks/avo_tasks.rake
@@ -88,68 +88,6 @@ task "avo:gem_paths" do
   puts result
 end
 
-desc "Symlinks all Avo gems to tmp/avo/packages"
-task "avo:sym_link" do
-  puts "Running avo:sym_link"
-  base_path = Rails.root.join("tmp", "avo", "build-assets").to_s.gsub("/spec/dummy", "")
-
-  remove_directory_if_exists base_path
-
-  packages_path = "#{base_path}/packages"
-
-  if Dir.exist?(packages_path)
-    `rm -rf #{packages_path}/*`
-  else
-    `mkdir -p #{packages_path}`
-    `touch #{packages_path}/.keep`
-  end
-
-  gem_paths = `bundle list --paths 2>/dev/null`.split("\n")
-  # Must stay in step with the @source entries in app/assets/stylesheets/application.css —
-  # symlinking a gem core no longer scans just creates an unread directory. Both
-  # lists lose entries as gems migrate to BEM component classes, and this task
-  # is removed with the last one.
-  #
-  # Keep prose here free of bare Tailwind utility names: this file is inside
-  # core's automatic content detection, so a stray word emits a CSS rule.
-  ["avo-dashboards", "avo-kanban", "avo-forms"].each do |gem|
-    path = gem_paths.find { |gem_path| gem_path.include?("/#{gem}-") }
-
-    # If path is nil we check if package is defined outside of root (on release process it is)
-    if path.nil?
-      next if !Dir.exist?("../#{gem}")
-
-      path = File.expand_path("../#{gem}")
-    end
-
-    puts "[Avo->] Linking #{gem} to #{path}"
-    symlink_path path, "#{packages_path}/#{gem}"
-  end
-
-  application_css_path = Avo::Engine.root.join("app", "assets", "stylesheets", "application.css")
-  raise "[Avo->] Failed to find #{application_css_path}." unless File.exist?(application_css_path.to_s)
-
-  dest_css_path = "#{base_path}/application.css"
-  remove_file_if_exists dest_css_path
-
-  puts "[Avo->] Linking application.css to #{application_css_path}"
-  symlink_path application_css_path, dest_css_path
-end
-
-def remove_file_if_exists(path)
-  `rm #{path}` if File.exist?(path) || File.symlink?(path)
-end
-
-def remove_directory_if_exists(path)
-  `rm -rf #{path}` if Dir.exist?(path) || File.symlink?(path)
-end
-
-def symlink_path(from, to)
-  remove_file_if_exists to
-
-  `ln -s #{from} #{to}`
-end
-
 desc "Installs yarn dependencies for Avo"
 task "avo:yarn_install" do
   # tailwind.preset.js needs this dependencies in order to be required


### PR DESCRIPTION
Part of [AVO-1483](https://linear.app/avo-hq/issue/AVO-1483/dashboards-grid-regression).

Core scanned symlinked gem sources so their Tailwind utilities compiled into **core's** build, which loads after every gem stylesheet and would otherwise override them. The comment above the block called it what it was:

> Basically this is a hack to make sure that we dont have specificity issues with the packages stylesheets. However if we do this the packages builds are kinda irrelevant. And we also need to release a new version of avo anytime that a package stylesheet changes.

Gems now ship BEM component classes core has no selector for (avo-hq/workspace#80), so the scan has nothing left to do.

## The mechanism was already inert

`@source` pointed at `tmp/avo/build-assets/packages`, which only exists after a manual `bin/rails avo:sym_link`. No build or release step runs it — `yarn build` doesn't, and `app/assets/builds/` is gitignored, so released CSS is always built fresh without it.

Building `app/assets/stylesheets/application.css` with and without the entire block produces **byte-identical output** (359,672 bytes). Released core CSS never contained scanned-gem utilities. That's also why a gem could ship a class only core could resolve and never notice: `avo-dynamic_filters` uses `index-missing-resources:`, and `avo-kanban` uses `empty:kanban-dragging:*` — both custom variants registered here in core, neither ever compiled.

## Changes

- Delete the `@source` gem block and its rationale comment. The unrelated `@source not` cache excludes, `@source inline("break-all")`, and `safelist.txt` stay.
- Delete the `avo:sym_link` task and its three now-unused helpers (`symlink_path`, `remove_file_if_exists`, `remove_directory_if_exists`). No caller remains anywhere in the workspace or here; the only surviving mentions are Avo 3.0 docs describing the v3 gem.

A gem markup change no longer requires an avo core release.

## Merge order

Merge **after** avo-hq/workspace#80, which carries the gem migrations this assumes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
