### PR TITLE
Add a resource color option that tints the sidebar menu icon

### DIFF
--- a/app/assets/stylesheets/css/components/breadcrumbs.css
+++ b/app/assets/stylesheets/css/components/breadcrumbs.css
@@ -81,3 +81,23 @@
     }
   }
 }
+
+/* Resource color on the initials chip: reuses the avatar component's --bg/--text
+   tint variables, so the existing color-mix keeps it readable in both themes. */
+.breadcrumb-element--color-red .cado-avatar--initials { --bg: var(--color-red-400); --text: var(--color-red-600); }
+.breadcrumb-element--color-orange .cado-avatar--initials { --bg: var(--color-orange-400); --text: var(--color-orange-600); }
+.breadcrumb-element--color-amber .cado-avatar--initials { --bg: var(--color-amber-400); --text: var(--color-amber-600); }
+.breadcrumb-element--color-yellow .cado-avatar--initials { --bg: var(--color-yellow-400); --text: var(--color-yellow-600); }
+.breadcrumb-element--color-lime .cado-avatar--initials { --bg: var(--color-lime-400); --text: var(--color-lime-600); }
+.breadcrumb-element--color-green .cado-avatar--initials { --bg: var(--color-green-400); --text: var(--color-green-600); }
+.breadcrumb-element--color-emerald .cado-avatar--initials { --bg: var(--color-emerald-400); --text: var(--color-emerald-600); }
+.breadcrumb-element--color-teal .cado-avatar--initials { --bg: var(--color-teal-400); --text: var(--color-teal-600); }
+.breadcrumb-element--color-cyan .cado-avatar--initials { --bg: var(--color-cyan-400); --text: var(--color-cyan-600); }
+.breadcrumb-element--color-sky .cado-avatar--initials { --bg: var(--color-sky-400); --text: var(--color-sky-600); }
+.breadcrumb-element--color-blue .cado-avatar--initials { --bg: var(--color-blue-400); --text: var(--color-blue-600); }
+.breadcrumb-element--color-indigo .cado-avatar--initials { --bg: var(--color-indigo-400); --text: var(--color-indigo-600); }
+.breadcrumb-element--color-violet .cado-avatar--initials { --bg: var(--color-violet-400); --text: var(--color-violet-600); }
+.breadcrumb-element--color-purple .cado-avatar--initials { --bg: var(--color-purple-400); --text: var(--color-purple-600); }
+.breadcrumb-element--color-fuchsia .cado-avatar--initials { --bg: var(--color-fuchsia-400); --text: var(--color-fuchsia-600); }
+.breadcrumb-element--color-pink .cado-avatar--initials { --bg: var(--color-pink-400); --text: var(--color-pink-600); }
+.breadcrumb-element--color-rose .cado-avatar--initials { --bg: var(--color-rose-400); --text: var(--color-rose-600); }

--- a/app/assets/stylesheets/css/sidebar.css
+++ b/app/assets/stylesheets/css/sidebar.css
@@ -213,28 +213,50 @@
   color: var(--sidebar-icon-color, currentColor);
 }
 
