### PR TITLE
fix: restore shift-select on index tables

### DIFF
--- a/app/components/avo/row_selector_component.rb
+++ b/app/components/avo/row_selector_component.rb
@@ -5,12 +5,12 @@ class Avo::RowSelectorComponent < Avo::BaseComponent
   prop :index
   prop :checked, default: false
 
+  # Shift-select is wired on table rows only: grid items render this component without an index and
+  # have no table row for the controller to walk up to.
   def data_action
     data = "input->item-selector#toggle input->item-select-all#selectRow"
 
-    if Avo.plugin_manager.installed?("avo-pro")
-      data += " click->record-selector#toggleMultiple"
-    end
+    data += " click->record-selector#toggleMultiple" if @index.present?
 
     data
   end

--- a/app/javascript/js/controllers/record_selector_controller.js
+++ b/app/javascript/js/controllers/record_selector_controller.js
@@ -32,6 +32,12 @@ export default class extends Controller {
       return
     }
 
+    // Ranges are addressed by row. Index view types outside a table (avo-notifications renders one)
+    // give this component an index but no row to walk up to, so there's nothing to span.
+    if (!event.target.closest('tr')) {
+      return
+    }
+
     // If there's no last checked index and the shift key isn't pressed, set the starting index
     if (!this.hasLastCheckedIndex) {
       this.#setStartingIndex(event)
@@ -110,7 +116,8 @@ export default class extends Controller {
   #selectorMouseenterHandler(event) {
     // Add the highlighted-row class to the row that the mouse is over
     event.target.closest('tr').classList.add('highlighted-row')
-    if (this.lastCheckedIndex) {
+    // Check against null, not truthiness — index 0 is a valid anchor
+    if (this.hasLastCheckedIndex) {
       // Highlight the range of rows between the last checked index and the current index
       this.#highlightRange(this.lastCheckedIndex, parseInt(event.target.closest('tr').dataset.index))
     }
@@ -127,8 +134,8 @@ export default class extends Controller {
 
   // Highlight the range of rows between the start index and the end index
   #highlightRange(startIndex, endIndex) {
-    const theRange = difference(range(startIndex, endIndex))
-    theRange.forEach((index) => {
+    // `range` excludes the end index, but the hovered row is highlighted by the caller
+    range(startIndex, endIndex).forEach((index) => {
       const tr = document.querySelector(`tr[data-index="${index}"]`)
       tr.classList.add('highlighted-row')
     })

--- a/app/javascript/js/controllers/record_selector_controller.js
+++ b/app/javascript/js/controllers/record_selector_controller.js
@@ -9,8 +9,19 @@ export default class extends Controller {
 
   autoClicking = false
 
+  // Every lookup in here is scoped to this controller's element. A page can hold several tables (a
+  // show page renders one per has_many association) and each numbers its rows from zero, so a
+  // document-wide lookup by index always lands in the first table.
   get itemSelectorCells() {
-    return document.querySelectorAll('.item-selector-cell')
+    return this.element.querySelectorAll('.item-selector-cell')
+  }
+
+  #rowAt(index) {
+    return this.element.querySelector(`tr[data-index="${index}"]`)
+  }
+
+  #checkboxAt(index) {
+    return this.element.querySelector(`input[type="checkbox"][data-index="${index}"]`)
   }
 
   get hasLastCheckedIndex() {
@@ -63,7 +74,7 @@ export default class extends Controller {
 
     // Loop through the range of rows and toggle the checkboxes
     theRange.forEach((index) => {
-      const checkbox = document.querySelector(`input[type="checkbox"][data-index="${index}"]`)
+      const checkbox = this.#checkboxAt(index)
 
       // Toggle the checkbox if it's not in the same state as the target checkbox
       if (checkbox.checked !== state) {
@@ -127,7 +138,7 @@ export default class extends Controller {
     // Remove the highlighted-row class from the row that the mouse is over
     event.target.closest('tr').classList.remove('highlighted-row')
     // Remove the highlighted-row class from all rows
-    document.querySelectorAll('tr[data-index]').forEach((tr) => {
+    this.element.querySelectorAll('tr[data-index]').forEach((tr) => {
       tr.classList.remove('highlighted-row')
     })
   }
@@ -136,8 +147,7 @@ export default class extends Controller {
   #highlightRange(startIndex, endIndex) {
     // `range` excludes the end index, but the hovered row is highlighted by the caller
     range(startIndex, endIndex).forEach((index) => {
-      const tr = document.querySelector(`tr[data-index="${index}"]`)
-      tr.classList.add('highlighted-row')
+      this.#rowAt(index).classList.add('highlighted-row')
     })
   }
 

--- a/spec/features/avo/record_selector_spec.rb
+++ b/spec/features/avo/record_selector_spec.rb
@@ -8,18 +8,31 @@ RSpec.feature "RecordSelectors", type: :feature do
   it "hides the record selector" do
     visit "/admin/resources/comments"
 
-    expect(page).not_to have_selector 'input[type="checkbox"][data-action="input->item-selector#toggle input->item-select-all#selectRow"]'
+    expect(page).not_to have_selector record_selector_checkbox_selector
   end
 
   it "displays the record selector" do
     visit "/admin/resources/users"
 
-    expect(page).to have_selector 'input[type="checkbox"][data-action="input->item-selector#toggle input->item-select-all#selectRow"]'
+    expect(page).to have_selector record_selector_checkbox_selector
+  end
+
+  it "wires shift-select on table rows" do
+    visit "/admin/resources/users"
+
+    expect(page).to have_selector shift_selectable_checkbox_selector
   end
 
   it "displays the record selector on grid" do
     visit "/admin/resources/posts"
 
-    expect(page).to have_selector 'input[type="checkbox"][data-action="input->item-selector#toggle input->item-select-all#selectRow"]'
+    expect(page).to have_selector record_selector_checkbox_selector
+  end
+
+  # Grid items have no table row for the controller to walk up to
+  it "leaves shift-select off grid items" do
+    visit "/admin/resources/posts"
+
+    expect(page).not_to have_selector shift_selectable_checkbox_selector
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -6,6 +6,17 @@ def find_field_element(field_id)
   find("[data-field-id='#{field_id}']")
 end
 
+# The checkbox rendered by Avo::RowSelectorComponent. Matched on the leading actions so that adding
+# an action to the component doesn't send every caller hunting for the new literal.
+def record_selector_checkbox_selector
+  'input[type="checkbox"][data-action^="input->item-selector#toggle"]'
+end
+
+# Only table rows get shift-select wired; grid items have no row to walk up to.
+def shift_selectable_checkbox_selector
+  'input[type="checkbox"][data-action*="record-selector#toggleMultiple"]'
+end
+
 def field_wrapper(field_id, field_type = nil)
   if field_type.present?
     find("[data-field-id='#{field_id}'][data-field-type='#{field_type}']")

--- a/spec/system/avo/group_2/multiple_actions_flux_spec.rb
+++ b/spec/system/avo/group_2/multiple_actions_flux_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Multiple Actions Flux", type: :system do
         expect(page).to have_text "Spec City"
         expect(page).to have_text "123.456"
 
-        find(:css, 'input[type="checkbox"][data-action="input->item-selector#toggle input->item-select-all#selectRow"]', match: :first).set(true)
+        find(:css, record_selector_checkbox_selector, match: :first).set(true)
 
         open_panel_action(action_name: "Update")
 

--- a/spec/system/avo/group_2/select_all_spec.rb
+++ b/spec/system/avo/group_2/select_all_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe "SelectAll", type: :system do
 end
 
 def uncheck_first_record
-  find(:css, 'input[type="checkbox"][data-action="input->item-selector#toggle input->item-select-all#selectRow"]', match: :first).set(false)
+  find(:css, record_selector_checkbox_selector, match: :first).set(false)
   expect(page).not_to have_text info_string
 end
 

--- a/spec/system/avo/group_2/shift_select_records_spec.rb
+++ b/spec/system/avo/group_2/shift_select_records_spec.rb
@@ -1,49 +1,96 @@
 require "rails_helper"
 
 RSpec.describe "ShiftSelectRecords", type: :system do
-  let!(:fishes) { create_list :fish, 5 }
+  describe "on an index table" do
+    let!(:fishes) { create_list :fish, 5 }
 
-  before do
-    visit "/admin/resources/fish"
+    before do
+      visit "/admin/resources/fish"
 
-    expect(page).to have_selector record_selector_checkbox_selector, count: fishes.size
+      expect(page).to have_selector record_selector_checkbox_selector, count: fishes.size
+    end
+
+    it "selects every row between the two clicks when shift is held" do
+      row_checkbox(1).click
+      row_checkbox(4).click(:shift)
+
+      expect(checked_row_indexes).to eq [1, 2, 3, 4]
+    end
+
+    it "selects the range when shift-clicking upwards" do
+      row_checkbox(4).click
+      row_checkbox(1).click(:shift)
+
+      expect(checked_row_indexes).to eq [1, 2, 3, 4]
+    end
+
+    it "selects the range when it starts on the first row" do
+      row_checkbox(0).click
+      row_checkbox(2).click(:shift)
+
+      expect(checked_row_indexes).to eq [0, 1, 2]
+    end
+
+    it "previews the range on hover when it starts on the first row" do
+      row_checkbox(0).click
+      find("#{row_selector(3)} .item-selector-cell").hover
+
+      expect(page).to have_css "#{row_selector(1)}.highlighted-row"
+      expect(page).to have_css "#{row_selector(2)}.highlighted-row"
+    end
+
+    it "checks only the clicked row when shift is not held" do
+      row_checkbox(1).click
+      row_checkbox(4).click
+
+      expect(checked_row_indexes).to eq [1, 4]
+    end
   end
 
-  it "selects every row between the two clicks when shift is held" do
-    row_checkbox(1).click
-    row_checkbox(4).click(:shift)
+  # A show page renders one table per has_many association, and every table numbers its rows from
+  # zero, so an index only identifies a row within its own table.
+  describe "with more than one table on the page" do
+    let!(:person) { create :person }
+    let!(:spouses) { create_list :spouse, 4, person: person }
 
-    expect(checked_row_indexes).to eq [1, 2, 3, 4]
+    before do
+      visit "/admin/resources/people/#{person.id}"
+
+      expect(page).to have_selector shift_selectable_checkbox_selector, minimum: spouses.size * 2
+    end
+
+    it "selects the range inside the table that was clicked" do
+      in_table(1) do
+        row_checkbox(0).click
+        row_checkbox(2).click(:shift)
+
+        expect(checked_row_indexes).to eq [0, 1, 2]
+      end
+
+      in_table(0) do
+        expect(checked_row_indexes).to be_empty
+      end
+    end
+
+    it "previews the range inside the table that is hovered" do
+      in_table(1) do
+        row_checkbox(0).click
+        find("#{row_selector(2)} .item-selector-cell").hover
+
+        expect(page).to have_css "#{row_selector(1)}.highlighted-row"
+      end
+
+      in_table(0) do
+        expect(page).not_to have_css "tr.highlighted-row"
+      end
+    end
   end
+end
 
-  it "selects the range when shift-clicking upwards" do
-    row_checkbox(4).click
-    row_checkbox(1).click(:shift)
-
-    expect(checked_row_indexes).to eq [1, 2, 3, 4]
-  end
-
-  it "selects the range when it starts on the first row" do
-    row_checkbox(0).click
-    row_checkbox(2).click(:shift)
-
-    expect(checked_row_indexes).to eq [0, 1, 2]
-  end
-
-  it "previews the range on hover when it starts on the first row" do
-    row_checkbox(0).click
-    find("#{row_selector(3)} .item-selector-cell").hover
-
-    expect(page).to have_css "#{row_selector(1)}.highlighted-row"
-    expect(page).to have_css "#{row_selector(2)}.highlighted-row"
-  end
-
-  it "checks only the clicked row when shift is not held" do
-    row_checkbox(1).click
-    row_checkbox(4).click
-
-    expect(checked_row_indexes).to eq [1, 4]
-  end
+# The tables on a page, in render order. Each one is the element a record-selector controller is
+# mounted on.
+def in_table(position, &block)
+  within all("[data-controller~='record-selector']")[position], &block
 end
 
 def row_selector(index)

--- a/spec/system/avo/group_2/shift_select_records_spec.rb
+++ b/spec/system/avo/group_2/shift_select_records_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe "ShiftSelectRecords", type: :system do
+  let!(:fishes) { create_list :fish, 5 }
+
+  before do
+    visit "/admin/resources/fish"
+
+    expect(page).to have_selector record_selector_checkbox_selector, count: fishes.size
+  end
+
+  it "selects every row between the two clicks when shift is held" do
+    row_checkbox(1).click
+    row_checkbox(4).click(:shift)
+
+    expect(checked_row_indexes).to eq [1, 2, 3, 4]
+  end
+
+  it "selects the range when shift-clicking upwards" do
+    row_checkbox(4).click
+    row_checkbox(1).click(:shift)
+
+    expect(checked_row_indexes).to eq [1, 2, 3, 4]
+  end
+
+  it "selects the range when it starts on the first row" do
+    row_checkbox(0).click
+    row_checkbox(2).click(:shift)
+
+    expect(checked_row_indexes).to eq [0, 1, 2]
+  end
+
+  it "previews the range on hover when it starts on the first row" do
+    row_checkbox(0).click
+    find("#{row_selector(3)} .item-selector-cell").hover
+
+    expect(page).to have_css "#{row_selector(1)}.highlighted-row"
+    expect(page).to have_css "#{row_selector(2)}.highlighted-row"
+  end
+
+  it "checks only the clicked row when shift is not held" do
+    row_checkbox(1).click
+    row_checkbox(4).click
+
+    expect(checked_row_indexes).to eq [1, 4]
+  end
+end
+
+def row_selector(index)
+  %(tr[data-index="#{index}"])
+end
+
+def row_checkbox(index)
+  find(%(#{record_selector_checkbox_selector}[data-index="#{index}"]))
+end
+
+def checked_row_indexes
+  all(record_selector_checkbox_selector).select(&:checked?).map { |checkbox| checkbox[:"data-index"].to_i }.sort
+end

--- a/spec/system/avo/group_3/actions_spec.rb
+++ b/spec/system/avo/group_3/actions_spec.rb
@@ -474,13 +474,13 @@ RSpec.describe "Actions", type: :system do
 
       # Hover grid element, select post, and verify that action is not disabled anymore
       find("[data-component-name=\"avo/index/grid_item_component\"][data-resource-name=\"posts\"][data-record-id=\"#{post.to_param}\"]").hover
-      find('input[type="checkbox"][data-action="input->item-selector#toggle input->item-select-all#selectRow"]', visible: false).click
+      find(record_selector_checkbox_selector, visible: false).click
       click_on "Actions"
       expect(page.find("a", text: "Toggle post published")["data-disabled"]).to eq "false"
 
       # Hover grid element, "unselect" post, and verify that action is disabled again
       find("[data-component-name=\"avo/index/grid_item_component\"][data-resource-name=\"posts\"][data-record-id=\"#{post.to_param}\"]").hover
-      find('input[type="checkbox"][data-action="input->item-selector#toggle input->item-select-all#selectRow"]', visible: false).click
+      find(record_selector_checkbox_selector, visible: false).click
       click_on "Actions"
       expect(page.find("a", text: "Toggle post published")["data-disabled"]).to eq "true"
     end


### PR DESCRIPTION
Closes [AVO-1381](https://linear.app/avo-hq/issue/AVO-1381/figure-out-what-happened-with-hold-shift-select-on-tables-feature).

fixed

https://github.com/user-attachments/assets/ab46af20-4f1d-4560-a73a-95af34ba78aa




## The bug

Shift-clicking a row selector to select a range does nothing. Check row 2, hold <kbd>Shift</kbd>, check row 5 — rows 3 and 4 stay unchecked. Reproduces on any Avo 4 app, no config needed.

## Cause

`Avo::RowSelectorComponent#data_action` gated the Stimulus action behind `Avo.plugin_manager.installed?("avo-pro")`:

```ruby
if Avo.plugin_manager.installed?("avo-pro")   # always false in Avo 4
  data += " click->record-selector#toggleMultiple"
end
```

`avo-pro` doesn't exist in Avo 4 — the tier was split into per-feature gems — so the gate was permanently false and the action was never attached. The ticket guessed the feature "was not extracted from avo-pro", but it's the opposite: the implementation (Stimulus controller, CSS, `data-index` attributes, the shift-aware row-click handler) was always in core. Only the gate was pro-specific.

This was a one-off, not systemic: every other `plugin_manager.installed?` gate in core names a gem still registered in the workspace.

## Second bug: ranges leaked across tables

Turning the feature back on exposed a second one. Row lookups ran against `document`:

```js
document.querySelector(`input[type="checkbox"][data-index="${index}"]`)
```

`data-index` is only unique *within* one table — every table numbers its rows from zero. On a page with more than one index table (a show page renders one per `has_many` association), a range always resolved into the **first** table: shift-clicking rows 0 and 2 in the second table checked row 1 of the first one, and the hover preview highlighted the wrong table too.

Stimulus already mounts one `record-selector` instance per index view, so `this.element` is the scope that was missing. All four lookups now go through it — the checkbox toggling, the hover highlight, the highlight clearing, and the list of hoverable cells. The click that opens a range needs no lookup at all: `closest('tr')` is in the right table by construction.

As a side effect this also stops each controller from binding mouse listeners to *every* selector cell on the page, which had all three instances reacting to a hover over any one table.

## Also fixed

Two defects in `record_selector_controller.js`, both unreachable while the feature was gated off:

- **Hover preview skipped when anchored on the first row.** `if (this.lastCheckedIndex)` treats index `0` as falsy.
- **Crash outside tables.** `toggleMultiple` walked up to the enclosing `tr` without checking one exists. `avo-notifications` renders a row selector inside a plain `div`, so the first click threw a `TypeError` — and since `lastCheckedIndex` is assigned before the throw, every later click threw too. The controller now checks for its row.

## Tests

`spec/system/avo/group_2/shift_select_records_spec.rb` covers, on a single index table: range selection downward, upward, anchored on row 0, the hover preview, and a no-shift control.

A second group runs against a Person show page — three `has_many` tables, each numbering rows from zero — and asserts that both the selection and the hover preview stay inside the table that was clicked. Both examples were verified to fail before the scoping fix (`expected: [0, 1, 2], got: [0, 2]`) and pass after.

Four spec files hardcoded the full `data-action` string, so they broke the moment the action list changed. They now share two helpers in `spec/support/helpers.rb`.

## Coverage gap

`js_errors` is commented out in `spec/rails_helper.rb`, so a JS exception in a Stimulus action doesn't fail a spec. The crash above went unnoticed for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
