### PR TITLE
fix(i18n): trust resource name on the index create button

### DIFF
--- a/app/components/avo/views/resource_index_component.html.erb
+++ b/app/components/avo/views/resource_index_component.html.erb
@@ -62,7 +62,7 @@
         <% end %>
 
         <% header.with_controls do %>
-          <% @resource.render_index_controls(item: singular_resource_name.downcase).each do |control| %>
+          <% @resource.render_index_controls(item: singular_resource_name).each do |control| %>
             <%= render_control control %>
           <% end %>
         <% end %>

--- a/app/components/avo/views/resource_index_component.rb
+++ b/app/components/avo/views/resource_index_component.rb
@@ -97,13 +97,16 @@ class Avo::Views::ResourceIndexComponent < Avo::ResourceComponent
     )
   end
 
+  # Feeds the "%{item}" interpolation in the index create/attach buttons, so it
+  # returns the sentence form: a translated name stays verbatim, a generated one
+  # is lowercased. The buttons upcase_first the sentence.
   def singular_resource_name
     if @reflection.present?
-      return name.singularize if field.present?
+      return field.sentence_name.singularize if field.present?
 
-      reflection_resource.name
+      reflection_resource.sentence_name
     else
-      @resource.singular_name || @resource.model_class.model_name.name.downcase
+      @resource.sentence_name.presence || @resource.model_class.model_name.name.downcase
     end
   end
 

--- a/lib/avo/resources/controls/attach_button.rb
+++ b/lib/avo/resources/controls/attach_button.rb
@@ -6,7 +6,9 @@ module Avo
           super
 
           if args[:item].present?
-            @label = I18n.t("avo.attach_item", item: args[:item]) if label.nil?
+            # upcase_first because locales like de put the item first
+            # ("%{item} anhängen"); the interpolated name stays as translated.
+            @label = I18n.t("avo.attach_item", item: args[:item]).upcase_first if label.nil?
           end
         end
       end

--- a/lib/avo/resources/controls/create_button.rb
+++ b/lib/avo/resources/controls/create_button.rb
@@ -6,7 +6,11 @@ module Avo
           super
 
           if args[:item].present?
-            @label = I18n.t("avo.create_new_item", item: args[:item].humanize(capitalize: false)) if label.nil?
+            # upcase_first, not humanize: the item is already the sentence form
+            # (translation verbatim, generated fallback lowercased), and locales
+            # like de put it first ("%{item} hinzufügen"), so only the sentence's
+            # initial is cased -- the interpolated name stays as translated.
+            @label = I18n.t("avo.create_new_item", item: args[:item]).upcase_first if label.nil?
           end
         end
       end

--- a/spec/features/avo/i18n_spec.rb
+++ b/spec/features/avo/i18n_spec.rb
@@ -139,6 +139,12 @@ RSpec.feature "i18n", type: :feature do
       expect(page).to have_text("Create new API Product")
     end
 
+    it "interpolates the translated resource name into the index create button" do
+      visit avo.resources_products_path
+
+      expect(page).to have_link("Create new API Product")
+    end
+
     it "still capitalizes Avo's own chrome strings" do
       visit avo.new_resources_product_path
 

--- a/spec/features/avo/localization_spec.rb
+++ b/spec/features/avo/localization_spec.rb
@@ -5,7 +5,9 @@ RSpec.feature "Localization spec", type: :feature do
     it "translates the resource name on the create button" do
       visit avo.resources_products_path(force_locale: :pt)
 
-      expect(page).to have_text "Criar novo produto"
+      # The pt fixture defines the product name as "Produto", so it is used
+      # verbatim -- the create button no longer downcases the first word.
+      expect(page).to have_text "Criar novo Produto"
     end
   end
 end


### PR DESCRIPTION
# Description

Follow-up to #4639. That PR made Avo render resolved resource and field translations verbatim, but one surface was missed: the **create button on the resource index page**.

For a resource translated `"API Product"`, the index create button rendered **`Create new api product`**. The name was downcased twice on the way to the button — once at the call site (`singular_resource_name.downcase`) and again inside the control (`humanize(capitalize: false)`) — so the casing this contract is meant to preserve was destroyed. Every other create/heading surface already trusted the translation.

# Fix

The item now flows through `sentence_name` (a translated name verbatim, a generated one lowercased), and the create/attach controls `upcase_first` the whole interpolated sentence. This mirrors exactly what `Avo::Resources::Base#default_panel_name` already does for the new-page heading, so the index button and the new-page heading finally agree.

| File | Change |
| --- | --- |
| `lib/avo/resources/controls/create_button.rb` | `humanize(capitalize: false)` on the item → `upcase_first` on the sentence |
| `lib/avo/resources/controls/attach_button.rb` | `upcase_first` on the sentence (the same item feeds it; de/nl/ja/tr put the item first) |
| `app/components/avo/views/resource_index_component.rb` | `singular_resource_name` returns the sentence form via `sentence_name` |
| `app/components/avo/views/resource_index_component.html.erb` | drop the `.downcase` at the call site |

`upcase_first` (not `humanize`) is the right tool: locales like `de` interpolate the item first (`"%{item} hinzufügen"`), so only the sentence's initial is cased while the interpolated name stays exactly as translated.

# Behavior

| Locale / translation | Before | After |
| --- | --- | --- |
| en, `"API Product"` | `Create new api product` | `Create new API Product` |
| en, no translation (generated) | `Create new post` | `Create new post` (unchanged) |
| pt, `"Produto"` | `Criar novo produto` | `Criar novo Produto` |

The generated-fallback path is unchanged, so association create buttons (`Create new post`, `Attach post`) keep their existing lowercased-noun rendering.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (not applicable — behavior now matches the contract already documented for #4639)
- [x] I have added tests that prove my fix is effective
- [ ] I tested the design in Light and Dark mode (not applicable — text casing only)

# Tests

- `spec/features/avo/i18n_spec.rb` — new example asserting the index create button renders `Create new API Product` verbatim (fails before this change, passes after).
- `spec/features/avo/localization_spec.rb` — the pt example now expects `Criar novo Produto`. The pt fixture defines the product name as `"Produto"`, so under the verbatim contract it renders capitalized. This is the same flip #4639 made for the lowercase `cursos` courses fixture, applied to a capitalized fixture.

Verified against a `main` baseline on the same machine: zero new failures across `spec/features spec/requests`. The association create/attach specs (`has_many_field`, `multiple_resources`, `use_resource`) stay green. `spec/components` green; StandardRB and erb-lint clean.