-/* Resource color — tints only the icon stroke. Each modifier sets a scoped
+/* Resource color: tints only the icon stroke. Each modifier sets a scoped
    variable that only the icon wrapper consumes; the link's own color, hover
-   and active rules stay untouched. Mixing the 500 shade with a slice of
-   `--color-primary` (same trick as `--badge-bg` in css/components/ui/badge.css)
-   self-adapts the tint in dark mode, where `--color-primary` flips. */
-.sidebar-link--color-red { --sidebar-icon-color: color-mix(in oklab, var(--color-red-500), var(--color-primary) 15%); }
-.sidebar-link--color-orange { --sidebar-icon-color: color-mix(in oklab, var(--color-orange-500), var(--color-primary) 15%); }
-.sidebar-link--color-amber { --sidebar-icon-color: color-mix(in oklab, var(--color-amber-500), var(--color-primary) 15%); }
-.sidebar-link--color-yellow { --sidebar-icon-color: color-mix(in oklab, var(--color-yellow-500), var(--color-primary) 15%); }
-.sidebar-link--color-lime { --sidebar-icon-color: color-mix(in oklab, var(--color-lime-500), var(--color-primary) 15%); }
-.sidebar-link--color-green { --sidebar-icon-color: color-mix(in oklab, var(--color-green-500), var(--color-primary) 15%); }
-.sidebar-link--color-emerald { --sidebar-icon-color: color-mix(in oklab, var(--color-emerald-500), var(--color-primary) 15%); }
-.sidebar-link--color-teal { --sidebar-icon-color: color-mix(in oklab, var(--color-teal-500), var(--color-primary) 15%); }
-.sidebar-link--color-cyan { --sidebar-icon-color: color-mix(in oklab, var(--color-cyan-500), var(--color-primary) 15%); }
-.sidebar-link--color-sky { --sidebar-icon-color: color-mix(in oklab, var(--color-sky-500), var(--color-primary) 15%); }
-.sidebar-link--color-blue { --sidebar-icon-color: color-mix(in oklab, var(--color-blue-500), var(--color-primary) 15%); }
-.sidebar-link--color-indigo { --sidebar-icon-color: color-mix(in oklab, var(--color-indigo-500), var(--color-primary) 15%); }
-.sidebar-link--color-violet { --sidebar-icon-color: color-mix(in oklab, var(--color-violet-500), var(--color-primary) 15%); }
-.sidebar-link--color-purple { --sidebar-icon-color: color-mix(in oklab, var(--color-purple-500), var(--color-primary) 15%); }
-.sidebar-link--color-fuchsia { --sidebar-icon-color: color-mix(in oklab, var(--color-fuchsia-500), var(--color-primary) 15%); }
-.sidebar-link--color-pink { --sidebar-icon-color: color-mix(in oklab, var(--color-pink-500), var(--color-primary) 15%); }
-.sidebar-link--color-rose { --sidebar-icon-color: color-mix(in oklab, var(--color-rose-500), var(--color-primary) 15%); }
+   and active rules stay untouched. Light theme uses the 600 shade (700 for
+   the yellow family, which cannot reach 3:1 non-text contrast on the light
+   sidebar otherwise); dark theme overrides to the 400 shade below. */
+.sidebar-link--color-red { --sidebar-icon-color: var(--color-red-600); }
+.sidebar-link--color-orange { --sidebar-icon-color: var(--color-orange-600); }
+.sidebar-link--color-amber { --sidebar-icon-color: var(--color-amber-700); }
+.sidebar-link--color-yellow { --sidebar-icon-color: var(--color-yellow-700); }
+.sidebar-link--color-lime { --sidebar-icon-color: var(--color-lime-700); }
+.sidebar-link--color-green { --sidebar-icon-color: var(--color-green-600); }
+.sidebar-link--color-emerald { --sidebar-icon-color: var(--color-emerald-600); }
+.sidebar-link--color-teal { --sidebar-icon-color: var(--color-teal-600); }
+.sidebar-link--color-cyan { --sidebar-icon-color: var(--color-cyan-600); }
+.sidebar-link--color-sky { --sidebar-icon-color: var(--color-sky-600); }
+.sidebar-link--color-blue { --sidebar-icon-color: var(--color-blue-600); }
+.sidebar-link--color-indigo { --sidebar-icon-color: var(--color-indigo-600); }
+.sidebar-link--color-violet { --sidebar-icon-color: var(--color-violet-600); }
+.sidebar-link--color-purple { --sidebar-icon-color: var(--color-purple-600); }
+.sidebar-link--color-fuchsia { --sidebar-icon-color: var(--color-fuchsia-600); }
+.sidebar-link--color-pink { --sidebar-icon-color: var(--color-pink-600); }
+.sidebar-link--color-rose { --sidebar-icon-color: var(--color-rose-600); }
+
+/* Dark theme: lift the tints to the 400 shade so they stay legible on the
+   dark sidebar background. */
+.dark {
+  .sidebar-link--color-red { --sidebar-icon-color: var(--color-red-400); }
+  .sidebar-link--color-orange { --sidebar-icon-color: var(--color-orange-400); }
+  .sidebar-link--color-amber { --sidebar-icon-color: var(--color-amber-400); }
+  .sidebar-link--color-yellow { --sidebar-icon-color: var(--color-yellow-400); }
+  .sidebar-link--color-lime { --sidebar-icon-color: var(--color-lime-400); }
+  .sidebar-link--color-green { --sidebar-icon-color: var(--color-green-400); }
+  .sidebar-link--color-emerald { --sidebar-icon-color: var(--color-emerald-400); }
+  .sidebar-link--color-teal { --sidebar-icon-color: var(--color-teal-400); }
+  .sidebar-link--color-cyan { --sidebar-icon-color: var(--color-cyan-400); }
+  .sidebar-link--color-sky { --sidebar-icon-color: var(--color-sky-400); }
+  .sidebar-link--color-blue { --sidebar-icon-color: var(--color-blue-400); }
+  .sidebar-link--color-indigo { --sidebar-icon-color: var(--color-indigo-400); }
+  .sidebar-link--color-violet { --sidebar-icon-color: var(--color-violet-400); }
+  .sidebar-link--color-purple { --sidebar-icon-color: var(--color-purple-400); }
+  .sidebar-link--color-fuchsia { --sidebar-icon-color: var(--color-fuchsia-400); }
+  .sidebar-link--color-pink { --sidebar-icon-color: var(--color-pink-400); }
+  .sidebar-link--color-rose { --sidebar-icon-color: var(--color-rose-400); }
+}
 
 /* Reserve same width when group has icons but this link has none (alignment) */
 .sidebar-link__icon-wrapper--placeholder {

--- a/app/assets/stylesheets/css/sidebar.css
+++ b/app/assets/stylesheets/css/sidebar.css
@@ -210,7 +210,31 @@
 
 .sidebar-link__icon-wrapper {
   @apply shrink-0 flex items-center justify-center;
+  color: var(--sidebar-icon-color, currentColor);
 }
+
+/* Resource color — tints only the icon stroke. Each modifier sets a scoped
+   variable that only the icon wrapper consumes; the link's own color, hover
+   and active rules stay untouched. Mixing the 500 shade with a slice of
+   `--color-primary` (same trick as `--badge-bg` in css/components/ui/badge.css)
+   self-adapts the tint in dark mode, where `--color-primary` flips. */
+.sidebar-link--color-red { --sidebar-icon-color: color-mix(in oklab, var(--color-red-500), var(--color-primary) 15%); }
+.sidebar-link--color-orange { --sidebar-icon-color: color-mix(in oklab, var(--color-orange-500), var(--color-primary) 15%); }
+.sidebar-link--color-amber { --sidebar-icon-color: color-mix(in oklab, var(--color-amber-500), var(--color-primary) 15%); }
+.sidebar-link--color-yellow { --sidebar-icon-color: color-mix(in oklab, var(--color-yellow-500), var(--color-primary) 15%); }
+.sidebar-link--color-lime { --sidebar-icon-color: color-mix(in oklab, var(--color-lime-500), var(--color-primary) 15%); }
+.sidebar-link--color-green { --sidebar-icon-color: color-mix(in oklab, var(--color-green-500), var(--color-primary) 15%); }
+.sidebar-link--color-emerald { --sidebar-icon-color: color-mix(in oklab, var(--color-emerald-500), var(--color-primary) 15%); }
+.sidebar-link--color-teal { --sidebar-icon-color: color-mix(in oklab, var(--color-teal-500), var(--color-primary) 15%); }
+.sidebar-link--color-cyan { --sidebar-icon-color: color-mix(in oklab, var(--color-cyan-500), var(--color-primary) 15%); }
+.sidebar-link--color-sky { --sidebar-icon-color: color-mix(in oklab, var(--color-sky-500), var(--color-primary) 15%); }
+.sidebar-link--color-blue { --sidebar-icon-color: color-mix(in oklab, var(--color-blue-500), var(--color-primary) 15%); }
+.sidebar-link--color-indigo { --sidebar-icon-color: color-mix(in oklab, var(--color-indigo-500), var(--color-primary) 15%); }
+.sidebar-link--color-violet { --sidebar-icon-color: color-mix(in oklab, var(--color-violet-500), var(--color-primary) 15%); }
+.sidebar-link--color-purple { --sidebar-icon-color: color-mix(in oklab, var(--color-purple-500), var(--color-primary) 15%); }
+.sidebar-link--color-fuchsia { --sidebar-icon-color: color-mix(in oklab, var(--color-fuchsia-500), var(--color-primary) 15%); }
+.sidebar-link--color-pink { --sidebar-icon-color: color-mix(in oklab, var(--color-pink-500), var(--color-primary) 15%); }
+.sidebar-link--color-rose { --sidebar-icon-color: color-mix(in oklab, var(--color-rose-500), var(--color-primary) 15%); }
 
 /* Reserve same width when group has icons but this link has none (alignment) */
 .sidebar-link__icon-wrapper--placeholder {

--- a/app/components/avo/breadcrumb_element_component.html.erb
+++ b/app/components/avo/breadcrumb_element_component.html.erb
@@ -1,5 +1,6 @@
 <%= wrapper_element class: class_names(
   "breadcrumb-element",
+  color_class,
   "breadcrumb-element--link": link?
 ) do %>
   <% if @avatar.present? %>

--- a/app/components/avo/breadcrumb_element_component.rb
+++ b/app/components/avo/breadcrumb_element_component.rb
@@ -6,6 +6,16 @@ class Avo::BreadcrumbElementComponent < Avo::BaseComponent
   prop :icon, default: nil
   prop :initials, default: nil
   prop :avatar
+  # Resource color: tints the initials chip, same palette as the sidebar icon.
+  prop :color, default: nil do |value|
+    next nil if value.blank?
+    value = value.to_sym if value.respond_to?(:to_sym)
+    Avo::Sidebar::LinkComponent::PALETTE_COLORS.include?(value) ? value : nil
+  end
+
+  def color_class
+    "breadcrumb-element--color-#{@color}" if @color.present?
+  end
 
   def link?
     @url.present?

--- a/app/components/avo/breadcrumbs_component.html.erb
+++ b/app/components/avo/breadcrumbs_component.html.erb
@@ -8,7 +8,8 @@
         url: item.path,
         icon: item.icon,
         avatar: item.avatar,
-        initials: item.initials
+        initials: item.initials,
+        color: item.respond_to?(:color) ? item.color : nil
       ) %>
 
       <% unless is_last %>

--- a/app/components/avo/sidebar/link_component.rb
+++ b/app/components/avo/sidebar/link_component.rb
@@ -6,10 +6,9 @@ require "view_component/version"
 # about menus; callers pass the path, label and resolved `active` (a match mode
 # like :inclusive, or a boolean to force it).
 class Avo::Sidebar::LinkComponent < Avo::BaseComponent
-  # The raw Tailwind palette names accepted for the tinted sidebar icon — the
-  # non-semantic subset of Avo::UI::BadgeComponent::VALID_COLORS. Each has a
-  # matching `.sidebar-link--color-<name>` rule in css/sidebar.css.
-  PALETTE_COLORS = %i[red orange amber yellow lime green emerald teal cyan sky blue indigo violet purple fuchsia pink rose].freeze unless defined?(PALETTE_COLORS)
+  # The raw Tailwind palette names accepted for the tinted sidebar icon. Each
+  # has a matching `.sidebar-link--color-<name>` rule in css/sidebar.css.
+  PALETTE_COLORS = (Avo::UI::BadgeComponent::VALID_COLORS - %i[neutral success info warning danger]).freeze unless defined?(PALETTE_COLORS)
 
   prop :label
   prop :path

--- a/app/components/avo/sidebar/link_component.rb
+++ b/app/components/avo/sidebar/link_component.rb
@@ -6,6 +6,11 @@ require "view_component/version"
 # about menus; callers pass the path, label and resolved `active` (a match mode
 # like :inclusive, or a boolean to force it).
 class Avo::Sidebar::LinkComponent < Avo::BaseComponent
+  # The raw Tailwind palette names accepted for the tinted sidebar icon — the
+  # non-semantic subset of Avo::UI::BadgeComponent::VALID_COLORS. Each has a
+  # matching `.sidebar-link--color-<name>` rule in css/sidebar.css.
+  PALETTE_COLORS = %i[red orange amber yellow lime green emerald teal cyan sky blue indigo violet purple fuchsia pink rose].freeze unless defined?(PALETTE_COLORS)
+
   prop :label
   prop :path
   prop :active, default: :inclusive do |value|
@@ -19,6 +24,14 @@ class Avo::Sidebar::LinkComponent < Avo::BaseComponent
   prop :reserve_icon_space, default: false
   prop :args, kind: :**, default: {}.freeze
   prop :hotkey, default: nil
+  # Resource color: tints only the icon stroke via a CSS modifier; unknown or
+  # blank values normalize to nil, which emits no modifier at all.
+  prop :color, default: nil do |value|
+    next nil if value.blank?
+
+    normalized = value.to_s.to_sym
+    PALETTE_COLORS.include?(normalized) ? normalized : nil
+  end
   prop :variant, default: :default
   prop :bar_class, default: ""
 
@@ -27,9 +40,13 @@ class Avo::Sidebar::LinkComponent < Avo::BaseComponent
   end
 
   def root_css_class
-    return "sidebar-link" unless subitem?
+    return ["sidebar-link", color_class].reject(&:blank?).join(" ") unless subitem?
 
     ["sidebar-subitem", @bar_class].reject(&:blank?).join(" ")
+  end
+
+  def color_class
+    "sidebar-link--color-#{@color}" if @color.present?
   end
 
   # Sub-items don't show icons (for now); top-level links do.

--- a/app/components/avo/sidebar_component.html.erb
+++ b/app/components/avo/sidebar_component.html.erb
@@ -21,7 +21,7 @@
               <%= render Avo::Sidebar::HeadingComponent.new title: t('avo.dashboards'), icon: "tabler/outline/layout-dashboard" %>
 
               <% dashboards.sort_by { |r| r.navigation_label }.each do |dashboard| %>
-                <%= render Avo::Sidebar::LinkComponent.new label: dashboard.navigation_label, path: helpers.avo_dashboards.dashboard_path(dashboard), hotkey: dashboard.try(:hotkey).presence %>
+                <%= render Avo::Sidebar::LinkComponent.new label: dashboard.navigation_label, path: helpers.avo_dashboards.dashboard_path(dashboard), hotkey: dashboard.try(:hotkey).presence, color: dashboard.try(:color) %>
               <% end %>
             </div>
           <% end %>
@@ -30,7 +30,7 @@
             <%= render Avo::Sidebar::HeadingComponent.new title: t('avo.resources'), icon: "tabler/outline/topology-star-3" %>
 
             <% resources.sort_by { |r| r.navigation_label }.each do |resource| %>
-              <%= render Avo::Sidebar::LinkComponent.new label: resource.navigation_label, path: helpers.resources_path(resource: resource), icon: resource.icon, hotkey: resource.try(:hotkey).presence %>
+              <%= render Avo::Sidebar::LinkComponent.new label: resource.navigation_label, path: helpers.resources_path(resource: resource), icon: resource.icon, hotkey: resource.try(:hotkey).presence, color: resource.try(:color) %>
             <% end %>
           </div>
 

--- a/app/controllers/avo/base_controller.rb
+++ b/app/controllers/avo/base_controller.rb
@@ -24,10 +24,10 @@ module Avo
       if @reflection.present? && !turbo_frame_request?
         # A good rule of thumb is that the resource name entry (Users) gets just the initials
         # The record name gets initials and avatar
-        add_breadcrumb title: @record.class.to_s.pluralize, path: resources_path(resource: @parent_resource), initials: @parent_resource.class.initials
-        add_breadcrumb title: @parent_resource.record_title, path: resource_path(record: @record, resource: @parent_resource), initials: @parent_resource.initials, avatar: @parent_resource.avatar
+        add_breadcrumb title: @record.class.to_s.pluralize, path: resources_path(resource: @parent_resource), initials: @parent_resource.class.initials, color: @parent_resource.class.color
+        add_breadcrumb title: @parent_resource.record_title, path: resource_path(record: @record, resource: @parent_resource), initials: @parent_resource.initials, avatar: @parent_resource.avatar, color: @parent_resource.class.color
       end
-      add_breadcrumb title: @resource.plural_name, initials: @resource.class.initials
+      add_breadcrumb title: @resource.plural_name, initials: @resource.class.initials, color: @resource.class.color
 
       set_applied_filters
       set_index_params
@@ -97,7 +97,7 @@ module Avo
 
       add_via_breadcrumbs
 
-      add_breadcrumb title: @resource.record_title, path: nil, avatar: @resource.avatar, initials: @resource.initials
+      add_breadcrumb title: @resource.record_title, path: nil, avatar: @resource.avatar, initials: @resource.initials, color: @resource.class.color
       add_breadcrumb title: I18n.t("avo.details").upcase_first, path: nil
 
       set_component_for __method__
@@ -117,12 +117,12 @@ module Avo
         via_record = via_resource.find_record params[:via_record_id], params: params
         via_resource = via_resource.new record: via_record
 
-        add_breadcrumb title: via_resource.plural_name, path: resources_path(resource: via_resource), initials: via_resource.class.initials
-        add_breadcrumb title: via_resource.record_title, path: resource_path(record: via_record, resource: via_resource), avatar: via_resource.avatar, initials: via_resource.initials
+        add_breadcrumb title: via_resource.plural_name, path: resources_path(resource: via_resource), initials: via_resource.class.initials, color: via_resource.class.color
+        add_breadcrumb title: via_resource.record_title, path: resource_path(record: via_record, resource: via_resource), avatar: via_resource.avatar, initials: via_resource.initials, color: via_resource.class.color
 
-        add_breadcrumb title: @resource.plural_name, initials: @resource.class.initials
+        add_breadcrumb title: @resource.plural_name, initials: @resource.class.initials, color: @resource.class.color
       else
-        add_breadcrumb title: @resource.plural_name, path: resources_path(resource: @resource), initials: @resource.class.initials
+        add_breadcrumb title: @resource.plural_name, path: resources_path(resource: @resource), initials: @resource.class.initials, color: @resource.class.color
       end
 
       add_breadcrumb title: t("avo.new").humanize
@@ -168,8 +168,8 @@ module Avo
       saved = save_record
       @resource.hydrate(record: @record, view: Avo::ViewInquirer.new(:new), user: _current_user)
 
-      add_breadcrumb title: @resource.plural_name, path: resources_path(resource: @resource), initials: @resource.class.initials
-      add_breadcrumb title: t("avo.new").humanize, path: nil, avatar: @resource.avatar, initials: @resource.initials
+      add_breadcrumb title: @resource.plural_name, path: resources_path(resource: @resource), initials: @resource.class.initials, color: @resource.class.color
+      add_breadcrumb title: t("avo.new").humanize, path: nil, avatar: @resource.avatar, initials: @resource.initials, color: @resource.class.color
       set_actions
 
       set_component_for :edit
@@ -416,7 +416,7 @@ module Avo
       # Go through all filters
       @resource.get_filters
         .select do |filter|
-          filter[:class].instance_methods(false).include? :react
+          filter[:class].method_defined?(:react, false)
         end
         .each do |filter|
           # Run the react method if it's present
@@ -446,19 +446,19 @@ module Avo
         via_record = via_resource.find_record params[:via_record_id], params: params
         via_resource = via_resource.new record: via_record
 
-        add_breadcrumb title: via_resource.plural_name, path: resources_path(resource: @resource), initials: via_resource.class.initials
-        add_breadcrumb title: via_resource.record_title, path: resource_path(record: via_record, resource: via_resource), avatar: via_resource.avatar, initials: via_resource.initials
+        add_breadcrumb title: via_resource.plural_name, path: resources_path(resource: @resource), initials: via_resource.class.initials, color: via_resource.class.color
+        add_breadcrumb title: via_resource.record_title, path: resource_path(record: via_record, resource: via_resource), avatar: via_resource.avatar, initials: via_resource.initials, color: via_resource.class.color
 
         last_crumb_args = {
           via_resource_class: params[:via_resource_class],
           via_record_id: params[:via_record_id]
         }
-        add_breadcrumb title: @resource.plural_name, initials: @resource.class.initials
+        add_breadcrumb title: @resource.plural_name, initials: @resource.class.initials, color: @resource.class.color
       else
-        add_breadcrumb title: @resource.plural_name, path: resources_path(resource: @resource), initials: @resource.class.initials
+        add_breadcrumb title: @resource.plural_name, path: resources_path(resource: @resource), initials: @resource.class.initials, color: @resource.class.color
       end
 
-      add_breadcrumb title: @resource.record_title, path: resource_path(record: @resource.record, resource: @resource, **last_crumb_args), avatar: @resource.avatar, initials: @resource.initials
+      add_breadcrumb title: @resource.record_title, path: resource_path(record: @resource.record, resource: @resource, **last_crumb_args), avatar: @resource.avatar, initials: @resource.initials, color: @resource.class.color
       add_breadcrumb title: t("avo.edit").humanize
     end
 
@@ -611,7 +611,7 @@ module Avo
 
     # Set pagy locale from params or from avo configuration, if both nil locale = "en"
     def set_pagy_locale
-      @pagy_locale = locale.to_s || Avo.configuration.default_locale || "en"
+      @pagy_locale = locale.to_s
       Pagy::I18n.locale = @pagy_locale if defined?(Pagy::I18n) && Pagy::I18n.respond_to?(:locale=)
     end
 
@@ -738,12 +738,12 @@ module Avo
         via_record = via_resource.find_record params[:via_record_id], params: params
         via_resource = via_resource.new record: via_record
 
-        add_breadcrumb title: via_resource.plural_name, path: resources_path(resource: via_resource), initials: via_resource.class.initials
-        add_breadcrumb title: via_resource.record_title, path: resource_path(record: via_record, resource: via_resource), avatar: via_resource.avatar, initials: via_resource.initials
+        add_breadcrumb title: via_resource.plural_name, path: resources_path(resource: via_resource), initials: via_resource.class.initials, color: via_resource.class.color
+        add_breadcrumb title: via_resource.record_title, path: resource_path(record: via_record, resource: via_resource), avatar: via_resource.avatar, initials: via_resource.initials, color: via_resource.class.color
 
-        add_breadcrumb title: @resource.plural_name, path: nil, initials: @resource.class.initials
+        add_breadcrumb title: @resource.plural_name, path: nil, initials: @resource.class.initials, color: @resource.class.color
       else
-        add_breadcrumb title: @resource.plural_name, path: resources_path(resource: @resource), initials: @resource.class.initials
+        add_breadcrumb title: @resource.plural_name, path: resources_path(resource: @resource), initials: @resource.class.initials, color: @resource.class.color
       end
     end
 

--- a/lib/avo/concerns/breadcrumbs.rb
+++ b/lib/avo/concerns/breadcrumbs.rb
@@ -15,7 +15,7 @@ module Avo
         helper_method :add_breadcrumb, :avo_breadcrumbs
       end
 
-      Crumb = Data.define(:title, :path, :avatar, :initials, :icon) unless defined?(Crumb)
+      Crumb = Data.define(:title, :path, :avatar, :initials, :icon, :color) unless defined?(Crumb)
 
       class Builder
         extend PropInitializer::Properties
@@ -26,8 +26,8 @@ module Avo
         def breadcrumbs = context.avo_breadcrumbs
       end
 
-      def add_breadcrumb(title: nil, path: nil, avatar: nil, initials: nil, icon: nil)
-        avo_breadcrumbs << Crumb.new(title:, path:, avatar:, initials:, icon:)
+      def add_breadcrumb(title: nil, path: nil, avatar: nil, initials: nil, icon: nil, color: nil)
+        avo_breadcrumbs << Crumb.new(title:, path:, avatar:, initials:, icon:, color:)
       end
 
       def avo_breadcrumbs

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -76,6 +76,7 @@ module Avo
       class_attribute :confirm_on_save, default: false
       class_attribute :visible_on_sidebar, default: true
       class_attribute :hotkey, default: nil
+      class_attribute :color, default: nil
       class_attribute :index_query, default: -> {
         query
       }

--- a/spec/components/avo/breadcrumb_element_component_spec.rb
+++ b/spec/components/avo/breadcrumb_element_component_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Avo::BreadcrumbElementComponent, type: :component do
+  describe "resource color on the initials chip" do
+    it "adds the palette modifier to the element" do
+      render_inline described_class.new(text: "Users", initials: "U", color: :purple, avatar: nil)
+
+      expect(page).to have_css ".breadcrumb-element.breadcrumb-element--color-purple .cado-avatar--initials"
+    end
+
+    it "accepts string values" do
+      render_inline described_class.new(text: "Users", initials: "U", color: "teal", avatar: nil)
+
+      expect(page).to have_css ".breadcrumb-element--color-teal"
+    end
+
+    it "renders no modifier without a color" do
+      render_inline described_class.new(text: "Users", initials: "U", avatar: nil)
+
+      expect(page).not_to have_css "[class*='breadcrumb-element--color-']"
+    end
+
+    it "renders no modifier for an unknown color" do
+      render_inline described_class.new(text: "Users", initials: "U", color: :bogus, avatar: nil)
+
+      expect(page).not_to have_css "[class*='breadcrumb-element--color-']"
+    end
+  end
+end

--- a/spec/components/avo/sidebar/link_component_spec.rb
+++ b/spec/components/avo/sidebar/link_component_spec.rb
@@ -64,6 +64,15 @@ RSpec.describe Avo::Sidebar::LinkComponent, type: :component do
   end
 
   describe "resource color modifier" do
+    it "has a stylesheet rule for every palette name" do
+      css = Rails.root.join("../../app/assets/stylesheets/css/sidebar.css").read
+
+      described_class::PALETTE_COLORS.each do |name|
+        expect(css).to include(".sidebar-link--color-#{name} "), "missing light-theme CSS rule for #{name}"
+        expect(css.scan(".sidebar-link--color-#{name} ").size).to be >= 2, "missing dark-theme CSS rule for #{name}"
+      end
+    end
+
     before do
       # Same rationale as the external-link rendering block below: the
       # component-test view context doesn't expose `root_path_without_url`.

--- a/spec/components/avo/sidebar/link_component_spec.rb
+++ b/spec/components/avo/sidebar/link_component_spec.rb
@@ -63,6 +63,47 @@ RSpec.describe Avo::Sidebar::LinkComponent, type: :component do
     end
   end
 
+  describe "resource color modifier" do
+    before do
+      # Same rationale as the external-link rendering block below: the
+      # component-test view context doesn't expose `root_path_without_url`.
+      allow_any_instance_of(described_class).to receive(:is_external?).and_return(true)
+      allow_any_instance_of(described_class).to receive(:root_link?).and_return(false)
+    end
+
+    it "adds the palette modifier to the root element" do
+      render_inline(described_class.new(label: "Projects", path: "/avo/resources/projects", color: :purple))
+
+      expect(page).to have_css("a.sidebar-link.sidebar-link--color-purple")
+    end
+
+    it "emits no color modifier when no color is given" do
+      render_inline(described_class.new(label: "Projects", path: "/avo/resources/projects"))
+
+      expect(page.find("a.sidebar-link")[:class]).not_to include("sidebar-link--color-")
+    end
+
+    it "ignores colors outside the palette whitelist" do
+      render_inline(described_class.new(label: "Projects", path: "/avo/resources/projects", color: :bogus))
+
+      expect(page.find("a.sidebar-link")[:class]).not_to include("sidebar-link--color-")
+    end
+
+    it "accepts string colors" do
+      render_inline(described_class.new(label: "Projects", path: "/avo/resources/projects", color: "teal"))
+
+      expect(page).to have_css("a.sidebar-link.sidebar-link--color-teal")
+    end
+
+    it "keeps the modifier alongside active-state handling" do
+      allow_any_instance_of(described_class).to receive(:is_external?).and_return(false)
+
+      render_inline(described_class.new(label: "Projects", path: "/avo/resources/projects", color: :purple, active: true))
+
+      expect(page).to have_css("a.sidebar-link.active.sidebar-link--color-purple")
+    end
+  end
+
   # Unit 4 / R12: label truncation itself is measured in the browser
   # (spec/system/avo/group_1/sidebar_spec.rb), which also covers the label
   # wrapper, `title` and hotkey badge on a real (internal) resource link. This


### PR DESCRIPTION
# Description

Resources can now declare a color that tints their sidebar menu icon, so related resources can be grouped visually into recognizable "namespaces":

```ruby
class Avo::Resources::Ticket < Avo::BaseResource
  self.color = :purple
end
```

`Avo::Sidebar::LinkComponent` gains a `color:` prop backed by a 17-name Tailwind palette (`red` ... `rose`, the non-semantic subset of `Avo::UI::BadgeComponent::VALID_COLORS`). The resolved name emits a `sidebar-link--color-<name>` modifier whose CSS sets a `--sidebar-icon-color` variable that only the icon wrapper consumes — label text and hover/active row backgrounds keep their current neutral styling, and the icon keeps its tint through hover/active. Unknown or blank values normalize to `nil` and render today's markup unchanged. Light theme uses the 600 shade (700 for yellow/amber/lime, which can't reach 3:1 non-text contrast on the light sidebar otherwise); dark theme overrides to the 400 shade.

