### PR TITLE
Spin the refreshable icon in the direction its arrows point

### DIFF
--- a/app/javascript/js/controllers/fields/panel_refresh_controller.js
+++ b/app/javascript/js/controllers/fields/panel_refresh_controller.js
@@ -3,7 +3,8 @@ import { Controller } from '@hotwired/stimulus'
 export default class extends Controller {
   refresh() {
     const frame = this.context.scope.element.closest('turbo-frame')
-    this.element.querySelector('svg').classList.add('animate-spin')
+    // The tabler refresh icon's arrows point counterclockwise, so the spin must run in reverse to match.
+    this.element.querySelector('svg').classList.add('animate-spin', '[animation-direction:reverse]')
     if (frame) {
       frame.classList.add('opacity-50')
       frame.addEventListener('turbo:frame-load', () => {


### PR DESCRIPTION
The tabler `refresh` icon's arrows run counterclockwise, but the panel refresh controller added `animate-spin`, which rotates clockwise — so the icon spun backwards while refreshing. This reverses the animation direction to match the artwork.

Fixes [AVO-1696](https://linear.app/avo/issue/AVO-1696)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-class CSS animation tweak in a Stimulus controller; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes a visual mismatch on panel refresh: the Tabler refresh icon’s arrows point counterclockwise, but `animate-spin` rotated clockwise.
> 
> In `panel_refresh_controller.js`, the refresh handler now adds Tailwind’s `[animation-direction:reverse]` alongside `animate-spin` on the SVG, with a short comment explaining why.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18822d8fe3db9c8f487307103387ca7946863db1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->