### PR TITLE
Allow reload_record/reload_records to be called without an argument

### DIFF
--- a/lib/avo/base_action.rb
+++ b/lib/avo/base_action.rb
@@ -286,7 +286,7 @@ module Avo
       self
     end
 
-    def reload_record(records)
+    def reload_record(records = @query)
       # Force close modal to avoid default redirect to
       # Redirect is 100% not wanted when using reload_record
       close_modal

--- a/spec/lib/avo/base_action_spec.rb
+++ b/spec/lib/avo/base_action_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Avo::BaseAction do
+  # `reload_record` / `reload_records` may be called with no argument, in which case they reload the
+  # records the action is already operating on (its `query`). This is the documented behaviour; the
+  # argument used to be required, so a bare `reload_record` raised ArgumentError.
+  describe "#reload_record without an argument" do
+    let(:records) { [Object.new, Object.new] }
+    # A double for view_type only — reload_record reads it to pick the row/grid streamer, whose body
+    # is a lambda stored for later and never run here, so no real resource or records are needed.
+    let(:resource) { instance_double(Avo::Resources::User, view_type: :table) }
+    let(:action) { Avo::Actions::ToggleInactive.new(resource: resource, query: records) }
+
+    it "reloads the records the action is operating on" do
+      action.reload_record
+
+      expect(action.records_to_reload).to eq(records)
+    end
+
+    it "is aliased as reload_records" do
+      action.reload_records
+
+      expect(action.records_to_reload).to eq(records)
+    end
+  end
+end


### PR DESCRIPTION
Ports #4691 to `main`. That PR was merged into `4-dev`, which is 108 commits behind `main` (v4.0.2 vs v4.1.1), so the fix never reached the branch we ship from.

`reload_record` / `reload_records` now default to the action's own `query`, so an action that wants to reload exactly the records it just operated on can call it bare:

```ruby
def handle(**args)
  # ...
  reload_record
end
```

The argument used to be required, so a bare call raised `ArgumentError: wrong number of arguments (given 0, expected 1)`.

Same commit as #4691, cherry-picked onto `main` (it applied cleanly), plus its spec.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow API fix with backward-compatible behavior when callers still pass records; risk is mainly if `@query` is nil on a bare call.
> 
> **Overview**
> **`reload_record` / `reload_records` can be called with no argument** and will refresh the records the action is already operating on (`@query`), matching documented behavior that previously raised `ArgumentError` on a bare call.
> 
> The change is a single default on `Avo::BaseAction#reload_record` (`records = @query`); explicit record lists still work unchanged. A small spec covers the no-arg path and the `reload_records` alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8458876718f4b53e462ee6b051eb41a9bae3b9aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->