The core auto-generated sidebar passes `resource.color` the same way it passes `hotkey`; the avo-menu gem (companion PR in the workspace repo, same branch name) adds the menu-entry `color:` override with resource-class fallback, mirroring how `icon`/`hotkey` resolve.

Follow-up in the same PR: the breadcrumb initials chip is tinted with the resource color too, through the avatar component's existing `--bg`/`--text` tint variables (`add_breadcrumb` now carries `color:`).

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I tested the design in Light and Dark mode, and all default themes

## Screenshots & recording

No recording; verified in a running app via computed styles (see below).

## Manual review steps

1. In an app (or the avo-menu dummy), set `self.color = :purple` on a resource.
2. Load the admin panel: the resource's sidebar icon is purple; its label and the row hover/active backgrounds are unchanged.
3. Toggle dark mode: the icon shifts to the lighter 400 shade (verified via `getComputedStyle` on the icon wrapper: purple-600 in light, purple-400 in dark; neutral items carry no `--sidebar-icon-color`).
4. A spec pins every palette name to a light and dark CSS rule, so the Ruby whitelist and the stylesheet cannot drift silently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly presentational UI and optional resource configuration; the Pagy locale fallback removal is a small behavioral change worth a quick smoke test on paginated indexes.
> 
> **Overview**
> Resources can declare **`self.color`** (a whitelisted Tailwind palette name) so navigation visually groups related models. The auto-generated sidebar passes **`color:`** into **`Avo::Sidebar::LinkComponent`**, which adds a **`sidebar-link--color-*`** modifier and tints **only the icon** via **`--sidebar-icon-color`**, with separate light (600/700) and dark (400) shades for contrast.
> 
> The same color flows through breadcrumbs: **`add_breadcrumb`** and crumb data gain **`color`**, **`BreadcrumbElementComponent`** validates against the shared palette, and CSS tints **initials chips** on resource crumbs. **`BaseController`** breadcrumb calls now include **`@resource.class.color`** (and via-resource colors) across index/show/new/edit flows.
> 
> Specs cover palette CSS parity for sidebar links and breadcrumb color modifiers. The PR also switches reactive filter detection to **`method_defined?(:react, false)`** and simplifies Pagy locale to **`locale.to_s`** without the previous config/`"en"` fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34ee050fd1ce7108d6646b7d8df2ec281eddf72a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
