### PR TITLE
feat: add opt-in "Back to top" button

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -174,6 +174,7 @@
   @import "./css/components/field-wrapper.css";
   @import "./css/components/avatar.css";
   @import "./css/components/alert.css";
+  @import "./css/components/back_to_top.css";
   @import "./css/components/breadcrumbs.css";
   @import "./css/components/button.css";
   @import "./css/components/grid.css";

--- a/app/assets/stylesheets/css/components/back_to_top.css
+++ b/app/assets/stylesheets/css/components/back_to_top.css
@@ -1,0 +1,37 @@
+/* "Back to top" pill, mirroring the Furo docs theme (diataxis.fr): a fixed
+   button centered just below the navbar that reveals when the user scrolls back
+   up and hides when scrolling down. Visibility is driven by the back_to_top
+   Stimulus controller toggling `.back-to-top--visible`. */
+.back-to-top {
+  @apply fixed z-50 flex items-center gap-1 rounded-2xl bg-primary ps-2 pe-3 py-2 text-content no-underline;
+
+  inset-inline-start: 50%;
+  top: calc(var(--top-navbar-height) + 0.5rem);
+  font-size: 0.8125rem;
+  box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 0.05), 0 0 1px 0 hsl(220 9% 46% / 0.5);
+
+  /* Hidden by default. Uses opacity/visibility rather than the `hidden`
+     attribute so appearing/disappearing can transition. */
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateX(-50%) translateY(-0.5rem);
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+
+  &:hover {
+    @apply text-content bg-secondary;
+  }
+}
+
+.back-to-top--visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateX(-50%) translateY(0);
+}
+
+.back-to-top__icon {
+  @apply size-4 shrink-0;
+
+  fill: currentColor;
+}

--- a/app/javascript/js/controllers.js
+++ b/app/javascript/js/controllers.js
@@ -4,6 +4,7 @@ import ActionController from './controllers/action_controller'
 import ActionsOverflowController from './controllers/actions_overflow_controller'
 import ActionsPickerController from './controllers/actions_picker_controller'
 import AttachmentsController from './controllers/attachments_controller'
+import BackToTopController from './controllers/back_to_top_controller'
 import BelongsToFieldController from './controllers/fields/belongs_to_field_controller'
 import BooleanFilterController from './controllers/boolean_filter_controller'
 import CardFiltersController from './controllers/card_filters_controller'
@@ -76,6 +77,7 @@ application.register('confirm-dialog', ConfirmDialogController)
 application.register('actions-overflow', ActionsOverflowController)
 application.register('actions-picker', ActionsPickerController)
 application.register('attachments', AttachmentsController)
+application.register('back-to-top', BackToTopController)
 application.register('boolean-filter', BooleanFilterController)
 application.register('card-filters', CardFiltersController)
 application.register('clear-input', ClearInputController)

