### PR TITLE
Rework the avo:skills install into a screen-per-question panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,8 @@ brakeman_results.html
 .env
 .env.test
 *~
+
+# Written by `rails g avo:skills`, by hand or from its specs. Generated output.
+spec/dummy/.agents/
+spec/dummy/.claude/
+spec/dummy/.cursor/

--- a/lib/generators/avo/skills_generator.rb
+++ b/lib/generators/avo/skills_generator.rb
@@ -1,3 +1,4 @@
+require "tmpdir"
 require_relative "base_generator"
 require_relative "skills_install_panel"
 
@@ -5,12 +6,12 @@ module Generators
   module Avo
     # Installs the Avo skills loader into the host app.
     #
-    # Only the loader is copied — the skills themselves stay inside the gem, which
-    # is the whole point: a copied skill tree drifts from the locked Avo version
-    # with nothing to refresh it. Re-running this generator refreshes the loader.
+    # Only the loader is written — the skills themselves stay inside the gem,
+    # which is the point: a copied skill tree drifts from the locked Avo version
+    # with nothing to refresh it.
     #
-    # Deliberately its own namespace rather than part of `avo:install`, so it does
-    # not change behavior for apps that already ran the installer.
+    # There is one way to run this and it asks. No flags: a flag per question is
+    # a second surface to document, keep in step with the screens, and get wrong.
     class SkillsGenerator < BaseGenerator
       source_root File.expand_path("templates", __dir__)
 
@@ -18,212 +19,281 @@ module Generators
       desc "Install the Avo skills loader so coding agents read the instructions that ship with this app's Avo version."
 
       # Claude Code scans .claude/skills; .agents/skills is the cross-agent
