### PR TITLE
fix: widen the media library attach modal (AVO-1416)

### DIFF
--- a/app/assets/stylesheets/css/components/modal.css
+++ b/app/assets/stylesheets/css/components/modal.css
@@ -233,6 +233,12 @@
   }
 }
 
+.modal--width-5xl {
+  .modal__card {
+    @apply w-5xl;
+  }
+}
+
 .modal--width-25 {
   .modal__card {
     @apply w-[25dvw];

--- a/app/components/avo/modal_component.html.erb
+++ b/app/components/avo/modal_component.html.erb
@@ -16,7 +16,6 @@
     role="dialog"
     aria-modal="true"
     class="modal__card-container"
-    data-modal-size-target="container"
   >
     <div class="modal__card" data-<%= ctrl %>-target="card">
       <div class="card">

--- a/app/components/avo/modal_component.rb
+++ b/app/components/avo/modal_component.rb
@@ -4,7 +4,7 @@ class Avo::ModalComponent < Avo::BaseComponent
   renders_one :heading
   renders_one :controls
 
-  prop :width, default: :xl # :sm, :md, :lg, :xl, :2xl, :3xl, :4xl, :full
+  prop :width, default: :xl # :sm, :md, :lg, :xl, :2xl, :3xl, :4xl, :5xl, :full
   prop :height, default: :auto # :auto, :sm, :md, :lg, :xl, :2xl, :3xl, :4xl, :full
   prop :body_class
   prop :close_modal_on_backdrop_click, default: true, reader: :public

--- a/app/javascript/js/controllers/modal_size_controller.js
+++ b/app/javascript/js/controllers/modal_size_controller.js
@@ -2,8 +2,6 @@ import { Controller } from '@hotwired/stimulus'
 
 // Connects to data-controller="modal-size"
 export default class extends Controller {
-  static targets = ['container']
-
   static values = {
     currentWidth: String,
     currentHeight: String,
@@ -28,56 +26,18 @@ export default class extends Controller {
   }
 
   updateWidthClass(width) {
-    // Remove all modal width classes from the modal element
-    this.modalElement.classList.remove(
-      'modal--width-sm',
-      'modal--width-md',
-      'modal--width-lg',
-      'modal--width-xl',
-      'modal--width-2xl',
-      'modal--width-3xl',
-      'modal--width-4xl',
-      'modal--width-full',
-      'modal--width-25',
-      'modal--width-50',
-      'modal--width-75',
-      'modal--width-100',
-    )
-
-    // Remove all width classes from the container
-    this.containerTarget.classList.remove('w-sm', 'w-md', 'w-lg', 'w-xl', 'w-2xl', 'w-3xl', 'w-4xl', 'w-full')
-
-    // Add the new modal width class to the modal element
-    this.modalElement.classList.add(`modal--width-${width}`)
-
-    // Add the corresponding width class to the container
-    if (width === 'full') {
-      this.containerTarget.classList.add('w-full')
-    } else {
-      this.containerTarget.classList.add(`w-${width}`)
-    }
+    this.#swapModifier('modal--width-', width)
   }
 
   updateHeightClass(height) {
-    // Remove all modal height classes from the modal element
-    this.modalElement.classList.remove(
-      'modal--height-auto',
-      'modal--height-sm',
-      'modal--height-md',
-      'modal--height-lg',
-      'modal--height-xl',
-      'modal--height-2xl',
-      'modal--height-3xl',
-      'modal--height-4xl',
-      'modal--height-full',
-      'modal--height-25',
-      'modal--height-50',
-      'modal--height-75',
-      'modal--height-100',
-    )
+    this.#swapModifier('modal--height-', height)
+  }
 
-    // Add the new modal height class to the modal element
-    // The CSS will handle applying the appropriate height to .modal__card
-    this.modalElement.classList.add(`modal--height-${height}`)
+  // The CSS owns the sizes: each `modal--width-*` / `modal--height-*` modifier
+  // sizes `.modal__card`. Swapping by prefix means a new size token is a CSS
+  // rule and nothing else — no list here to keep in sync with the stylesheet.
+  #swapModifier(prefix, value) {
+    this.modalElement.classList.remove(...[...this.modalElement.classList].filter((name) => name.startsWith(prefix)))
+    this.modalElement.classList.add(`${prefix}${value}`)
   }
 }

--- a/app/views/avo/media_library/index.html.erb
+++ b/app/views/avo/media_library/index.html.erb
@@ -1,6 +1,9 @@
 <%= render Avo::TurboFrameWrapperComponent.new(turbo_frame_request_id) do %>
   <% if turbo_frame_request_id %>
-    <%= render Avo::ModalComponent.new(title: t("avo.media_library.title")) do |c| %>
+    <%# The library is a grid of media cards (13rem floor per card), so the default
+        :xl modal fits two columns and 4xl three, leaving a ragged last row. 5xl
+        fits four, so a page of 12 lands as three full rows. %>
+    <%= render Avo::ModalComponent.new(title: t("avo.media_library.title"), width: :"5xl") do |c| %>
       <div class="p-4">
         <%= render Avo::MediaLibrary::ListComponent.new attaching: @attaching %>
       </div>

--- a/spec/requests/avo/media_library_request_spec.rb
+++ b/spec/requests/avo/media_library_request_spec.rb
@@ -92,6 +92,14 @@ RSpec.describe "Media library edit", type: :request do
     expect(response.body).to include("attachment.jpg")
   end
 
+  # AVO-1416: the attach modal has to be wide enough for the media grid.
+  it "renders the attach modal at the wide size" do
+    get "/admin/attach-media", headers: {"Turbo-Frame" => Avo::MODAL_FRAME_ID.to_s}
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("modal--width-5xl")
+  end
+
   it "exposes routable blob URLs in attach mode when a listed blob has a blank filename" do
     broken = create_image_blob
     broken.update_column(:filename, "")


### PR DESCRIPTION
Closes [AVO-1416](https://linear.app/avo-hq/issue/AVO-1416/media-library-attach-modal-should-be-much-wider).

**Before**
<img width="3858" height="1926" alt="CleanShot 2026-07-01 at 11 10 00@2x" src="https://github.com/user-attachments/assets/6fb31f67-047c-4b2d-9458-461dd0a4e7ca" />

**After**
<img width="3820" height="1778" alt="CleanShot 2026-07-31 at 03 01 38@2x" src="https://github.com/user-attachments/assets/d2ba6a0f-f362-479a-b9b9-cbe5f6815736" />

## The fix

The media library renders a grid of media cards with a 13rem floor per card (`--grid-min-col` in `grid.css`), so the attach modal's default `:xl` width (36rem) only fit **two columns**.

Adds a `5xl` (64rem) modal width token and uses it for the library. Measured in the browser against a real library:

| Width | Columns | Page of 12 |
|-------|---------|------------|
| `xl` (36rem, before) | 2 | 6 rows |
| `4xl` (56rem) | 3 | 4 rows, ragged last one |
| **`5xl` (64rem)** | **4** | **3 full rows** |
| `6xl` (72rem) | 5 | 2 rows + a 2-card orphan |

`5xl` is the one that divides the page evenly. It still clamps to the viewport on small screens through the existing `max-width: calc(100dvw - 2rem)` on `.modal__card`.

## Modal size controller cleanup

`modal_size_controller.js` removed size classes by naming every one of them in two hardcoded lists. A new CSS token silently did nothing unless the JS lists were updated too — the old code demonstrably fails this way: driving it against a `5xl` modal leaves `modal--width-5xl` stuck alongside every size you switch to, so the card never resizes.

It now swaps modifiers by prefix. A new size is a CSS rule and nothing else.

The container width classes it also maintained are removed. `.modal__card-container` is `size-full`, so those classes never changed its measured width — 2400px with or without them, for every token — and the card's width has always come from the CSS modifier. The `if (width === 'full')` branch was redundant on its own terms too, since `` `w-${'full'}` `` is the same string. The now-unused `container` target and its `data-modal-size-target` attribute go with it.

## Verification

Every width and height token measured live, old code vs new, on a 2400x1114 viewport — identical in both:

- widths: `sm` 384, `md` 448, `lg` 512, `xl` 576, `2xl` 672, `3xl` 768, `4xl` 896, `5xl` 1024, `25` 600, `50` 1200, `75` 1800, `100` 2368, `full` 2368
- heights: `auto` 1082, `sm` 384 … `4xl` 896, `25/50/75` 278/557/835, `100`/`full` 1082

Also checked visually: the media library modal (4 columns, centred), a `4xl` resource modal, and a `full` modal via `?modal_layout=true&modal_width=full`.

Specs: new request spec pins the attach modal width (fails before, passes after); `spec/requests/avo/media_library_request_spec.rb` and `spec/system/avo/group_1/has_and_belongs_to_many_field_spec.rb` green.

## Docs

No update needed — modal widths aren't a documented public option (`params[:modal_width]` is internal plumbing), and the media library page documents behaviour rather than modal sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)