### PR TITLE
fix(panel): space sibling cards inside a panel body

### DIFF
--- a/app/assets/stylesheets/css/components/ui/panel.css
+++ b/app/assets/stylesheets/css/components/ui/panel.css
@@ -21,6 +21,14 @@
   @apply w-full;
 }
 
+/* Several `card`s declared in one `panel do ... end` block land as adjacent
+   children of the body, which is a plain block container — so without this they
+   render flush, borders touching. Matches the panel's own `gap-y-4` rhythm.
+   Adjacent-sibling scoped so a lone card stays flush with the panel. */
+.panel__body > .card + .card {
+  @apply mt-4;
+}
+
 /* Shift+T anchors focus on the panel body. Mirror the table view's focus state:
    suppress the body's own (clipped) outline and lift the ring to the whole panel,
    exactly like `.card:has(table:focus-visible)` does for the index table. */

--- a/spec/system/avo/group_1/hotkey_spec.rb
+++ b/spec/system/avo/group_1/hotkey_spec.rb
@@ -414,6 +414,11 @@ RSpec.describe "Keyboard shortcuts", type: :system do
       JS
 
       expect(hidden_ancestor).to be(false)
+    ensure
+      # `with_temporary_items` sets a class attribute that outlives the example,
+      # so without this the swapped-in tabs leak into every later spec that
+      # renders a Person.
+      Avo::Resources::Person.restore_items_from_backup
     end
 
     it "does not focus obscured panel content while a modal is open" do

--- a/spec/system/avo/group_1/panel_card_spacing_spec.rb
+++ b/spec/system/avo/group_1/panel_card_spacing_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+# AVO-1499: sibling cards declared in the same `panel do ... end` block render as
+# adjacent `.panel__body > .card` elements. The panel body is a plain block
+# container, so without a rule of its own the cards sit back to back with their
+# borders touching.
+RSpec.describe "panel card spacing", type: :system do
+  let!(:person) { create :person }
+
+  # `--spacing` * 4 -> 1rem. The panel's own `gap-y-4` between header, content and
+  # footer uses the same step, so cards line up with the rest of the panel rhythm.
+  let(:expected_gap) { 16 }
+
+  # Declared here rather than leaning on the dummy app's Person resource: another
+  # spec in this group swaps that resource's items out, so a shared definition
+  # would make this spec order-dependent.
+  #
+  # The first panel is the reported shape (two cards, one body); the second gives
+  # the lone-card case something to measure.
+  before do
+    Avo::Resources::Person.with_temporary_items do
+      panel title: "Sibling cards" do
+        card title: "First card" do
+          field :name, as: :text
+        end
+
+        card title: "Second card" do
+          field :type, as: :text
+        end
+      end
+
+      panel title: "Lone card" do
+        card title: "Only card" do
+          field :name, as: :text
+        end
+      end
+    end
+
+    visit avo.resources_person_path(person)
+
+    expect(page).to have_text "First card"
+    expect(page).to have_text "Second card"
+  end
+
+  after { Avo::Resources::Person.restore_items_from_backup }
+
+  # Distance between the bottom border of one card and the top border of the next.
+  # Measuring the rendered boxes keeps the assertion honest about the visual
+  # result rather than about the property that happens to produce it.
+  def gap_between_panel_cards
+    page.evaluate_script(<<~JS)
+      (() => {
+        const body = [...document.querySelectorAll('.panel__body')].find(
+          (candidate) => candidate.querySelectorAll(':scope > .card').length > 1
+        )
+        if (!body) return null
+
+        const [first, second] = body.querySelectorAll(':scope > .card')
+
+        return second.getBoundingClientRect().top - first.getBoundingClientRect().bottom
+      })()
+    JS
+  end
+
+  it "separates sibling cards inside a panel body" do
+    expect(gap_between_panel_cards).to be_within(1).of(expected_gap)
+  end
+
+  # The single-card case is the common one; it must not gain a stray offset from
+  # the sibling rule.
+  it "leaves a lone card in a panel body flush with the panel" do
+    lone_card_offset = page.evaluate_script(<<~JS)
+      (() => {
+        const body = [...document.querySelectorAll('.panel__body')].find(
+          (candidate) => candidate.querySelectorAll(':scope > .card').length === 1
+        )
+        if (!body) return null
+
+        const card = body.querySelector(':scope > .card')
+
+        return card.getBoundingClientRect().top - body.getBoundingClientRect().top
+      })()
+    JS
+
+    expect(lone_card_offset).to be_within(1).of(0)
+  end
+end


### PR DESCRIPTION
Closes [AVO-1499](https://linear.app/avo-hq/issue/AVO-1499/fix-panel-margin-top-issue)

## Problem

Cards declared in the same `panel do ... end` block render back to back, borders touching:

```ruby
panel do
  card title: "Software Engineer" do
    field :company, stacked: true, width: 50 do
      "TechCorp Inc."
    end
  end

  card title: "Software Engineer 2" do
    field :company_2, stacked: true, width: 50 do
      "TechCorp Inc. 2"
    end
  end
end
```

Each `card` item becomes a direct child of `.panel__body`, which is a plain block container with no spacing rule of its own — so nothing separates the siblings.

## Fix

An adjacent-sibling rule in `panel.css`, using the same step as the panel's own `gap-y-4` so cards line up with the rest of the panel rhythm:

```css
.panel__body > .card + .card {
  @apply mt-4;
}
```

Scoped to `+` so a lone card — the common case — stays flush with the panel.

## Testing

New `spec/system/avo/group_1/panel_card_spacing_spec.rb` measures the real rendered distance between the two card boxes rather than asserting on the property that produces it. It fails at `0` without the CSS change and passes at `16` with it. A second example guards the lone-card case against gaining a stray offset.

Full `spec/system/avo/group_1` run: 226 examples, 0 failures.

## Drive-by

`hotkey_spec.rb` swaps `Avo::Resources::Person`'s items via `with_temporary_items`, which sets a class attribute that outlives the example, and never restored it — the swapped-in "First"/"Second" tabs leaked into every later spec rendering a Person. That is how the new spec first tripped. Added the missing `restore_items_from_backup`. Happy to split this out if you would rather keep the PR to the CSS change.

## Docs

No change needed — the 4.0 card/panel pages document declaration and intra-card padding, not spacing between sibling cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)