### PR TITLE
fix: apply style and data html attributes to the label and content elements

### DIFF
--- a/app/components/avo/field_wrapper_component.html.erb
+++ b/app/components/avo/field_wrapper_component.html.erb
@@ -4,8 +4,9 @@
   style: style,
   data: data do %>
   <%= content_tag :div,
-    class: class_names("field-wrapper__label", @field.get_html(:classes, view: @view, element: :label)),
-    data: {slot: "label"} do %>
+    class: label_classes,
+    style: label_style,
+    data: label_data do %>
     <span class="self-center">
     <% if @form.present? %>
       <%= @form.label label_for, label %>
@@ -19,8 +20,9 @@
     </span>
   <% end %>
   <%= content_tag :div,
-    class: class_names("field-wrapper__content", @field.get_html(:classes, view: @view, element: :content)),
-    data: {slot: "value"} do %>
+    class: content_classes,
+    style: content_style,
+    data: content_data do %>
     <%= tag.div class: "field-wrapper__content-wrapper" do %>
       <% if on_show? %>
         <div class="flex flex-row items-center group gap-x-1 group/clipboard w-full">

--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -43,6 +43,34 @@ class Avo::FieldWrapperComponent < Avo::BaseComponent
     "#{@style} #{@field.get_html(:style, view: @view, element: :wrapper)}"
   end
 
+  def label_classes
+    class_names("field-wrapper__label", @field.get_html(:classes, view: @view, element: :label))
+  end
+
+  # Returned as-is so a blank value stays `nil` and `content_tag` omits the
+  # attribute instead of rendering an empty `style` on every field wrapper.
+  def label_style
+    @field.get_html(:style, view: @view, element: :label)
+  end
+
+  # The slot goes first so field-declared data merges on top of it rather than
+  # replacing it — `[data-slot="label"]` is a selector the app relies on.
+  def label_data
+    {slot: "label"}.merge(@field.get_html(:data, view: @view, element: :label))
+  end
+
+  def content_classes
+    class_names("field-wrapper__content", @field.get_html(:classes, view: @view, element: :content))
+  end
+
+  def content_style
+    @field.get_html(:style, view: @view, element: :content)
+  end
+
+  def content_data
+    {slot: "value"}.merge(@field.get_html(:data, view: @view, element: :content))
+  end
+
   def label
     @label || @field.name
   end

--- a/spec/dummy/app/avo/resources/product.rb
+++ b/spec/dummy/app/avo/resources/product.rb
@@ -50,13 +50,29 @@ class Avo::Resources::Product < Avo::BaseResource
         field :title, as: :text, html: {
           show: {
             label: {
-              classes: "bg-gray-50 !text-pink-600"
+              classes: "bg-gray-50 !text-pink-600",
+              style: "letter-spacing: 0.5px;",
+              data: {show_label_marker: "title"}
             },
             content: {
-              classes: "bg-gray-50 !text-pink-600"
+              classes: "bg-gray-50 !text-pink-600",
+              style: "letter-spacing: 1px;",
+              data: {show_content_marker: "title"}
             },
             wrapper: {
               classes: "bg-gray-50"
+            }
+          },
+          edit: {
+            label: {
+              classes: "bg-gray-100 !text-blue-600",
+              style: "letter-spacing: 1.5px;",
+              data: {edit_label_marker: "title"}
+            },
+            content: {
+              classes: "bg-gray-100 !text-blue-600",
+              style: "letter-spacing: 2px;",
+              data: {edit_content_marker: "title"}
             }
           }
         }

--- a/spec/dummy/app/avo/resources/team.rb
+++ b/spec/dummy/app/avo/resources/team.rb
@@ -36,6 +36,28 @@ class Avo::Resources::Team < Avo::BaseResource
               end
             end
           end
