### PR TITLE
Simplify back-to-top pill visibility logic

### DIFF
--- a/app/assets/stylesheets/css/components/back_to_top.css
+++ b/app/assets/stylesheets/css/components/back_to_top.css
@@ -1,7 +1,7 @@
-/* "Back to top" pill, mirroring the Furo docs theme (diataxis.fr): a fixed
-   button centered just below the navbar that reveals when the user scrolls back
-   up and hides when scrolling down. Visibility is driven by the back_to_top
-   Stimulus controller toggling `.back-to-top--visible`. */
+/* "Back to top" pill: a fixed button centered just below the navbar that
+   reveals once the page is scrolled past the configured threshold. Visibility
+   is driven by the back_to_top Stimulus controller toggling
+   `.back-to-top--visible`. */
 .back-to-top {
   @apply fixed z-50 flex items-center gap-1 rounded-2xl bg-primary ps-2 pe-3 py-2 text-content no-underline;
 

--- a/app/assets/stylesheets/css/components/back_to_top.css
+++ b/app/assets/stylesheets/css/components/back_to_top.css
@@ -3,7 +3,7 @@
    is driven by the back_to_top Stimulus controller toggling
    `.back-to-top--visible`. */
 .back-to-top {
-  @apply fixed z-50 flex items-center gap-1 rounded-2xl bg-primary ps-2 pe-3 py-2 text-content no-underline;
+  @apply fixed z-50 flex items-center gap-1 rounded-2xl bg-primary ps-2 pe-3 py-1 text-content no-underline;
 
   inset-inline-start: 50%;
   top: calc(var(--top-navbar-height) + 0.5rem);

--- a/app/javascript/js/controllers/back_to_top_controller.js
+++ b/app/javascript/js/controllers/back_to_top_controller.js
@@ -1,15 +1,14 @@
 import { Controller } from '@hotwired/stimulus'
 
-// Reveals a "Back to top" pill when the user scrolls back up, mirroring the
-// Furo docs theme (used by diataxis.fr): hidden within `threshold` px of the
-// top, shown on upward scroll, hidden again on downward scroll.
+// Reveals a "Back to top" pill once the page is scrolled `threshold` px down,
+// in either direction, and hides it again near the top.
 export default class extends Controller {
-  static values = { threshold: { type: Number, default: 64 } }
+  static values = { threshold: { type: Number, default: 400 } }
 
   connect() {
-    this.lastScroll = this.scrollTop
     this.onScroll = this.onScroll.bind(this)
     window.addEventListener('scroll', this.onScroll, { passive: true })
+    this.onScroll()
   }
 
   disconnect() {
@@ -21,17 +20,11 @@ export default class extends Controller {
   }
 
   onScroll() {
-    const current = this.scrollTop
-
-    if (current < this.thresholdValue) {
+    if (this.scrollTop >= this.thresholdValue) {
+      this.show()
+    } else {
       this.hide()
-    } else if (current < this.lastScroll) {
-      this.show() // scrolling up
-    } else if (current > this.lastScroll) {
-      this.hide() // scrolling down
     }
-
-    this.lastScroll = current
   }
 
   scrollToTop(event) {

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -227,11 +227,11 @@ module Avo
     end
 
     # "Back to top" pill. `enabled` toggles it; `threshold` is how many pixels
-    # the page must be scrolled down before an upward scroll reveals it.
+    # the page must be scrolled down before it shows up.
     unless defined?(BACK_TO_TOP_DEFAULTS)
       BACK_TO_TOP_DEFAULTS = {
-        enabled: false,
-        threshold: 64
+        enabled: true,
+        threshold: 400
       }.freeze
     end
 

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -50,7 +50,6 @@ Avo.configure do |config|
   config.search_debounce = 300
   # config.field_wrapper_layout = :stacked
   config.click_row_to_view_record = true
-  config.back_to_top = {enabled: true}
 
   config.turbo = {
     instant_click: true


### PR DESCRIPTION
# Description

Simplifies the "Back to top" pill visibility behavior by removing the directional scroll detection logic. The pill now shows whenever the page is scrolled past a configurable threshold (default 400px) and hides when near the top, regardless of scroll direction.

**Changes:**
- Removed `lastScroll` tracking and upward/downward scroll detection
- Simplified `onScroll()` logic to a single threshold check
- Updated default threshold from 64px to 400px
- Changed default `enabled` state from `false` to `true`
- Updated documentation comments to reflect the new behavior
- Removed redundant config override in dummy app

This makes the component more predictable and easier to understand while reducing code complexity.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I tested the design in Light and Dark mode, and all default themes

## Manual review steps

1. Scroll down the page past 400px
2. Verify the "Back to top" pill appears
3. Scroll back to the top
4. Verify the pill disappears when near the top
5. Scroll down and up in various patterns
6. Confirm the pill visibility only depends on scroll position, not direction

https://claude.ai/code/session_01HF9nve6oLrKfzMqQz64vMY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk UX and default-config changes to a non-critical navigation affordance; no auth, data, or security impact.
> 
> **Overview**
> The **back-to-top** pill no longer depends on scroll direction. It **shows whenever** `scrollTop` is at or past the threshold and **hides** when the user is nearer the top, with an initial `onScroll()` on connect so state matches the page on load.
> 
> **Defaults change:** `BACK_TO_TOP` is **enabled by default** and the threshold moves from **64px to 400px** (Stimulus default and `Avo` configuration). The dummy app drops its explicit `config.back_to_top = { enabled: true }` override.
> 
> Styling tweaks the pill with slightly less vertical padding (`py-1` vs `py-2`); comments are updated to match the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25a3eb2790a74c40e818f01e5e1b56cb24759547. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->