### PR TITLE
docs: recommend an engine initializer for register_configuration

### DIFF
--- a/lib/avo/plugin_manager.rb
+++ b/lib/avo/plugin_manager.rb
@@ -88,8 +88,9 @@ module Avo
     #     config.intelligence.thinking_effort = "medium"
     #   end
     #
-    # Call it at require time, not from an :avo_boot hook — the host's avo.rb
-    # initializer reads the accessor, and initializers run before Avo.boot.
+    # Call it from an engine initializer ordered `before: :load_config_initializers`
+    # (or at require time) — the host's avo.rb reads the accessor, so it must be
+    # defined before config/initializers run. An :avo_boot hook is too late.
     # Instances are memoized per Configuration object, so replacing
     # Avo.configuration resets plugin configs along with everything else.
     def register_configuration(name, klass)


### PR DESCRIPTION
Follow-up to #4676 (comment-only). The doc comment said to call `register_configuration` at require time; the idiomatic call site is an engine initializer ordered `before: :load_config_initializers` — which is how avo-intelligence now consumes it (avo-hq/workspace#105). Require time still works; `:avo_boot` is too late either way.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only documentation update with no code or configuration behavior changes.
> 
> **Overview**
> **Documentation-only** change to the `register_configuration` comment in `plugin_manager.rb`.
> 
> The guidance now tells plugin authors to call **`register_configuration` from a Rails engine initializer ordered `before: :load_config_initializers`** (or still at require time), because the host app’s `config/initializers/avo.rb` needs the `config.<namespace>` accessor **before** initializers run. It also clarifies that registering on an **`:avo_boot` hook is too late** for that flow.
> 
> No runtime behavior changes—only when/how integrators are advised to register plugin configuration namespaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4cbf4013cc731509cc3dd29e3e237296c4e15a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->