### PR TITLE
test: re-enable the Cmd/Ctrl+Enter form submit hotkey spec

### DIFF
--- a/spec/system/avo/group_1/hotkey_spec.rb
+++ b/spec/system/avo/group_1/hotkey_spec.rb
@@ -29,17 +29,25 @@ RSpec.describe "Keyboard shortcuts", type: :system do
     page.evaluate_script("document.activeElement && document.activeElement.value")
   end
 
-  def dispatch_active_element_keydown(key)
+  def dispatch_active_element_keydown(key, ctrl_key: false, meta_key: false)
     page.execute_script(<<~JS)
       const activeElement = document.activeElement
       if (activeElement) {
         activeElement.dispatchEvent(new KeyboardEvent("keydown", {
           key: #{key.to_json},
+          ctrlKey: #{ctrl_key},
+          metaKey: #{meta_key},
           bubbles: true,
           cancelable: true
         }))
       }
     JS
+  end
+
+  def focus_field(field_id)
+    page.execute_script("document.getElementById(#{field_id.to_json}).focus()")
+
+    expect(page.evaluate_script("document.activeElement && document.activeElement.id")).to eq(field_id)
   end
 
   def focus_resource_table
@@ -299,18 +307,24 @@ RSpec.describe "Keyboard shortcuts", type: :system do
     expect(active_element_value).to eq("confirm")
   end
 
-  # it "submits the form with command or control enter" do
-  #   project = create(:project, name: "Original name")
+  # The binding lives on the `form` element, so the keydown has to originate from a
+  # field inside it and bubble up — dispatching on `body` never reaches the form.
+  # (`fill_in` leaves focus on `body`, hence the explicit `focus_field`.)
+  {"command" => {meta_key: true}, "control" => {ctrl_key: true}}.each do |modifier, options|
+    it "submits the form with #{modifier} enter" do
+      project = create(:project, name: "Original name")
 
-  #   visit "/admin/resources/projects/#{project.id}/edit"
+      visit "/admin/resources/projects/#{project.id}/edit"
 
-  #   fill_in "project_name", with: "Updated from hotkey"
-  #   dispatch_keydown("Enter", meta_key: true)
+      fill_in "project_name", with: "Updated from hotkey"
+      focus_field("project_name")
+      dispatch_active_element_keydown("Enter", **options)
 
-  #   expect(page).to have_text("Project was successfully updated")
-  #   expect(page).to have_current_path("/admin/resources/projects/#{project.id}")
-  #   expect(project.reload.name).to eq("Updated from hotkey")
-  # end
+      expect(page).to have_text("Project was successfully updated")
+      expect(page).to have_current_path("/admin/resources/projects/#{project.id}")
+      expect(project.reload.name).to eq("Updated from hotkey")
+    end
+  end
 
   describe "Shift+T focuses the screen content" do
     def active_element_descriptor


### PR DESCRIPTION
Closes [AVO-1117](https://linear.app/avo-hq/issue/AVO-1117/re-enable-hotkey-specrb-spec).

## Why it was disabled

The `"submits the form with command or control enter"` example in `spec/system/avo/group_1/hotkey_spec.rb` was commented out during the Avo 4 open beta. It dispatched the keydown on `document.body` — but events bubble *up*, so it never reached the `<form>` element that actually carries the binding:

```ruby
# lib/avo/concerns/form_builder.rb:14
action: "keydown.ctrl+enter->form#submit keydown.meta+enter->form#submit"
```

What it *did* exercise was the Save button's `@github/hotkey` `"Mod+Enter"` (`app/components/avo/resource_component.rb:217`). That one is document-level, but `Mod` resolves to **Meta on macOS and Ctrl on Linux** — so the test passed locally with `meta_key: true` and would have failed on CI.

Verified in the browser:

| dispatched from | Cmd+Enter | Ctrl+Enter |
|-----------------|-----------|------------|
| `document.body` | submits (via `@github/hotkey`, macOS only) | nothing |
| focused field   | `requestSubmit()` | `requestSubmit()` |

## The fix

Dispatch from the focused field so the test covers the real Stimulus binding, which is platform-independent, and run it for both modifiers.

- `dispatch_active_element_keydown` gained `ctrl_key:`/`meta_key:` kwargs (defaulting to `false`), matching the sibling `dispatch_keydown` helper. Stimulus checks modifier flags exactly, so the unset one must be `false`.
- Added a small `focus_field` helper — `fill_in` leaves `document.activeElement` on `body` under Cuprite.

## Testing

- `2 examples, 0 failures` for the re-enabled examples
- `38 examples, 0 failures` for the full file, three consecutive runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)