### PR TITLE
Show the disabled state visually on select inputs

### DIFF
--- a/app/assets/stylesheets/css/components/input.css
+++ b/app/assets/stylesheets/css/components/input.css
@@ -206,6 +206,15 @@
     background-position: left var(--input-icon-offset) center;
   }
 
+  /* The component-layer rules above re-apply text-content and a full-contrast
+     chevron, overriding the base-layer disabled style. Keep this rule after
+     the .dark chevron rule so it wins in both modes. */
+  select:not([multiple]):disabled {
+    @apply text-content-secondary;
+    /* Chevron: content-secondary-ish gray, readable in light and dark */
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%239ca3af' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M6 9l6 6l6 -6'/%3E%3C/svg%3E");
+  }
+
   /* The base reset sets `overflow: hidden` on every select, which clips the
      options past the visible rows and leaves no way to scroll to them. */
   select[multiple] {


### PR DESCRIPTION
## Description

A disabled select (e.g. a `belongs_to` field with `disabled: true`) looked identical to an enabled one.

The `disabled` attribute was rendered correctly, and the base layer dims disabled inputs with `text-content-secondary` — but the component-layer custom-chevron rule (`select:not([multiple])`) re-applies `text-content` and a full-contrast chevron, overriding the disabled style. This affected every non-multiple select, not just `belongs_to`.

## Fix

One rule in `input.css`: `select:not([multiple]):disabled` dims the text to `text-content-secondary` and swaps in a gray chevron (same pattern the date field already uses for its disabled calendar icon). Placed after the `.dark` chevron rule so it wins the specificity tie in both light and dark mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation fix for disabled selects; no behavior, auth, or data changes.
> 
> **Overview**
> **Disabled single-selects** (`select:not([multiple])`) no longer look enabled. Component-layer chevron rules were re-applying full-contrast text and icons on top of the base disabled styles.
> 
> Adds a **`select:not([multiple]):disabled`** rule in `input.css` that sets **`text-content-secondary`** and a **gray chevron** (same `#9ca3af` stroke pattern as disabled date fields). The rule is ordered **after** the `.dark` chevron override so disabled styling wins in light and dark mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ed1f8fdd38853b7db55b24b6de011af8b5c0c0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->