### PR TITLE
fix: stop Inter's contextual alternates rendering `0x0` as `0×0` in inputs

### DIFF
--- a/app/assets/stylesheets/css/components/input.css
+++ b/app/assets/stylesheets/css/components/input.css
@@ -27,6 +27,9 @@
     padding-block: var(--input-py);
     font-size: var(--input-font-size);
     line-height: var(--input-leading);
+    /* Inter's contextual alternates render "0x0" as "0×0" while typing in
+       browsers that shape form controls (Firefox). Visual only, but confusing. */
+    font-variant-ligatures: no-contextual;
   }
 
   tags.tagify {


### PR DESCRIPTION
Fixes #4648

## Description

Typing a digit-`x`-digit sequence (e.g. `0x0`) in any Avo form input visually renders as `0×0` in Firefox.

This isn't Firefox transforming characters — it's the Inter font's `calt` (contextual alternates) OpenType feature, which substitutes a multiplication-sign glyph for `x` between digits ([documented Inter behavior](https://github.com/rsms/inter/blob/master/docs/_data/feature_samples.yml)). It only shows up in Firefox because Firefox runs full OpenType shaping inside form controls, while Chrome/Safari skip contextual alternates in `<input>` elements. The underlying value is unaffected — it's purely visual, but confusing while typing.

## Fix

Add `font-variant-ligatures: no-contextual` to the base input rule, which already covers all text inputs, textareas, selects, `.input-field`, `.textarea-field`, and tagify fields.

This disables only the `calt` feature. The reporter suggested `font-variant-ligatures: none`, but that would also kill common ligatures (fi/fl) for no benefit — `no-contextual` is the targeted equivalent of `font-feature-settings: "calt" 0`, with the advantage that it composes with other `font-variant-*` longhands instead of clobbering any `font-feature-settings` list.

Display text (index/show views) is intentionally left alone — `3×4` in prose is Inter behaving as designed.

## Checklist

- [x] Purely visual CSS fix, no behavior change
- [x] No docs update needed (internal rendering fix)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely visual CSS on form controls with no behavior or data changes; scope is limited to disabling Inter’s contextual alternates in inputs.
> 
> **Overview**
> Fixes a **Firefox-only visual glitch** where digit-`x`-digit text (e.g. `0x0`) in Avo form fields looked like `0×0` because Inter’s `calt` feature substitutes a multiplication sign between digits. Submitted values were always correct; only on-screen shaping was wrong.
> 
> The shared base input rule in `input.css` now sets **`font-variant-ligatures: no-contextual`**, which turns off contextual alternates for text inputs, textareas, selects, `.input-field` / `.textarea-field`, and Tagify—without disabling common `fi`/`fl` ligatures. Read-only display text is unchanged so prose like `3×4` still uses Inter as designed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ced7b151d924160235e54c6d83bc5e08379d579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->