### PR TITLE
refactor: collapse the three sidebar configs into config.sidebar

### DIFF
--- a/app/assets/stylesheets/css/layout.css
+++ b/app/assets/stylesheets/css/layout.css
@@ -61,7 +61,7 @@
      app/views/avo/partials/_sidebar_width_override.html.erb (server-validated
      from the avo.sidebar.width cookie). With no cookie it is undefined and the
      fallback chain takes over: --sidebar-width-default, written by the same
-     carrier when the host sets Avo.configuration.sidebar_default_width, then
+     carrier when the host sets Avo.configuration.sidebar[:default_width], then
      --spacing(64) for the untouched 256px. That chain is deliberately INSIDE
      this media block — below lg the sidebar is a full-height overlay, so a wide
      configured default would cover a phone screen and the base declaration's

--- a/app/helpers/avo/application_helper.rb
+++ b/app/helpers/avo/application_helper.rb
@@ -292,7 +292,7 @@ module Avo
     def sidebar_width_max = SIDEBAR_WIDTH_MAX
 
     # Already clamped into the bounds by Avo::Configuration.
-    def sidebar_width_default = Avo.configuration.sidebar_default_width
+    def sidebar_width_default = Avo.configuration.sidebar[:default_width]
 
     # nil when the host has not changed the starting width, so the pre-paint
     # carrier emits nothing at all and the stylesheet's own --spacing(64)

--- a/app/javascript/js/controllers/sidebar_resize_controller.js
+++ b/app/javascript/js/controllers/sidebar_resize_controller.js
@@ -226,7 +226,7 @@ export default class extends Controller {
   }
 
   // The width the sidebar starts at with no stored preference — Avo's 256px
-  // unless the host set Avo.configuration.sidebar_default_width. This is what
+  // unless the host set Avo.configuration.sidebar[:default_width]. This is what
   // remove-when-default compares against, so reading it from config rather than
   // hardcoding 256 is what keeps a configured host from accumulating a cookie
   // that merely restates their own default.

--- a/app/views/avo/partials/_navbar.html.erb
+++ b/app/views/avo/partials/_navbar.html.erb
@@ -6,8 +6,8 @@
 <%= content_tag :nav, class: class_names("top-navbar", {"print:hidden": Avo.configuration.hide_layout_when_printing}) do %>
   <div class="top-navbar__start">
     <%# Mobile always needs a toggle to reach the overlay sidebar. Desktop toggle
-        is optional and controlled by sidebar_toggle_visible. %>
-    <%= a_button class: class_names("shrink-0 -ms-1.5 lg:ms-0", "lg:hidden": !Avo.configuration.sidebar_toggle_visible),
+        is optional and controlled by sidebar[:toggle_visible]. %>
+    <%= a_button class: class_names("shrink-0 -ms-1.5 lg:ms-0", "lg:hidden": !Avo.configuration.sidebar[:toggle_visible]),
                  size: :sm,
                  style: :text,
                  padding: :sm,

--- a/app/views/avo/partials/_sidebar_resize_handle.html.erb
+++ b/app/views/avo/partials/_sidebar_resize_handle.html.erb
@@ -1,6 +1,6 @@
 <%# Resize handle for the desktop sidebar (R1–R3, R8, R18, R20–R22).
 
