### PR TITLE
fix(assets): let the host app's Tailwind build win avo/application.css under Sprockets

### DIFF
--- a/lib/avo/engine.rb
+++ b/lib/avo/engine.rb
@@ -144,6 +144,23 @@ module Avo
         if defined?(::Sprockets)
           # Tell sprockets where your assets are located
           app.config.assets.precompile += %w[avo_manifest.js]
+
+          # Listed after avo_manifest.js on purpose. When the Tailwind integration is on, the
+          # app builds its own app/assets/builds/avo/application.css to replace the stock one
+          # we ship — but our avo_manifest.js and the app's manifest.js both `link_tree
+          # ../builds`, so two different files compile under the logical path
+          # avo/application.css and Sprockets keeps whichever it wrote last. Since we append
+          # our manifest after the app's, ours used to win and production served a stylesheet
+          # with none of the app's utilities in it. Silently: the build succeeded, the file was
+          # right there, and only the precompiled manifest pointed elsewhere.
+          #
+          # Naming the logical path here compiles it once more, last, and Sprockets resolves it
+          # through the load path — which picks the app's build when it has one (its
+          # app/assets/builds precedes ours) and our stock file when it doesn't. That also
+          # covers apps whose manifest.js doesn't link ../builds at all.
+          #
+          # Propshaft resolves through the load path to begin with, so it was never affected.
+          app.config.assets.precompile += %w[avo/application.css]
         end
       end
     end


### PR DESCRIPTION
On **Sprockets**, apps using the Tailwind integration are served our stock stylesheet in production instead of the one they build — so every utility compiled from their own source silently does nothing. Nothing errors: the build runs and writes a correct file, precompile just ships a different one.

Our `avo_manifest.js` and the app's `manifest.js` both `link_tree ../builds`, so two different files compile under the logical path `avo/application.css`. Sprockets keeps whichever it wrote last, and `initializer "avo.assets"` appends ours after the app's.

**Propshaft was never affected** — it resolves through the load path, where the app's build already wins. Dev is fine on Sprockets too, for the same reason. Only the precompiled manifest gets it wrong.

## Fix

```ruby
app.config.assets.precompile += %w[avo_manifest.js]
app.config.assets.precompile += %w[avo/application.css]
```

Naming the logical path last compiles it once more; Sprockets resolves it through the load path, picking the app's build when it has one and our stock file when it doesn't. Correct both ways, no conditionals. Also covers apps whose `manifest.js` doesn't link `../builds`.

## Verified

`audit-logging.avodemo.com` is affected today (Sprockets, `tailwindcss-rails 4.4.0`). Same app, only the avo version changed:

| | manifest serves |
| --- | --- |
| avo 4.0.9 | 365,047 — our stock CSS ❌ |
| this branch | 347,259 — the app's own build ✅ |
| this branch, integration off | 365,047 — our stock CSS ✅ |

Also reproduced before/after on avohq.io.

**No spec** — our dummy app runs Propshaft, so it can't exercise this path.
