### PR TITLE
fix(custom-controls): forward extra link attributes, drop control options

### DIFF
--- a/app/components/avo/actions_component.rb
+++ b/app/components/avo/actions_component.rb
@@ -78,10 +78,18 @@ class Avo::ActionsComponent < Avo::BaseComponent
     when defined?(Avo::CustomControls::Resources::Controls::Action) && Avo::CustomControls::Resources::Controls::Action
       render_action_link(action.action, icon: action.icon)
     when defined?(Avo::CustomControls::Resources::Controls::LinkTo) && Avo::CustomControls::Resources::Controls::LinkTo
-      link_to action.args[:path],
-        class: action.args.delete(:class),
-        **action.args.except(:path, :label, :icon) do
-          raw("#{icon(action.args[:icon])} #{action.args[:label]}")
+      # Dropdown items render as plain links, not ButtonComponents, so the styling
+      # options have nothing to land in — spreading the raw kwargs leaked them into
+      # the markup (color: :fuchsia rendered as color="fuchsia"). Excluding
+      # CONTROL_OPTIONS drops those and the internal plumbing while still forwarding
+      # genuine HTML attributes like rel:.
+      link_to action.path,
+        **action.args.except(*Avo::Resources::Controls::BaseControl::CONTROL_OPTIONS),
+        class: action.classes,
+        title: action.title,
+        target: action.target,
+        data: action.data do
+          raw("#{icon(action.icon)} #{action.label}")
         end
     end
   end

--- a/app/components/avo/resource_component.rb
+++ b/app/components/avo/resource_component.rb
@@ -305,7 +305,10 @@ class Avo::ResourceComponent < Avo::BaseComponent
   end
 
   def render_link_to(link)
+    # Anything outside CONTROL_OPTIONS is a plain HTML attribute (rel:, id:…) and
+    # rides ButtonComponent's `prop :args, kind: :**` wildcard onto the <a> tag.
     a_link link.path,
+      **link.args.except(*Avo::Resources::Controls::BaseControl::CONTROL_OPTIONS),
       color: link.color,
       style: link.style,
       icon: link.icon,

--- a/lib/avo/resources/controls/base_control.rb
+++ b/lib/avo/resources/controls/base_control.rb
@@ -2,6 +2,17 @@ module Avo
   module Resources
     module Controls
       class BaseControl
+        # Keys the control consumes itself, either as an option it renders from
+        # (`style`, `icon`…) or as internal plumbing merged in by `execute_block`
+        # (`as_index_control`, `item`…). Everything a user passes *outside* this
+        # list is forwarded to the rendered element as an HTML attribute, so
+        # `link_to "Docs", url, rel: "noopener"` reaches the `<a>` tag.
+        CONTROL_OPTIONS = %i[
+          label path title target data class
+          style color size icon icon_class confirmation_message
+          as_index_control from_custom_list item
+        ].freeze unless defined?(CONTROL_OPTIONS)
+
         attr_reader :label, :title, :color, :style, :icon, :icon_class, :confirmation_message, :size, :as_index_control
 
         def initialize(**args)

--- a/lib/avo/resources/controls/base_control.rb
+++ b/lib/avo/resources/controls/base_control.rb
@@ -2,16 +2,18 @@ module Avo
   module Resources
     module Controls
       class BaseControl
