### PR TITLE
feat: add Avo.plugin_manager.register_configuration

### DIFF
--- a/lib/avo/plugin_manager.rb
+++ b/lib/avo/plugin_manager.rb
@@ -96,11 +96,15 @@ module Avo
       name = name.to_sym
       @configuration_namespaces ||= {}
 
-      # Guard against a plugin silently shadowing a core option (or another
-      # plugin's namespace). Re-registering the same namespace is fine — boot
-      # runs more than once.
-      if !@configuration_namespaces.key?(name) && Avo::Configuration.method_defined?(name)
+      # Guard against a plugin silently shadowing a core option or another
+      # plugin's namespace. Re-registering the same namespace with the same
+      # class is fine — boot runs more than once.
+      existing = @configuration_namespaces[name]
+      if existing.nil? && Avo::Configuration.method_defined?(name)
         raise ArgumentError, "Avo::Configuration already defines ##{name}; pick a different configuration namespace."
+      end
+      if !existing.nil? && existing != klass
+        raise ArgumentError, "Configuration namespace :#{name} is already registered with #{existing}; pick a different namespace."
       end
 
       @configuration_namespaces[name] = klass

--- a/lib/avo/plugin_manager.rb
+++ b/lib/avo/plugin_manager.rb
@@ -79,6 +79,41 @@ module Avo
       Avo::Menu::Builder.register_item(name, &block)
     end
 
+    # Register a plugin's configuration namespace on Avo::Configuration so host
+    # apps configure the plugin from config/initializers/avo.rb:
+    #
+    #   Avo.plugin_manager.register_configuration :intelligence, Avo::Intelligence::Configuration
+    #
+    #   Avo.configure do |config|
+    #     config.intelligence.thinking_effort = "medium"
+    #   end
+    #
+    # Call it at require time, not from an :avo_boot hook — the host's avo.rb
+    # initializer reads the accessor, and initializers run before Avo.boot.
+    # Instances are memoized per Configuration object, so replacing
+    # Avo.configuration resets plugin configs along with everything else.
+    def register_configuration(name, klass)
+      name = name.to_sym
+      @configuration_namespaces ||= {}
+
+      # Guard against a plugin silently shadowing a core option (or another
+      # plugin's namespace). Re-registering the same namespace is fine — boot
+      # runs more than once.
+      if !@configuration_namespaces.key?(name) && Avo::Configuration.method_defined?(name)
+        raise ArgumentError, "Avo::Configuration already defines ##{name}; pick a different configuration namespace."
+      end
+
+      @configuration_namespaces[name] = klass
+
+      Avo::Configuration.define_method(name) do
+        (@plugin_configurations ||= {})[name] ||= klass.new
+      end
+
+      Avo::Configuration.define_method(:"#{name}=") do |value|
+        (@plugin_configurations ||= {})[name] = value
+      end
+    end
+
     def register_resource_tool
     end
 

--- a/spec/lib/avo/plugin_manager_spec.rb
+++ b/spec/lib/avo/plugin_manager_spec.rb
@@ -103,4 +103,60 @@ RSpec.describe Avo::PluginManager do
       expect { manager.mount_engine(engine_b, at: "/b") }.not_to raise_error
     end
   end