+          show do
+            label do
+              style do
+                if record.color
+                  "color: #{record.color}"
+                end
+              end
+              data do
+                {block_label_marker: "name"}
+              end
+            end
+            content do
+              style do
+                if record.color
+                  "color: #{record.color}"
+                end
+              end
+              data do
+                {block_content_marker: "name"}
+              end
+            end
+          end
         end
         field :logo, as: :external_image, hide_on: :show do
           if record&.url

--- a/spec/features/avo/html_attribute_spec.rb
+++ b/spec/features/avo/html_attribute_spec.rb
@@ -2,12 +2,11 @@ require "rails_helper"
 
 RSpec.feature "HtmlAttributes", type: :feature do
   let(:product) { create :product }
+  let(:label) { field_wrapper(:title).find('[data-slot="label"]') }
+  let(:content) { field_wrapper(:title).find('[data-slot="value"]') }
 
   context "on show" do
     before { visit avo.resources_product_path product }
-
-    let(:label) { field_wrapper(:title).find('[data-slot="label"]') }
-    let(:content) { field_wrapper(:title).find('[data-slot="value"]') }
 
     it "renders the html attributes" do
       expect(content[:class]).to include "bg-gray-50 !text-pink-600"
@@ -37,9 +36,6 @@ RSpec.feature "HtmlAttributes", type: :feature do
 
   context "on edit" do
     before { visit avo.edit_resources_product_path product }
-
-    let(:label) { field_wrapper(:title).find('[data-slot="label"]') }
-    let(:content) { field_wrapper(:title).find('[data-slot="value"]') }
 
     it "renders the classes, style and data attributes on the label element" do
       expect(label[:class]).to include "bg-gray-100 !text-blue-600"
