### PR TITLE
feat: segmented control CSS component

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -142,6 +142,7 @@
 
   /* UI 4 */
   @import "./css/components/ui/card.css";
+  @import "./css/components/ui/segmented_control.css";
   @import "./css/components/ui/panel.css";
   @import "./css/components/ui/panel_header.css";
   @import "./css/components/ui/description_list.css";

--- a/app/assets/stylesheets/css/components/ui/segmented_control.css
+++ b/app/assets/stylesheets/css/components/ui/segmented_control.css
@@ -1,0 +1,39 @@
+/* Segmented control — a radio group styled as a strip of buttons. Pure CSS,
+   no JS: the visually-hidden radios keep the group accessible and keyboard
+   navigable, while the adjacent label reflects the checked state.
+
+   Markup:
+   <div class="segmented-control" role="radiogroup">
+     <input class="segmented-control__input" type="radio" id="x-a" name="x" value="a" checked>
+     <label class="segmented-control__option" for="x-a">A</label>
+     <input class="segmented-control__input" type="radio" id="x-b" name="x" value="b">
+     <label class="segmented-control__option" for="x-b">B</label>
+   </div>
+*/
+.segmented-control {
+  @apply inline-flex items-center self-start rounded border border-tertiary bg-secondary overflow-hidden text-xs;
+}
+
+.segmented-control__input {
+  @apply sr-only;
+}
+
+.segmented-control__option {
+  @apply cursor-pointer select-none py-0.5 px-2 text-content-secondary transition-colors;
+
+  &:not(:last-child) {
+    @apply border-e border-tertiary;
+  }
+
+  &:hover {
+    @apply text-content;
+  }
+}
+
+.segmented-control__input:checked + .segmented-control__option {
+  @apply bg-accent text-accent-foreground;
+}
+
+.segmented-control__input:focus-visible + .segmented-control__option {
+  @apply ring-2 ring-inset ring-accent;
+}


### PR DESCRIPTION
Adds a pure-CSS segmented control (radio group styled as a strip of buttons) as a UI 4 component. Visually hidden radios keep it accessible and keyboard navigable — no JS. BEM-named, RTL-safe (`border-e`), themed via color tokens.

No consumers yet; markup pattern is documented at the top of the stylesheet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CSS with no runtime or behavioral changes until markup adopts the new classes.
> 
> **Overview**
> Introduces a **UI 4** segmented control: a radio group styled as a horizontal button strip, implemented with **pure CSS** (visually hidden radios + adjacent labels for checked, hover, and focus-visible states).
> 
> The stylesheet documents the expected BEM markup (`segmented-control`, `__input`, `__option`) and uses theme tokens plus `border-e` for RTL-safe dividers. **`application.css`** now imports `segmented_control.css` alongside other UI components. **No views or JS use it yet**—this is styling-only groundwork.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbbbdd1bac14a65e3dda388872eb65c37edbdfaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->