### PR TITLE
Inline search for popover dropdowns

### DIFF
--- a/app/assets/stylesheets/css/components/ui/dropdown.css
+++ b/app/assets/stylesheets/css/components/ui/dropdown.css
@@ -60,6 +60,61 @@
   @apply flex flex-col items-start self-stretch px-1;
 }
 
+/* ==========================================================================
+   Inline search (DropdownComponent searchable:)
+   A filter input pinned above the list; the popover-menu controller hides
+   non-matching items and reveals the empty state.
+
+   Styled as a command-palette header row (the familiar Linear/Raycast shape):
+   full-bleed input, the bottom border is the only field chrome, and the icon,
+   text, and empty state sit on the same column grid as the menu items below.
+   ========================================================================== */
+
+.dropdown-menu__search {
+  @apply self-stretch border-b border-tertiary;
+  /* Line the search row up with the items: icon starts where item icons do
+     (list px + item px), same icon size, same icon-to-text gap. The
+     search-input prefix position and input padding both derive from these. */
+  --input-icon-offset: --spacing(3);
+  --input-icon-size: --spacing(4);
+  --input-icon-gap: --spacing(1.5);
+  min-inline-size: 14rem;
+}
+
+.dropdown-menu__search .search-input__input {
+  @apply w-full h-9 rounded-none border-none bg-transparent text-sm text-content;
+}
+
+.dropdown-menu__search .search-input__input::placeholder {
+  color: var(--color-content-secondary);
+}
+
+/* The input is auto-focused on open and the caret shows position — a boxy
+   ring around a full-bleed row reads as noise, not focus. */
+.dropdown-menu__search .search-input__input:focus-visible {
+  outline: none;
+}
+
+/* Forced-colors mode still needs a visible focus indicator. */
+@media (forced-colors: active) {
+  .dropdown-menu__search .search-input__input:focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
+}
+
+/* Empty state text sits on the item-label column, under the input text. */
+.dropdown-menu__search-empty {
+  @apply m-0 py-2 text-sm text-content-secondary;
+  padding-inline: calc(--spacing(3) + --spacing(4) + --spacing(1.5)) --spacing(3);
+}
+
+/* Filtered-out items are hidden with the `hidden` attribute; the item rules
+   below apply `display: flex`, which would otherwise win over the UA style. */
+.dropdown-menu__list :is(a, button)[hidden] {
+  display: none;
+}
+
 /* The `a`/`button` selectors style real menu items, but a dropdown can also host
    a `.dropdown-card` (see the `:has(.dropdown-card)` block above). Controls inside
    that card — e.g. a footer action button — are not menu items, so exclude them and

--- a/app/components/avo/u_i/dropdown_component.html.erb
+++ b/app/components/avo/u_i/dropdown_component.html.erb
@@ -9,11 +9,26 @@
         class: class_names("popover-menu__panel", @classes),
         data: {controller: "popover-menu"} do %>
         <div class="dropdown-menu">
+          <% if @searchable %>
+            <div class="dropdown-menu__search search-input">
+              <input type="search"
+                     class="search-input__input"
+                     placeholder="<%= search_placeholder %>"
+                     aria-label="<%= search_placeholder %>"
+                     autocomplete="off"
+                     data-popover-menu-target="searchInput"
+                     data-action="input->popover-menu#filter">
+              <span class="search-input__prefix" aria-hidden="true"><%= helpers.svg "tabler/outline/search" %></span>
+            </div>
+          <% end %>
           <div class="dropdown-menu__group">
             <div class="dropdown-menu__list">
               <%= items %>
             </div>
           </div>
+          <% if @searchable %>
+            <p class="dropdown-menu__search-empty" data-popover-menu-target="empty" hidden>No matching options</p>
+          <% end %>
         </div>
       <% end %>
     <% end %>

--- a/app/components/avo/u_i/dropdown_component.rb
+++ b/app/components/avo/u_i/dropdown_component.rb
@@ -7,6 +7,10 @@ class Avo::UI::DropdownComponent < Avo::BaseComponent
   prop :open, default: false
   prop :dropdown_menu_classes, default: ""
   prop :popover_mode, default: false
+  # Renders a filter input above the items that narrows them as the user types
+  # (client-side, over the rendered items). Popover mode only.
+  prop :searchable, default: false
+  prop :search_placeholder
 
   renders_one :trigger
   renders_one :items
@@ -19,6 +23,10 @@ class Avo::UI::DropdownComponent < Avo::BaseComponent
 
   def popover_id
     @popover_id ||= "popover-#{SecureRandom.hex(3)}"
+  end
+
+  def search_placeholder
+    @search_placeholder || I18n.t("avo.search.placeholder", default: "Search")
   end
 
   def data

--- a/app/javascript/js/controllers/popover_menu_controller.js
+++ b/app/javascript/js/controllers/popover_menu_controller.js
@@ -1,6 +1,8 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
+  static targets = ['searchInput', 'empty']
+
   // Used by both onToggle (auto-focus) and handleKeydown (arrow navigation).
   get focusableItems() {
     return [...this.element.querySelectorAll('a, button')].filter(
@@ -25,9 +27,19 @@ export default class extends Controller {
   onToggle(event) {
     if (event.newState !== 'open') return
 
+    // Each open starts unfiltered — a leftover query from the last visit would
+    // silently hide items.
+    if (this.hasSearchInputTarget) this.resetFilter()
+
     // requestAnimationFrame ensures the popover is fully rendered before we focus.
     // Focusing before the browser paints causes the scroll to jump in some cases.
     requestAnimationFrame(() => {
+      // A searchable menu hands focus to its filter input so the user can just type.
+      if (this.hasSearchInputTarget) {
+        this.searchInputTarget.focus()
+        return
+      }
+
       const items = this.focusableItems
       if (items.length === 0) return
 
@@ -38,24 +50,46 @@ export default class extends Controller {
     })
   }
 
+  // Narrows the rendered items to those whose text matches the query. Items are
+  // queried at call time (not cached) so lazily loaded content — e.g. a
+  // turbo-frame inside the list — is filterable as soon as it arrives. An item
+  // carrying data-filter-text matches on that instead of its full text, so
+  // decorations (timestamps, tags) don't count as matches.
+  filter() {
+    const query = this.searchInputTarget.value.trim().toLowerCase()
+    let anyVisible = false
+
+    this.element.querySelectorAll('.dropdown-menu__list a, .dropdown-menu__list button').forEach((item) => {
+      const text = item.dataset.filterText ?? item.textContent
+      const match = query === '' || text.replace(/\s+/g, ' ').trim().toLowerCase().includes(query)
+      item.hidden = !match
+      if (match) anyVisible = true
+    })
+
+    if (this.hasEmptyTarget) this.emptyTarget.hidden = anyVisible || query === ''
+  }
+
+  resetFilter() {
+    this.searchInputTarget.value = ''
+    this.filter()
+  }
+
   handleKeydown(event) {
     // The keydown listener is always attached, so guard against firing when closed.
     if (!this.element.matches(':popover-open')) return
 
-    const items = this.focusableItems
-    if (items.length === 0) return
-
-    const idx = items.indexOf(document.activeElement)
-
     switch (event.key) {
       case 'ArrowDown':
+      case 'ArrowUp': {
+        const items = this.focusableItems
+        if (items.length === 0) return
+
         event.preventDefault()
-        items[idx < items.length - 1 ? idx + 1 : 0].focus()
+        const idx = items.indexOf(document.activeElement)
+        if (event.key === 'ArrowDown') items[idx < items.length - 1 ? idx + 1 : 0].focus()
+        else items[idx > 0 ? idx - 1 : items.length - 1].focus()
         break
-      case 'ArrowUp':
-        event.preventDefault()
-        items[idx > 0 ? idx - 1 : items.length - 1].focus()
-        break
+      }
       case 'Escape':
         // Close on Escape ourselves. Native popover light-dismiss is unreliable
         // here because other document-level keydown handlers (e.g. the index-row
@@ -63,7 +97,13 @@ export default class extends Controller {
         // also reacting; hidePopover restores focus to the trigger.
         event.preventDefault()
         event.stopPropagation()
-        this.element.hidePopover()
+        // With a non-empty search query the first Escape only clears it; the next closes.
+        if (this.hasSearchInputTarget && this.searchInputTarget.value !== '') {
+          this.resetFilter()
+          this.searchInputTarget.focus()
+        } else {
+          this.element.hidePopover()
+        }
         break
       default:
     }

--- a/spec/components/avo/u_i/dropdown_component_spec.rb
+++ b/spec/components/avo/u_i/dropdown_component_spec.rb
@@ -33,5 +33,24 @@ RSpec.describe Avo::UI::DropdownComponent, type: :component do
       expect(page).to have_css(".dropdown-menu__list", text: "First")
       expect(page).to have_css(".dropdown-menu__list", text: "Second")
     end
+
+    it "renders a search input and empty state when searchable in popover mode" do
+      render_inline(described_class.new(popover_mode: true, searchable: true)) do |component|
+        component.with_trigger { "Trigger" }
+        component.with_items { "Item" }
+      end
+
+      expect(page).to have_css('.dropdown-menu__search input[data-popover-menu-target="searchInput"][placeholder="Search"]')
+      expect(page).to have_css('.dropdown-menu__search-empty[data-popover-menu-target="empty"][hidden]', visible: :hidden)
+    end
+
+    it "does not render a search input when not searchable" do
+      render_inline(described_class.new(popover_mode: true)) do |component|
+        component.with_trigger { "Trigger" }
+        component.with_items { "Item" }
+      end
+
+      expect(page).not_to have_css(".dropdown-menu__search")
+    end
   end
 end

--- a/spec/dummy/test/components/previews/u_i/dropdown_component_preview.rb
+++ b/spec/dummy/test/components/previews/u_i/dropdown_component_preview.rb
@@ -37,6 +37,11 @@ module UI
     def default
       render_with_template(template: "u_i/dropdown_component_preview/default")
     end
+
+    # Popover dropdown with an inline search input that filters the items
+    def searchable
+      render_with_template(template: "u_i/dropdown_component_preview/searchable")
+    end
     # @!endgroup
   end
 end

--- a/spec/dummy/test/components/previews/u_i/dropdown_component_preview/searchable.html.erb
+++ b/spec/dummy/test/components/previews/u_i/dropdown_component_preview/searchable.html.erb
@@ -1,0 +1,18 @@
+<div class="border-2 border-gray-200 rounded-md p-4 w-96 flex justify-center items-center">
+  <%= render Avo::UI::DropdownComponent.new(popover_mode: true, searchable: true) do |component| %>
+    <% component.with_trigger do %>
+      <button type="button"
+              class="inline-flex items-center justify-center rounded-md p-1 cursor-pointer"
+              popovertarget="<%= component.popover_id %>"
+              aria-haspopup="menu"
+              aria-label="Fruits">
+        <%= svg "tabler/outline/dots-vertical" %>
+      </button>
+    <% end %>
+    <% component.with_items do %>
+      <% %w[Apple Avocado Banana Cherry Mango Peach Pear Plum].each do |fruit| %>
+        <%= button_tag(fruit, type: "button") %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>


### PR DESCRIPTION
## Description

Adds an opt-in inline search row to `Avo::UI::DropdownComponent` (popover mode):

```erb
<%= render Avo::UI::DropdownComponent.new(popover_mode: true, searchable: true, search_placeholder: "Search chats…") do |component| %>
```

- Command-palette-style header row: full-bleed input, bottom border as the only chrome, icon/text aligned to the item column grid, no boxy focus ring (forced-colors mode keeps a visible outline).
- `popover-menu` controller filters items as the user types, focuses the input on open, resets the query on each open, and Escape clears a non-empty query before a second Escape closes.
- Items are queried at filter time, so lazily loaded content (e.g. a turbo-frame inside the list) is searchable when it arrives.
- An item carrying `data-filter-text` matches on that instead of its full text, so decorations (timestamps, tags) don't count as matches.
- `[hidden]` display guard for filtered items (item rules apply `display: flex`, which would beat the UA style).

First consumer: avo-intelligence's recent-chats menu (separate PR in the workspace repo, depends on this one).

## Checklist

- [x] Component specs (searchable rendering, default placeholder, non-searchable unchanged)
- [x] Lookbook preview (`searchable`)
- [x] Verified in the browser (dark/light, keyboard nav, Escape behavior, empty state)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in UI and client-side filtering in popover dropdowns only; no auth, data, or server-side behavior changes.
> 
> **Overview**
> Adds an **opt-in** `searchable:` mode to `Avo::UI::DropdownComponent` when `popover_mode: true`, with optional `search_placeholder` (defaults via I18n).
> 
> Popover menus get a command-palette-style filter row above the list; the **`popover-menu`** Stimulus controller filters list `a`/`button` items as the user types (including lazily loaded list content), honors optional `data-filter-text` on items, resets the query on each open, focuses the search input on open, and uses **Escape** to clear a non-empty query before closing. A “No matching options” empty state appears when nothing matches.
> 
> **CSS** aligns the search row with item columns, suppresses the default focus ring (with forced-colors fallback), and forces `[hidden]` items to `display: none` so flex item styles don’t show filtered rows.
> 
> Component specs and a Lookbook **`searchable`** preview document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc257b3075b805adc547492e7f6fee0240041f3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->