### PR TITLE
Follow the avo-intelligence rename to avo-ai in the shortcuts modal

### DIFF
--- a/app/components/avo/keyboard_shortcuts_component.rb
+++ b/app/components/avo/keyboard_shortcuts_component.rb
@@ -90,11 +90,12 @@ class Avo::KeyboardShortcutsComponent < Avo::BaseComponent
 
   private
 
-  # avo-intelligence binds Cmd/Ctrl+J itself (its chat bar listens for the keydown directly, so it
+  # avo-ai binds Cmd/Ctrl+J itself (its chat bar listens for the keydown directly, so it
   # fires from inside a field too). Core has no assistant to open, so the modal only lists it when
-  # the gem is installed.
+  # the gem is installed. The old name is still accepted so an app on the last avo-intelligence
+  # alpha keeps its shortcut row.
   def assistant_shortcuts
-    return [] unless Avo.plugin_manager.installed?("avo-intelligence")
+    return [] unless Avo.plugin_manager.installed?("avo-ai") || Avo.plugin_manager.installed?("avo-intelligence")
 
     [shortcut(action: "Open the assistant", keys: {mac: ["Cmd", "J"], other: ["Ctrl", "J"]})]
   end

--- a/app/components/avo/keyboard_shortcuts_component.rb
+++ b/app/components/avo/keyboard_shortcuts_component.rb
@@ -92,10 +92,9 @@ class Avo::KeyboardShortcutsComponent < Avo::BaseComponent
 
   # avo-ai binds Cmd/Ctrl+J itself (its chat bar listens for the keydown directly, so it
   # fires from inside a field too). Core has no assistant to open, so the modal only lists it when
-  # the gem is installed. The old name is still accepted so an app on the last avo-intelligence
-  # alpha keeps its shortcut row.
+  # the gem is installed.
   def assistant_shortcuts
-    return [] unless Avo.plugin_manager.installed?("avo-ai") || Avo.plugin_manager.installed?("avo-intelligence")
+    return [] unless Avo.plugin_manager.installed?("avo-ai")
 
     [shortcut(action: "Open the assistant", keys: {mac: ["Cmd", "J"], other: ["Ctrl", "J"]})]
   end

--- a/lib/avo/plugin_manager.rb
+++ b/lib/avo/plugin_manager.rb
@@ -82,10 +82,10 @@ module Avo
     # Register a plugin's configuration namespace on Avo::Configuration so host
     # apps configure the plugin from config/initializers/avo.rb:
     #
-    #   Avo.plugin_manager.register_configuration :intelligence, Avo::Intelligence::Configuration
+    #   Avo.plugin_manager.register_configuration :ai, Avo::Ai::Configuration
     #
     #   Avo.configure do |config|
-    #     config.intelligence.thinking_effort = "medium"
+    #     config.ai.thinking_effort = "medium"
     #   end
     #
     # Call it from an engine initializer ordered `before: :load_config_initializers`

--- a/spec/components/avo/keyboard_shortcuts_component_spec.rb
+++ b/spec/components/avo/keyboard_shortcuts_component_spec.rb
@@ -25,14 +25,4 @@ RSpec.describe Avo::KeyboardShortcutsComponent, type: :component do
     render_inline(described_class.new)
     expect(page).to have_text("Open the assistant")
   end
-
-  # avo-intelligence is avo-ai's former name; an app still on one of its alphas registers the
-  # old plugin name and must keep the row.
-  it "lists the assistant shortcut under the former avo-intelligence gem name" do
-    allow(Avo.plugin_manager).to receive(:installed?).and_call_original
-    allow(Avo.plugin_manager).to receive(:installed?).with("avo-intelligence").and_return(true)
-
-    render_inline(described_class.new)
-    expect(page).to have_text("Open the assistant")
-  end
 end

--- a/spec/components/avo/keyboard_shortcuts_component_spec.rb
+++ b/spec/components/avo/keyboard_shortcuts_component_spec.rb
@@ -13,12 +13,22 @@ RSpec.describe Avo::KeyboardShortcutsComponent, type: :component do
     expect(page).to have_text("CTRL")
   end
 
-  # The assistant shortcut belongs to avo-intelligence, so the modal must not advertise a key
+  # The assistant shortcut belongs to avo-ai, so the modal must not advertise a key
   # nothing is listening for when the gem isn't installed.
-  it "lists the assistant shortcut only when avo-intelligence is installed" do
+  it "lists the assistant shortcut only when avo-ai is installed" do
     render_inline(described_class.new)
     expect(page).not_to have_text("Open the assistant")
 
+    allow(Avo.plugin_manager).to receive(:installed?).and_call_original
+    allow(Avo.plugin_manager).to receive(:installed?).with("avo-ai").and_return(true)
+
+    render_inline(described_class.new)
+    expect(page).to have_text("Open the assistant")
+  end
+
+  # avo-intelligence is avo-ai's former name; an app still on one of its alphas registers the
+  # old plugin name and must keep the row.
+  it "lists the assistant shortcut under the former avo-intelligence gem name" do
     allow(Avo.plugin_manager).to receive(:installed?).and_call_original
     allow(Avo.plugin_manager).to receive(:installed?).with("avo-intelligence").and_return(true)
 


### PR DESCRIPTION
The `avo-intelligence` gem is being renamed to `avo-ai` ([AVO-1665](https://linear.app/avo-hq/issue/AVO-1665/rename-avo-intelligence-to-avo-ai), avo-hq/workspace#181). Core has one behavioral reference to the gem: the keyboard-shortcuts modal only lists "Open the assistant" when the gem is installed, and it looks the gem up by name.

The check now looks for `avo-ai`, and only that. There's no fallback to the old name: an app still on an `avo-intelligence` alpha loses the shortcut row until it upgrades. That's the intended trade — the rename is a clean break, and a compatibility branch in core would outlive the alphas it was written for.

Also updates the `register_configuration` doc comment in `plugin_manager.rb`, which used `:intelligence` as its worked example.

## Testing

`bundle exec rspec spec/components/avo/keyboard_shortcuts_component_spec.rb` — 2 examples, 0 failures. `standardrb` clean on both changed files.

https://claude.ai/code/session_01NyQ2MDutk8VHoxSDQDFmcm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String and documentation renames tied to a gem rename; behavior only affects whether the assistant shortcut appears when avo-ai is installed.
> 
> **Overview**
> Aligns core with the **avo-intelligence → avo-ai** gem rename.
> 
> The keyboard shortcuts modal now treats **`avo-ai`** as the installed plugin when deciding whether to show **Open the assistant** (`Cmd/Ctrl+J`); comments and the component spec were updated to match. **`Avo::PluginManager#register_configuration`** docs now use **`config.ai`** and **`Avo::Ai::Configuration`** instead of the old `:intelligence` example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eef59f8a1f39cdd5a4bf14d456797b45813135b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->