### PR TITLE
Render server-side dates/times in the visitor's browser time zone via config.use_browser_timezone

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -98,6 +98,16 @@ Guards:
 - Assert slug uniqueness within the set at boot; raise and point the author at `self.param` on conflict.
 - During a transition, also accept the legacy value so bookmarked URLs keep working (`scope.param == p || scope.name == p`); drop the fallback a version later.
 
+## Translations
+
+When you touch translations (any key in `lib/generators/avo/templates/locales/*.yml`), fill in the other languages before declaring done:
+
+```sh
+bundle exec i18n-tasks translate-missing --backend=openai
+```
+
+It needs `OPENAI_API_KEY` in the environment; if it is not set, ask the developer to run the command instead of skipping it.
+
 ## Logging in (development & testing)
 
 The dummy app at `spec/dummy` uses Devise for authentication. Avo is mounted at `/admin` and is wrapped in an `authenticate :user, ->(user) { user.is_admin? }` block, so you need an admin user to reach it.

--- a/app/controllers/avo/base_application_controller.rb
+++ b/app/controllers/avo/base_application_controller.rb
@@ -18,6 +18,7 @@ module Avo
     before_action :decode_params
     around_action :set_avo_locale
     around_action :set_force_locale, if: -> { params[:force_locale].present? }
+    around_action :set_browser_timezone, if: -> { Avo.configuration.use_browser_timezone }
     before_action :init_app
     before_action :set_active_storage_current_host
     before_action :set_resource_name
@@ -276,6 +277,25 @@ module Avo
     # Temporary set the locale and reverting at the end of the request.
     def set_force_locale(&action)
       I18n.with_locale(params[:force_locale], &action)
+    end
+
+    # The browser-timezone Stimulus controller mirrors the viewer's IANA zone
+    # into a cookie (no HTTP header carries it), so every response renders in
+    # the viewer's local zone. `ActiveSupport::TimeZone[]` validates the
+    # user-controlled cookie — junk lookups return nil and we fall back to the
+    # app zone. The one-shot `timezone_changed` cookie is set right before the
+    # controller's Turbo reload, so the reloaded page announces the change once.
+    def set_browser_timezone(&action)
+      zone = ActiveSupport::TimeZone[cookies["#{Avo::COOKIES_KEY}.browser_timezone"].to_s]
+      return yield if zone.nil?
+
+      if cookies.delete("#{Avo::COOKIES_KEY}.timezone_changed").present?
+        flash.now[:notice] = t("avo.timezone_changed",
+          timezone: zone.tzinfo.name,
+          default: "Dates and times are now displayed in your time zone (%{timezone}).")
+      end
+
+      Time.use_zone(zone, &action)
     end
 
     def set_sidebar_open

--- a/app/javascript/js/controllers.js
+++ b/app/javascript/js/controllers.js
@@ -7,6 +7,7 @@ import AttachmentsController from './controllers/attachments_controller'
 import BackToTopController from './controllers/back_to_top_controller'
 import BelongsToFieldController from './controllers/fields/belongs_to_field_controller'
 import BooleanFilterController from './controllers/boolean_filter_controller'
+import BrowserTimezoneController from './controllers/browser_timezone_controller'
 import CheckboxListFieldController from './controllers/fields/checkbox_list_field_controller'
 import ClearInputController from './controllers/fields/clear_input_controller'
 import CodeFieldController from './controllers/fields/code_field_controller'
@@ -78,6 +79,7 @@ application.register('actions-picker', ActionsPickerController)
 application.register('attachments', AttachmentsController)
 application.register('back-to-top', BackToTopController)
 application.register('boolean-filter', BooleanFilterController)
+application.register('browser-timezone', BrowserTimezoneController)
 application.register('clear-input', ClearInputController)
 application.register('appearance', AppearanceController)
 application.register('appearance-preview', AppearancePreviewController)