+
+  describe "#register_configuration" do
+    let(:config_class) do
+      Class.new do
+        attr_accessor :thinking_effort
+      end
+    end
+
+    after do
+      if Avo::Configuration.method_defined?(:my_plugin)
+        Avo::Configuration.remove_method(:my_plugin)
+        Avo::Configuration.remove_method(:my_plugin=)
+      end
+    end
+
+    it "defines a memoized namespace accessor on Avo::Configuration" do
+      manager.register_configuration :my_plugin, config_class
+
+      configuration = Avo::Configuration.new
+      configuration.my_plugin.thinking_effort = "high"
+
+      expect(configuration.my_plugin).to be_a(config_class)
+      expect(configuration.my_plugin.thinking_effort).to eq("high")
+      expect(configuration.my_plugin).to equal(configuration.my_plugin)
+    end
+
+    it "memoizes per Configuration instance, so replacing Avo.configuration resets plugin configs" do
+      manager.register_configuration :my_plugin, config_class
+
+      one = Avo::Configuration.new
+      two = Avo::Configuration.new
+
+      expect(one.my_plugin).not_to equal(two.my_plugin)
+    end
+
+    it "allows assigning a whole configuration object" do
+      manager.register_configuration :my_plugin, config_class
+
+      configuration = Avo::Configuration.new
+      replacement = config_class.new
+      configuration.my_plugin = replacement
+
+      expect(configuration.my_plugin).to equal(replacement)
+    end
+
+    it "raises when the namespace would shadow an existing option" do
+      expect { manager.register_configuration :appearance, config_class }
+        .to raise_error(ArgumentError, /already defines/)
+    end
+
+    it "allows re-registering the same namespace across boots" do
+      manager.register_configuration :my_plugin, config_class
+
+      expect { manager.register_configuration :my_plugin, config_class }.not_to raise_error
+    end
+  end
 end

--- a/spec/lib/avo/plugin_manager_spec.rb
+++ b/spec/lib/avo/plugin_manager_spec.rb
@@ -158,5 +158,14 @@ RSpec.describe Avo::PluginManager do
 
       expect { manager.register_configuration :my_plugin, config_class }.not_to raise_error
     end
+
+    it "raises when a different class tries to claim an already-registered namespace" do
+      manager.register_configuration :my_plugin, config_class
+
+      other_class = Class.new
+      expect { manager.register_configuration :my_plugin, other_class }
+        .to raise_error(ArgumentError, /already registered/)
+      expect(Avo::Configuration.new.my_plugin).to be_a(config_class)
+    end
   end
 end


### PR DESCRIPTION
## What

Adds a registration API for plugin configuration namespaces, alongside `register_field` / `register_view_type`:

```ruby
# in the plugin gem, at require time
Avo.plugin_manager.register_configuration :intelligence, Avo::Intelligence::Configuration
```

Host apps then configure the plugin from the main Avo initializer instead of a per-gem one:

```ruby
Avo.configure do |config|
  config.intelligence.thinking_effort = "medium"
  config.intelligence.thinking_budget = 2048
end
```

The namespace object is whatever class the plugin registers, so any value shape works — strings, booleans, hashes, lambdas.

## Design notes

- **Memoized per `Configuration` instance** — replacing `Avo.configuration` resets plugin configs along with everything else.
- **Shadow guard** — registering a namespace that would override an existing `Avo::Configuration` method (e.g. `appearance`) raises `ArgumentError`. Re-registering the same namespace is allowed since boot runs more than once.
- **A writer is defined too** (`config.intelligence = MyConfig.new`), mainly useful for resetting in tests.
- Must be called at require time, not in an `:avo_boot` hook — host initializers run before `Avo.boot`, and the accessor has to exist when `config/initializers/avo.rb` reads it. This mirrors how the nested `config.appearance` object already works.

First consumer: avo-intelligence (avo-hq/workspace#105).

## Testing

New examples in `spec/lib/avo/plugin_manager_spec.rb` covering memoization, per-instance isolation, assignment, the shadow guard, and re-registration. 13 examples, 0 failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dynamically defines methods on Avo::Configuration at load time; mis-timed or conflicting registrations could break host initializers, though shadow and duplicate-class checks limit silent overrides.
> 
> **Overview**
> Adds **`Avo.plugin_manager.register_configuration`** so gems can expose a nested config object on **`Avo::Configuration`** (e.g. `config.intelligence.thinking_effort` in `config/initializers/avo.rb`) instead of separate per-gem initializers.
> 
> Registration defines a memoized reader and writer on **`Avo::Configuration`**, keyed per configuration instance via `@plugin_configurations`. **ArgumentError** is raised if the namespace would shadow an existing core option (e.g. `appearance`) or if another class already owns the same namespace; re-registering the same name and class is allowed for repeated boots.
> 
> Specs in **`plugin_manager_spec.rb`** cover memoization, per-instance isolation, whole-object assignment, shadowing, re-registration, and conflicting class registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e353dd6ba16c91a01d8c701821834a1cf190b0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->