### PR TITLE
List the assistant's Cmd/Ctrl+J shortcut in the shortcuts modal

### DIFF
--- a/app/components/avo/keyboard_shortcuts_component.rb
+++ b/app/components/avo/keyboard_shortcuts_component.rb
@@ -17,7 +17,8 @@ class Avo::KeyboardShortcutsComponent < Avo::BaseComponent
             keys_aria_label: "Up arrow or down arrow"
           ),
           shortcut(action: "Go back", keys: ["B"]),
-          shortcut(action: "Toggle keyboard shortcut badges", keys: ["Shift", "K"])
+          shortcut(action: "Toggle keyboard shortcut badges", keys: ["Shift", "K"]),
+          *assistant_shortcuts
         ]
       ),
       build_section(
@@ -88,6 +89,15 @@ class Avo::KeyboardShortcutsComponent < Avo::BaseComponent
   end
 
   private
+
+  # avo-intelligence binds Cmd/Ctrl+J itself (its chat bar listens for the keydown directly, so it
+  # fires from inside a field too). Core has no assistant to open, so the modal only lists it when
+  # the gem is installed.
+  def assistant_shortcuts
+    return [] unless Avo.plugin_manager.installed?("avo-intelligence")
+
+    [shortcut(action: "Open the assistant", keys: {mac: ["Cmd", "J"], other: ["Ctrl", "J"]})]
+  end
 
   def build_section(title, shortcuts)
     {

--- a/spec/components/avo/keyboard_shortcuts_component_spec.rb
+++ b/spec/components/avo/keyboard_shortcuts_component_spec.rb
@@ -12,4 +12,17 @@ RSpec.describe Avo::KeyboardShortcutsComponent, type: :component do
     expect(page).to have_text("⌘")
     expect(page).to have_text("CTRL")
   end
+
+  # The assistant shortcut belongs to avo-intelligence, so the modal must not advertise a key
+  # nothing is listening for when the gem isn't installed.
+  it "lists the assistant shortcut only when avo-intelligence is installed" do
+    render_inline(described_class.new)
+    expect(page).not_to have_text("Open the assistant")
+
+    allow(Avo.plugin_manager).to receive(:installed?).and_call_original
+    allow(Avo.plugin_manager).to receive(:installed?).with("avo-intelligence").and_return(true)
+
+    render_inline(described_class.new)
+    expect(page).to have_text("Open the assistant")
+  end
 end


### PR DESCRIPTION
`avo-intelligence` binds <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>J</kbd> to open the chat bar, but the <kbd>?</kbd> shortcuts modal never listed it.

Adds it to the **Navigation** section, gated on the gem being installed — core ships the modal to every app, and most don't have the assistant, so listing a key nothing is listening for would be worse than omitting it. `Avo.plugin_manager.installed?` is the existing idiom for this kind of branch (`sidebar_component.rb`, `resource_component.rb`, `_navbar.html.erb`).

```ruby
def assistant_shortcuts
  return [] unless Avo.plugin_manager.installed?("avo-intelligence")

  [shortcut(action: "Open the assistant", keys: {mac: ["Cmd", "J"], other: ["Ctrl", "J"]})]
end
```

The `{mac:, other:}` chord shape reuses the component's existing platform split, so the badge renders ⌘ or CTRL per OS like the global-search entry.

## Testing

`spec/components/avo/keyboard_shortcuts_component_spec.rb` covers both states — absent by default, present when the plugin is installed. 2 examples, 0 failures.

## Docs

Documented in avo-hq/docs.avohq.io#595, which adds an `## Assistant` section to the keyboard shortcuts page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, display-only change behind an existing plugin check; no auth, data, or runtime shortcut behavior in core.
> 
> **Overview**
> The **Navigation** section of the keyboard shortcuts modal now includes **Open the assistant** (`Cmd`/`Ctrl`+`J`) when `avo-intelligence` is installed, using the same mac/other chord rendering as global search.
> 
> Without the gem, the entry is omitted so core apps do not show a shortcut nothing handles. `assistant_shortcuts` is spliced into the Navigation list via `*assistant_shortcuts` and gated on `Avo.plugin_manager.installed?("avo-intelligence")`.
> 
> A component spec asserts the text is absent by default and present when the plugin is stubbed as installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e308dae6745e2fb781eb9ea380d2f7351b3236a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->