--- a/app/javascript/js/controllers/browser_timezone_controller.js
+++ b/app/javascript/js/controllers/browser_timezone_controller.js
@@ -1,0 +1,35 @@
+import Cookies from 'js-cookie'
+import { Controller } from '@hotwired/stimulus'
+
+// Mirrors the browser's IANA time zone into a cookie so the server can render
+// dates and times in the viewer's local zone (see BaseApplicationController#set_browser_timezone).
+// Attached to <body> only when `config.use_browser_timezone` is on.
+//
+// The zone only exists inside the browser's JS runtime — no HTTP header carries
+// it — so the first-ever request renders in the server zone. When the cookie is
+// missing or stale, we set it and soft-reload once through Turbo. The one-shot
+// `timezone_changed` cookie tells the server to announce the change with a flash.
+export default class extends Controller {
+  connect() {
+    const zone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+    if (!zone || Cookies.get(this.cookieKey) === zone) return
+
+    Cookies.set(this.cookieKey, zone, { expires: 365, sameSite: 'Lax' })
+
+    // Read-back proves the cookie stuck. With cookies blocked the write is a
+    // no-op, and reloading would loop forever — so we stay on the server zone.
+    if (Cookies.get(this.cookieKey) !== zone) return
+
+    Cookies.set(this.changedCookieKey, '1', { sameSite: 'Lax' })
+    window.Turbo.visit(window.location.href, { action: 'replace' })
+  }
+
+  get cookieKey() {
+    return `${window.Avo.configuration.cookies_key}.browser_timezone`
+  }
+
+  get changedCookieKey() {
+    return `${window.Avo.configuration.cookies_key}.timezone_changed`
+  }
+}

--- a/app/views/layouts/avo/application.html.erb
+++ b/app/views/layouts/avo/application.html.erb
@@ -46,7 +46,7 @@
     <%= content_for :head %>
   </head>
 
-  <body class="<%= class_names("floating-controls bg-background", *body_classes, "all-fields-stacked": Avo.configuration.use_stacked_fields) %>">
+  <body class="<%= class_names("floating-controls bg-background", *body_classes, "all-fields-stacked": Avo.configuration.use_stacked_fields) %>"<% if Avo.configuration.use_browser_timezone %> data-controller="browser-timezone"<% end %>>
     <a href="#main-sidebar" class="skip-to-content"><%= t("avo.skip_to_sidebar") %></a>
     <a href="#main-content" class="skip-to-content"><%= t("avo.skip_to_content") %></a>
 

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -205,7 +205,7 @@ module Avo
       @model_generator_hook = true
       @send_metadata = true
       @use_stacked_fields = false
-      @use_browser_timezone = false
+      @use_browser_timezone = true
       @default_editor_url = "cursor://file/%{path}"
       @sidebar = {}
       @body_classes = []

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -63,6 +63,7 @@ module Avo
     attr_accessor :model_generator_hook
     attr_accessor :send_metadata
     attr_accessor :use_stacked_fields
+    attr_accessor :use_browser_timezone
     attr_accessor :default_editor_url
     attr_writer :body_classes
     attr_writer :sidebar
@@ -204,6 +205,7 @@ module Avo
       @model_generator_hook = true
       @send_metadata = true
       @use_stacked_fields = false
+      @use_browser_timezone = false
       @default_editor_url = "cursor://file/%{path}"
       @sidebar = {}
       @body_classes = []

--- a/lib/avo/skills/avo-admin-config/SKILL.md
+++ b/lib/avo/skills/avo-admin-config/SKILL.md
@@ -56,6 +56,7 @@ Every option below is a `config.<name>` assignment inside `Avo.configure`. Most 
 config.app_name = "Avocadelicious"              # navbar label next to the logo
 config.app_name = -> { I18n.t "app_name" }      # block form for dynamic/i18n names
 config.timezone = "UTC"                          # for date/datetime fields
