### PR TITLE
Teach the shipped skills about the lexxy field (AVO-1236)

### DIFF
--- a/lib/avo/skills/avo-fields/SKILL.md
+++ b/lib/avo/skills/avo-fields/SKILL.md
@@ -194,6 +194,7 @@ end
 
 - **Gem-gated types break without their companion gem** (the field silently fails to render or raises). If the user asks for one, tell them to add the gem:
   - `:rhino` → `gem "avo-rhino_field"`
+  - `:lexxy` → `gem "avo-lexxy_field"` (Basecamp's Lexxy editor for Action Text; needs Rails >= 8.0.2)
   - `:markdown` → `gem "marksmith"` + `gem "commonmarker"`
   - `:money` → `gem "avo-money_field"` + `gem "money-rails", "~> 1.12"` (and `monetize :price_cents` on the model)
   - `:location` / `:area` → `gem "mapkick-rb"` (**not** `mapkick`) + `MAPBOX_ACCESS_TOKEN` env var

--- a/lib/avo/skills/avo-media-library/SKILL.md
+++ b/lib/avo/skills/avo-media-library/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: avo-media-library
-description: Turn on and manage Avo's Media Library — a central browser/manager for every uploaded asset, plus an asset picker inside the trix, rhino, and markdown rich-text editors — configured in config/initializers/avo.rb. Use when the user wants to "let users upload and manage images", "have one place to view and manage all our assets/uploads", "add an image or asset gallery to the admin", "insert/pick an existing image in the rich-text editor while writing content", "reuse uploaded images across records", "a digital asset manager for the admin", or "browse all the files I've uploaded" — and when they want to turn the Media Library on or off, hide or conditionally show its sidebar item, re-add it to a customized menu, or disable the gallery picker on a markdown field. Disabled by default and gated behind `defined?(Avo::MediaLibrary)`; Community license; currently in Alpha (breaking changes expected).
+description: Turn on and manage Avo's Media Library — a central browser/manager for every uploaded asset, plus an asset picker inside the trix, rhino, markdown, and lexxy rich-text editors — configured in config/initializers/avo.rb. Use when the user wants to "let users upload and manage images", "have one place to view and manage all our assets/uploads", "add an image or asset gallery to the admin", "insert/pick an existing image in the rich-text editor while writing content", "reuse uploaded images across records", "a digital asset manager for the admin", or "browse all the files I've uploaded" — and when they want to turn the Media Library on or off, hide or conditionally show its sidebar item, re-add it to a customized menu, or disable the gallery picker on a markdown field. Disabled by default and gated behind `defined?(Avo::MediaLibrary)`; Community license; currently in Alpha (breaking changes expected).
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash, WebFetch
 metadata:
   requires-gem: none — Community (Alpha)
@@ -10,14 +10,14 @@ metadata:
 
 # Enable and manage the Avo Media Library
 
-The Media Library is a central place to browse and manage every asset uploaded to an Avo admin, and it doubles as an asset picker inside Avo's three rich-text editors (`trix`, `rhino`, `markdown`) — a button in each editor opens a modal, and the selected asset is injected into the content. It is **not a separate gem**: it ships inside Avo, gated behind `defined?(Avo::MediaLibrary)`, and is **disabled by default**. All configuration lives in `config/initializers/avo.rb`.
+The Media Library is a central place to browse and manage every asset uploaded to an Avo admin, and it doubles as an asset picker inside Avo's rich-text editors (`trix`, `rhino`, `markdown`, `lexxy`) — a button in each editor opens a modal, and the selected asset is injected into the content. It is **not a separate gem**: it ships inside Avo, gated behind `defined?(Avo::MediaLibrary)`, and is **disabled by default**. All configuration lives in `config/initializers/avo.rb`.
 
 **License:** Community (free). **Status:** Alpha — future releases may contain breaking changes, so tell the user this and point them at the upgrade guide when they adopt it.
 
 **Docs** (fetch on demand — do not rely on memory for exact option names or defaults):
 - Docs map / index: https://docs.avohq.io/4.0/docs-map.md
 - Media Library guide: https://docs.avohq.io/4.0/media-library.md
-- Rich-text fields it plugs into: https://docs.avohq.io/4.0/fields/trix.md · https://docs.avohq.io/4.0/fields/rhino.md · https://docs.avohq.io/4.0/fields/markdown.md
+- Rich-text fields it plugs into: https://docs.avohq.io/4.0/fields/trix.md · https://docs.avohq.io/4.0/fields/rhino.md · https://docs.avohq.io/4.0/fields/markdown.md · https://docs.avohq.io/4.0/fields/lexxy.md
 - Menu editor (for re-adding the item): https://docs.avohq.io/4.0/menu-editor.md
 - Blocks / `Avo::Current` in config lambdas: https://docs.avohq.io/4.0/execution-context.md
 
@@ -26,7 +26,7 @@ The Media Library is a central place to browse and manage every asset uploaded t
 Reach for this skill when the goal is either of the Media Library's two jobs:
 
 1. **A central asset manager** — one screen to browse and manage all uploaded assets ("a gallery in the admin", "a digital asset manager", "see every file we've uploaded", "reuse images across records").
-2. **An asset picker in the editors** — inserting or reusing an existing image while writing rich-text content in a `trix`, `rhino`, or `markdown` field.
+2. **An asset picker in the editors** — inserting or reusing an existing image while writing rich-text content in a `trix`, `rhino`, `markdown`, or `lexxy` field.
 
 Also use it for the on/off and visibility controls: enabling/disabling the whole feature, hiding or conditionally showing its sidebar item, re-adding it after the menu is customized, and toggling the picker off on a single markdown field.
 
@@ -86,18 +86,19 @@ end
    end
    ```
 
-5. **Use it with the editors.** Once enabled, every `trix`, `rhino`, and `markdown` field automatically gets a Media Library button in its toolbar — no per-field opt-in. Just declare the field as usual (this is **avo-fields** territory):
+5. **Use it with the editors.** Once enabled, every `trix`, `rhino`, `markdown`, and `lexxy` field automatically gets a Media Library button in its toolbar — no per-field opt-in. Just declare the field as usual (this is **avo-fields** territory):
    ```ruby
    field :body, as: :trix
    field :body, as: :rhino
    field :body, as: :markdown
+   field :body, as: :lexxy
    ```
 
 6. **Disable the picker on a single markdown field (optional).** The `markdown` field accepts a `media_library` option (defaults to `true`). Set it to `false` to hide the gallery button on that one field while the Media Library stays enabled everywhere else:
    ```ruby
    field :body, as: :markdown, media_library: false
    ```
-   This is **markdown-only** — `trix` and `rhino` have no per-field toggle. To remove the picker from those, the only lever is the global killswitch.
+   This is **markdown-only** — `trix` and `rhino` have no per-field toggle. To remove the picker from those, the only lever is the global killswitch. The `lexxy` field hides its button when attachments are disabled (`attachments_disabled: true`, the default on plain columns).
 
 7. **Report** what you changed (see below). No need to run the app; a `ruby -c` on the initializer is enough to sanity-check syntax.
 
@@ -108,7 +109,7 @@ end
 - **`config.enabled` is an all-or-nothing killswitch.** Flipping it off hides the menu item, blocks the routes, *and* hides the editor icons — for everyone. There is no per-user or per-resource enable; use `config.visible` (a block) if you only want to gate who *sees the menu item*.
 - **`enabled` and `visible` are different levers.** `enabled` = whole feature on/off. `visible` = just the sidebar item (Boolean or block). Hiding the item with `visible = false` does not disable uploads or the editor picker.
 - **A customized menu drops the item.** If `config.main_menu` is defined, the Media Library sidebar item won't appear on its own — re-add it manually with `link_to "Media Library", avo.media_library_index_path`.
-- **`media_library: false` is markdown-only.** `trix` and `rhino` don't support per-field toggling; the killswitch is the only way to remove their buttons.
+- **`media_library: false` is markdown-only.** `trix` and `rhino` don't support per-field toggling; the killswitch is the only way to remove their buttons. `lexxy` follows its own `attachments_disabled` option.
 - **It's `Avo::MediaLibrary.configure`, not `Avo.configure`.** The enable/visible settings live on their own configuration object. Only the menu `link_to` goes inside the main `Avo.configure` block.
 
 ## Report


### PR DESCRIPTION
# Description

Teaches Avo's shipped agent skills about the new `:lexxy` field, which lives in the separate [`avo-lexxy_field`](https://github.com/avo-hq/avo-lexxy_field) gem (Basecamp's Lexxy editor for Action Text).

Skills-only — no runtime code in avo core changes here. Two files:

- **`avo-fields`** — adds `:lexxy` to the gem-gated field types list, so an agent asked for a Lexxy field tells the user to add `gem "avo-lexxy_field"` instead of writing a field type that silently fails to render. Notes the Rails >= 8.0.2 floor that `lexxy` itself carries.
- **`avo-media-library`** — the Media Library's asset picker now shows up in Lexxy's toolbar too, so the skill's description, the editor list, the usage step, and the gotchas all needed `lexxy` alongside `trix`, `rhino`, and `markdown`. Also records that `lexxy` has no `media_library:` option — it hides the picker via its own `attachments_disabled`, which defaults to `true` on plain columns.

Without this, an agent working in a customer's app keeps producing the pre-Lexxy API for as long as the gem is installed. That's the whole point of the gem-shipped skills contract in `.claude/rules/gem-shipped-skills.md`.

Related: AVO-1236. Docs page lands separately on `avo-1236/docs/lexxy-field` in avo-hq/docs.avohq.io — the `fields/lexxy.md` URL these skills cite is live once that merges.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I tested the design in Light and Dark mode, and all default themes

No tests and no design pass: this changes markdown skill content only, no Ruby, ERB, or CSS. `ws audit-skills` is the gate for these files and it comes back clean.

## Screenshots & recording

N/A — markdown content.

## Manual review steps

1. `ws audit-skills` → `15 gem(s) ship skills; all valid.`
2. Read `lib/avo/skills/avo-fields/SKILL.md` and confirm the `:lexxy` line sits with the other gem-gated types and names the right gem.
3. Read `lib/avo/skills/avo-media-library/SKILL.md` and confirm `lexxy` appears everywhere the other three editors are listed, and that the `media_library: false` gotcha correctly says the option is markdown-only while `lexxy` uses `attachments_disabled`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only skill documentation; no Ruby, ERB, or runtime behavior changes.
> 
> **Overview**
> Updates **gem-shipped agent skills** so agents know about the new **`:lexxy`** rich-text field (`avo-lexxy_field`, Rails ≥ 8.0.2)—no Avo runtime changes.
> 
> In **`avo-fields`**, **`:lexxy`** is added to the gem-gated types list so agents tell users to install `avo-lexxy_field` instead of declaring a type that won’t render.
> 
> In **`avo-media-library`**, **`lexxy`** is included wherever the other editors (`trix`, `rhino`, `markdown`) are described, plus a link to `fields/lexxy.md`. The skill also notes that Lexxy has no `media_library:` toggle—the picker is controlled via **`attachments_disabled`** (default `true` on plain columns).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2f5c7aa5f4945cf2b4e0515395996f321a0ff40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->