-  Rendered only when Avo.configuration.sidebar_resizable is on (the S5
+  Rendered only when Avo.configuration.sidebar[:resizable] is on (the S5
   accessibility off-switch), and always with `hidden` present (R20). The
   sidebar_resize controller is the SINGLE owner of that attribute: it removes
   `hidden` on connect when the sidebar is open at >= lg, and re-adds it
@@ -18,7 +18,7 @@
   (Unit 8 makes valuenow track the drag). They are required, not optional:
   axe-core 4.12 lists aria-valuenow as a mandatory attribute of role="separator".
   With no stored width the value is the starting width — Avo's 256px unless the
-  host set Avo.configuration.sidebar_default_width. %>
+  host set Avo.configuration.sidebar[:default_width]. %>
 <% current_width = @sidebar_width || sidebar_width_default %>
 <%= tag.div "",
   class: class_names("sidebar-resize-handle", "print:hidden": Avo.configuration.hide_layout_when_printing),

--- a/app/views/avo/partials/_sidebar_width_override.html.erb
+++ b/app/views/avo/partials/_sidebar_width_override.html.erb
@@ -3,7 +3,7 @@
   <script nonce="<%= content_security_policy_nonce %>">
     // Apply the sidebar width before first paint to avoid a 256px flash (R15).
     // Both values below are produced server-side as Integers within bounds
-    // (Avo::ApplicationHelper#sidebar_width, Avo::Configuration#sidebar_default_width),
+    // (Avo::ApplicationHelper#sidebar_width, Avo::Configuration#sidebar),
     // so they are interpolated as bare JS number literals — never a string taken
     // from the cookie or from the host's initializer.
     //

--- a/app/views/layouts/avo/application.html.erb
+++ b/app/views/layouts/avo/application.html.erb
@@ -67,7 +67,7 @@
       <%# Immediately after the sidebar wrapper: after every nav link and both %>
       <%# skip links in the tab order, before the content. Must stay inside %>
       <%# .main to inherit --sidebar-offset-size, which positions it. %>
-      <%= render partial: "avo/partials/sidebar_resize_handle" if Avo.configuration.sidebar_resizable %>
+      <%= render partial: "avo/partials/sidebar_resize_handle" if Avo.configuration.sidebar[:resizable] %>
 
       <div class="flex lg:hidden">
         <%= render Avo::SidebarComponent.new sidebar_open: @sidebar_open, for_mobile: true %>

--- a/lib/avo.rb
+++ b/lib/avo.rb
@@ -37,7 +37,7 @@ module Avo
   # css/layout.css keeps a commented duplicate of the bounds.
   #
   # All three are private_constant. The BOUNDS have no host-facing knob by
-  # design. The DEFAULT does — `Avo.configuration.sidebar_default_width` — and
+  # design. The DEFAULT does — `Avo.configuration.sidebar[:default_width]` — and
   # this constant is only its fallback, so it must not become public API by
   # accident either. Reachable inside Avo via unqualified lexical lookup (e.g.
   # from Avo::Configuration and Avo::ApplicationHelper, both nested in Avo);

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -65,17 +65,7 @@ module Avo
     attr_accessor :use_stacked_fields
     attr_accessor :default_editor_url
     attr_writer :body_classes
-    attr_accessor :sidebar_toggle_visible
-    # Off-switch for the drag-to-resize sidebar handle. Drag-only resizing is a
-    # known WCAG SC 2.5.7 (Dragging Movements) gap, so a host with an AA/VPAT
-    # obligation can disable it entirely; when false the handle is neither
-    # rendered nor wired up.
-    attr_accessor :sidebar_resizable
-    # Width the desktop sidebar starts at, in pixels, before the user drags it.
-    # Only applies at >= lg: below that the sidebar is a full-height overlay, and
-    # a wide configured value would cover a phone screen, so the mobile default
-    # stays 256px regardless.
-    attr_writer :sidebar_default_width
+    attr_writer :sidebar
     attr_accessor :tailwindcss_integration_enabled
     attr_accessor :mount_lookbook
 
@@ -215,9 +205,7 @@ module Avo
       @send_metadata = true
       @use_stacked_fields = false
       @default_editor_url = "cursor://file/%{path}"
-      @sidebar_toggle_visible = true
-      @sidebar_resizable = true
-      @sidebar_default_width = SIDEBAR_WIDTH_DEFAULT
+      @sidebar = {}
       @body_classes = []
       @tailwindcss_integration_enabled = true
       @mount_lookbook = false
@@ -244,6 +232,29 @@ module Avo
       BACK_TO_TOP_DEFAULTS = {
         enabled: false,
         threshold: 64
+      }.freeze
+    end
+
+    # Sidebar.
+    #
+    # `toggle_visible` shows the navbar button that collapses the desktop
+    # sidebar. On mobile the toggle is always visible regardless.
+    #
+    # `resizable` is the off-switch for the drag-to-resize handle. Drag-only
+    # resizing is a known WCAG SC 2.5.7 (Dragging Movements) gap, so a host with
+    # an AA/VPAT obligation can disable it entirely; when false the handle is
+    # neither rendered nor wired up.
+    #
+    # `default_width` is where the desktop sidebar starts, in pixels, before the
+    # user drags it. Only applies at >= lg: below that the sidebar is a
+    # full-height overlay, and a wide configured value would cover a phone
+    # screen, so the mobile default stays 256px regardless. It is absent here and
+    # filled in by the #sidebar reader: SIDEBAR_WIDTH_DEFAULT (lib/avo.rb) isn't
+    # defined yet when this constant is evaluated at require time.
+    unless defined?(SIDEBAR_DEFAULTS)
+      SIDEBAR_DEFAULTS = {
+        toggle_visible: true,
+        resizable: true
       }.freeze
     end
 
@@ -447,16 +458,28 @@ module Avo
       Avo::ExecutionContext.new(target: @body_classes).handle
     end
 
-    # Clamped into the same [SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX] range the drag
-    # and the persisted cookie use — outside it the sidebar would start at a
-    # width the handle cannot drag back to, and aria-valuenow would sit outside
-    # its own declared min/max. Anything unparseable falls back to the built-in
-    # default rather than clamping to the minimum, so a typo does not silently
-    # ship a 200px sidebar. The bounds constants stay private (lib/avo.rb):
-    # this accessor is the only host-facing width knob.
-    def sidebar_default_width
-      Integer(@sidebar_default_width, exception: false)
-        &.clamp(SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX) || SIDEBAR_WIDTH_DEFAULT
+    # `default_width` is clamped into the same [SIDEBAR_WIDTH_MIN,
+    # SIDEBAR_WIDTH_MAX] range the drag and the persisted cookie use — outside it
+    # the sidebar would start at a width the handle cannot drag back to, and
+    # aria-valuenow would sit outside its own declared min/max. Anything
+    # unparseable falls back to the built-in default rather than clamping to the
+    # minimum, so a typo does not silently ship a 200px sidebar. The bounds
+    # constants stay private (lib/avo.rb): this hash is the only host-facing knob.
+    def sidebar
+      config = SIDEBAR_DEFAULTS.merge(@sidebar)
+      width = Integer(config[:default_width], exception: false)&.clamp(SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX)
+
+      config.merge(default_width: width || SIDEBAR_WIDTH_DEFAULT)
+    end
+
+    # Backward-compatible flat accessor — the canonical home is now
+    # `config.sidebar[:toggle_visible]`.
+    def sidebar_toggle_visible
+      sidebar[:toggle_visible]
+    end
+
+    def sidebar_toggle_visible=(value)
+      @sidebar[:toggle_visible] = value
     end
 
     def persistence

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -104,14 +104,21 @@ Avo.configure do |config|
   # }
 
   ## == Sidebar ==
-  # Width the sidebar starts at on desktop, in pixels, before a user drags it.
-  # Clamped to 200..480. Only applies at >= lg — below that the sidebar is a
-  # full-height overlay and stays 256px so it cannot cover a phone screen.
-  # config.sidebar_default_width = 256
+  # config.sidebar = {
+  #   # Show the navbar button that collapses the sidebar on desktop. On mobile
+  #   # the toggle is always visible regardless of this setting.
+  #   toggle_visible: true,
   #
-  # Set to false to remove the drag-to-resize handle entirely. Drag-only resizing
-  # is a known WCAG SC 2.5.7 gap, so hosts with an AA/VPAT obligation can opt out.
-  # config.sidebar_resizable = true
+  #   # Set to false to remove the drag-to-resize handle entirely. Drag-only
+  #   # resizing is a known WCAG SC 2.5.7 gap, so hosts with an AA/VPAT
+  #   # obligation can opt out.
+  #   resizable: true,
+  #
+  #   # Width the sidebar starts at on desktop, in pixels, before a user drags it.
+  #   # Clamped to 200..480. Only applies at >= lg — below that the sidebar is a
+  #   # full-height overlay and stays 256px so it cannot cover a phone screen.
+  #   default_width: 256
+  # }
 
   ## == Back to top button ==
   # config.back_to_top = {

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -62,7 +62,7 @@ Avo.configure do |config|
   #   show_on_hover: true
   # }
 
-  config.sidebar_toggle_visible = true
+  config.sidebar = {toggle_visible: true}
 
   # config.hotkeys = {
   #   enabled: true,

--- a/spec/lib/avo/configuration/sidebar_spec.rb
+++ b/spec/lib/avo/configuration/sidebar_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+# `config.sidebar` merges over the defaults, so setting one key must not wipe the
+# other two. Clamping of `default_width` is covered in
+# spec/requests/avo/sidebar_width_request_spec.rb.
+RSpec.describe "Avo.configuration.sidebar" do
+  around do |example|
+    original = Avo.configuration.sidebar
+    example.run
+    Avo.configuration.sidebar = original
+  end
+
+  it "fills in the keys the host didn't set" do
+    Avo.configuration.sidebar = {resizable: false}
+
+    expect(Avo.configuration.sidebar).to eq(toggle_visible: true, resizable: false, default_width: 256)
+  end
+
+  # `sidebar_toggle_visible` shipped before the hash existed.
+  it "keeps the flat sidebar_toggle_visible accessor working" do
+    Avo.configuration.sidebar_toggle_visible = false
+
+    expect(Avo.configuration.sidebar[:toggle_visible]).to be false
+    expect(Avo.configuration.sidebar_toggle_visible).to be false
+  end
+end

--- a/spec/requests/avo/sidebar_width_request_spec.rb
+++ b/spec/requests/avo/sidebar_width_request_spec.rb
@@ -161,11 +161,12 @@ RSpec.describe "Sidebar resize handle", type: :request do
   # The S5 off-switch: drag-only resizing is a known WCAG SC 2.5.7 gap, so a host
   # under an AA/VPAT obligation can remove the affordance entirely rather than
   # inherit a failure by upgrading.
-  context "with Avo.configuration.sidebar_resizable = false" do
+  context "with Avo.configuration.sidebar[:resizable] = false" do
     around do |example|
-      Avo.configuration.sidebar_resizable = false
+      original = Avo.configuration.sidebar
+      Avo.configuration.sidebar = original.merge(resizable: false)
       example.run
-      Avo.configuration.sidebar_resizable = true
+      Avo.configuration.sidebar = original
     end
 
     it "renders no handle at all" do
@@ -176,7 +177,7 @@ RSpec.describe "Sidebar resize handle", type: :request do
   end
 end
 
-# Avo.configuration.sidebar_default_width — the host-facing knob for where the
+# Avo.configuration.sidebar[:default_width] — the host-facing knob for where the
 # sidebar starts before anyone drags it. The bounds around it stay unconfigurable
 # by design; this is the only width knob.
 RSpec.describe "Sidebar default width configuration", type: :request do
@@ -187,11 +188,11 @@ RSpec.describe "Sidebar default width configuration", type: :request do
   let(:path) { "/admin/failed_to_load" }
 
   def with_default_width(value)
-    original = Avo.configuration.sidebar_default_width
-    Avo.configuration.sidebar_default_width = value
+    original = Avo.configuration.sidebar
+    Avo.configuration.sidebar = original.merge(default_width: value)
     yield
   ensure
-    Avo.configuration.sidebar_default_width = original
+    Avo.configuration.sidebar = original
   end
 
   def carrier_script
@@ -204,25 +205,25 @@ RSpec.describe "Sidebar default width configuration", type: :request do
 
   describe "clamping" do
     it "accepts a value inside the bounds" do
-      with_default_width(400) { expect(Avo.configuration.sidebar_default_width).to eq(400) }
+      with_default_width(400) { expect(Avo.configuration.sidebar[:default_width]).to eq(400) }
     end
 
     # Outside the bounds the sidebar would start at a width the handle cannot
     # drag back to, and aria-valuenow would sit outside its own min/max.
     it "clamps above the maximum and below the minimum" do
-      with_default_width(9999) { expect(Avo.configuration.sidebar_default_width).to eq(480) }
-      with_default_width(10) { expect(Avo.configuration.sidebar_default_width).to eq(200) }
+      with_default_width(9999) { expect(Avo.configuration.sidebar[:default_width]).to eq(480) }
+      with_default_width(10) { expect(Avo.configuration.sidebar[:default_width]).to eq(200) }
     end
 
     it "accepts a numeric string" do
-      with_default_width("400") { expect(Avo.configuration.sidebar_default_width).to eq(400) }
+      with_default_width("400") { expect(Avo.configuration.sidebar[:default_width]).to eq(400) }
     end
 
     # A typo must not silently ship a 200px sidebar, which is what clamping an
     # unparseable value would do.
     it "falls back to 256 rather than the minimum for an unusable value" do
-      with_default_width("wide") { expect(Avo.configuration.sidebar_default_width).to eq(256) }
-      with_default_width(nil) { expect(Avo.configuration.sidebar_default_width).to eq(256) }
+      with_default_width("wide") { expect(Avo.configuration.sidebar[:default_width]).to eq(256) }
+      with_default_width(nil) { expect(Avo.configuration.sidebar[:default_width]).to eq(256) }
     end
   end
 

--- a/spec/system/avo/group_1/sidebar_resize_spec.rb
+++ b/spec/system/avo/group_1/sidebar_resize_spec.rb
@@ -743,7 +743,7 @@ RSpec.describe "sidebar resize drag (Units 6-7)", type: :system do
   end
 end
 
-# Avo.configuration.sidebar_default_width in the browser: the configured width has
+# Avo.configuration.sidebar[:default_width] in the browser: the configured width has
 # to reach the rendered layout, stay subordinate to a dragged width, and — the
 # part worth a spec — NOT leak below lg, where the sidebar is a full-height
 # overlay and a wide value would cover the screen.
@@ -752,10 +752,10 @@ RSpec.describe "sidebar default width configuration (browser)", type: :system do
   let(:index_path) { "/admin/resources/users" }
 
   around do |example|
-    original = Avo.configuration.sidebar_default_width
-    Avo.configuration.sidebar_default_width = 400
+    original = Avo.configuration.sidebar
+    Avo.configuration.sidebar = original.merge(default_width: 400)
     example.run
-    Avo.configuration.sidebar_default_width = original
+    Avo.configuration.sidebar = original
   end
 
   def visit_avo(width:, height: 900, cookies: {})

--- a/spec/system/avo/group_1/sidebar_spec.rb
+++ b/spec/system/avo/group_1/sidebar_spec.rb
@@ -64,12 +64,12 @@ RSpec.describe "sidebar", type: :system do
     end
   end
 
-  context "when sidebar_toggle_visible is false" do
+  context "when sidebar[:toggle_visible] is false" do
     around do |example|
-      original = Avo.configuration.sidebar_toggle_visible
-      Avo.configuration.sidebar_toggle_visible = false
+      original = Avo.configuration.sidebar
+      Avo.configuration.sidebar = original.merge(toggle_visible: false)
       example.run
-      Avo.configuration.sidebar_toggle_visible = original
+      Avo.configuration.sidebar = original
     end
 
     it "hides the desktop toggle but keeps mobile access" do


### PR DESCRIPTION
`sidebar_toggle_visible`, `sidebar_resizable` and `sidebar_default_width` become one hash merged over defaults — the same shape as `back_to_top`, `hotkeys` and `associations`.

```ruby
config.sidebar = {
  toggle_visible: true, # navbar collapse button on desktop
  resizable: true,      # drag-to-resize handle
  default_width: 256    # clamped 200..480; unparseable falls back to 256
}
```

### Backward compatibility

`sidebar_toggle_visible` shipped in 4.0.19 and is documented, so it stays as a flat accessor writing into the hash. `sidebar_resizable` and `sidebar_default_width` landed after the last release (#4665, unreleased), so they're removed outright with no shim.

### Notes

`default_width` is deliberately absent from `SIDEBAR_DEFAULTS`: `SIDEBAR_WIDTH_DEFAULT` (lib/avo.rb) isn't defined when that constant is evaluated at require time, so the `#sidebar` reader supplies it alongside the clamp. Same require-time trap the `ASSOCIATIONS_DEFAULTS` comment already warns about.

Docs PR: avo-hq/docs.avohq.io#588

### Verification

- `spec/requests/avo/sidebar_width_request_spec.rb` + `spec/helpers/avo/application_helper_spec.rb` — 70 examples, 0 failures
- `spec/system/avo/group_1/sidebar_spec.rb` + `sidebar_resize_spec.rb` — 51 examples, 0 failures
- New `spec/lib/avo/configuration/sidebar_spec.rb` covering partial-hash merge and the back-compat accessor
- standardrb clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public initializer API for sidebar behavior; hosts on unreleased flat keys must migrate, though documented `sidebar_toggle_visible` still works and runtime behavior is covered by extensive sidebar specs.
> 
> **Overview**
> Consolidates **`sidebar_toggle_visible`**, **`sidebar_resizable`**, and **`sidebar_default_width`** into one host-facing **`config.sidebar`** hash with **`toggle_visible`**, **`resizable`**, and **`default_width`**, aligned with other grouped options such as **`back_to_top`** and **`hotkeys`**.
> 
> **`Avo::Configuration`** now stores **`@sidebar`**, merges **`SIDEBAR_DEFAULTS`**, and exposes a **`#sidebar`** reader that still **clamps** **`default_width`** (200–480, unparseable → 256). **`default_width`** is omitted from the frozen defaults constant and filled in the reader because **`SIDEBAR_WIDTH_DEFAULT`** is not available at require time.
> 
> Call sites in **views**, **helpers**, **layout CSS comments**, and **sidebar resize JS** read **`Avo.configuration.sidebar[:…]`** instead of the old accessors. The **generator initializer** and **dummy app** use the hash shape.
> 
> **Backward compatibility:** documented **`sidebar_toggle_visible`** remains as flat getter/setter that read/write **`sidebar[:toggle_visible]`**. **`sidebar_resizable`** and **`sidebar_default_width`** are removed with no shim (treated as unreleased).
> 
> Adds **`spec/lib/avo/configuration/sidebar_spec.rb`** for partial-hash merge and the toggle accessor; request/system sidebar specs are updated to set config via **`sidebar.merge(...)`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf7e8e5b1982d3486ce1342f7300e8ee53ef0a09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->