+config.use_browser_timezone = true               # render server-side dates/times in each visitor's own zone (default false); detects the browser zone via cookie, soft-reloads once and shows an alert
 config.currency = "USD"                          # for currency fields
 config.locale   = "en-US"                        # force Avo's UI locale (default: I18n.default_locale)
 ```

--- a/lib/avo/skills/avo-admin-config/SKILL.md
+++ b/lib/avo/skills/avo-admin-config/SKILL.md
@@ -56,7 +56,7 @@ Every option below is a `config.<name>` assignment inside `Avo.configure`. Most 
 config.app_name = "Avocadelicious"              # navbar label next to the logo
 config.app_name = -> { I18n.t "app_name" }      # block form for dynamic/i18n names
 config.timezone = "UTC"                          # for date/datetime fields
-config.use_browser_timezone = true               # render server-side dates/times in each visitor's own zone (default false); detects the browser zone via cookie, soft-reloads once and shows an alert
+config.use_browser_timezone = false              # render everyone in the app's configured zone instead; default true renders each visitor's own zone (cookie-detected, one soft reload + alert)
 config.currency = "USD"                          # for currency fields
 config.locale   = "en-US"                        # force Avo's UI locale (default: I18n.default_locale)
 ```

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -144,6 +144,7 @@ Avo.configure do |config|
   # config.density = :normal # :tight, :normal, :relaxed
   # config.app_name = 'Avocadelicious'
   # config.timezone = 'UTC'
+  # config.use_browser_timezone = false # render server-side dates/times in each visitor's own time zone
   # config.currency = 'USD'
   # config.hide_layout_when_printing = false
   # config.container_width = :large # :full, :large, or :small. Hash for per-view: { index: :full, single: :small }

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -144,7 +144,7 @@ Avo.configure do |config|
   # config.density = :normal # :tight, :normal, :relaxed
   # config.app_name = 'Avocadelicious'
   # config.timezone = 'UTC'
-  # config.use_browser_timezone = false # render server-side dates/times in each visitor's own time zone
+  # config.use_browser_timezone = true # set false to render dates/times in the app's configured zone for everyone
   # config.currency = 'USD'
   # config.hide_layout_when_printing = false
   # config.container_width = :large # :full, :large, or :small. Hash for per-view: { index: :full, single: :small }

--- a/lib/generators/avo/templates/locales/avo.ar.yml
+++ b/lib/generators/avo/templates/locales/avo.ar.yml
@@ -222,6 +222,7 @@ ar:
     switch_to_view: التبديل إلى عرض %{view_type}
     table_view: عرض الجدول
     this_field_has_attachments_disabled: هذا الحقل لديه المرفقات معطلة.
+    timezone_changed: تُعرض التواريخ والأوقات الآن في منطقتك الزمنية (%{timezone}).
     tools: الأدوات
     'true': صحيح
     type_to_search: اكتب للبحث.

--- a/lib/generators/avo/templates/locales/avo.de.yml
+++ b/lib/generators/avo/templates/locales/avo.de.yml
@@ -204,6 +204,7 @@ de:
     switch_to_view: Wechseln zur %{view_type}-Ansicht
     table_view: Tabellenansicht
     this_field_has_attachments_disabled: Für dieses Feld sind Anhänge deaktiviert.
+    timezone_changed: Daten und Zeiten werden jetzt in Ihrer Zeitzone (%{timezone}) angezeigt.
     tools: Werkzeuge
     'true': Wahr
     type_to_search: Tippen, um zu suchen.

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -204,6 +204,7 @@ en:
     switch_to_view: Switch to %{view_type} view
     table_view: Table view
     this_field_has_attachments_disabled: This field has attachments disabled.
+    timezone_changed: Dates and times are now displayed in your time zone (%{timezone}).
     tools: Tools
     'true': 'True'
     type_to_search: Type to search.

--- a/lib/generators/avo/templates/locales/avo.es.yml
+++ b/lib/generators/avo/templates/locales/avo.es.yml
@@ -206,6 +206,7 @@ es:
     switch_to_view: Cambiar a la vista %{view_type}
     table_view: Vista en tabla
     this_field_has_attachments_disabled: Este campo tiene los adjuntos deshabilitados.
+    timezone_changed: Las fechas y horas ahora se muestran en su zona horaria (%{timezone}).
     tools: Herramientas
     'true': Verdadero
     type_to_search: Escribe para buscar.

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -206,6 +206,7 @@ fr:
     switch_to_view: Passez à la vue %{view_type}
     table_view: Vue table
     this_field_has_attachments_disabled: Ce champ a les pièces jointes désactivées.
