### PR TITLE
fix: keep the tab group aligned with sibling panels inside the create modal

### DIFF
--- a/app/assets/stylesheets/css/components/modal.css
+++ b/app/assets/stylesheets/css/components/modal.css
@@ -170,7 +170,7 @@
 }
 
 .modal__body-content {
-  @apply w-full min-h-48 rounded-card-wrapper border border-tertiary bg-primary;
+  @apply w-full min-h-48 rounded-card-wrapper border border-tertiary bg-primary p-4;
 }
 
 /* Belongs-to "Create new" embeds an edit form in the modal. Drop the nested

--- a/app/assets/stylesheets/css/components/ui/tabs.css
+++ b/app/assets/stylesheets/css/components/ui/tabs.css
@@ -184,6 +184,16 @@
     }
   }
 
+  /* The breakout above assumes the container has padding to give up. The
+     belongs-to "Create new" modal has exactly as much as the breakout consumes,
+     so the dashed border ends up flush against the modal edge while the sibling
+     panels stay inset. Keep the group in flow there and let its own padding
+     hold the content off the border. AVO-1365. */
+  .modal-form-body .tab-group {
+    width: 100%;
+    margin-inline: 0;
+  }
+
   /* ============================================
      ACTIVE INDICATOR VIEW TRANSITION
      ============================================ */


### PR DESCRIPTION
## The problem

**before**
<img width="1102" height="905" alt="CleanShot 2026-07-30 at 18 31 17" src="https://github.com/user-attachments/assets/43571786-69f2-4969-81b1-cd1babc8f236" />
**after**
<img width="2088" height="1712" alt="CleanShot 2026-07-30 at 21 36 19@2x" src="https://github.com/user-attachments/assets/055dc0a3-8d8c-410c-9b38-94d34fb434de" />