### PR TITLE
Pass a menu item's data attributes to the section/group root element

### DIFF
--- a/app/components/avo/sidebar/base_item_component.rb
+++ b/app/components/avo/sidebar/base_item_component.rb
@@ -32,6 +32,6 @@ class Avo::Sidebar::BaseItemComponent < Avo::BaseComponent
       result[:menu_key_param] = key
       result[:menu_default_collapsed_state] = collapsed ? "collapsed" : "expanded"
     end
-    result
+    result.merge(item.data || {})
   end
 end


### PR DESCRIPTION
Fixes [AVO-1681](https://linear.app/avo-hq/issue/AVO-1681/sidebar-sectiongroup-root-elements-drop-the-menu-items-data-attributes).

Menu `section`/`group` items accept a `data:` option, but `Avo::Sidebar::BaseItemComponent#data` only built the collapse-controller attributes, so the item's own data never reached the rendered root element — leaf items (links, resources, dashboards, actions) already pass `item.data` through. Reported by a customer who monkey-patched exactly this to pass colors to menu sections.

One-line fix in the shared method, covering both `SectionComponent` and `GroupComponent`: merge `item.data` last, so the item's data wins on key collision.

Component specs live in the workspace repo's sidebar suite (where core's sidebar components are already tested): avo-hq/workspace PR adds `gems/avo-menu/spec/components/avo/sidebar/section_component_spec.rb` covering section root, collapsable section (collapse data and item data coexist), and group root. Red before this change, green after.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to HTML data attributes on sidebar section/group roots; no auth, data, or business-logic impact.
> 
> **Overview**
> **Section and group** sidebar items can declare a `data:` hash, but `Avo::Sidebar::BaseItemComponent#data` only emitted collapse-controller attributes, so those custom attributes never appeared on the rendered root (unlike leaf menu items).
> 
> `#data` now **`merge`s `item.data`** after building the collapsable menu Stimulus attrs, so both apply on `SectionComponent` and `GroupComponent`; item keys override on collision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbda8971ea12b4aaf710e1ea0f1d5ec71d362c2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->