+    timezone_changed: Les dates et heures sont désormais affichées dans votre fuseau horaire (%{timezone}).
     tools: Outils
     'true': Vrai
     type_to_search: Type à rechercher.

--- a/lib/generators/avo/templates/locales/avo.it.yml
+++ b/lib/generators/avo/templates/locales/avo.it.yml
@@ -204,6 +204,7 @@ it:
     switch_to_view: Passa a vista %{view_type}
     table_view: Vista tabella
     this_field_has_attachments_disabled: Gli allegati sono disabilitati per questo campo.
+    timezone_changed: Le date e gli orari sono ora visualizzati nel tuo fuso orario (%{timezone}).
     tools: Strumenti
     'true': Vero
     type_to_search: Digita per cercare.

--- a/lib/generators/avo/templates/locales/avo.ja.yml
+++ b/lib/generators/avo/templates/locales/avo.ja.yml
@@ -206,6 +206,7 @@ ja:
     switch_to_view: "%{view_type}ビューに切り替える"
     table_view: テーブルビュー
     this_field_has_attachments_disabled: このフィールドには添付ファイルが無効になっています。
+    timezone_changed: 日付と時刻は現在、あなたのタイムゾーン (%{timezone}) で表示されています。
     tools: ツール
     'true': 真
     type_to_search: 検索する内容を入力してください。

--- a/lib/generators/avo/templates/locales/avo.nb.yml
+++ b/lib/generators/avo/templates/locales/avo.nb.yml
@@ -206,6 +206,7 @@ nb:
     switch_to_view: Bytt til %{view_type} vis
     table_view: Tabell visning
     this_field_has_attachments_disabled: Dette feltet har vedlegg deaktivert.
+    timezone_changed: Datoer og tider vises nå i din tidssone (%{timezone}).
     tools: Redskapene
     'true': Sann
     type_to_search: Søk.

--- a/lib/generators/avo/templates/locales/avo.nl.yml
+++ b/lib/generators/avo/templates/locales/avo.nl.yml
@@ -204,6 +204,7 @@ nl:
     switch_to_view: Schakelen naar %{view_type}-weergave
     table_view: Tabelweergave
     this_field_has_attachments_disabled: Bijlagen zijn uitgeschakeld voor dit veld.
+    timezone_changed: Data en tijden worden nu weergegeven in uw tijdzone (%{timezone}).
     tools: Gereedschappen
     'true': Waar
     type_to_search: Typ om te zoeken.

--- a/lib/generators/avo/templates/locales/avo.nn.yml
+++ b/lib/generators/avo/templates/locales/avo.nn.yml
@@ -206,6 +206,7 @@ nn:
     switch_to_view: Bytt til %{view_type} vis
     table_view: Tabellvisning
     this_field_has_attachments_disabled: Dette feltet har vedlegg deaktivert.
+    timezone_changed: Datoar og tidspunkter blir no viste i tidssonen din (%{timezone}).
     tools: Reiskapane
     'true': Sann
     type_to_search: Søk.

--- a/lib/generators/avo/templates/locales/avo.pl.yml
+++ b/lib/generators/avo/templates/locales/avo.pl.yml
@@ -210,6 +210,7 @@ pl:
     switch_to_view: Przełącz na widok %{view_type}
     table_view: Widok tabelaryczny
     this_field_has_attachments_disabled: Załączniki są wyłączone dla tego pola.
+    timezone_changed: Daty i czasy są teraz wyświetlane w Twojej strefie czasowej (%{timezone}).
     tools: Narzędzia
     'true': Prawda
     type_to_search: Wpisz, aby wyszukać.

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -206,6 +206,7 @@ pt-BR:
     switch_to_view: Alterar para visão %{view_type}
     table_view: Visualização em tabela
     this_field_has_attachments_disabled: Este campo tem anexos desativados.