-      # convention; .cursor/skills is what Cursor reads. Installing to all three
-      # is why the loader is copied rather than symlinked — a symlink into a
-      # version-named gem directory breaks on the next `bundle update`.
-      TARGETS = {
-        "claude" => ".claude/skills/avo",
-        "agents" => ".agents/skills/avo",
-        "cursor" => ".cursor/skills/avo"
+      # convention; .cursor/skills is what Cursor reads.
+      AGENTS = {
+        "agents" => {dir: ".agents/skills/avo", label: ".agents/skills", hint: "Codex, Gemini CLI, Goose, Amp, OpenCode"},
+        "claude" => {dir: ".claude/skills/avo", label: ".claude/skills", hint: "Claude Code"},
+        "cursor" => {dir: ".cursor/skills/avo", label: ".cursor/skills", hint: "Cursor"}
       }.freeze
 
-      # Where a pre-gem install of avo-hq/skills materialized its catalog.
-      # `npx skills add` writes project-locally, so the stale copies land in the
-      # same directories this generator installs into.
-      LEGACY_ROOTS = [
-        ".claude/skills",
-        ".agents/skills",
-        ".cursor/skills"
-      ].freeze
+      # The copy the others link to. Vendor-neutral on purpose: the real file
+      # should not live in a directory named after one tool.
+      CANONICAL = "agents"
 
-      # Checked, reported, and never deleted. This directory is shared by every
-      # project on the machine — a skill here may be deliberately installed for
-      # a different app, and a generator run inside one project has no business
-      # removing it. The user gets the command instead.
+      # Where a pre-gem install of avo-hq/skills left its catalog, and where an
+      # early 4.1.1 install left the resolver we no longer ship.
+      LEGACY_ROOTS = [".claude/skills", ".agents/skills", ".cursor/skills"].freeze
       GLOBAL_LEGACY_ROOT = "~/.claude/skills"
 
-      class_option :global, type: :boolean,
-        desc: "Install to your home directory instead of this app, so every Avo project on this machine shares one loader"
-      class_option :only, type: :string, desc: "Install one target only (#{TARGETS.keys.join(", ")})"
-      class_option :panel, type: :boolean, default: true,
-        desc: "Show the interactive install panel (skipped automatically without a TTY, or when --global/--only is given)"
-      class_option :path, type: :string, desc: "Install to this directory instead of the default scan paths"
-      class_option :clean_legacy, type: :boolean,
-        desc: "Remove skills left by a pre-gem install of avo-hq/skills (skips the prompt either way)"
-
       def install_loader
-        return if panel_cancelled?
+        return if answers.cancelled?
 
-        # Only the loader is written. The resolver stays inside the gem, where
-        # `bundle update` refreshes it and it cannot drift; a copy in the app
-        # would be one more file to keep in sync, and 250 lines of shell in
-        # someone's repo is a reasonable thing to be suspicious of.
-        destinations.each { |destination| copy_file "skills/SKILL.md", File.join(destination, "SKILL.md") }
-      end
-
-      # A leftover catalog sits in the same scan directories as the loader and
-      # can shadow it, silently serving instructions written for a different Avo
-      # version — which is the whole problem this feature removes. Install time
-      # is the right place to catch it: it is the one moment we know the user is
-      # present and thinking about skills.
-      def clean_legacy_skills
-        leftovers = legacy_skill_dirs
-        global = global_legacy_skill_dirs
-        return if leftovers.empty? && global.empty?
-
-        if leftovers.any?
-          say "\nFound #{pluralize_skills(leftovers.length)} in this project from a previous avo-hq/skills install:"
-          by_directory(leftovers).each { |dir, count| say "  #{dir}#{" " * padding(dir)}#{count}", :yellow }
-          say "These are not version-pinned and can shadow the skills that ship with your Avo gem."
-
-          if remove_legacy?
-            by_directory(leftovers).each do |dir, count|
-              leftovers.select { |path| display_dir(path) == dir }.each { |path| FileUtils.rm_rf(path) }
-              say_status :remove, "#{dir} (#{pluralize_skills(count)})", :red
-            end
+        canonical = nil
+        destinations.each do |dir|
+          if canonical.nil? || !link?
+            copy_file "skills/SKILL.md", File.join(dir, "SKILL.md")
+            canonical ||= dir
           else
-            report_kept(leftovers)
+            link_or_copy(canonical, dir)
           end
         end
+      end
 
-        report_global(global) if global.any?
-        say "\nIf you installed the Claude Code plugin, remove it with: /plugin uninstall avo-skills"
+      def clean_legacy_skills
+        return if answers.cancelled?
+
+        remove_or_report(legacy_skill_dirs, remove: remove_legacy?)
+        remove_or_report(shared_legacy_skill_dirs, remove: remove_shared_legacy?)
       end
 
       no_tasks do
-        def remove_legacy?
-          return options[:clean_legacy] unless options[:clean_legacy].nil?
-          # No TTY to answer, so keep the files and say where they are.
-          return false if options[:quiet]
-
-          yes?("\nRemove them? [y/N]")
+        def answers
+          @answers ||= SkillsInstallPanel.interactive? ? ask_the_user : take_the_defaults
         end
 
-        def report_kept(leftovers)
-          say "\nLeaving them in place. Remove them later with:", :yellow
-          say "  #{removal_command(leftovers)}"
+        # Answering "No" on the last screen is a cancel — the user was shown what
+        # was about to happen and declined it.
+        def ask_the_user
+          result = SkillsInstallPanel.new(screens, defaults: defaults).run
+          return declined if result.cancelled? || result[:confirm] == false
+
+          SkillsInstallPanel::Result.new(defaults.merge(result.answers), false)
         end
 
-        def report_global(global)
-          say "\nAlso found #{pluralize_skills(global.length)} in #{GLOBAL_LEGACY_ROOT}, shared by every project on this machine:", :yellow
-          by_directory(global).each { |dir, count| say "  #{dir}#{" " * padding(dir)}#{count}" }
-          say "Not removing those — another project may still want them. If not, run:"
-          say "  #{removal_command(global)}"
+        def declined
+          say("Cancelled. Nothing was installed.", :yellow)
+          SkillsInstallPanel::Result.new({}, true)
         end
 
-        # One glob per directory rather than one path per skill: with the full
-        # catalog installed this is the difference between a readable command
-        # and 35 pasted paths.
+        # No terminal to ask on — piped, or a test run. Install what the screens
+        # recommend, but neither destructive one: nobody was there to decline.
+        def take_the_defaults
+          SkillsInstallPanel::Result.new(defaults.merge(clean_legacy: false, clean_shared_legacy: false), false)
+        end
+
+        def defaults
+          {
+            where: "app", agents: AGENTS.keys, link: symlinks_supported?,
+            clean_legacy: true, clean_shared_legacy: true, confirm: true
+          }
+        end
+
+        # A cleanup screen only when there is something to remove there, and the
+        # link screen only once there is more than one directory to keep in step.
+        def screens
+          list = [where_screen]
+          list << legacy_screen if legacy_skill_dirs.any?
+          list << shared_legacy_screen if shared_legacy_skill_dirs.any?
+          list << agents_screen
+          list << link_screen if symlinks_supported?
+          list << confirm_screen
+          list
+        end
+
+        def where_screen
+          SkillsInstallPanel::Screen.new(
+            key: :where, kind: :radio, title: "Where should the Avo skills loader go?",
+            hint: "It finds the gem from the working directory, so one copy serves every project correctly.",
+            options: [
+              SkillsInstallPanel::Option.new(key: "app", label: "This app", hint: "commit it, your team gets it", recommended: true),
+              SkillsInstallPanel::Option.new(key: "machine", label: "This machine", hint: "one install, every Avo project")
+            ]
+          )
+        end
+
+        def legacy_screen
+          SkillsInstallPanel::Screen.new(
+            key: :clean_legacy, kind: :radio,
+            title: "Remove the #{pluralize_skills(legacy_skill_dirs.length)} left by an earlier install?",
+            hint: "They are not version-pinned and can shadow the skills that ship with your gem.",
+            options: [
+              SkillsInstallPanel::Option.new(key: true, label: "Yes, remove them", recommended: true),
+              SkillsInstallPanel::Option.new(key: false, label: "No, leave them")
+            ]
+          )
+        end
+
+        # Kept a separate question from the project one: this directory is shared
+        # with every other project on the machine, and that is worth its own yes.
+        def shared_legacy_screen
+          SkillsInstallPanel::Screen.new(
+            key: :clean_shared_legacy, kind: :radio,
+            title: "Remove the #{pluralize_skills(shared_legacy_skill_dirs.length)} in #{GLOBAL_LEGACY_ROOT}?",
+            hint: "That directory is shared by every project on this machine, not just this one.",
+            options: [
+              SkillsInstallPanel::Option.new(key: true, label: "Yes, remove them", recommended: true),
+              SkillsInstallPanel::Option.new(key: false, label: "No, leave them")
+            ]
+          )
+        end
+
+        def confirm_screen
+          SkillsInstallPanel::Screen.new(
+            key: :confirm, kind: :radio, title: "Run the installation?", hint: nil,
+            summary: ->(a) { summary_lines(a) },
+            options: [
+              SkillsInstallPanel::Option.new(key: true, label: "Yes, install", recommended: true),
+              SkillsInstallPanel::Option.new(key: false, label: "No, cancel")
+            ]
+          )
+        end
+
+        def summary_lines(a)
+          agents = Array(a[:agents]).select { AGENTS.key?(_1) }
+          root = (a[:where] == "machine") ? "~/" : ""
+          lines = [
+            summary_row("Install to", (a[:where] == "machine") ? "this machine (your home directory)" : "this app"),
+            summary_row("Directories", agents.map { "#{root}#{AGENTS.fetch(_1)[:label]}" }.join(", "))
+          ]
+          lines << summary_row("Extra copies", a[:link] ? "symlinked to #{root}#{AGENTS.fetch(CANONICAL)[:label]}" : "written separately") if agents.length > 1
+          lines << summary_row("Remove", "#{pluralize_skills(legacy_skill_dirs.length)} left in this project") if legacy_skill_dirs.any? && a[:clean_legacy]
+          lines << summary_row("Remove", "#{pluralize_skills(shared_legacy_skill_dirs.length)} in #{GLOBAL_LEGACY_ROOT}") if shared_legacy_skill_dirs.any? && a[:clean_shared_legacy]
+          lines
+        end
+
+        def summary_row(label, value) = "#{label.ljust(14)}#{value}"
+
+        def agents_screen
+          SkillsInstallPanel::Screen.new(
+            key: :agents, kind: :checkbox, title: "Which agents should read it?", hint: nil,
+            options: AGENTS.map { |key, a| SkillsInstallPanel::Option.new(key: key, label: a[:label], hint: a[:hint]) }
+          )
+        end
+
+        def link_screen
+          SkillsInstallPanel::Screen.new(
+            key: :link, kind: :radio, title: "How should the extra directories be written?",
+            hint: "One real file keeps them identical and makes an update a single edit.",
+            options: [
+              SkillsInstallPanel::Option.new(key: true, label: "Symlink to one copy", hint: ".#{CANONICAL}/skills holds the file", recommended: true),
+              SkillsInstallPanel::Option.new(key: false, label: "Separate copies", hint: "use when symlinks are awkward")
+            ],
+            visible_when: ->(a) { Array(a[:agents]).length > 1 }
+          )
+        end
+
+        def destinations
+          dirs = selected_agent_keys.map { |k| AGENTS.fetch(k)[:dir] }
+          global? ? dirs.map { File.expand_path("~/#{_1}") } : dirs
+        end
+
+        # Canonical first, so it is the one written as a real file.
+        def selected_agent_keys
+          keys = Array(answers[:agents]).select { AGENTS.key?(_1) }
+          keys = AGENTS.keys if keys.empty?
+          keys.sort_by { |k| (k == CANONICAL) ? 0 : 1 }
+        end
+
+        def global? = answers[:where] == "machine"
+
+        def link? = !!answers[:link]
+
+        def remove_legacy? = !!answers[:clean_legacy]
+
+        def remove_shared_legacy? = !!answers[:clean_shared_legacy]
+
+        def remove_or_report(dirs, remove:)
+          return if dirs.empty?
+
+          if remove
+            by_directory(dirs).each do |dir, count|
+              dirs.select { |p| display_dir(p) == dir }.each { |p| FileUtils.rm_rf(p) }
+              say_status :remove, "#{dir} (#{pluralize_skills(count)})", :red
+            end
+          else
+            # By directory, never one line per skill: the full catalog is 35 per
+            # scan path, and listing them buries everything else.
+            say "\nLeaving #{pluralize_skills(dirs.length)} in place:", :yellow
+            by_directory(dirs).each { |dir, count| say "  #{dir}  #{count}" }
+            say "Remove them later with:"
+            say "  #{removal_command(dirs)}"
+          end
+        end
+
+        # Probed, not assumed: Windows without developer mode, and some CI
+        # checkouts, cannot create one. A real file beats a broken install.
+        def symlinks_supported?
+          return @symlinks_supported if defined?(@symlinks_supported)
+
+          @symlinks_supported =
+            begin
+              Dir.mktmpdir do |dir|
+                File.write(File.join(dir, "target"), "x")
+                File.symlink(File.join(dir, "target"), File.join(dir, "link"))
+                File.symlink?(File.join(dir, "link"))
+              end
+            rescue NotImplementedError, SystemCallError
+              false
+            end
+        end
+
+        # `destination` is absolute for a machine-wide install and relative for
+        # an app one, so expand rather than join — File.join would nest the
+        # absolute path under the app root.
+        def link_or_copy(canonical, destination)
+          target = File.expand_path(File.join(destination, "SKILL.md"), destination_root)
+          source = File.expand_path(File.join(canonical, "SKILL.md"), destination_root)
+          FileUtils.mkdir_p(File.dirname(target))
+          FileUtils.rm_f(target)
+          File.symlink(relative_link(source, target), target)
+          say_status :symlink, "#{display_path(destination)}/SKILL.md → #{display_path(canonical)}/SKILL.md", :green
+        rescue NotImplementedError, SystemCallError => e
+          say_status :copy, "#{display_path(destination)}/SKILL.md (symlink unavailable: #{e.class})", :yellow
+          copy_file "skills/SKILL.md", File.join(destination, "SKILL.md")
+        end
+
+        # Relative so the link survives the repo being cloned elsewhere.
+        def relative_link(source, target)
+          Pathname.new(source).relative_path_from(Pathname.new(File.dirname(target))).to_s
+        end
+
+        # Subtracts the shared ones so the two cleanup questions never cover the
+        # same directory — they can overlap when the generator runs in ~.
+        def legacy_skill_dirs
+          skill_dirs_in(LEGACY_ROOTS.map { File.expand_path(_1, destination_root) }) - shared_legacy_skill_dirs
+        end
+
+        def shared_legacy_skill_dirs
+          skill_dirs_in([File.expand_path(GLOBAL_LEGACY_ROOT)])
+        end
+
+        # A leftover skill directory, or the scripts/ directory an early 4.1.1
+        # install left behind. A `rm -rf` driven by a name glob alone is not
+        # something to hand a user.
+        def skill_dirs_in(roots)
+          roots.flat_map { |root| Dir.glob(File.join(root, "avo-*")) + Dir.glob(File.join(root, "avo", "scripts")) }
+            .select { |dir| File.directory?(dir) && (File.file?(File.join(dir, "SKILL.md")) || File.basename(dir) == "scripts") }
+            .uniq
+            .sort
+        end
+
         def removal_command(dirs)
           "rm -rf #{by_directory(dirs).keys.map { "#{_1}avo-*" }.join(" ")}"
         end
 
-        # Directory => how many legacy skills sit in it, so a full catalog
-        # reports three lines instead of a hundred.
         def by_directory(dirs)
           dirs.group_by { display_dir(_1) }.transform_values(&:count).sort.to_h
         end
 
-        def display_dir(path)
-          "#{display_path(File.dirname(path))}/"
-        end
+        def display_dir(path) = "#{display_path(File.dirname(path))}/"
 
-        def padding(dir)
-          [2, 28 - dir.length].max
-        end
-
-        def pluralize_skills(count)
-          "#{count} skill#{"s" unless count == 1}"
-        end
-
-        # Cleanup is scoped to wherever this run installs. A project install must
-        # not delete from the home directory another project may still rely on;
-        # a --global install is exactly the case where home is fair game.
-        def legacy_skill_dirs
-          roots = global_install? ? [File.expand_path(GLOBAL_LEGACY_ROOT)] : LEGACY_ROOTS.map { File.expand_path(_1, destination_root) }
-          skill_dirs_in(roots)
-        end
-
-        def global_legacy_skill_dirs
-          return [] if global_install?
-
-          skill_dirs_in([File.expand_path(GLOBAL_LEGACY_ROOT)])
-        end
-
-        # Only directories that actually look like a skill are eligible — a
-        # `rm -rf` driven by a name glob alone is not something to hand a user.
-        def skill_dirs_in(roots)
-          roots.flat_map { |root| Dir.glob(File.join(root, "avo-*")) }
-            .select { |dir| File.directory?(dir) && File.file?(File.join(dir, "SKILL.md")) }
-            .uniq
-            .sort
-        end
+        def pluralize_skills(count) = "#{count} skill#{"s" unless count == 1}"
 
         def display_path(dir)
           home = File.expand_path("~")
           return dir.sub(home, "~") if dir.start_with?(home) && !dir.start_with?(File.expand_path(destination_root))
 
           dir.delete_prefix("#{File.expand_path(destination_root)}/")
-        end
-
-        # The loader holds no per-project state — it finds the app by walking up
-        # from the working directory at run time — so one global copy serves
-        # every Avo project on the machine, each resolving its own lock.
-        def destinations
-          return [options[:path]] if options[:path].present?
-
-          return roots.map { |target| File.expand_path("~/#{target}") } if global_install?
-
-          if (only = options[:only]).present?
-            target = TARGETS[only]
-            raise ::Thor::Error, "Unknown --only value #{only.inspect}. Valid values: #{TARGETS.keys.join(", ")}." if target.nil?
-
-            return [target]
-          end
-
-          TARGETS.values
-        end
-
-        def roots
-          return [TARGETS.fetch(options[:only])] if options[:only].present? && TARGETS.key?(options[:only])
-          return panel_choice.targets.map { |key| TARGETS.fetch(key) } if panel_choice
-
-          TARGETS.values
-        end
-
-        # Shown once, memoized, and only when the user has not already answered
-        # with flags. Without a TTY there is nobody to answer, so the defaults
-        # stand and the install is silent.
-        def panel_choice
-          return @panel_choice if defined?(@panel_choice)
-
-          @panel_choice = if skip_panel?
-            nil
-          else
-            SkillsInstallPanel.new.run
-          end
-        end
-
-        def skip_panel?
-          options[:panel] == false ||
-            options[:quiet] ||
-            options[:path].present? ||
-            options[:only].present? ||
-            !options[:global].nil? ||
-            !SkillsInstallPanel.interactive?
-        end
-
-        def panel_cancelled?
-          return false unless panel_choice&.cancelled?
-
-          say "Cancelled. Nothing was installed.", :yellow
-          true
-        end
-
-        def global_install?
-          return options[:global] unless options[:global].nil?
-
-          panel_choice&.scope == "global"
         end
       end
     end

--- a/lib/generators/avo/skills_install_panel.rb
+++ b/lib/generators/avo/skills_install_panel.rb
@@ -2,97 +2,183 @@ require "io/console"
 
 module Generators
   module Avo
-    # A small keyboard-driven panel for `rails g avo:skills`.
+    # The `rails g avo:skills` install flow: one question per screen, answered
+    # up front, then the generator runs to completion without interrupting.
     #
-    # Two groups with different semantics: scope is a radio (this app OR the
-    # machine), targets are checkboxes (any combination of scan directories).
-    # Written against io/console from stdlib rather than a prompt gem, because
-    # avo is a dependency of other people's apps and a TUI is not worth adding
-    # one for.
+    # Two screen kinds. A :radio moves its selection with the arrows, so
+    # down-then-enter picks the second option — pressing space to commit a
+    # highlighted row is a step people miss. A :checkbox has an independent
+    # state per row, so there space is the toggle and the arrows only move.
     #
-    # Falls back to defaults whenever there is no interactive terminal, so
-    # `-q`, CI, and piped invocations behave predictably. Callers pass explicit
-    # flags to skip the panel entirely.
+    # Written against io/console from stdlib rather than a prompt gem: avo is a
+    # dependency of other people's apps, and a TUI is not worth adding one for.
     class SkillsInstallPanel
-      SCOPES = [
-        {key: "local", label: "This app", hint: "committed, so the whole team gets it"},
-        {key: "global", label: "This machine", hint: "one install, every Avo project"}
-      ].freeze
+      # `visible_when` takes the answers so far, so a screen that only makes
+      # sense given an earlier answer is skipped rather than asked pointlessly.
+      # `summary` takes them too, and renders above the options — how the final
+      # confirm screen shows what it is about to do.
+      Screen = Struct.new(:key, :kind, :title, :hint, :options, :visible_when, :summary)
+      Option = Struct.new(:key, :label, :hint, :recommended)
 
-      TARGETS = [
-        {key: "claude", label: ".claude/skills", hint: "Claude Code"},
-        {key: "agents", label: ".agents/skills", hint: "Codex, Gemini CLI, Goose, Amp, OpenCode"},
-        {key: "cursor", label: ".cursor/skills", hint: "Cursor"}
-      ].freeze
-
-      Result = Struct.new(:scope, :targets, :cancelled) do
+      Result = Struct.new(:answers, :cancelled) do
         def cancelled? = !!cancelled
+        def [](key) = answers[key]
       end
 
       def self.interactive?
         $stdin.tty? && $stdout.tty?
       end
 
-      def initialize(input: $stdin, output: $stdout)
+      # `defaults` seeds each screen, including one that never becomes visible —
+      # its default is then simply the answer.
+      def initialize(screens, defaults: {}, input: $stdin, output: $stdout)
+        @screens = screens
         @input = input
         @output = output
-        @scope = 0
-        @targets = TARGETS.map { |t| [t[:key], true] }.to_h
-        @cursor = 0
-        @rows_drawn = 0
+        @answers = {}
+        @screens.each { |s| @answers[s.key] = defaults.fetch(s.key) { initial_for(s) } }
       end
 
-      # Rows are the two scopes then the three targets, so one cursor walks
-      # both groups and the whole panel is arrow-navigable.
-      def rows
-        SCOPES.length + TARGETS.length
-      end
-
+      # `step` carries the direction, so a skipped screen is stepped over the
+      # way it was entered — otherwise going back would walk into it forwards.
       def run
-        render
-        loop do
-          case read_key
-          when :up then move(-1)
-          when :down then move(1)
-          when :space then toggle
-          when :enter then return finish
-          when :cancel then return cancel
+        index = 0
+        step = 1
+
+        while index < @screens.length
+          screen = @screens[index]
+          unless visible?(screen)
+            index += step
+            next
           end
-          render
+
+          case ask(screen, first: first_visible?(index))
+          when :back then step = -1
+          when :cancel then return Result.new({}, true)
+          else step = 1
+          end
+          index += step
         end
+
+        Result.new(@answers, false)
       end
 
       private
 
+      def visible?(screen) = screen.visible_when.nil? || screen.visible_when.call(@answers)
+
+      # Back is only offered when there is an earlier screen still worth
+      # returning to, so a hidden first screen does not strand the user.
+      def first_visible?(index) = @screens[0...index].none? { visible?(_1) }
+
       attr_reader :input, :output
 
-      def move(delta)
-        @cursor = (@cursor + delta) % rows
-      end
-
-      def toggle
-        if @cursor < SCOPES.length
-          @scope = @cursor
+      def initial_for(screen)
+        if screen.kind == :radio
+          (screen.options.find(&:recommended) || screen.options.first).key
         else
-          key = TARGETS[@cursor - SCOPES.length][:key]
-          # Refuse to empty the set: an install with no target writes nothing
-          # and looks like a silent no-op.
-          @targets[key] = !@targets[key] unless @targets[key] && selected_targets.length == 1
+          screen.options.map(&:key)
         end
       end
 
-      def selected_targets
-        TARGETS.map { |t| t[:key] }.select { |k| @targets[k] }
+      def ask(screen, first:)
+        cursor = start_cursor(screen)
+        rows = 0
+
+        loop do
+          rows = draw(screen, cursor, rows, first: first)
+
+          case read_key
+          when :up then cursor = (cursor - 1) % screen.options.length
+          when :down then cursor = (cursor + 1) % screen.options.length
+          when :space then toggle(screen, cursor)
+          when :enter then return commit(screen, cursor, rows)
+          when :back then (return erase(rows) { :back }) unless first
+          when :cancel then return erase(rows) { :cancel }
+          end
+
+          # A radio's selection follows the cursor, so moving is choosing and
+          # enter alone is enough.
+          @answers[screen.key] = screen.options[cursor].key if screen.kind == :radio
+        end
       end
 
-      def finish
-        clear
-        Result.new(SCOPES[@scope][:key], selected_targets, false)
+      def start_cursor(screen)
+        return 0 unless screen.kind == :radio
+
+        screen.options.index { |o| o.key == @answers[screen.key] } || 0
       end
 
-      def cancel
-        clear
-        Result.new(nil, [], true)
+      def toggle(screen, cursor)
+        return if screen.kind == :radio
+
+        key = screen.options[cursor].key
+        selected = @answers[screen.key]
+        # Refuse to empty the set: installing nowhere writes nothing and reads
+        # as a silent no-op.
+        return if selected == [key]
+
+        @answers[screen.key] = selected.include?(key) ? selected - [key] : selected + [key]
+        @answers[screen.key] = screen.options.map(&:key).select { |k| @answers[screen.key].include?(k) }
+      end
+
+      def commit(screen, cursor, rows)
+        @answers[screen.key] = screen.options[cursor].key if screen.kind == :radio
+        erase(rows) { :next }
+      end
+
+      def erase(rows)
+        output.print("\e[#{rows}A\e[J") if rows.positive?
+        yield
+      end
+
+      def draw(screen, cursor, previous_rows, first:)
+        output.print("\e[#{previous_rows}A\e[J") if previous_rows.positive?
+
+        lines = ["", "  #{bold(screen.title)}"]
+        lines << "  #{dim(screen.hint)}" if screen.hint
+        lines << ""
+
+        if screen.summary
+          screen.summary.call(@answers).each { |line| lines << "    #{line}" }
+          lines << ""
+        end
+
+        screen.options.each_with_index do |option, i|
+          lines << option_row(screen, option, i, cursor)
+        end
+
+        lines << ""
+        lines << "  #{dim(keys_hint(screen, first: first))}"
+        lines << ""
+
+        output.print(lines.join("\n") + "\n")
+        lines.length
+      end
+
+      def option_row(screen, option, index, cursor)
+        marker =
+          if screen.kind == :radio
+            (@answers[screen.key] == option.key) ? "(•)" : "( )"
+          else
+            @answers[screen.key].include?(option.key) ? "[x]" : "[ ]"
+          end
+
+        label = option.label
+        label += " #{dim("(recommended)")}" if option.recommended
+        text = "#{(cursor == index) ? "›" : " "} #{marker} #{label}"
+        text += "  #{dim(option.hint)}" if option.hint
+
+        (cursor == index) ? "  #{bold(text)}" : "  #{text}"
+      end
+
+      def keys_hint(screen, first:)
+        parts = ["↑↓ move"]
+        parts << "space toggle" if screen.kind == :checkbox
+        parts << "enter continue"
+        parts << "← back" unless first
+        parts << "q cancel"
+        parts.join("   ")
       end
 
       def read_key
@@ -100,70 +186,37 @@ module Generators
         case char
         when "\r", "\n" then :enter
         when " " then :space
-        when "", "q", "\e" then escape_or_cancel(char)
+        # nil is EOF: stdin closed, or a test keyboard ran dry. Treat it as
+        # cancel rather than spinning on it forever.
+        when nil, "q", "\u0003", "\u0004" then :cancel
+        when "\e" then escape_sequence
         else :none
         end
       rescue Interrupt
         :cancel
       end
 
-      # An arrow key arrives as ESC [ A. A bare ESC means cancel, so peek at
-      # what follows before deciding.
-      def escape_or_cancel(char)
-        return :cancel unless char == "\e"
+      # Arrows arrive as ESC [ A. A bare ESC cancels, so peek before deciding.
+      def escape_sequence
         return :cancel unless input.respond_to?(:read_nonblock)
 
         begin
           seq = input.read_nonblock(2)
-        rescue IO::WaitReadable, EOFError, Errno::EAGAIN
+        rescue IO::WaitReadable, EOFError, Errno::EAGAIN, Errno::EWOULDBLOCK
           return :cancel
         end
 
         case seq
         when "[A" then :up
         when "[B" then :down
+        when "[D" then :back
         else :none
         end
       end
 
-      def clear
-        output.print("\e[#{@rows_drawn}A\e[J") if @rows_drawn.positive?
-        @rows_drawn = 0
-      end
+      def bold(text) = "\e[1m#{text}\e[0m"
 
-      def render
-        clear
-        lines = []
-        lines << ""
-        lines << "  Install the Avo skills loader"
-        lines << ""
-        lines << "  #{dim("Where")}"
-        SCOPES.each_with_index do |scope, i|
-          lines << row(i, (@scope == i) ? "(•)" : "( )", scope[:label], scope[:hint])
-        end
-        lines << ""
-        lines << "  #{dim("Which agents")}"
-        TARGETS.each_with_index do |target, i|
-          lines << row(SCOPES.length + i, @targets[target[:key]] ? "[x]" : "[ ]", target[:label], target[:hint])
-        end
-        lines << ""
-        lines << "  #{dim("↑↓ move   space select   enter install   q cancel")}"
-        lines << ""
-
-        output.print(lines.join("\n") + "\n")
-        @rows_drawn = lines.length
-      end
-
-      def row(index, marker, label, hint)
-        active = @cursor == index
-        pointer = active ? "›" : " "
-        text = "#{pointer} #{marker} #{label.ljust(16)} #{dim(hint)}"
-        active ? "  \e[1m#{text}\e[0m" : "  #{text}"
-      end
-
-      def dim(text)
-        "\e[2m#{text}\e[0m"
-      end
+      def dim(text) = "\e[2m#{text}\e[0m"
     end
   end
 end

--- a/lib/generators/avo/skills_install_panel.rb
+++ b/lib/generators/avo/skills_install_panel.rb
@@ -22,6 +22,7 @@ module Generators
 
       Result = Struct.new(:answers, :cancelled) do
         def cancelled? = !!cancelled
+
         def [](key) = answers[key]
       end
 

--- a/spec/features/avo/generators/skills_generator_spec.rb
+++ b/spec/features/avo/generators/skills_generator_spec.rb
@@ -5,11 +5,58 @@ require "tmpdir"
 # something invokes it. Requiring it keeps the unit-level examples order-independent.
 require "generators/avo/skills_generator"
 
+# The generator has no flags to reach past the panel with, so these drive the
+# real thing: a fake tty on $stdin/$stdout, and the keys someone would press.
+class FakeKeyboard
+  KEYS = {
+    up: ["\e", "[A"], down: ["\e", "[B"], back: ["\e", "[D"],
+    space: [" "], enter: ["\r"], cancel: ["q"]
+  }.freeze
+
+  def initialize(keys)
+    @chars = keys.flat_map { KEYS.fetch(_1) }
+  end
+
+  def getch = @chars.shift
+
+  def read_nonblock(_n) = @chars.shift
+
+  def tty? = true
+end
+
+class FakeTerminal < StringIO
+  def tty? = true
+end
+
 RSpec.feature "skills generator", type: :feature, acquire_lock: :generator do
   let(:targets) { %w[.claude/skills/avo .agents/skills/avo .cursor/skills/avo] }
 
-  def generate(args = ["-q", "--skip-avo-version"])
-    Rails::Generators.invoke("avo:skills", args, {destination_root: Rails.root})
+  # Screens, in order: where, [project leftovers], [shared leftovers], agents,
+  # [link], confirm. The bracketed ones appear only when they apply, so every
+  # key sequence below is written against exactly the screens that example gets.
+  let(:all_defaults) { [:enter, :enter, :enter, :enter] }
+
+  # ~/.claude/skills is scanned for leftovers, so a real home directory would
+  # make the screen list depend on whose machine the suite runs on.
+  around do |example|
+    Dir.mktmpdir("fake-home") do |home|
+      @home = home
+      original = ENV["HOME"]
+      ENV["HOME"] = home
+      example.run
+    ensure
+      ENV["HOME"] = original
+    end
+  end
+
+  def generate(keys = all_defaults, args: [])
+    original_in, original_out = $stdin, $stdout
+    $stdin = FakeKeyboard.new(keys)
+    $stdout = FakeTerminal.new
+    Rails::Generators.invoke("avo:skills", ["--skip-avo-version", *args], {destination_root: Rails.root})
+    $stdout.string
+  ensure
+    $stdin, $stdout = original_in, original_out
   end
 
   def cleanup
@@ -37,75 +84,165 @@ RSpec.feature "skills generator", type: :feature, acquire_lock: :generator do
     end
   end
 
-  it "copies rather than symlinks, so bundle update cannot break the link" do
+  # One real file, linked from the rest: an update is then a single edit, and
+  # the three directories cannot drift apart.
+  it "writes one real file and symlinks the others to it" do
     generate
 
-    targets.each { |target| expect(File).not_to be_symlink Rails.root.join(target, "SKILL.md").to_s }
+    expect(File).not_to be_symlink Rails.root.join(".agents/skills/avo/SKILL.md").to_s
+    expect(File).to be_symlink Rails.root.join(".claude/skills/avo/SKILL.md").to_s
+    expect(File).to be_symlink Rails.root.join(".cursor/skills/avo/SKILL.md").to_s
+  end
+
+  # Relative, so the link still resolves after the repo is cloned somewhere else.
+  it "links relatively, not to this machine's absolute path" do
+    generate
+
+    expect(File.readlink(Rails.root.join(".claude/skills/avo/SKILL.md").to_s)).not_to start_with "/"
+  end
+
+  it "reads as the same loader through every directory" do
+    generate
+
+    bodies = targets.map { File.read(Rails.root.join(_1, "SKILL.md")) }
+
+    expect(bodies.uniq.length).to eq 1
   end
 
   it "refreshes an edited loader when re-run" do
     generate
 
-    loader = Rails.root.join(".claude/skills/avo/SKILL.md")
-    File.write(loader, "# stale local edit
-")
-    generate(["-q", "--skip-avo-version", "--force"])
+    loader = Rails.root.join(".agents/skills/avo/SKILL.md")
+    File.write(loader, "# stale local edit\n")
+    generate(all_defaults, args: ["--force"])
 
     expect(File.read(loader)).to eq File.read(Avo::Engine.root.join("lib/generators/avo/templates/skills/SKILL.md"))
   end
 
-  it "installs one target only with --only" do
-    generate(["-q", "--skip-avo-version", "--only", "claude"])
+  describe "answering the panel" do
+    it "installs only the agents left ticked" do
+      # untick .agents, move to .cursor, untick it, leaving .claude
+      generate([:enter, :space, :down, :down, :space, :enter, :enter])
 
-    expect(File).to exist Rails.root.join(".claude/skills/avo/SKILL.md").to_s
-    expect(File).not_to exist Rails.root.join(".agents/skills/avo/SKILL.md").to_s
-    expect(File).not_to exist Rails.root.join(".cursor/skills/avo/SKILL.md").to_s
-  end
-
-  it "rejects an unknown --only value instead of installing nothing silently" do
-    # Thor catches Thor::Error and prints it rather than propagating through
-    # `invoke`, so the observable contract is: named message, nothing installed.
-    original = $stderr
-    $stderr = StringIO.new
-    begin
-      generate(["-q", "--skip-avo-version", "--only", "nope"])
-      output = $stderr.string
-    ensure
-      $stderr = original
+      expect(File).to exist Rails.root.join(".claude/skills/avo/SKILL.md").to_s
+      expect(File).not_to exist Rails.root.join(".agents/skills/avo/SKILL.md").to_s
+      expect(File).not_to exist Rails.root.join(".cursor/skills/avo/SKILL.md").to_s
     end
 
-    expect(output).to match(/Unknown --only value/)
-    targets.each { |target| expect(File).not_to exist Rails.root.join(target, "SKILL.md").to_s }
+    # Nothing to keep in step with one directory, so the question is not worth
+    # a screen.
+    it "does not ask about linking when only one agent is picked" do
+      output = generate([:enter, :space, :down, :down, :space, :enter, :enter])
+
+      expect(output).not_to include "How should the extra directories be written?"
+    end
+
+    it "asks about linking once more than one agent is picked" do
+      expect(generate).to include "How should the extra directories be written?"
+    end
+
+    it "writes separate copies when asked to" do
+      generate([:enter, :enter, :down, :enter, :enter])
+
+      targets.each { |target| expect(File).not_to be_symlink Rails.root.join(target, "SKILL.md").to_s }
+      targets.each { |target| expect(File).to exist Rails.root.join(target, "SKILL.md").to_s }
+    end
+
+    it "installs nothing when cancelled" do
+      generate([:cancel])
+
+      targets.each { |target| expect(File).not_to exist Rails.root.join(target, "SKILL.md").to_s }
+    end
+
+    it "says so rather than failing silently when cancelled" do
+      expect(generate([:cancel])).to include "Cancelled. Nothing was installed."
+    end
   end
 
-  describe "--global" do
-    let(:global_targets) { %w[.claude/skills/avo .agents/skills/avo .cursor/skills/avo] }
+  # The last screen, so nothing is written before the user has seen what the
+  # answers add up to.
+  describe "the confirm screen" do
+    it "lists the answers back before installing" do
+      output = generate
 
-    around do |example|
-      Dir.mktmpdir("fake-home") do |home|
-        @home = home
-        original = ENV["HOME"]
-        ENV["HOME"] = home
-        example.run
-      ensure
-        ENV["HOME"] = original
-      end
+      expect(output).to include "Run the installation?"
+      expect(output).to match(/Install to\s+this app/)
+      expect(output).to match(/Directories\s+\.agents\/skills, \.claude\/skills, \.cursor\/skills/)
+      expect(output).to match(/Extra copies\s+symlinked to \.agents\/skills/)
     end
+
+    it "reflects the answers actually given, not the defaults" do
+      output = generate([:down, :enter, :enter, :down, :enter])
+
+      expect(output).to match(/Install to\s+this machine/)
+      expect(output).to match(/Extra copies\s+written separately/)
+    end
+
+    it "omits the copies row when there is only one directory" do
+      output = generate([:enter, :space, :down, :down, :space, :enter, :enter])
+
+      expect(output).not_to include "Extra copies"
+    end
+
+    it "installs nothing when the answer is no" do
+      generate([:enter, :enter, :enter, :down, :enter])
+
+      targets.each { |target| expect(File).not_to exist Rails.root.join(target, "SKILL.md").to_s }
+    end
+
+    it "goes back from it to change an answer" do
+      # confirm -> back to link -> pick separate copies -> confirm
+      generate([:enter, :enter, :enter, :back, :down, :enter, :enter])
+
+      targets.each { |target| expect(File).not_to be_symlink Rails.root.join(target, "SKILL.md").to_s }
+    end
+  end
+
+  # Windows without developer mode, and some CI checkouts, cannot create one.
+  # A real file beats a broken install.
+  it "falls back to copying when the filesystem has no symlinks" do
+    generator = Generators::Avo::SkillsGenerator.new([], ["--skip-avo-version"], destination_root: Rails.root.to_s)
+    allow(generator).to receive(:symlinks_supported?).and_return(true)
+    allow(File).to receive(:symlink).and_raise(Errno::EPERM)
+
+    generator.install_loader
+
+    targets.each { |target| expect(File).to exist Rails.root.join(target, "SKILL.md").to_s }
+    targets.each { |target| expect(File).not_to be_symlink Rails.root.join(target, "SKILL.md").to_s }
+  end
+
+  describe "installing for the whole machine" do
+    let(:machine_keys) { [:down, :enter, :enter, :enter, :enter] }
 
     it "installs to the home directory, not the app" do
-      generate(["-q", "--skip-avo-version", "--global"])
+      generate(machine_keys)
 
-      global_targets.each { |t| expect(File).to exist File.join(@home, t, "SKILL.md") }
-      global_targets.each { |t| expect(File).not_to exist Rails.root.join(t, "SKILL.md").to_s }
+      targets.each { |t| expect(File).to exist File.join(@home, t, "SKILL.md") }
+      targets.each { |t| expect(File).not_to exist Rails.root.join(t, "SKILL.md").to_s }
     end
 
     # One copy serves every project, so it must be the same bytes the gem ships —
     # otherwise it would report itself stale everywhere.
     it "is otherwise the same file the app install writes" do
-      generate(["-q", "--skip-avo-version", "--global"])
+      generate(machine_keys)
 
-      global = File.read(File.join(@home, ".claude/skills/avo/SKILL.md"))
-      expect(global).to eq File.read(Avo::Engine.root.join("lib/generators/avo/templates/skills/SKILL.md"))
+      machine = File.read(File.join(@home, ".claude/skills/avo/SKILL.md"))
+      expect(machine).to eq File.read(Avo::Engine.root.join("lib/generators/avo/templates/skills/SKILL.md"))
+    end
+
+    # The link is between two directories under the same home, so it must not
+    # reach back into the app root that Thor was pointed at.
+    it "links between the home directories, not back into the app" do
+      generate(machine_keys)
+
+      link = File.join(@home, ".claude/skills/avo/SKILL.md")
+
+      expect(File).to be_symlink link
+      expect(File.realpath(link)).to eq File.realpath(File.join(@home, ".agents/skills/avo/SKILL.md"))
+    end
+
+    it "shows the home paths on the confirm screen" do
+      expect(generate(machine_keys)).to match(%r{Directories\s+~/\.agents/skills})
     end
   end
 
@@ -119,25 +256,54 @@ RSpec.feature "skills generator", type: :feature, acquire_lock: :generator do
       end
     end
 
+    def plant_shared(*names)
+      names.map do |name|
+        dir = File.join(@home, ".claude/skills", name)
+        FileUtils.mkdir_p(dir)
+        File.write(File.join(dir, "SKILL.md"), "---\nname: #{name}\n---\n")
+        dir
+      end
+    end
+
+    # One extra screen with leftovers present, so one extra answer.
+    let(:clean_them) { [:enter, :enter, :enter, :enter, :enter] }
+    let(:keep_them) { [:enter, :down, :enter, :enter, :enter, :enter] }
+
+    it "asks only when there is something to remove" do
+      plant_legacy("avo-fields")
+
+      expect(generate(clean_them)).to include "left by an earlier install?"
+    end
+
+    it "does not ask when there is nothing to remove" do
+      expect(generate).not_to include "left by an earlier install?"
+    end
+
     it "removes a leftover catalog when asked" do
       stale = plant_legacy("avo-fields", "avo-kanban")
-      generate(["-q", "--skip-avo-version", "--clean-legacy"])
+      generate(clean_them)
 
       stale.each { |dir| expect(Dir).not_to exist dir.to_s }
     end
 
     it "leaves the loader it just installed alone" do
       plant_legacy("avo-fields")
-      generate(["-q", "--skip-avo-version", "--clean-legacy"])
+      generate(clean_them)
 
       expect(File).to exist Rails.root.join(".claude/skills/avo/SKILL.md").to_s
     end
 
     it "keeps leftovers when told not to clean" do
       stale = plant_legacy("avo-fields")
-      generate(["-q", "--skip-avo-version", "--no-clean-legacy"])
+      generate(keep_them)
 
       stale.each { |dir| expect(Dir).to exist dir.to_s }
+    end
+
+    it "names the removal on the confirm screen" do
+      plant_legacy("avo-fields", "avo-kanban")
+
+      expect(generate(clean_them)).to match(/Remove\s+2 skills left in this project/)
     end
 
     # A `rm -rf` driven by a name glob alone is not something to hand a user.
@@ -146,35 +312,64 @@ RSpec.feature "skills generator", type: :feature, acquire_lock: :generator do
       FileUtils.mkdir_p(unrelated)
       File.write(unrelated.join("README.md"), "not a skill")
 
-      generate(["-q", "--skip-avo-version", "--clean-legacy"])
+      generate
 
       expect(Dir).to exist unrelated.to_s
     end
 
     it "cleans every scan directory, not just Claude's" do
       stale = %w[.claude/skills .agents/skills .cursor/skills].flat_map { plant_legacy("avo-fields", root: _1) }
-      generate(["-q", "--skip-avo-version", "--clean-legacy"])
+      generate(clean_them)
 
       stale.each { |dir| expect(Dir).not_to exist dir.to_s }
     end
 
-    it "does not prompt in quiet mode and keeps the files" do
+    # A run with no terminal never showed the question, so nobody declined it.
+    it "keeps them when there was no terminal to ask on" do
       stale = plant_legacy("avo-fields")
-      generate
+      Rails::Generators.invoke("avo:skills", ["--skip-avo-version", "-q"], {destination_root: Rails.root})
 
       stale.each { |dir| expect(Dir).to exist dir.to_s }
     end
 
-    # ~/.claude/skills is shared by every project on the machine. A generator run
-    # inside one app must not delete from it — another app may still want those
-    # skills, and a test suite must never be able to wipe a real home directory.
-    it "never deletes from the shared home skills directory" do
-      home_skills = File.expand_path("~/.claude/skills")
+    # ~/.claude/skills is shared with every other project, so it gets its own
+    # question rather than riding along on the project one.
+    describe "the shared home directory" do
+      it "asks about it separately" do
+        plant_shared("avo-fields")
 
-      expect(FileUtils).not_to receive(:rm_rf).with(a_string_starting_with(home_skills))
+        expect(generate(clean_them)).to include "shared by every project on this machine"
+      end
 
-      plant_legacy("avo-fields")
-      generate(["-q", "--skip-avo-version", "--clean-legacy"])
+      it "removes them when asked" do
+        stale = plant_shared("avo-fields", "avo-kanban")
+        generate(clean_them)
+
+        stale.each { |dir| expect(Dir).not_to exist dir.to_s }
+      end
+
+      it "keeps them when told not to" do
+        stale = plant_shared("avo-fields")
+        generate(keep_them)
+
+        stale.each { |dir| expect(Dir).to exist dir.to_s }
+      end
+
+      it "asks twice when both places have leftovers" do
+        plant_legacy("avo-fields")
+        plant_shared("avo-kanban")
+        output = generate([:enter, :enter, :enter, :enter, :enter, :enter])
+
+        expect(output).to include "left by an earlier install?"
+        expect(output).to include "shared by every project on this machine"
+      end
+
+      it "never removes them on a run with no terminal to ask on" do
+        stale = plant_shared("avo-fields")
+        Rails::Generators.invoke("avo:skills", ["--skip-avo-version", "-q"], {destination_root: Rails.root})
+
+        stale.each { |dir| expect(Dir).to exist dir.to_s }
+      end
     end
 
     # These exercise the reporting directly, so they run against their own temp
@@ -195,8 +390,10 @@ RSpec.feature "skills generator", type: :feature, acquire_lock: :generator do
         end
       end
 
-      def report(args = ["--skip-avo-version", "--no-clean-legacy"])
-        generator = Generators::Avo::SkillsGenerator.new([], args, destination_root: @sandbox)
+      # No terminal here, so the generator takes the defaults and keeps them,
+      # which is exactly the branch that reports.
+      def report
+        generator = Generators::Avo::SkillsGenerator.new([], ["--skip-avo-version"], destination_root: @sandbox)
         yield generator if block_given?
         capture_generator_output { generator.clean_legacy_skills }
       end
@@ -210,7 +407,7 @@ RSpec.feature "skills generator", type: :feature, acquire_lock: :generator do
 
         output = report
 
-        expect(output).to include("Found 70 skills")
+        expect(output).to include("Leaving 70 skills in place")
         expect(output).to match(%r{^\s+\.claude/skills/\s+35$})
         expect(output).to match(%r{^\s+\.agents/skills/\s+35$})
         expect(output).not_to include("avo-skill-1\n")
@@ -226,14 +423,13 @@ RSpec.feature "skills generator", type: :feature, acquire_lock: :generator do
         expect(output).not_to include("avo-fields avo-kanban")
       end
 
-      it "reports home leftovers instead of removing them" do
-        output = report(["--skip-avo-version"]) do |generator|
-          allow(generator).to receive(:global_legacy_skill_dirs)
+      it "reports the shared ones under a tilde, not an absolute path" do
+        output = report do |generator|
+          allow(generator).to receive(:shared_legacy_skill_dirs)
             .and_return([File.expand_path("~/.claude/skills/avo-fields")])
           allow(generator).to receive(:legacy_skill_dirs).and_return([])
         end
 
-        expect(output).to match(/Not removing those/)
         expect(output).to match(%r{^\s+~/\.claude/skills/\s+1$})
         expect(output).to include("rm -rf ~/.claude/skills/avo-*")
       end

--- a/spec/lib/avo/skills/install_panel_spec.rb
+++ b/spec/lib/avo/skills/install_panel_spec.rb
@@ -2,13 +2,13 @@ require "rails_helper"
 require "stringio"
 require "generators/avo/skills_install_panel"
 
-# Drives the panel through a fake keyboard. Scope is a radio and targets are
-# checkboxes, so the interesting cases are the ones where those two behaviors
-# differ.
-# `getch` reads one character; arrow keys arrive as ESC then "[A"/"[B", which
+# `getch` reads one character; arrows arrive as ESC then "[A"/"[B"/"[D", which
 # the panel reads with a follow-up read_nonblock.
 class FakeKeyboard
-  KEYS = {up: ["\e", "[A"], down: ["\e", "[B"], space: [" "], enter: ["\r"], cancel: ["q"]}.freeze
+  KEYS = {
+    up: ["\e", "[A"], down: ["\e", "[B"], back: ["\e", "[D"],
+    space: [" "], enter: ["\r"], cancel: ["q"]
+  }.freeze
 
   def initialize(keys)
     @chars = keys.flat_map { KEYS.fetch(_1) }
@@ -20,85 +20,212 @@ class FakeKeyboard
 end
 
 RSpec.describe Generators::Avo::SkillsInstallPanel do
-  def run(*keys)
-    described_class.new(input: FakeKeyboard.new(keys), output: StringIO.new).run
+  def radio(key = :where)
+    described_class::Screen.new(key: key, kind: :radio, title: "Where?", hint: nil, options: [
+      described_class::Option.new(key: "app", label: "This app", recommended: true),
+      described_class::Option.new(key: "machine", label: "This machine")
+    ])
   end
 
-  it "defaults to this app with every agent selected" do
-    result = run(:enter)
-
-    expect(result.scope).to eq "local"
-    expect(result.targets).to eq %w[claude agents cursor]
-    expect(result).not_to be_cancelled
+  def checkbox(key = :agents)
+    described_class::Screen.new(key: key, kind: :checkbox, title: "Which agents?", hint: nil, options: [
+      described_class::Option.new(key: "agents", label: ".agents/skills"),
+      described_class::Option.new(key: "claude", label: ".claude/skills"),
+      described_class::Option.new(key: "cursor", label: ".cursor/skills")
+    ])
   end
 
-  it "selects the global scope" do
-    result = run(:down, :space, :enter)
-
-    expect(result.scope).to eq "global"
+  def run(screens, keys, defaults: {})
+    list = screens.is_a?(Array) ? screens : [screens]
+    described_class.new(list, defaults: defaults, input: FakeKeyboard.new(keys), output: StringIO.new).run
   end
 
-  # Radio, not checkbox: choosing one scope must clear the other.
-  it "keeps the scope exclusive" do
-    result = run(:down, :space, :up, :space, :enter)
+  describe "a radio screen" do
+    # The bug from the review: Adrian pressed down, then enter, and it kept the
+    # first option. Moving must *be* choosing.
+    it "selects with down then enter, no space" do
+      expect(run(radio, [:down, :enter])[:where]).to eq "machine"
+    end
 
-    expect(result.scope).to eq "local"
-  end
+    it "still selects with space, for anyone who reaches for it" do
+      expect(run(radio, [:down, :space, :enter])[:where]).to eq "machine"
+    end
 
-  it "toggles an agent off without touching the others" do
-    result = run(:down, :down, :space, :enter)   # rows: 0 app, 1 machine, 2 .claude
+    it "defaults to the recommended option" do
+      expect(run(radio, [:enter])[:where]).to eq "app"
+    end
 
-    expect(result.targets).to eq %w[agents cursor]
-    expect(result.scope).to eq "local"
-  end
-
-  it "toggles an agent back on" do
-    result = run(:down, :down, :space, :space, :enter)
-
-    expect(result.targets).to eq %w[claude agents cursor]
-  end
-
-  # An install with no target writes nothing and reads as a silent no-op, so
-  # the last selected agent refuses to turn off.
-  it "refuses to leave zero agents selected" do
-    result = run(:down, :down, :space, :down, :space, :down, :space, :enter)
-
-    expect(result.targets.length).to eq 1
-  end
-
-  it "wraps the cursor from the last row to the first" do
-    result = run(:up, :space, :enter)
-
-    expect(result.targets).to eq %w[claude agents]
-  end
-
-  it "cancels on q without choosing anything" do
-    result = run(:cancel)
-
-    expect(result).to be_cancelled
-    expect(result.targets).to be_empty
-  end
-
-  describe "rendering" do
-    it "shows both groups, the keybindings, and the current selection" do
-      output = StringIO.new
-      described_class.new(input: FakeKeyboard.new([:enter]), output: output).run
-      plain = output.string.gsub(/\e\[[0-9;]*[A-Za-z]/, "")
-
-      expect(plain).to include("Install the Avo skills loader")
-      expect(plain).to include("This app", "This machine")
-      expect(plain).to include(".claude/skills", ".agents/skills", ".cursor/skills")
-      expect(plain).to include("space select", "enter install", "q cancel")
-      expect(plain).to include("(•)")
-      expect(plain).to include("[x]")
+    it "wraps around" do
+      expect(run(radio, [:up, :enter])[:where]).to eq "machine"
     end
   end
 
-  describe ".interactive?" do
-    it "is false when stdin is not a tty, so CI and piped runs skip the panel" do
-      allow($stdin).to receive(:tty?).and_return(false)
+  describe "a checkbox screen" do
+    it "starts with everything selected and space toggles one off" do
+      expect(run(checkbox, [:down, :space, :enter])[:agents]).to eq %w[agents cursor]
+    end
 
-      expect(described_class).not_to be_interactive
+    # Re-selecting must put it back in declared position, not append it, so the
+    # canonical directory stays first and gets the real file.
+    it "keeps the declared order when something is toggled off and back on" do
+      answer = run(checkbox, [:space, :space, :enter])
+
+      expect(answer[:agents]).to eq %w[agents claude cursor]
+    end
+
+    it "puts a re-selected middle option back in the middle" do
+      answer = run(checkbox, [:down, :space, :space, :enter])
+
+      expect(answer[:agents]).to eq %w[agents claude cursor]
+    end
+
+    # Installing nowhere writes nothing and reads as a silent no-op.
+    it "refuses to leave nothing selected" do
+      expect(run(checkbox, [:space, :down, :space, :down, :space, :enter])[:agents].length).to eq 1
+    end
+  end
+
+  describe "moving between screens" do
+    it "answers each screen in turn" do
+      answer = run([radio, checkbox], [:down, :enter, :down, :space, :enter])
+
+      expect(answer[:where]).to eq "machine"
+      expect(answer[:agents]).to eq %w[agents cursor]
+    end
+
+    # Paul's note: with everything on one screen there was no way back once you
+    # had moved past a group.
+    it "goes back to a previous screen and keeps what was answered there" do
+      answer = run([radio, checkbox], [:down, :enter, :back, :enter, :enter])
+
+      expect(answer[:where]).to eq "machine"
+    end
+
+    it "lets a re-answered screen change the result" do
+      answer = run([radio, checkbox], [:down, :enter, :back, :up, :enter, :enter])
+
+      expect(answer[:where]).to eq "app"
+    end
+
+    it "has no back on the first screen, so q there cancels" do
+      expect(run([radio, checkbox], [:back])).to be_cancelled
+    end
+
+    it "cancels from a later screen too" do
+      expect(run([radio, checkbox], [:down, :enter, :cancel])).to be_cancelled
+    end
+  end
+
+  # A question that does not apply given an earlier answer should not be asked
+  # at all — the alternative is a screen whose answer changes nothing.
+  describe "a screen that only sometimes applies" do
+    def conditional(visible_when)
+      described_class::Screen.new(key: :link, kind: :radio, title: "Link them?", hint: nil, visible_when: visible_when, options: [
+        described_class::Option.new(key: true, label: "Yes", recommended: true),
+        described_class::Option.new(key: false, label: "No")
+      ])
+    end
+
+    it "is skipped when its condition is false" do
+      screens = [radio, conditional(->(a) { a[:where] == "machine" })]
+      out = StringIO.new
+      described_class.new(screens, input: FakeKeyboard.new([:enter]), output: out).run
+
+      expect(out.string).not_to include "Link them?"
+    end
+
+    it "is asked when its condition is true" do
+      screens = [radio, conditional(->(a) { a[:where] == "app" })]
+      out = StringIO.new
+      described_class.new(screens, input: FakeKeyboard.new([:enter, :enter]), output: out).run
+
+      expect(out.string).to include "Link them?"
+    end
+
+    # Its default stands in for the answer, so downstream code never sees a nil
+    # for a question that was never put.
+    it "keeps its default as the answer when skipped" do
+      screens = [radio, conditional(->(_a) { false })]
+
+      answer = described_class.new(screens, input: FakeKeyboard.new([:enter]), output: StringIO.new).run
+
+      expect(answer[:link]).to be true
+    end
+
+    # Stepping backwards has to step *over* it the same way, or back would walk
+    # into the skipped screen forwards and hang there.
+    it "is stepped over going back, not walked into" do
+      screens = [radio, conditional(->(_a) { false }), checkbox]
+
+      answer = described_class.new(screens, input: FakeKeyboard.new([:enter, :back, :down, :enter, :enter]), output: StringIO.new).run
+
+      expect(answer[:where]).to eq "machine"
+    end
+  end
+
+  describe "a summary" do
+    def confirm(summary)
+      described_class::Screen.new(key: :confirm, kind: :radio, title: "Run it?", hint: nil, summary: summary, options: [
+        described_class::Option.new(key: true, label: "Yes", recommended: true),
+        described_class::Option.new(key: false, label: "No")
+      ])
+    end
+
+    it "renders above the options" do
+      out = StringIO.new
+      described_class.new([confirm(->(_a) { ["Install to    this app"] })], input: FakeKeyboard.new([:enter]), output: out).run
+      plain = out.string.gsub(/\e\[[0-9;]*[A-Za-z]/, "")
+
+      expect(plain.index("Install to    this app")).to be < plain.index("Yes")
+    end
+
+    # Built from the answers when the screen is drawn, so it shows what was
+    # actually chosen rather than what was proposed.
+    it "reads the answers given on earlier screens" do
+      screens = [radio, confirm(->(a) { ["chose: #{a[:where]}"] })]
+      out = StringIO.new
+      described_class.new(screens, input: FakeKeyboard.new([:down, :enter, :enter]), output: out).run
+
+      expect(out.string).to include "chose: machine"
+    end
+  end
+
+  describe "defaults" do
+    it "seeds a screen so a flag pre-selects it" do
+      expect(run(radio, [:enter], defaults: {where: "machine"})[:where]).to eq "machine"
+    end
+
+    it "puts the cursor on the seeded option, so enter keeps it" do
+      expect(run(radio, [:enter], defaults: {where: "machine"})[:where]).to eq "machine"
+    end
+  end
+
+  describe "rendering" do
+    it "marks the recommended option and shows the keys for the screen kind" do
+      out = StringIO.new
+      described_class.new([checkbox], input: FakeKeyboard.new([:enter]), output: out).run
+      plain = out.string.gsub(/\e\[[0-9;]*[A-Za-z]/, "")
+
+      expect(plain).to include("Which agents?", "[x] .agents/skills")
+      expect(plain).to include("space toggle")
+    end
+
+    it "omits the space hint on a radio, where space is not needed" do
+      out = StringIO.new
+      described_class.new([radio], input: FakeKeyboard.new([:enter]), output: out).run
+      plain = out.string.gsub(/\e\[[0-9;]*[A-Za-z]/, "")
+
+      expect(plain).to include("(recommended)")
+      expect(plain).not_to include("space toggle")
+    end
+
+    it "offers back only once there is somewhere to go" do
+      out = StringIO.new
+      described_class.new([radio, checkbox], input: FakeKeyboard.new([:enter, :enter]), output: out).run
+      frames = out.string.split("\e[J")
+
+      expect(frames.first).not_to include("back")
+      expect(frames.last).to include("back")
     end
   end
 end


### PR DESCRIPTION
Follow-up to #4693, acting on Adrian's feedback on the 4.1.1 install flow.

## What was wrong

Everything was on one screen. Moving the highlight and pressing <kbd>enter</kbd> kept the *first* option — you had to press space to commit the row, which is a step people miss. And once you had moved past a group there was no way back to it.

## What it does now

One question per screen. A radio's selection follows the cursor, so moving is choosing and <kbd>enter</kbd> alone is enough. A checkbox keeps space as the toggle. <kbd>←</kbd> goes back and keeps what was already answered.

Screens that do not apply are skipped rather than asked pointlessly:

- the link question only once more than one directory is picked
- each cleanup question only when there is something to remove there

Nothing is written until a final confirm screen lists what is about to happen:

```
  Run the installation?

    Install to    this app
    Directories   .agents/skills, .claude/skills, .cursor/skills
    Extra copies  symlinked to .agents/skills
    Remove        2 skills left in this project
    Remove        1 skill in ~/.claude/skills

  › (•) Yes, install (recommended)
    ( ) No, cancel
```

### Removing leftovers is a question, not a printed suggestion

Both scopes are asked, with **Yes** preselected. The project and `~/.claude/skills` get separate screens — that second directory is shared with every other project on the machine, so it deserves its own yes rather than riding along on the project answer. Decline either and the `rm -rf` is printed for later.

### One real file, symlinked from the rest

Pick several agent directories and you get one file plus relative symlinks, so refreshing the loader is a single edit and the directories cannot drift apart. `.agents/skills` holds it, being the vendor-neutral one. A filesystem that cannot symlink is detected and the write falls back to a copy rather than failing.

### No flags

`--where`, `--agents`, `--global`, `--only`, `--path`, `--yes` — all gone. A flag per question is a second surface to document and keep in step with the screens. There is one way to run this and it asks.

A run with no terminal — piped, or the suite — installs the recommended answers and **removes nothing**: nobody was there to decline a delete.

## Verification

- 453 examples green across `spec/features/avo/generators` and `spec/lib`; standardrb clean.
- The real `bin/rails g avo:skills` driven through a PTY with leftovers planted in both scopes: all six screens in order, summary correct, both cleanups executed, symlinks written and resolving.
- The generator specs drive the actual panel through a fake tty rather than reaching past it — there is no flag left to reach past it with.

Back-navigation has to step *over* a skipped screen in the direction it was entered; getting that wrong hangs the panel, so there is a test pinning it.

Docs updated in avo-hq/docs.avohq.io#599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)