### PR TITLE
refactor(card): drop dead variant prop, split header compaction per axis

### DIFF
--- a/app/assets/stylesheets/css/components/ui/card.css
+++ b/app/assets/stylesheets/css/components/ui/card.css
@@ -14,28 +14,16 @@
   overflow-x: clip;
 }
 
-/* Card variants */
-.card--default {
-  /* Default styling already applied */
-}
+/* Card modifiers. Combine as needed via the `class` option. */
 
-.card--compact {
-  /* Compact variant - smaller spacing */
+/* Tightens the wrapper padding around the card's contents. */
+.card--compact-wrapper {
   .card__wrapper {
     @apply p-0.5;
   }
-
-  .card__header {
-    @apply py-2 px-3;
-  }
 }
 
-.card--full-width {
-  /* Full width variant */
-  @apply w-full;
-}
-
-/* Padded variant. `.card__body` ships unpadded so wide content (tables,
+/* Padded modifier. `.card__body` ships unpadded so wide content (tables,
    scrollers) can sit flush to the card edge. Add `card--padded` to a card whose
    body holds free-form content (custom tools, forms, prose) that should get the
    standard card padding. Usage: `panel.with_card(class: "card--padded")`. */
@@ -110,9 +98,5 @@
 @media (max-width: 768px) {
   .card__header {
     @apply py-2 px-3;
-  }
-
-  .card--compact .card__header {
-    @apply py-1 px-2;
   }
 }

--- a/app/assets/stylesheets/css/components/ui/card.css
+++ b/app/assets/stylesheets/css/components/ui/card.css
@@ -65,9 +65,33 @@
   }
 }
 
