### PR TITLE
fix: guard relationship default hydration

### DIFF
--- a/app/components/avo/fields/belongs_to_field/edit_component.rb
+++ b/app/components/avo/fields/belongs_to_field/edit_component.rb
@@ -62,6 +62,7 @@ class Avo::Fields::BelongsToField::EditComponent < Avo::Fields::EditComponent
 
     helpers.new_resource_path(**{
       via_relation: @field.id.to_s,
+      via_relation_class: resource.model_class.to_s,
       resource: target_resource || @field.target_resource,
       via_record_id: resource.record.persisted? ? resource.record.to_param : nil,
       via_belongs_to_resource_class: resource.class.name

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -573,18 +573,18 @@ module Avo
 
             if field.type == "belongs_to"
 
-              reflection = @record.class.reflect_on_association(@params[:via_relation]) if @params[:via_relation].present?
+              reflection = @record.class.reflect_on_association(@params[:via_relation]) if @params[:via_relation].present? && @params[:via_record_id].present?
 
-              if field.polymorphic_as.present? && field.types.map(&:to_s).include?(@params[:via_relation_class])
+              if field.polymorphic_as.present? && field.types.map(&:to_s).include?(@params[:via_relation_class]) && @params[:via_record_id].present?
                 # set the value to the actual record
                 via_resource = Avo.resource_manager.get_resource_by_model_class(@params[:via_relation_class])
-                value = via_resource.find_record(@params[:via_record_id])
+                value = via_resource.find_record(@params[:via_record_id]) if via_resource.present?
               elsif reflection.present? && reflection.foreign_key.present? && field.id.to_s == @params[:via_relation].to_s
                 resource = Avo.resource_manager.get_resource_by_model_class params[:via_relation_class]
-                record = resource.find_record @params[:via_record_id], params: params
+                record = resource.find_record @params[:via_record_id], params: params if resource.present?
                 id_param = reflection.options[:primary_key] || :id
 
-                value = record.send(id_param)
+                value = record.send(id_param) if record.present?
               end
             end
 

--- a/lib/avo/resources/base.rb
+++ b/lib/avo/resources/base.rb
@@ -573,13 +573,13 @@ module Avo
 
             if field.type == "belongs_to"
 
-              reflection = @record.class.reflect_on_association(@params[:via_relation]) if @params[:via_relation].present? && @params[:via_record_id].present?
+              reflection = @record.class.reflect_on_association(@params[:via_relation]) if @params[:via_relation].present?
 
               if field.polymorphic_as.present? && field.types.map(&:to_s).include?(@params[:via_relation_class]) && @params[:via_record_id].present?
                 # set the value to the actual record
                 via_resource = Avo.resource_manager.get_resource_by_model_class(@params[:via_relation_class])
                 value = via_resource.find_record(@params[:via_record_id]) if via_resource.present?
-              elsif reflection.present? && reflection.foreign_key.present? && field.id.to_s == @params[:via_relation].to_s
+              elsif reflection.present? && reflection.foreign_key.present? && field.id.to_s == @params[:via_relation].to_s && @params[:via_record_id].present?
                 resource = Avo.resource_manager.get_resource_by_model_class params[:via_relation_class]
                 record = resource.find_record @params[:via_record_id], params: params if resource.present?
                 id_param = reflection.options[:primary_key] || :id

--- a/spec/features/avo/resource_hydration_spec.rb
+++ b/spec/features/avo/resource_hydration_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+
+RSpec.describe "Resource hydration", type: :feature do
+  let(:resource_manager) { Avo::Resources::ResourceManager.new }
+
+  around do |example|
+    previous_resource_manager = Avo::Current.resource_manager
+    Avo::Current.resource_manager = resource_manager
+    example.run
+  ensure
+    Avo::Current.resource_manager = previous_resource_manager
+  end
+
+  describe "belongs-to defaults" do
+    let(:user) { create :user }
+    let(:existing_parent) { user }
+    let(:post) { Post.new(user: existing_parent) }
+    let(:via_record_id) { user.to_param }
+    let(:current_params) { {} }
+    let(:resource) do
+      Avo::Resources::Post.new(
+        view: :new,
+        params: {
+          via_relation: "user",
+          via_relation_class: "User",
+          via_record_id: via_record_id
+        }
+      ).detect_fields
+    end
+
+    subject(:hydrate_resource) do
+      resource.hydrate(
+        record: post,
+        view: Avo::ViewInquirer.new(:new)
+      )
+    end
+
+    before do
+      allow(Avo::Current).to receive(:params).and_return(current_params)
+    end
+
+    it "preserves the parent when current params omit the relation class" do
+      expect { hydrate_resource }.not_to raise_error
+
+      expect(post.user).to eq user
+    end
+
+    context "with complete relationship params" do
+      let(:existing_parent) { nil }
+      let(:current_params) { {via_relation_class: "User"} }
+
+      it "assigns the parent" do
+        hydrate_resource
+
+        expect(post.user_id).to eq user.id
+      end
+    end
+
+    context "without a relationship record ID" do
+      let(:via_record_id) { nil }
+      let(:current_params) { {via_relation_class: "User"} }
+
+      it "preserves the parent without querying for it" do
+        resource
+        post
+        user_queries = []
+        subscriber = lambda do |_name, _started, _finished, _unique_id, payload|
+          user_queries << payload[:sql] if payload[:sql].include?('FROM "users"')
+        end
+
+        ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record") do
+          hydrate_resource
+        end
+
+        expect(user_queries).to be_empty
+        expect(post.user).to eq user
+      end
+    end
+  end
+
+  describe "polymorphic belongs-to defaults" do
+    let(:project) { create :project }
+    let(:review) { Review.new(reviewable: project) }
+    let(:resource) do
+      Avo::Resources::Review.new(
+        view: :new,
+        params: {
+          via_relation: "reviewable",
+          via_relation_class: "Project",
+          via_record_id: project.to_param
+        }
+      ).detect_fields
+    end
+    let(:resource_manager) do
+      Avo::Resources::ResourceManager.new.tap do |manager|
+        manager.resources.reject! do |available_resource|
+          available_resource.model_class == Project
+        end
+      end
+    end
+
+    subject(:hydrate_resource) do
+      resource.hydrate(
+        record: review,
+        view: Avo::ViewInquirer.new(:new)
+      )
+    end
+
+    before do
+      allow(Avo::Current).to receive(:params).and_return({})
+    end
+
+    it "preserves the parent when its Avo resource is unavailable" do
+      expect { hydrate_resource }.not_to raise_error
+
+      expect(review.reviewable).to eq project
+    end
+  end
+end


### PR DESCRIPTION
# Description

Nested association creates can commit the child record and then fail during the post-save `:new` hydration pass. The resource retains cached `via_relation` params, while the current request can lack `via_relation_class`; `get_resource_by_model_class` then returns `nil` and Avo dereferences it with `find_record`.

This backports the defensive relationship-hydration behavior from #4444 to `3.x`:

- require a relationship record ID before reflecting or resolving a parent
- guard missing regular and polymorphic Avo resources
- guard custom resource finders that return no record
- preserve an already assigned parent when the relationship default cannot be resolved

Valid relationship creates keep the same resource lookup and parent query. Missing IDs now skip the lookup entirely; the regression suite asserts that no parent SQL query is made in that case.

Fixes https://github.com/avo-hq/avo/issues/4712

# Checklist

- [x] I have performed a self-review of my own code
- [x] Comments are not required; the guards follow the existing hydration branches
- [x] Documentation changes are not required for this v3 bug fix
- [x] I have added tests that prove my fix is effective

## Screenshots & recording

Not applicable. This fixes a server-side post-save exception and Turbo loading state.

## Manual review steps

1. Run `bin/test ./spec/features/avo/resource_hydration_spec.rb ./spec/features/avo/default_field_spec.rb ./spec/features/avo/create_through_record_spec.rb ./spec/features/avo/has_many_field_spec.rb ./spec/features/avo/belongs_to_polymorphic_spec.rb`.
2. Verify all 37 examples pass, including regular, missing-ID, and missing-polymorphic-resource hydration cases.
3. Run `bundle exec standardrb lib/avo/resources/base.rb spec/features/avo/resource_hydration_spec.rb`.
