### PR TITLE
feat(sidebar): add a warning state to the status indicator

### DIFF
--- a/app/assets/stylesheets/css/sidebar.css
+++ b/app/assets/stylesheets/css/sidebar.css
@@ -460,6 +460,10 @@
   @apply bg-orange-400;
 }
 
+.sidebar-status__indicator--warning {
+  @apply bg-amber-400;
+}
+
 .sidebar-status__hint {
   @apply absolute text-xs hidden text-center w-full -ms-4;
   color: var(--sidebar-content-secondary);


### PR DESCRIPTION
One CSS rule. Part of a three-repo change that surfaces Avo 4 trial state inside a customer's own app; this half is inert on its own.

The Avo Status indicator has only `--ok` and `--error`. `sidebar_component.html.erb` already interpolates `Avo.app_status` straight into the class name, so a third status value needs a variant and **no template change** — an unrecognised status renders an unstyled dot today.

Uses `bg-amber-400` to match the neighbouring rules' raw-palette convention (`--ok` and `--error` use `bg-green-400` / `bg-orange-400`) rather than the semantic `--color-warning` token, which resolves to yellow-500 and would break the local pattern. Amber is this design system's established attention colour (`badge--amber`, the amber accent theme).

Nothing in this repo selects the new state. The `avo-licensing` gem does that separately, so merging this alone changes nothing visible.

No test: a non-behavioural CSS variant. No CSS linter applies here — no stylelint config, and `ws audit-css` scans `gems/` only.

Incidental finding, deliberately **not** changed: the existing `--error` rule uses `bg-orange-400`, not red. Left alone as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## Context

Part of **[AVO-1548 — Enable "No credit card" trials](https://linear.app/avo-hq/issue/AVO-1548/enable-no-credit-card-trials)**.

AVO-1548 itself shipped by setting `AVO4_TRIAL_REQUIRE_CARD` in production. These PRs are the consequences of that flip: a card-free trial is cancelled by Stripe at its end date, so the difference between keeping and losing access became a piece of billing state customers could not see.

| | |
|---|---|
| `avo-hq/avohq.io-v3#696` | HQ side: in-trial payment entry, status panel, email reminders, index badge — **merged** |
| `avo-hq/clerk#84` | clerk describes the trial in its validation response — **merge first** |
| `avo-hq/avo#4670` | sidebar status indicator gains a warning state — independent |
| `avo-hq/workspace#94` | the gem renders it — needs clerk#84 merged and deployed |

Plan covering all three repos: `docs/plans/2026-07-28-001-feat-trial-visibility-in-app-plan.md` (on the clerk branch).