-        # Keys the control consumes itself, either as an option it renders from
-        # (`style`, `icon`…) or as internal plumbing merged in by `execute_block`
-        # (`as_index_control`, `item`…). Everything a user passes *outside* this
-        # list is forwarded to the rendered element as an HTML attribute, so
-        # `link_to "Docs", url, rel: "noopener"` reaches the `<a>` tag.
-        CONTROL_OPTIONS = %i[
-          label path title target data class
-          style color size icon icon_class confirmation_message
-          as_index_control from_custom_list item
-        ].freeze unless defined?(CONTROL_OPTIONS)
+        unless defined?(CONTROL_OPTIONS)
+          # Keys the control consumes itself, either as an option it renders from
+          # (`style`, `icon`…) or as internal plumbing merged in by `execute_block`
+          # (`as_index_control`, `item`…). Everything a user passes *outside* this
+          # list is forwarded to the rendered element as an HTML attribute, so
+          # `link_to "Docs", url, rel: "noopener"` reaches the `<a>` tag.
+          CONTROL_OPTIONS = %i[
+            label path title target data class
+            style color size icon icon_class confirmation_message
+            as_index_control from_custom_list item
+          ].freeze
+        end
 
         attr_reader :label, :title, :color, :style, :icon, :icon_class, :confirmation_message, :size, :as_index_control
 


### PR DESCRIPTION
## What

Custom control links handled kwargs inconsistently, and neither path was right.

**Header and row bars** (`ResourceComponent#render_link_to`) hand-picked which kwargs to pass to `a_link`, so genuine HTML attributes never reached the `<a>`:

```ruby
link_to "Docs", "https://avohq.io/docs", rel: "noopener"   # rel silently dropped
```

That's despite `ButtonComponent` already exposing `prop :args, kind: :**` for exactly this — the wildcard was there, nothing fed it. The docs have claimed `rel:` is forwarded for a long time; it wasn't.

**List dropdowns** (`ActionsComponent#render_item`) did the opposite and spread everything:

```ruby
link_to action.args[:path],
  class: action.args.delete(:class),
  **action.args.except(:path, :label, :icon)
```

Dropdown items render as plain links, not ButtonComponents, so `style`/`color`/`size` had nothing to land in and leaked into the markup as `<a color="fuchsia" style="primary">`. The internal plumbing `execute_block` merges in (`as_index_control`, `item`) was one option name away from leaking too. And `.delete(:class)` mutated the control's stored args, so a re-render would drop the class.

## Fix

Add `BaseControl::CONTROL_OPTIONS` — the keys a control consumes itself — and have both paths exclude exactly those and forward the rest. Extra attributes now reach the `<a>` in both contexts; control options and plumbing stay out of the HTML.

One list, two call sites, so the two paths can't drift apart again.

## Verifying

Specs in **avo-hq/workspace#83** (that repo owns the addon; the avo suite has no custom-controls dependency). Expected red until this merges.

Both directions are covered and both were confirmed to fail without this change:

```
Failure/Error: expect(info_link[:rel]).to eq "noopener"     # header path
Failure/Error: expect(fish_link[:color]).to be_blank        # list path
```

Addon system suite with this applied: **30 examples, 0 failures**.

## Note

`CONTROL_OPTIONS` uses `unless defined?(...)`, matching `ActionsList::ACTIONS_LIST_DROPDOWN_ICON` in the same directory — these lib files get loaded twice and warn otherwise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted rendering fix for custom control links with no auth or data-layer changes; behavior aligns with documented forwarding and removes invalid HTML leakage.
> 
> **Overview**
> Introduces **`BaseControl::CONTROL_OPTIONS`** as the single list of kwargs a custom control owns (styling, labels, internal plumbing). Both link render paths now **`except` that list** and forward everything else to the `<a>` tag.
> 
> **Header/row links** (`ResourceComponent#render_link_to`) previously only passed a fixed set of options into `a_link`, so documented extras like **`rel:`** never reached the anchor despite `ButtonComponent` supporting a `**` args wildcard. Those attributes are now spread onto `a_link` after stripping control keys.
> 
> **List dropdown links** (`ActionsComponent` for custom `LinkTo`) previously spread nearly all of `action.args`, which leaked **`color`/`style`** into invalid HTML attributes and risked exposing internal keys; it also **`delete`d `:class`** and mutated stored args. Rendering now uses **`action.path`**, explicit `class`/`title`/`target`/`data`, and the same **`CONTROL_OPTIONS`** filter so styling stays on the control API and only real HTML attributes pass through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e62c29610cd450ea6ef8550a8eedf7fba8e9c1d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->