### PR TITLE
Invert the back to top enter/exit transition

### DIFF
--- a/app/assets/stylesheets/css/components/back_to_top.css
+++ b/app/assets/stylesheets/css/components/back_to_top.css
@@ -15,7 +15,7 @@
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
-  transform: translateX(-50%) translateY(-0.5rem);
+  transform: translateX(-50%) translateY(0.5rem);
   transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
 
   &:hover {


### PR DESCRIPTION
The back to top pill now slides up into place on enter and drops down on exit — previously it dropped in from above and exited upward. One-line flip of the hidden-state `translateY` offset; the visible state and transition timing are unchanged.

https://claude.ai/code/session_01NvETb9iJrpg66JAifUKjyg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS transform tweak for a UI animation; no logic, API, or data changes.
> 
> **Overview**
> **Inverts the back-to-top pill slide animation** so it rises into place when shown and moves down when hidden.
> 
> The default (hidden) `.back-to-top` transform changes from `translateY(-0.5rem)` to `translateY(0.5rem)`; `.back-to-top--visible` still ends at `translateY(0)` with the same opacity/visibility transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a743ed24a048cedb87b9ab918b307225d82c7e51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->