--- a/app/javascript/js/controllers/back_to_top_controller.js
+++ b/app/javascript/js/controllers/back_to_top_controller.js
@@ -1,0 +1,49 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Reveals a "Back to top" pill when the user scrolls back up, mirroring the
+// Furo docs theme (used by diataxis.fr): hidden within `threshold` px of the
+// top, shown on upward scroll, hidden again on downward scroll.
+export default class extends Controller {
+  static values = { threshold: { type: Number, default: 64 } }
+
+  connect() {
+    this.lastScroll = this.scrollTop
+    this.onScroll = this.onScroll.bind(this)
+    window.addEventListener('scroll', this.onScroll, { passive: true })
+  }
+
+  disconnect() {
+    window.removeEventListener('scroll', this.onScroll)
+  }
+
+  get scrollTop() {
+    return window.pageYOffset || document.documentElement.scrollTop
+  }
+
+  onScroll() {
+    const current = this.scrollTop
+
+    if (current < this.thresholdValue) {
+      this.hide()
+    } else if (current < this.lastScroll) {
+      this.show() // scrolling up
+    } else if (current > this.lastScroll) {
+      this.hide() // scrolling down
+    }
+
+    this.lastScroll = current
+  }
+
+  scrollToTop(event) {
+    event.preventDefault()
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  show() {
+    this.element.classList.add('back-to-top--visible')
+  }
+
+  hide() {
+    this.element.classList.remove('back-to-top--visible')
+  }
+}

--- a/app/views/avo/partials/_back_to_top.html.erb
+++ b/app/views/avo/partials/_back_to_top.html.erb
@@ -1,0 +1,6 @@
+<a href="#" class="back-to-top" data-controller="back-to-top" data-back-to-top-threshold-value="<%= Avo.configuration.back_to_top[:threshold] %>" data-action="click->back-to-top#scrollToTop">
+  <svg class="back-to-top__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M13 20h-2V8l-5.5 5.5-1.42-1.42L12 4.16l7.92 7.92-1.42 1.42L13 8v12z"></path>
+  </svg>
+  <span><%= t("avo.back_to_top") %></span>
+</a>

--- a/app/views/layouts/avo/application.html.erb
+++ b/app/views/layouts/avo/application.html.erb
@@ -57,6 +57,8 @@
     >
       <%= render partial: "avo/partials/navbar", locals: {resource: @resource} %>
 
+      <%= render partial: "avo/partials/back_to_top" if Avo.configuration.back_to_top[:enabled] %>
+
       <div id="main-sidebar" tabindex="-1" class="hidden lg:flex">
         <%= render Avo::SidebarComponent.new sidebar_open: @sidebar_open %>
       </div>

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -11,6 +11,7 @@ module Avo
     attr_writer :persistence
     attr_writer :resource_row_controls_config
     attr_writer :hotkeys
+    attr_writer :back_to_top
     attr_writer :associations
     # When unset, Tailwind scans Rails.root.join("app"). Each entry is an absolute path or a path relative to Rails.root.
     attr_writer :tailwindcss_content_sources
@@ -194,6 +195,7 @@ module Avo
       @column_types_mapping = {}
       @resource_row_controls_config = {}
       @hotkeys = {}
+      @back_to_top = {}
       @associations = {}
       @global_search = {
         enabled: true,
@@ -221,6 +223,15 @@ module Avo
       HOTKEYS_DEFAULTS = {
         enabled: true,
         show_key_badges: true
+      }.freeze
+    end
+
+    # "Back to top" pill. `enabled` toggles it; `threshold` is how many pixels
+    # the page must be scrolled down before an upward scroll reveals it.
+    unless defined?(BACK_TO_TOP_DEFAULTS)
+      BACK_TO_TOP_DEFAULTS = {
+        enabled: false,
+        threshold: 64
       }.freeze
     end
 
@@ -252,6 +263,10 @@ module Avo
 
     def hotkeys
       HOTKEYS_DEFAULTS.merge @hotkeys
+    end
+
+    def back_to_top
+      BACK_TO_TOP_DEFAULTS.merge @back_to_top
     end
 
     def associations

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -103,6 +103,12 @@ Avo.configure do |config|
   #   show_key_badges: true   # Set to false to hide inline kbd badge elements from the UI
   # }
 
+  ## == Back to top button ==
+  # config.back_to_top = {
+  #   enabled: true,   # Off by default; set to true to show the "Back to top" pill
+  #   threshold: 64    # Pixels scrolled down before an upward scroll reveals it
+  # }
+
   ## == Associations ==
   # config.associations = {
   #   # Cap how many records a belongs_to/attach lookup lists before showing the

--- a/lib/generators/avo/templates/locales/avo.ar.yml
+++ b/lib/generators/avo/templates/locales/avo.ar.yml
@@ -70,6 +70,7 @@ ar:
     attachment_class_detached: "%{attachment_class} تم فصل"
     attachment_destroyed: تم حذف المرفق
     attachment_failed: فشل في إرفاق %{attachment_class}
+    back_to_top: العودة إلى الأعلى
     cancel: إلغاء
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.de.yml
+++ b/lib/generators/avo/templates/locales/avo.de.yml
@@ -64,6 +64,7 @@ de:
     attachment_class_detached: "%{attachment_class} abgehängt."
     attachment_destroyed: Anhang gelöscht
     attachment_failed: "%{attachment_class} konnte nicht angehängt werden"
+    back_to_top: Zurück nach oben
     cancel: Abbrechen
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -64,6 +64,7 @@ en:
     attachment_class_detached: "%{attachment_class} detached."
     attachment_destroyed: Attachment destroyed
     attachment_failed: Failed to attach %{attachment_class}
+    back_to_top: Back to top
     cancel: Cancel
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.es.yml
+++ b/lib/generators/avo/templates/locales/avo.es.yml
@@ -66,6 +66,7 @@ es:
     attachment_class_detached: "%{attachment_class} adjuntado/a."
     attachment_destroyed: Adjunto eliminado
     attachment_failed: No se pudo adjuntar %{attachment_class}
+    back_to_top: Volver arriba
     cancel: Cancelar
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -66,6 +66,7 @@ fr:
     attachment_class_detached: "%{attachment_class} détaché."
     attachment_destroyed: Pièce jointe détruite
     attachment_failed: Échec de l'ajout de %{attachment_class}
+    back_to_top: Retour en haut
     cancel: Annuler
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.it.yml
+++ b/lib/generators/avo/templates/locales/avo.it.yml
@@ -64,6 +64,7 @@ it:
     attachment_class_detached: "%{attachment_class} staccato."
     attachment_destroyed: Allegato distrutto
     attachment_failed: Impossibile allegare %{attachment_class}
+    back_to_top: Torna su
     cancel: Annulla
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.ja.yml
+++ b/lib/generators/avo/templates/locales/avo.ja.yml
@@ -66,6 +66,7 @@ ja:
     attachment_class_detached: "%{attachment_class}をデタッチしました。"
     attachment_destroyed: アタッチは削除されました
     attachment_failed: "%{attachment_class}の添付に失敗しました"
+    back_to_top: トップに戻る
     cancel: キャンセル
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.nb.yml
+++ b/lib/generators/avo/templates/locales/avo.nb.yml
@@ -66,6 +66,7 @@ nb:
     attachment_class_detached: "%{attachment_class} fjernet."
     attachment_destroyed: Vedlett slettet
     attachment_failed: Kunne ikke legge ved %{attachment_class}
+    back_to_top: Til toppen
     cancel: Avbryt
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.nl.yml
+++ b/lib/generators/avo/templates/locales/avo.nl.yml
@@ -64,6 +64,7 @@ nl:
     attachment_class_detached: "%{attachment_class} losgekoppeld."
     attachment_destroyed: Bijlage verwijderd
     attachment_failed: Kon %{attachment_class} niet bijvoegen
+    back_to_top: Terug naar boven
     cancel: Annuleren
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.nn.yml
+++ b/lib/generators/avo/templates/locales/avo.nn.yml
@@ -66,6 +66,7 @@ nn:
     attachment_class_detached: "%{attachment_class} fjerna."
     attachment_destroyed: Vedlegg sletta
     attachment_failed: Klarte ikkje å legge ved %{attachment_class}
+    back_to_top: Tilbake til toppen
     cancel: Avbryt
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.pl.yml
+++ b/lib/generators/avo/templates/locales/avo.pl.yml
@@ -64,6 +64,7 @@ pl:
     attachment_class_detached: "%{attachment_class} odłączony."
     attachment_destroyed: Załącznik usunięty
     attachment_failed: Nie udało się dołączyć %{attachment_class}
+    back_to_top: Powrót na górę
     cancel: Anuluj
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -66,6 +66,7 @@ pt-BR:
     attachment_class_detached: "%{attachment_class} separado."
     attachment_destroyed: Anexo destruído
     attachment_failed: Não foi possível anexar %{attachment_class}
+    back_to_top: Voltar ao topo
     cancel: Cancelar
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.pt.yml
+++ b/lib/generators/avo/templates/locales/avo.pt.yml
@@ -66,6 +66,7 @@ pt:
     attachment_class_detached: "%{attachment_class} separado."
     attachment_destroyed: Anexo destruído
     attachment_failed: Não foi possível anexar %{attachment_class}
+    back_to_top: Voltar ao topo
     cancel: Cancelar
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -67,6 +67,7 @@ ro:
     attachment_class_detached: "%{attachment_class} separat."
     attachment_destroyed: Atașamentul a fost distrus
     attachment_failed: Nu s-a reușit atașarea %{attachment_class}
+    back_to_top: Înapoi la început
     cancel: Anulează
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.ru.yml
+++ b/lib/generators/avo/templates/locales/avo.ru.yml
@@ -64,6 +64,7 @@ ru:
     attachment_class_detached: "%{attachment_class} отсоединено."
     attachment_destroyed: Вложение удалено
     attachment_failed: Не удалось прикрепить %{attachment_class}
+    back_to_top: Вернуться к началу
     cancel: Отмена
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -66,6 +66,7 @@ tr:
     attachment_class_detached: "%{attachment_class} ilişkisi kesildi."
     attachment_destroyed: Ek silindi
     attachment_failed: "%{attachment_class} eklenemedi"
+    back_to_top: Yukarı dön
     cancel: İptal et
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.ua.yml
+++ b/lib/generators/avo/templates/locales/avo.ua.yml
@@ -64,6 +64,7 @@ ua:
     attachment_class_detached: "%{attachment_class} відкріплено."
     attachment_destroyed: Вкладення знищено
     attachment_failed: Не вдалося прикріпити %{attachment_class}
+    back_to_top: Назад до верху
     cancel: Скасувати
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.zh-TW.yml
+++ b/lib/generators/avo/templates/locales/avo.zh-TW.yml
@@ -64,6 +64,7 @@ zh-TW:
     attachment_class_detached: "%{attachment_class} 已分離。"
     attachment_destroyed: 附件已刪除
     attachment_failed: 無法附加 %{attachment_class}
+    back_to_top: 回到頂部
     cancel: 取消
     checkbox_list:
       hidden_selections:

--- a/lib/generators/avo/templates/locales/avo.zh.yml
+++ b/lib/generators/avo/templates/locales/avo.zh.yml
@@ -64,6 +64,7 @@ zh:
     attachment_class_detached: "%{attachment_class} 已分离。"
     attachment_destroyed: 附件已删除
     attachment_failed: 无法附加 %{attachment_class}
+    back_to_top: 返回顶部
     cancel: 取消
     checkbox_list:
       hidden_selections:

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -50,6 +50,7 @@ Avo.configure do |config|
   config.search_debounce = 300
   # config.field_wrapper_layout = :stacked
   config.click_row_to_view_record = true
+  config.back_to_top = {enabled: true}
 
   config.turbo = {
     instant_click: true


### PR DESCRIPTION
Adds a floating "Back to top" pill that appears when you scroll back up a long page, modeled on the [Furo docs theme](https://diataxis.fr/explanation/).

## Behavior

Lifted from Furo's implementation so it feels identical:

- Hidden while within `threshold` px (default `64`) of the top of the page
- Reveals on an **upward** scroll past that threshold
- Hides again on a **downward** scroll
- Clicking it smooth-scrolls back to the top

The scroll-direction reveal is what makes it feel unobtrusive — it only shows up at the moment you're already heading back up.

## Transition

Furo hard-toggles `display: none ↔ flex`, which can't animate. Here visibility is driven by a `.back-to-top--visible` class toggling opacity/transform instead, so it gets a 0.2s fade-and-slide in and out.

This is the one intentional departure from the repo convention of using the `hidden` attribute for visibility (`CLAUDE.md`) — `display: none` rules out a transition.

## Configuration

Off by default, so existing apps don't pick up new chrome on upgrade. Opt in from the initializer:

```ruby
config.back_to_top = {
  enabled: true, # show the pill
  threshold: 64  # px scrolled down before an upward scroll reveals it
}
```

Follows the existing `hotkeys` pattern — a defaults-merge getter, so setting one key keeps the other's default.

Enabled in the dummy app so it shows up while developing.

## Notes

- Styling uses Avo tokens (`bg-primary`, `text-content`), so it's theme-aware in light/dark, and is RTL-safe (`inset-inline-start`, `ps`/`pe`).
- Sits at `z-50` — above the sticky breadcrumbs, below the navbar.
- Label goes through i18n (`avo.back_to_top`); only `en` is filled in, other locales fall back.
- Docs PR: avo-hq/docs (adds a `back_to_top` entry to the customization API page).

## Verification

Config resolves correctly with partial overrides (`{enabled: false}` keeps `threshold: 64`, and vice versa). Assets build clean and the new classes/controller land in the bundles. I have **not** eyeballed it in a running browser yet — worth a quick look before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UI behind a disabled-by-default flag; no auth or data changes. Minor layout/z-index interaction with navbar and breadcrumbs worth a quick visual check when enabled.
> 
> **Overview**
> Adds an **opt-in floating “Back to top” pill** to the Avo admin layout, modeled on Furo-style scroll behavior.
> 
> **Configuration** follows the existing `hotkeys` pattern: `config.back_to_top` with `enabled: false` by default and `threshold: 64`, merged via `BACK_TO_TOP_DEFAULTS`. The initializer template documents the option; the dummy app enables it for development.
> 
> **UI and behavior**: a partial renders below the navbar when enabled. A Stimulus controller listens to window scroll—hidden near the top, shown on upward scroll past the threshold, hidden on downward scroll—and smooth-scrolls to top on click. CSS uses opacity/transform transitions (`.back-to-top--visible`) instead of `hidden` so the pill can animate.
> 
> **i18n**: `avo.back_to_top` is added across generator locale templates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c23e7be0f019bde57fd84c54e2f15741dfb9fbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->