-.card--compact-header {
+/* Header compaction is split per axis so a card can shorten its header without
+   also narrowing it. Compose the two when you want both. */
+.card--compact-header-y {
   .card__header {
-    @apply py-1 px-2;
+    @apply py-1;
+  }
+
+  /* Most of a header's height is leading, not padding, so the title is
+     tightened here too. Scoped to the modifier so cards without it keep the
+     design system's leading; the description keeps the base value. */
+  .card__title {
+    @apply leading-normal;
+  }
+}
+
+.card--compact-header-x {
+  .card__header {
+    @apply px-2;
+  }
+
+  /* A header holding a control pulls its end padding in so the control sits
+     near the edge, keeping a hair of breathing room. This has to be repeated
+     here because `.card--compact-header-x .card__header` (0,2,0) outranks the
+     base `.card__header:has(select)` (0,1,1) that sets it. */
+  .card__header:has(select),
+  .card__header:has(.button) {
+    @apply pe-1;
   }
 }
 

--- a/app/components/avo/fields/trix_field/edit_component.html.erb
+++ b/app/components/avo/fields/trix_field/edit_component.html.erb
@@ -1,7 +1,7 @@
 <%= field_wrapper(**field_wrapper_args, full_width: true) do %>
   <% toolbar_id = "#{@input_id}-toolbar" %>
   <%= content_tag :div,
-    class: class_names("card card--full-width card--compact-header max-w-4xl", @input_id),
+    class: class_names("card card--compact-header w-full max-w-4xl", @input_id),
     data: do %>
     <div class="card__wrapper">
       <div class="card__header !p-1">

--- a/app/components/avo/fields/trix_field/edit_component.html.erb
+++ b/app/components/avo/fields/trix_field/edit_component.html.erb
@@ -1,7 +1,7 @@
 <%= field_wrapper(**field_wrapper_args, full_width: true) do %>
   <% toolbar_id = "#{@input_id}-toolbar" %>
   <%= content_tag :div,
-    class: class_names("card card--compact-header w-full max-w-4xl", @input_id),
+    class: class_names("card w-full max-w-4xl", @input_id),
     data: do %>
     <div class="card__wrapper">
       <div class="card__header !p-1">

--- a/app/components/avo/items/switcher_component.html.erb
+++ b/app/components/avo/items/switcher_component.html.erb
@@ -2,7 +2,7 @@
   <%= render panel_component %>
 <% elsif item.is_card? %>
   <%= render Avo::UI::CardComponent.new(
-    class: "card--compact-header",
+    class: "card--compact-header-y",
     title: item.title,
     description: item.description,
     index:

--- a/app/components/avo/items/switcher_component.html.erb
+++ b/app/components/avo/items/switcher_component.html.erb
@@ -2,6 +2,7 @@
   <%= render panel_component %>
 <% elsif item.is_card? %>
   <%= render Avo::UI::CardComponent.new(
+    class: "card--compact-header",
     title: item.title,
     description: item.description,
     index:

--- a/app/components/avo/u_i/card_component.rb
+++ b/app/components/avo/u_i/card_component.rb
@@ -8,7 +8,6 @@ class Avo::UI::CardComponent < Avo::BaseComponent
   # Opt-in body padding via the `.card--padded` modifier. Defaults to false so
   # cards holding wide content (index tables, scrollers) stay flush to the edge.
   prop :padded, default: -> { false }
-  prop :variant, default: -> { :default }
   prop :options, kind: :**
   prop :data, default: -> { {}.freeze }
   prop :index


### PR DESCRIPTION
## What

Two related cleanups to `Avo::UI::CardComponent` and its stylesheet.

**1. `prop :variant` was dead.** Nothing read it — neither the component nor its template mapped it to a class. Every call site sets modifiers through `class:` instead, because the useful cases combine them and a single-valued prop can't express that. Removed, along with the modifiers that had no users.

**2. `card--compact-header` squeezed both axes at once.** A card that only wanted a *shorter* header also got a *narrower* one. Split per axis.

## Modifiers

| Before | After |
|---|---|
| `card--default` | deleted — empty rule |
| `card--full-width` | deleted — one user (trix), now a plain `w-full` |
| `card--compact` | `card--compact-wrapper`, narrowed to the wrapper padding its name claims |
| `card--compact-header` | `card--compact-header-y` + `card--compact-header-x` |

## Call sites

- **avo-dashboards** takes both axes — rendered output unchanged
- **switcher cards** (`card do ... end` in a resource) take `-y` only: shorter header, full-width padding
- **trix** drops the modifier entirely; its header carries `!p-1`, so it was already a no-op there
- **avo-kanban** owns the header padding `card--compact` used to supply (see companion PR)

## Two things found while measuring

**Padding is not what makes a header tall.** At `py-1` the title and description leading account for 44 of the 48px. The title is tightened to `leading-normal` inside `-y`, scoped to the modifier so unmodified cards keep the design system's leading.

**`-x` silently undid a base rule.** `.card__header:has(select)` sets `pe-0` so a control sits near the card edge. It scores (0,1,1); `.card--compact-header-x .card__header` scores (0,2,0) and wins, so range selects gained back 8px. Re-asserted inside the modifier at `pe-1`. **The old `card--compact-header` had identical specificity and the same bug** — this is pre-existing, not introduced here.

## Verification

Measured computed styles in both dummy apps:

| | header height | padding |
|---|---|---|
| dashboards card (`-y` + `-x`) | 49px | `4px / 4px(select) / 4px / 8px` |
| switcher card (`-y` only) | 49px | `4px / 16px / 4px / 16px` |
| avo-kanban column | — | wrapper 2px, header `8px / 12px` (unchanged) |

## Companion PRs

- avo-hq/workspace#92 — avo-kanban rename, avo-dashboards composes both axes
- avo-hq/docs.avohq.io#584 — docs

Merge this first; the other two reference classes it introduces.

## Not done

- No lookbook preview for `CardComponent` — still missing, predates this PR
- The **base** `.card__header:has(select)` is still `pe-0`; only the modifier's copy is at `pe-1`, so the two disagree for unmodified cards
- Refresh-only cards keep full end padding — the refresh control matches neither `select` nor `.button`