@@ -73,6 +69,22 @@ RSpec.feature "HtmlAttributes", type: :feature do
 
       expect(field_element_by_resource_id("name", red_team.id)["style"]).to match(/color: #FF0000/)
       expect(field_element_by_resource_id("name", green_team.id)["style"]).to match(/color: #00FF00/)
+    end
+  end
+
+  context "with the block notation on show" do
+    let(:team) { create :team, color: "#FF0000" }
+
+    before { visit avo.resources_team_path team }
+
+    it "evaluates the block syntax for the label and content elements" do
+      label = field_wrapper(:name).find('[data-slot="label"]')
+      content = field_wrapper(:name).find('[data-slot="value"]')
+
+      expect(label[:style]).to match(/color: #FF0000/)
+      expect(label["data-block-label-marker"]).to eq "name"
+      expect(content[:style]).to match(/color: #FF0000/)
+      expect(content["data-block-content-marker"]).to eq "name"
     end
   end
 end

--- a/spec/features/avo/html_attribute_spec.rb
+++ b/spec/features/avo/html_attribute_spec.rb
@@ -4,11 +4,55 @@ RSpec.feature "HtmlAttributes", type: :feature do
   let(:product) { create :product }
 
   context "on show" do
-    it "renders the html attributes" do
-      visit avo.resources_product_path product
+    before { visit avo.resources_product_path product }
 
-      expect(field_wrapper(:title).find('[data-slot="value"]')[:class]).to include "bg-gray-50 !text-pink-600"
-      expect(field_wrapper(:title).find('[data-slot="label"]')[:class]).to include "bg-gray-50 !text-pink-600"
+    let(:label) { field_wrapper(:title).find('[data-slot="label"]') }
+    let(:content) { field_wrapper(:title).find('[data-slot="value"]') }
+
+    it "renders the html attributes" do
+      expect(content[:class]).to include "bg-gray-50 !text-pink-600"
+      expect(label[:class]).to include "bg-gray-50 !text-pink-600"
+    end
+
+    it "renders the style attribute on the label and content elements" do
+      expect(label[:style]).to include "letter-spacing: 0.5px"
+      expect(content[:style]).to include "letter-spacing: 1px"
+    end
+
+    it "renders the data attributes on the label and content elements" do
+      expect(label["data-show-label-marker"]).to eq "title"
+      expect(content["data-show-content-marker"]).to eq "title"
+    end
+
+    it "keeps the slot data attributes when the field declares its own data" do
+      expect(label["data-slot"]).to eq "label"
+      expect(content["data-slot"]).to eq "value"
+    end
+
+    it "renders no style attribute for a field without html options" do
+      expect(field_wrapper(:price).find('[data-slot="label"]')[:style]).to be_blank
+      expect(field_wrapper(:price).find('[data-slot="value"]')[:style]).to be_blank
+    end
+  end
+
+  context "on edit" do
+    before { visit avo.edit_resources_product_path product }
+
+    let(:label) { field_wrapper(:title).find('[data-slot="label"]') }
+    let(:content) { field_wrapper(:title).find('[data-slot="value"]') }
+
+    it "renders the classes, style and data attributes on the label element" do
+      expect(label[:class]).to include "bg-gray-100 !text-blue-600"
+      expect(label[:style]).to include "letter-spacing: 1.5px"
+      expect(label["data-edit-label-marker"]).to eq "title"
+      expect(label["data-slot"]).to eq "label"
+    end
+
+    it "renders the classes, style and data attributes on the content element" do
+      expect(content[:class]).to include "bg-gray-100 !text-blue-600"
+      expect(content[:style]).to include "letter-spacing: 2px"
+      expect(content["data-edit-content-marker"]).to eq "title"
+      expect(content["data-slot"]).to eq "value"
     end
   end
 


### PR DESCRIPTION
## Problem

The [`html` field option](https://docs.avohq.io/4.0/html.html) documents `style`, `classes`, and `data` on four elements — `wrapper`, `label`, `content`, and `input`.

On `label` and `content`, only `classes` reached the DOM. `style` and `data` were resolved correctly by `get_html` but never rendered, so declaring them failed silently — no error, no warning, no attribute:

```ruby
field :city, as: :text, html: {
  show: {
    content: {
      classes: "my-test-class",  # applied
      style: "background: red;"  # silently dropped
    }
  }
}
```

`Avo::FieldWrapperComponent` handled its three elements inconsistently:

| Element | `classes` | `style` | `data` |
| --- | --- | --- | --- |
| wrapper | yes | yes | yes |
| label | yes | **no** | **no** — hardcoded `{slot: "label"}` |
| content | yes | **no** | **no** — hardcoded `{slot: "value"}` |

The wrapper's attributes are assembled by the `classes`, `style`, and `data` methods on the component. The label and content elements never got the equivalent treatment: their `class:` was built inline in the template and their `data:` was a literal hash with no room for field-declared values.

## Solution

Move the label and content attribute assembly into component methods, mirroring the trio that already backs the wrapper, and render all three attribute kinds.

Field-declared `data` merges **on top of** Avo's own slot hash rather than replacing it, so `data-slot="label"` and `data-slot="value"` survive — `resource_edit_controller.js` and the test helpers select on them. A developer can still override a slot deliberately, but never by accident.

Blank values stay `nil`, so `content_tag` continues to omit the attribute and no empty `style` is emitted on fields that declare nothing.

`Avo::Index::FieldWrapperComponent` (index view), the `wrapper` element, and the `input` element are untouched.

## Verification

`spec/features/avo/html_attribute_spec.rb` grew from 2 examples to 9, added test-first and confirmed red against the unmodified component before the fix:

- `style` renders on `label` and `content`, on both `show` and `edit`
- `data` renders on `label` and `content`, on both `show` and `edit`
- `data-slot` survives when the field declares its own `data`
- a field with no `html` declaration renders **no** `style` attribute — guards against `style=""` noise on every field wrapper
- both notations covered: hash notation (`show`/`edit`) and block notation (`show`)
- the pre-existing `classes` and index examples still pass unchanged

The full `spec/features` suite (693 examples) was diffed against a baseline run on unmodified code — no new failures. `spec/components` (215 examples) passes. Standard and ERB Lint are clean.

## Docs

No docs change needed — `docs/4.0/html.md` already documents this behavior correctly, including that `index` offers only `wrapper`. This brings the implementation in line with the published contract.