### PR TITLE
Ask PR authors for a release-note line (AVO-1551)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,25 @@ Fixes # (issue)
   By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
 -->
 
+## Release note
+
+<!-- release-note-help
+This becomes the customer-facing line in Avo's release notes and feeds the
+monthly "what shipped" rollup. Write it for someone who uses Avo, not for a
+reviewer reading the diff.
+
+  Note  one line, no trailing period
+  Type  feature | fix | improvement | internal
+
+Use `internal` for changes users never see — CI, tooling, docs. A check
+reports a missing or unparseable note but never blocks the merge.
+
+Delete this comment once you have filled the two lines in.
+-->
+
+Note:
+Type:
+
 # Checklist:
 <!--
   Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)


### PR DESCRIPTION
Adds a release-note section to the PR template, so Avo's release notes are written by the person who made the change rather than derived from PR titles. Part of AVO-1551.

## Why

Avo 4 ships each gem independently, and the release notes for all of them are being rebuilt around a line the PR author writes: one customer-facing sentence plus a type. Titles alone produce a commit log, not something a user can read to decide whether to upgrade.

The same line feeds the monthly "what shipped" rollup that the changelog post and newsletter are written from — and that rollup becomes Avo's published minor release notes, so core's entries need to read well there too.

## What's here

Just the template section. Two fields:

- **Note** — one customer-facing line
- **Type** — `feature`, `fix`, `improvement`, or `internal`

`internal` is the escape hatch for changes users never see (CI, tooling, docs); those are dropped from customer-facing notes and from the rollup.

No package field, unlike the monorepo's version of this template — every PR here is the `avo` gem, so asking would be noise on every PR.

## An open decision, deliberately not made here

The **check** that reports on this section is not in this PR, and I'd rather flag why than ship it quietly.

The parser lives in `avo-hq/workspace` and is shared with the monorepo's release pipeline, so the two cannot drift. Running it here means checking out that repository — which is **private**. That needs a credential this repo does not have, and it would put private source on a public repository's runner. The alternative, reimplementing the parser here, guarantees the two drift apart the first time the note format changes.

Neither option is obviously right, so it wants a decision rather than a default. The template is useful on its own in the meantime: authors can fill it in today, and the tooling that reads it already handles a missing or unparseable section without failing anything.

## Related

- `avo-hq/workspace#162` — the parser, the labelling, and the per-package note assembly.
- `avo-hq/support#17` — the shared release workflow that publishes what this feeds.

Both are independent of this PR; nothing here depends on their merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSMKF76nJcDEv6JKDDsrVz