+    timezone_changed: As datas e horários agora são exibidos no seu fuso horário (%{timezone}).
     tools: Ferramentas
     'true': Verdadeiro
     type_to_search: Digite para buscar.

--- a/lib/generators/avo/templates/locales/avo.pt.yml
+++ b/lib/generators/avo/templates/locales/avo.pt.yml
@@ -206,6 +206,7 @@ pt:
     switch_to_view: Alterar para visão %{view_type}
     table_view: Visualização em tabela
     this_field_has_attachments_disabled: Este campo tem anexos desativados.
+    timezone_changed: As datas e horários agora são exibidos no seu fuso horário (%{timezone}).
     tools: Ferramentas
     'true': Verdadeiro
     type_to_search: Escreva para pesquisar.

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -210,6 +210,7 @@ ro:
     switch_to_view: Comutați la vizualizarea %{view_type}
     table_view: Vezi sub formă de tabel
     this_field_has_attachments_disabled: Acest câmp are atașamente dezactivate.
+    timezone_changed: Datele și orele sunt acum afișate în fusul tău orar (%{timezone}).
     tools: Instrumente
     'true': Adevărat
     type_to_search: Caută aici...

--- a/lib/generators/avo/templates/locales/avo.ru.yml
+++ b/lib/generators/avo/templates/locales/avo.ru.yml
@@ -210,6 +210,7 @@ ru:
     switch_to_view: Переключиться на вид %{view_type}
     table_view: Таблица
     this_field_has_attachments_disabled: Для этого поля прикрепления отключены.
+    timezone_changed: Даты и время теперь отображаются в вашем часовом поясе (%{timezone}).
     tools: Инструменты
     'true': Истина
     type_to_search: Поиск...

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -206,6 +206,7 @@ tr:
     switch_to_view: "%{view_type} görünümüne kay"
     table_view: Tablo görünümü
     this_field_has_attachments_disabled: Bu alanın ekleri devre dışı bırakıldı.
+    timezone_changed: Tarih ve saatler artık sizin zaman diliminizde (%{timezone}) görüntüleniyor.
     tools: Araçlar
     'true': Doğru
     type_to_search: Aramak için yazın.

--- a/lib/generators/avo/templates/locales/avo.ua.yml
+++ b/lib/generators/avo/templates/locales/avo.ua.yml
@@ -208,6 +208,7 @@ ua:
     switch_to_view: Перейти до виду %{view_type}
     table_view: Таблиця
     this_field_has_attachments_disabled: Прикріплення для цього поля вимкнено.
+    timezone_changed: Дати та часи тепер відображаються у вашому часовому поясі (%{timezone}).
     tools: Інструменти
     'true': Істина
     type_to_search: Введіть для пошуку.

--- a/lib/generators/avo/templates/locales/avo.zh-TW.yml
+++ b/lib/generators/avo/templates/locales/avo.zh-TW.yml
@@ -204,6 +204,7 @@ zh-TW:
     switch_to_view: 切換到 %{view_type} 視圖
     table_view: 表格視圖
     this_field_has_attachments_disabled: 此欄位已禁用附件。
+    timezone_changed: 日期和時間現在以您的時區 (%{timezone}) 顯示。
     tools: 工具
     'true': 真
     type_to_search: 輸入以搜尋。

--- a/lib/generators/avo/templates/locales/avo.zh.yml
+++ b/lib/generators/avo/templates/locales/avo.zh.yml
@@ -204,6 +204,7 @@ zh:
     switch_to_view: 切换到 %{view_type} 视图
     table_view: 表格视图
     this_field_has_attachments_disabled: 此字段已禁用附件。
+    timezone_changed: 日期和时间现在以您的时区 (%{timezone}) 显示。
     tools: 工具
     'true': 真
     type_to_search: 输入以搜索。

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -15,6 +15,10 @@ Avo.configure do |config|
 
   ## == App context ==
   config.current_user_method = :current_user
