### PR TITLE
Allow reload_record/reload_records to be called without an argument

### DIFF
--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -302,7 +302,7 @@ module Avo
       self
     end
 
-    def reload_record(records)
+    def reload_record(records = @query)
       # Force close modal to avoid default redirect to
       # Redirect is 100% not wanted when using reload_record
       close_modal

--- a/spec/lib/avo/base_action_spec.rb
+++ b/spec/lib/avo/base_action_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Avo::BaseAction do
+  # `reload_record` / `reload_records` may be called with no argument, in which case they reload the
+  # records the action is already operating on (its `query`). This is the documented behaviour; the
+  # argument used to be required, so a bare `reload_record` raised ArgumentError.
+  describe "#reload_record without an argument" do
+    let(:records) { [Object.new, Object.new] }
+    # A double for view_type only — reload_record reads it to pick the row/grid streamer, whose body
+    # is a lambda stored for later and never run here, so no real resource or records are needed.
+    let(:resource) { instance_double(Avo::Resources::User, view_type: :table) }
+    let(:action) { Avo::Actions::ToggleInactive.new(resource: resource, query: records) }
+
+    it "reloads the records the action is operating on" do
+      action.reload_record
+
+      expect(action.records_to_reload).to eq(records)
+    end
+
+    it "is aliased as reload_records" do
+      action.reload_records
+
+      expect(action.records_to_reload).to eq(records)
+    end
+  end
+end


### PR DESCRIPTION
## What

`reload_record` / `reload_records` can now be called with no argument, in which case they reload the records the action is already operating on (its `query`).

## Why

The [docs](https://docs.avohq.io/4.0/actions-api.html#reload_records) describe a no-argument usage, but `def reload_record(records)` required one, so a bare `reload_record` raised `ArgumentError`.

## Changes

- `lib/avo/base_action.rb` — default the argument to `@query` (the records the action runs on). `reload_records` is an alias, so it inherits the same behavior.
- `spec/lib/avo/base_action_spec.rb` — new spec covering the no-arg path for both `reload_record` and `reload_records`, asserting `records_to_reload` equals the acted-on records.

Docs wording is updated in a separate change to the docs repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible API fix in action response handling; existing callers that pass records are unchanged.
> 
> **Overview**
> **`reload_record` / `reload_records`** now match the documented API: calling them with no argument reloads the records the action is already operating on (`@query`), instead of raising `ArgumentError`.
> 
> In `lib/avo/base_action.rb`, the `records` parameter defaults to `@query`; explicit calls with a record list behave as before. **`spec/lib/avo/base_action_spec.rb`** adds coverage for the no-arg path on both `reload_record` and the `reload_records` alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d75213f350a8458107da3734da626843cf892834. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->