+  # Per-visitor time zones are on by default. Keep the suite deterministic —
+  # the first-load soft reload + flash would race every browser spec. The
+  # browser-timezone specs opt back in themselves.
+  config.use_browser_timezone = false if Rails.env.test?
   # config.is_admin_method = :is_admin?
   # config.is_developer_method = :is_developer?
   config.model_resource_mapping = {

--- a/spec/dummy/config/locales/avo.en.yml
+++ b/spec/dummy/config/locales/avo.en.yml
@@ -135,6 +135,7 @@ en:
     skip_to_sidebar: Skip to sidebar
     switch_to_view: Switch to %{view_type} view
     table_view: Table view
+    timezone_changed: Dates and times are now displayed in your time zone (%{timezone}).
     tools: Tools
     type_to_search: Type to search.
     unauthorized: Unauthorized

--- a/spec/requests/avo/browser_timezone_request_spec.rb
+++ b/spec/requests/avo/browser_timezone_request_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+# Server half of the browser-timezone feature: the browser-timezone Stimulus
+# controller mirrors the viewer's IANA zone into `avo.browser_timezone`, and
+# BaseApplicationController#set_browser_timezone wraps the request in it. The
+# one-shot `avo.timezone_changed` cookie (set right before the controller's
+# Turbo reload) makes the reloaded page announce the change once via flash.
+RSpec.describe "Browser timezone", type: :request do
+  let(:admin_user) { create :user, roles: {admin: true} }
+  let(:path) { "/admin/failed_to_load" }
+
+  before do
+    login_as admin_user
+    Avo.configuration.use_browser_timezone = true
+    allow(Time).to receive(:use_zone).and_call_original
+  end
+
+  after { Avo.configuration.use_browser_timezone = false }
+
+  it "renders the request in the cookie's zone" do
+    cookies["avo.browser_timezone"] = "Europe/Bucharest"
+
+    get path
+
+    expect(response).to have_http_status(:ok)
+    expect(Time).to have_received(:use_zone).with(ActiveSupport::TimeZone["Europe/Bucharest"])
+  end
+
+  it "announces the zone once when the changed cookie is present, and deletes it" do
+    cookies["avo.browser_timezone"] = "Europe/Bucharest"
+    cookies["avo.timezone_changed"] = "1"
+
+    get path
+
+    expect(response.body).to include("Dates and times are now displayed in your time zone (Europe/Bucharest).")
+
+    # The one-shot cookie is deleted, so a plain follow-up shows no flash.
+    expect(Array(response.headers["Set-Cookie"]).join).to include("avo.timezone_changed=;")
+    get path
+    expect(response.body).not_to include("Dates and times are now displayed")
+  end
+
+  it "falls back to the app zone on a junk cookie without raising" do
+    cookies["avo.browser_timezone"] = "Not/AZone"
+
+    get path
+
+    expect(response).to have_http_status(:ok)
+    expect(Time).not_to have_received(:use_zone)
+  end
+
+  it "does nothing when the config is off" do
+    Avo.configuration.use_browser_timezone = false
+    cookies["avo.browser_timezone"] = "Europe/Bucharest"
+
+    get path
+
+    expect(response).to have_http_status(:ok)
+    expect(Time).not_to have_received(:use_zone)
+    expect(response.body).not_to include('data-controller="browser-timezone"')
+  end
+
+  it "attaches the Stimulus controller to the body when enabled" do
+    get path
+
+    expect(response.body).to include('data-controller="browser-timezone"')
+  end
+end

--- a/spec/requests/avo/browser_timezone_request_spec.rb
+++ b/spec/requests/avo/browser_timezone_request_spec.rb
@@ -11,11 +11,14 @@ RSpec.describe "Browser timezone", type: :request do
 
   before do
     login_as admin_user
-    Avo.configuration.use_browser_timezone = true
     allow(Time).to receive(:use_zone).and_call_original
   end
 
-  after { Avo.configuration.use_browser_timezone = false }
+  after { Avo.configuration.use_browser_timezone = true }
+
+  it "is on by default" do
+    expect(Avo.configuration.use_browser_timezone).to be true
+  end
 
   it "renders the request in the cookie's zone" do
     cookies["avo.browser_timezone"] = "Europe/Bucharest"

--- a/spec/requests/avo/browser_timezone_request_spec.rb
+++ b/spec/requests/avo/browser_timezone_request_spec.rb
@@ -11,13 +11,17 @@ RSpec.describe "Browser timezone", type: :request do
 
   before do
     login_as admin_user
+    Avo.configuration.use_browser_timezone = true
     allow(Time).to receive(:use_zone).and_call_original
   end
 
-  after { Avo.configuration.use_browser_timezone = true }
+  # The dummy app pins the config off for the whole suite (the first-load soft
+  # reload would race every browser spec), so restore that, and assert the
+  # shipped default on a fresh configuration instead.
+  after { Avo.configuration.use_browser_timezone = false }
 
   it "is on by default" do
-    expect(Avo.configuration.use_browser_timezone).to be true
+    expect(Avo::Configuration.new.use_browser_timezone).to be true
   end
 
   it "renders the request in the cookie's zone" do


### PR DESCRIPTION
## Description

Adds an opt-in `config.use_browser_timezone = true` that makes every Avo request render server-side dates and times in the visitor's own time zone instead of the app's `Time.zone`.

No HTTP header carries the browser's time zone, so it has to be smuggled out of the JS runtime:

- A new `browser-timezone` Stimulus controller (attached to `<body>` only when the config is on) reads `Intl.DateTimeFormat().resolvedOptions().timeZone` and mirrors it into the `avo.browser_timezone` cookie.
- **Loop-proofing:** the controller writes the cookie and reads it back. If the read-back fails (cookies disabled), it does nothing — the user stays on the app zone forever, no reload loop. If it stuck, it sets a one-shot `avo.timezone_changed` cookie and soft-reloads once via `Turbo.visit(..., { action: "replace" })` (no full browser reload).
- `BaseApplicationController#set_browser_timezone` (around_action) validates the cookie through `ActiveSupport::TimeZone[]` — junk values fall back to the app zone without raising — and wraps the request in `Time.use_zone`.
- On the reloaded request the server deletes the one-shot cookie and shows a flash: "Dates and times are now displayed in your time zone (Europe/Bucharest)." — once per browser, ever; later visits render correctly on first paint with no reload and no alert.

The luxon-based datetime fields already convert client-side to the browser zone, so with this on, fields and server-rendered surfaces (e.g. the avo-calendar grid) agree.

## Checklist

- [x] Request specs: zone applied, alert shown once then cookie deleted, junk-cookie fallback, config off, controller attachment
- [x] Initializer template + `avo.en.yml` locale key (with inline `default:` for apps whose locale file predates the key)
- [x] `avo-admin-config` skill updated; `ws audit-skills` clean
- [x] docs.avohq.io: `4.0/customization.md` + `4.0/customization-api.md` updated (separate docs repo, uncommitted there)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every Avo request interprets time when enabled (default on), including cookie-driven `Time.use_zone` and a first-visit Turbo reload; validation limits abuse but display semantics shift app-wide.
> 
> **Overview**
> Adds **`config.use_browser_timezone`** (default **on**) so server-rendered dates and times follow each visitor’s local zone instead of only the app’s `config.timezone`. Set it to **false** to keep everyone on the configured app zone.
> 
> When enabled, a **`browser-timezone`** Stimulus controller on `<body>` writes the IANA zone from `Intl` into a cookie, then triggers a **one-time Turbo replace** reload (with read-back guarding against cookie-blocked reload loops). **`BaseApplicationController#set_browser_timezone`** validates that cookie via `ActiveSupport::TimeZone[]`, wraps the request in `Time.use_zone`, and shows a **one-shot flash** when the `timezone_changed` cookie is present.
> 
> Docs and templates cover the new option (`avo-admin-config`, initializer comment), **`avo.timezone_changed`** is added across locale files, **`agents.md`** documents filling missing translations via `i18n-tasks`, and the dummy app disables the feature in **test** so browser specs stay deterministic. Request specs cover zone application, flash/cookie cleanup, junk cookies, and config-off behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ad0fb88e16403288354366ab3d60dfe51a17ee3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->