### PR TITLE
Define the global search keys avo-advanced_search renders on defaults alone

### DIFF
--- a/lib/generators/avo/templates/locales/avo.ar.yml
+++ b/lib/generators/avo/templates/locales/avo.ar.yml
@@ -4,7 +4,7 @@ ar:
     action_ran_successfully: تم تنفيذ الأمر بنجاح!
     actions: أوامر
     add_filter: إضافة عامل تصفية
-    all: "الكل"
+    all: الكل
     and_x_other_resources: و %{count} موارد أخرى
     appearance:
       accent_picker: لون مميز
@@ -123,7 +123,7 @@ ar:
     filter_by: تصفية حسب
     filters: مرشحات
     global_search:
-      direct_match: "تطابق مباشر"
+      direct_match: تطابق مباشر
       empty_state:
         no_results_for_query: لم نتمكن من العثور على أي شيء يتطابق مع "%{query}"
         no_results_found: لم يتم العثور على نتائج
@@ -139,8 +139,8 @@ ar:
         select: اختيار
       results:
         count_of_total: "%{count} من %{total}"
-      search_results: "نتائج البحث"
-      searching_on: "البحث في:"
+      search_results: نتائج البحث
+      searching_on: 'البحث في:'
       show_all_results_for: عرض جميع النتائج لـ
     go_back: العودة للخلف
     grid_view: عرض الشبكة

--- a/lib/generators/avo/templates/locales/avo.ar.yml
+++ b/lib/generators/avo/templates/locales/avo.ar.yml
@@ -4,6 +4,7 @@ ar:
     action_ran_successfully: تم تنفيذ الأمر بنجاح!
     actions: أوامر
     add_filter: إضافة عامل تصفية
+    all: "الكل"
     and_x_other_resources: و %{count} موارد أخرى
     appearance:
       accent_picker: لون مميز
@@ -122,6 +123,7 @@ ar:
     filter_by: تصفية حسب
     filters: مرشحات
     global_search:
+      direct_match: "تطابق مباشر"
       empty_state:
         no_results_for_query: لم نتمكن من العثور على أي شيء يتطابق مع "%{query}"
         no_results_found: لم يتم العثور على نتائج
@@ -137,6 +139,8 @@ ar:
         select: اختيار
       results:
         count_of_total: "%{count} من %{total}"
+      search_results: "نتائج البحث"
+      searching_on: "البحث في:"
       show_all_results_for: عرض جميع النتائج لـ
     go_back: العودة للخلف
     grid_view: عرض الشبكة

--- a/lib/generators/avo/templates/locales/avo.de.yml
+++ b/lib/generators/avo/templates/locales/avo.de.yml
@@ -4,6 +4,7 @@ de:
     action_ran_successfully: Aktion erfolgreich durchgeführt!
     actions: Aktionen
     add_filter: Filter hinzufügen
+    all: "Alle"
     and_x_other_resources: und %{count} weitere Ressourcen
     appearance:
       accent_picker: Akzentfarbe
@@ -108,6 +109,7 @@ de:
     filter_by: Filtern nach
     filters: Filter
     global_search:
+      direct_match: "Direkter Treffer"
       empty_state:
         no_results_for_query: Wir konnten nichts finden, das "%{query}" entspricht
         no_results_found: Keine Ergebnisse gefunden
@@ -123,6 +125,8 @@ de:
         select: Auswählen
       results:
         count_of_total: "%{count} von %{total}"
+      search_results: "Suchergebnisse"
+      searching_on: "Suche in:"
       show_all_results_for: Alle Ergebnisse für anzeigen
     go_back: Zurück
     grid_view: Rasteransicht

--- a/lib/generators/avo/templates/locales/avo.de.yml
+++ b/lib/generators/avo/templates/locales/avo.de.yml
@@ -4,7 +4,7 @@ de:
     action_ran_successfully: Aktion erfolgreich durchgeführt!
     actions: Aktionen
     add_filter: Filter hinzufügen
-    all: "Alle"
+    all: Alle
     and_x_other_resources: und %{count} weitere Ressourcen
     appearance:
       accent_picker: Akzentfarbe
@@ -109,7 +109,7 @@ de:
     filter_by: Filtern nach
     filters: Filter
     global_search:
-      direct_match: "Direkter Treffer"
+      direct_match: Direkter Treffer
       empty_state:
         no_results_for_query: Wir konnten nichts finden, das "%{query}" entspricht
         no_results_found: Keine Ergebnisse gefunden
@@ -125,8 +125,8 @@ de:
         select: Auswählen
       results:
         count_of_total: "%{count} von %{total}"
-      search_results: "Suchergebnisse"
-      searching_on: "Suche in:"
+      search_results: Suchergebnisse
+      searching_on: 'Suche in:'
       show_all_results_for: Alle Ergebnisse für anzeigen
     go_back: Zurück
     grid_view: Rasteransicht

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -4,7 +4,7 @@ en:
     action_ran_successfully: Action ran successfully!
     actions: Actions
     add_filter: Add filter
-    all: "All"
+    all: All
     and_x_other_resources: and %{count} other resources
     appearance:
       accent_picker: Select accent color
@@ -109,7 +109,7 @@ en:
     filter_by: Filter by
     filters: Filters
     global_search:
-      direct_match: "Direct match"
+      direct_match: Direct match
       empty_state:
         no_results_for_query: We couldn't find anything matching "%{query}"
         no_results_found: No results found
@@ -125,8 +125,8 @@ en:
         select: Select
       results:
         count_of_total: "%{count} of %{total}"
-      search_results: "Search Results"
-      searching_on: "Searching on:"
+      search_results: Search Results
+      searching_on: 'Searching on:'
       show_all_results_for: Show all results for
     go_back: Go back
     grid_view: Grid view

--- a/lib/generators/avo/templates/locales/avo.en.yml
+++ b/lib/generators/avo/templates/locales/avo.en.yml
@@ -4,6 +4,7 @@ en:
     action_ran_successfully: Action ran successfully!
     actions: Actions
     add_filter: Add filter
+    all: "All"
     and_x_other_resources: and %{count} other resources
     appearance:
       accent_picker: Select accent color
@@ -108,6 +109,7 @@ en:
     filter_by: Filter by
     filters: Filters
     global_search:
+      direct_match: "Direct match"
       empty_state:
         no_results_for_query: We couldn't find anything matching "%{query}"
         no_results_found: No results found
@@ -123,6 +125,8 @@ en:
         select: Select
       results:
         count_of_total: "%{count} of %{total}"
+      search_results: "Search Results"
+      searching_on: "Searching on:"
       show_all_results_for: Show all results for
     go_back: Go back
     grid_view: Grid view

--- a/lib/generators/avo/templates/locales/avo.es.yml
+++ b/lib/generators/avo/templates/locales/avo.es.yml
@@ -4,7 +4,7 @@ es:
     action_ran_successfully: "¡Acción ejecutada con éxito!"
     actions: Acciones
     add_filter: Añadir filtro
-    all: "Todo"
+    all: Todo
     and_x_other_resources: y %{count} otros recursos
     appearance:
       accent_picker: Color de acento
@@ -111,7 +111,7 @@ es:
     filter_by: Filtrar por
     filters: Filtros
     global_search:
-      direct_match: "Coincidencia directa"
+      direct_match: Coincidencia directa
       empty_state:
         no_results_for_query: No pudimos encontrar nada que coincida con "%{query}"
         no_results_found: No se encontraron resultados
@@ -127,8 +127,8 @@ es:
         select: Seleccionar
       results:
         count_of_total: "%{count} de %{total}"
-      search_results: "Resultados de búsqueda"
-      searching_on: "Buscando en:"
+      search_results: Resultados de búsqueda
+      searching_on: 'Buscando en:'
       show_all_results_for: Mostrar todos los resultados para
     go_back: Volver
     grid_view: Vista en cuardrícula

--- a/lib/generators/avo/templates/locales/avo.es.yml
+++ b/lib/generators/avo/templates/locales/avo.es.yml
@@ -4,6 +4,7 @@ es:
     action_ran_successfully: "¡Acción ejecutada con éxito!"
     actions: Acciones
     add_filter: Añadir filtro
+    all: "Todo"
     and_x_other_resources: y %{count} otros recursos
     appearance:
       accent_picker: Color de acento
@@ -110,6 +111,7 @@ es:
     filter_by: Filtrar por
     filters: Filtros
     global_search:
+      direct_match: "Coincidencia directa"
       empty_state:
         no_results_for_query: No pudimos encontrar nada que coincida con "%{query}"
         no_results_found: No se encontraron resultados
@@ -125,6 +127,8 @@ es:
         select: Seleccionar
       results:
         count_of_total: "%{count} de %{total}"
+      search_results: "Resultados de búsqueda"
+      searching_on: "Buscando en:"
       show_all_results_for: Mostrar todos los resultados para
     go_back: Volver
     grid_view: Vista en cuardrícula

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -4,6 +4,7 @@ fr:
     action_ran_successfully: L'action s'est exécutée avec succès !
     actions: Actions
     add_filter: Ajouter un filtre
+    all: "Tout"
     and_x_other_resources: et %{count} autres ressources
     appearance:
       accent_picker: Couleur d'accent
@@ -110,6 +111,7 @@ fr:
     filter_by: Filtrer par
     filters: Filtres
     global_search:
+      direct_match: "Correspondance directe"
       empty_state:
         no_results_for_query: Nous n'avons trouvé aucun élément correspondant à "%{query}"
         no_results_found: Aucun résultat trouvé
@@ -125,6 +127,8 @@ fr:
         select: Sélectionner
       results:
         count_of_total: "%{count} sur %{total}"
+      search_results: "Résultats de recherche"
+      searching_on: "Recherche dans :"
       show_all_results_for: Afficher tous les résultats pour
     go_back: Retourner en arrière
     grid_view: Vue grille

--- a/lib/generators/avo/templates/locales/avo.fr.yml
+++ b/lib/generators/avo/templates/locales/avo.fr.yml
@@ -4,7 +4,7 @@ fr:
     action_ran_successfully: L'action s'est exécutée avec succès !
     actions: Actions
     add_filter: Ajouter un filtre
-    all: "Tout"
+    all: Tout
     and_x_other_resources: et %{count} autres ressources
     appearance:
       accent_picker: Couleur d'accent
@@ -111,7 +111,7 @@ fr:
     filter_by: Filtrer par
     filters: Filtres
     global_search:
-      direct_match: "Correspondance directe"
+      direct_match: Correspondance directe
       empty_state:
         no_results_for_query: Nous n'avons trouvé aucun élément correspondant à "%{query}"
         no_results_found: Aucun résultat trouvé
@@ -127,8 +127,8 @@ fr:
         select: Sélectionner
       results:
         count_of_total: "%{count} sur %{total}"
-      search_results: "Résultats de recherche"
-      searching_on: "Recherche dans :"
+      search_results: Résultats de recherche
+      searching_on: 'Recherche dans :'
       show_all_results_for: Afficher tous les résultats pour
     go_back: Retourner en arrière
     grid_view: Vue grille

--- a/lib/generators/avo/templates/locales/avo.it.yml
+++ b/lib/generators/avo/templates/locales/avo.it.yml
@@ -4,7 +4,7 @@ it:
     action_ran_successfully: L'azione è stata eseguita con successo!
     actions: Azioni
     add_filter: Aggiungi filtro
-    all: "Tutto"
+    all: Tutto
     and_x_other_resources: e altri %{count} risorse
     appearance:
       accent_picker: Colore accento
@@ -109,7 +109,7 @@ it:
     filter_by: Filtra per
     filters: Filtri
     global_search:
-      direct_match: "Corrispondenza diretta"
+      direct_match: Corrispondenza diretta
       empty_state:
         no_results_for_query: Non siamo riusciti a trovare nulla che corrisponda a "%{query}"
         no_results_found: Nessun risultato trovato
@@ -125,8 +125,8 @@ it:
         select: Seleziona
       results:
         count_of_total: "%{count} di %{total}"
-      search_results: "Risultati della ricerca"
-      searching_on: "Ricerca in:"
+      search_results: Risultati della ricerca
+      searching_on: 'Ricerca in:'
       show_all_results_for: Mostra tutti i risultati per
     go_back: Torna indietro
     grid_view: Vista griglia

--- a/lib/generators/avo/templates/locales/avo.it.yml
+++ b/lib/generators/avo/templates/locales/avo.it.yml
@@ -4,6 +4,7 @@ it:
     action_ran_successfully: L'azione è stata eseguita con successo!
     actions: Azioni
     add_filter: Aggiungi filtro
+    all: "Tutto"
     and_x_other_resources: e altri %{count} risorse
     appearance:
       accent_picker: Colore accento
@@ -108,6 +109,7 @@ it:
     filter_by: Filtra per
     filters: Filtri
     global_search:
+      direct_match: "Corrispondenza diretta"
       empty_state:
         no_results_for_query: Non siamo riusciti a trovare nulla che corrisponda a "%{query}"
         no_results_found: Nessun risultato trovato
@@ -123,6 +125,8 @@ it:
         select: Seleziona
       results:
         count_of_total: "%{count} di %{total}"
+      search_results: "Risultati della ricerca"
+      searching_on: "Ricerca in:"
       show_all_results_for: Mostra tutti i risultati per
     go_back: Torna indietro
     grid_view: Vista griglia

--- a/lib/generators/avo/templates/locales/avo.ja.yml
+++ b/lib/generators/avo/templates/locales/avo.ja.yml
@@ -4,6 +4,7 @@ ja:
     action_ran_successfully: アクションは正常に実行されました！
     actions: アクション
     add_filter: フィルターの追加
+    all: "すべて"
     and_x_other_resources: その他%{count}件のリソース
     appearance:
       accent_picker: アクセントカラー
@@ -110,6 +111,7 @@ ja:
     filter_by: フィルター条件
     filters: フィルター
     global_search:
+      direct_match: "完全一致"
       empty_state:
         no_results_for_query: '"%{query}" に一致するものが見つかりませんでした'
         no_results_found: 結果が見つかりませんでした
@@ -125,6 +127,8 @@ ja:
         select: 選択
       results:
         count_of_total: "%{count} / %{total}"
+      search_results: "検索結果"
+      searching_on: "検索対象:"
       show_all_results_for: すべての結果を表示
     go_back: 戻る
     grid_view: グリッドビュー

--- a/lib/generators/avo/templates/locales/avo.ja.yml
+++ b/lib/generators/avo/templates/locales/avo.ja.yml
@@ -4,7 +4,7 @@ ja:
     action_ran_successfully: アクションは正常に実行されました！
     actions: アクション
     add_filter: フィルターの追加
-    all: "すべて"
+    all: すべて
     and_x_other_resources: その他%{count}件のリソース
     appearance:
       accent_picker: アクセントカラー
@@ -111,7 +111,7 @@ ja:
     filter_by: フィルター条件
     filters: フィルター
     global_search:
-      direct_match: "完全一致"
+      direct_match: 完全一致
       empty_state:
         no_results_for_query: '"%{query}" に一致するものが見つかりませんでした'
         no_results_found: 結果が見つかりませんでした
@@ -127,8 +127,8 @@ ja:
         select: 選択
       results:
         count_of_total: "%{count} / %{total}"
-      search_results: "検索結果"
-      searching_on: "検索対象:"
+      search_results: 検索結果
+      searching_on: '検索対象:'
       show_all_results_for: すべての結果を表示
     go_back: 戻る
     grid_view: グリッドビュー

--- a/lib/generators/avo/templates/locales/avo.nb.yml
+++ b/lib/generators/avo/templates/locales/avo.nb.yml
@@ -4,6 +4,7 @@ nb:
     action_ran_successfully: Suksess!
     actions: Handlinger
     add_filter: Legg til filter
+    all: "Alle"
     and_x_other_resources: og %{count} andre ressurser
     appearance:
       accent_picker: Aksentfarge
@@ -110,6 +111,7 @@ nb:
     filter_by: Filtrer etter
     filters: Filter
     global_search:
+      direct_match: "Direkte treff"
       empty_state:
         no_results_for_query: Vi kunne ikke finne noe som matcher "%{query}"
         no_results_found: Ingen resultater funnet
@@ -125,6 +127,8 @@ nb:
         select: Velg
       results:
         count_of_total: "%{count} av %{total}"
+      search_results: "Søkeresultater"
+      searching_on: "Søker i:"
       show_all_results_for: Vis alle resultater for
     go_back: Gå tilbake
     grid_view: Grid visning

--- a/lib/generators/avo/templates/locales/avo.nb.yml
+++ b/lib/generators/avo/templates/locales/avo.nb.yml
@@ -4,7 +4,7 @@ nb:
     action_ran_successfully: Suksess!
     actions: Handlinger
     add_filter: Legg til filter
-    all: "Alle"
+    all: Alle
     and_x_other_resources: og %{count} andre ressurser
     appearance:
       accent_picker: Aksentfarge
@@ -111,7 +111,7 @@ nb:
     filter_by: Filtrer etter
     filters: Filter
     global_search:
-      direct_match: "Direkte treff"
+      direct_match: Direkte treff
       empty_state:
         no_results_for_query: Vi kunne ikke finne noe som matcher "%{query}"
         no_results_found: Ingen resultater funnet
@@ -127,8 +127,8 @@ nb:
         select: Velg
       results:
         count_of_total: "%{count} av %{total}"
-      search_results: "Søkeresultater"
-      searching_on: "Søker i:"
+      search_results: Søkeresultater
+      searching_on: 'Søker i:'
       show_all_results_for: Vis alle resultater for
     go_back: Gå tilbake
     grid_view: Grid visning

--- a/lib/generators/avo/templates/locales/avo.nl.yml
+++ b/lib/generators/avo/templates/locales/avo.nl.yml
@@ -4,6 +4,7 @@ nl:
     action_ran_successfully: Actie succesvol uitgevoerd!
     actions: Acties
     add_filter: Filter toevoegen
+    all: "Alles"
     and_x_other_resources: en %{count} andere bronnen
     appearance:
       accent_picker: Accentkleur
@@ -108,6 +109,7 @@ nl:
     filter_by: Filteren op
     filters: Filters
     global_search:
+      direct_match: "Directe overeenkomst"
       empty_state:
         no_results_for_query: We konden niets vinden dat overeenkomt met "%{query}"
         no_results_found: Geen resultaten gevonden
@@ -123,6 +125,8 @@ nl:
         select: Selecteren
       results:
         count_of_total: "%{count} van %{total}"
+      search_results: "Zoekresultaten"
+      searching_on: "Zoeken in:"
       show_all_results_for: Toon alle resultaten voor
     go_back: Terug
     grid_view: Rasterweergave

--- a/lib/generators/avo/templates/locales/avo.nl.yml
+++ b/lib/generators/avo/templates/locales/avo.nl.yml
@@ -4,7 +4,7 @@ nl:
     action_ran_successfully: Actie succesvol uitgevoerd!
     actions: Acties
     add_filter: Filter toevoegen
-    all: "Alles"
+    all: Alles
     and_x_other_resources: en %{count} andere bronnen
     appearance:
       accent_picker: Accentkleur
@@ -109,7 +109,7 @@ nl:
     filter_by: Filteren op
     filters: Filters
     global_search:
-      direct_match: "Directe overeenkomst"
+      direct_match: Directe overeenkomst
       empty_state:
         no_results_for_query: We konden niets vinden dat overeenkomt met "%{query}"
         no_results_found: Geen resultaten gevonden
@@ -125,8 +125,8 @@ nl:
         select: Selecteren
       results:
         count_of_total: "%{count} van %{total}"
-      search_results: "Zoekresultaten"
-      searching_on: "Zoeken in:"
+      search_results: Zoekresultaten
+      searching_on: 'Zoeken in:'
       show_all_results_for: Toon alle resultaten voor
     go_back: Terug
     grid_view: Rasterweergave

--- a/lib/generators/avo/templates/locales/avo.nn.yml
+++ b/lib/generators/avo/templates/locales/avo.nn.yml
@@ -4,6 +4,7 @@ nn:
     action_ran_successfully: Suksess!
     actions: Handlingar
     add_filter: Legg til filter
+    all: "Alle"
     and_x_other_resources: og %{count} andre ressursar
     appearance:
       accent_picker: Aksentfarge
@@ -110,6 +111,7 @@ nn:
     filter_by: Filtrer etter
     filters: Filter
     global_search:
+      direct_match: "Direkte treff"
       empty_state:
         no_results_for_query: Vi kunne ikke finne noe som matcher "%{query}"
         no_results_found: Ingen resultat funnet
@@ -125,6 +127,8 @@ nn:
         select: Vel
       results:
         count_of_total: "%{count} av %{total}"
+      search_results: "Søkeresultat"
+      searching_on: "Søkjer i:"
       show_all_results_for: Vis alle resultater for
     go_back: Gå tilbake
     grid_view: Gridvisning

--- a/lib/generators/avo/templates/locales/avo.nn.yml
+++ b/lib/generators/avo/templates/locales/avo.nn.yml
@@ -4,7 +4,7 @@ nn:
     action_ran_successfully: Suksess!
     actions: Handlingar
     add_filter: Legg til filter
-    all: "Alle"
+    all: Alle
     and_x_other_resources: og %{count} andre ressursar
     appearance:
       accent_picker: Aksentfarge
@@ -111,7 +111,7 @@ nn:
     filter_by: Filtrer etter
     filters: Filter
     global_search:
-      direct_match: "Direkte treff"
+      direct_match: Direkte treff
       empty_state:
         no_results_for_query: Vi kunne ikke finne noe som matcher "%{query}"
         no_results_found: Ingen resultat funnet
@@ -127,8 +127,8 @@ nn:
         select: Vel
       results:
         count_of_total: "%{count} av %{total}"
-      search_results: "Søkeresultat"
-      searching_on: "Søkjer i:"
+      search_results: Søkeresultat
+      searching_on: 'Søkjer i:'
       show_all_results_for: Vis alle resultater for
     go_back: Gå tilbake
     grid_view: Gridvisning

--- a/lib/generators/avo/templates/locales/avo.pl.yml
+++ b/lib/generators/avo/templates/locales/avo.pl.yml
@@ -4,6 +4,7 @@ pl:
     action_ran_successfully: Akcja została pomyślnie wykonana!
     actions: Akcje
     add_filter: Dodaj filtr
+    all: "Wszystko"
     and_x_other_resources: i %{count} innych zasobów
     appearance:
       accent_picker: Kolor akcentu
@@ -112,6 +113,7 @@ pl:
     filter_by: Filtruj według
     filters: Filtry
     global_search:
+      direct_match: "Bezpośrednie dopasowanie"
       empty_state:
         no_results_for_query: Nie mogliśmy znaleźć niczego pasującego do "%{query}"
         no_results_found: Nie znaleziono wyników
@@ -127,6 +129,8 @@ pl:
         select: Wybierz
       results:
         count_of_total: "%{count} z %{total}"
+      search_results: "Wyniki wyszukiwania"
+      searching_on: "Szukanie w:"
       show_all_results_for: Pokaż wszystkie wyniki dla
     go_back: Wróć
     grid_view: Widok siatki

--- a/lib/generators/avo/templates/locales/avo.pl.yml
+++ b/lib/generators/avo/templates/locales/avo.pl.yml
@@ -4,7 +4,7 @@ pl:
     action_ran_successfully: Akcja została pomyślnie wykonana!
     actions: Akcje
     add_filter: Dodaj filtr
-    all: "Wszystko"
+    all: Wszystko
     and_x_other_resources: i %{count} innych zasobów
     appearance:
       accent_picker: Kolor akcentu
@@ -113,7 +113,7 @@ pl:
     filter_by: Filtruj według
     filters: Filtry
     global_search:
-      direct_match: "Bezpośrednie dopasowanie"
+      direct_match: Bezpośrednie dopasowanie
       empty_state:
         no_results_for_query: Nie mogliśmy znaleźć niczego pasującego do "%{query}"
         no_results_found: Nie znaleziono wyników
@@ -129,8 +129,8 @@ pl:
         select: Wybierz
       results:
         count_of_total: "%{count} z %{total}"
-      search_results: "Wyniki wyszukiwania"
-      searching_on: "Szukanie w:"
+      search_results: Wyniki wyszukiwania
+      searching_on: 'Szukanie w:'
       show_all_results_for: Pokaż wszystkie wyniki dla
     go_back: Wróć
     grid_view: Widok siatki

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -4,6 +4,7 @@ pt-BR:
     action_ran_successfully: Ação executada com sucesso!
     actions: Ações
     add_filter: Adicionar filtro
+    all: "Tudo"
     and_x_other_resources: e %{count} outros recursos
     appearance:
       accent_picker: Cor de Acento
@@ -110,6 +111,7 @@ pt-BR:
     filter_by: Filtrar por
     filters: Filtros
     global_search:
+      direct_match: "Correspondência direta"
       empty_state:
         no_results_for_query: Não conseguimos encontrar nada correspondente a "%{query}"
         no_results_found: Nenhum resultado encontrado
@@ -125,6 +127,8 @@ pt-BR:
         select: Selecionar
       results:
         count_of_total: "%{count} de %{total}"
+      search_results: "Resultados da busca"
+      searching_on: "Buscando em:"
       show_all_results_for: Mostrar todos os resultados para
     go_back: Voltar
     grid_view: Visualização em grade

--- a/lib/generators/avo/templates/locales/avo.pt-BR.yml
+++ b/lib/generators/avo/templates/locales/avo.pt-BR.yml
@@ -4,7 +4,7 @@ pt-BR:
     action_ran_successfully: Ação executada com sucesso!
     actions: Ações
     add_filter: Adicionar filtro
-    all: "Tudo"
+    all: Tudo
     and_x_other_resources: e %{count} outros recursos
     appearance:
       accent_picker: Cor de Acento
@@ -111,7 +111,7 @@ pt-BR:
     filter_by: Filtrar por
     filters: Filtros
     global_search:
-      direct_match: "Correspondência direta"
+      direct_match: Correspondência direta
       empty_state:
         no_results_for_query: Não conseguimos encontrar nada correspondente a "%{query}"
         no_results_found: Nenhum resultado encontrado
@@ -127,8 +127,8 @@ pt-BR:
         select: Selecionar
       results:
         count_of_total: "%{count} de %{total}"
-      search_results: "Resultados da busca"
-      searching_on: "Buscando em:"
+      search_results: Resultados da busca
+      searching_on: 'Buscando em:'
       show_all_results_for: Mostrar todos os resultados para
     go_back: Voltar
     grid_view: Visualização em grade

--- a/lib/generators/avo/templates/locales/avo.pt.yml
+++ b/lib/generators/avo/templates/locales/avo.pt.yml
@@ -4,6 +4,7 @@ pt:
     action_ran_successfully: Ação executada com sucesso!
     actions: Ações
     add_filter: Adicionar filtro
+    all: "Tudo"
     and_x_other_resources: e %{count} outros recursos
     appearance:
       accent_picker: Cor de Acento
@@ -110,6 +111,7 @@ pt:
     filter_by: Filtrar por
     filters: Filtros
     global_search:
+      direct_match: "Correspondência direta"
       empty_state:
         no_results_for_query: Não conseguimos encontrar nada correspondente a "%{query}"
         no_results_found: Nenhum resultado encontrado
@@ -125,6 +127,8 @@ pt:
         select: Selecionar
       results:
         count_of_total: "%{count} de %{total}"
+      search_results: "Resultados da pesquisa"
+      searching_on: "A pesquisar em:"
       show_all_results_for: Mostrar todos os resultados para
     go_back: Voltar
     grid_view: Visualização em grelha

--- a/lib/generators/avo/templates/locales/avo.pt.yml
+++ b/lib/generators/avo/templates/locales/avo.pt.yml
@@ -4,7 +4,7 @@ pt:
     action_ran_successfully: Ação executada com sucesso!
     actions: Ações
     add_filter: Adicionar filtro
-    all: "Tudo"
+    all: Tudo
     and_x_other_resources: e %{count} outros recursos
     appearance:
       accent_picker: Cor de Acento
@@ -111,7 +111,7 @@ pt:
     filter_by: Filtrar por
     filters: Filtros
     global_search:
-      direct_match: "Correspondência direta"
+      direct_match: Correspondência direta
       empty_state:
         no_results_for_query: Não conseguimos encontrar nada correspondente a "%{query}"
         no_results_found: Nenhum resultado encontrado
@@ -127,8 +127,8 @@ pt:
         select: Selecionar
       results:
         count_of_total: "%{count} de %{total}"
-      search_results: "Resultados da pesquisa"
-      searching_on: "A pesquisar em:"
+      search_results: Resultados da pesquisa
+      searching_on: 'A pesquisar em:'
       show_all_results_for: Mostrar todos os resultados para
     go_back: Voltar
     grid_view: Visualização em grelha

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -4,6 +4,7 @@ ro:
     action_ran_successfully: Acțiunea a rulat cu succes!
     actions: Acțiuni
     add_filter: Adăugați filtru
+    all: "Toate"
     and_x_other_resources: plus alte %{count} recorduri
     appearance:
       accent_picker: Culoare accent
@@ -113,6 +114,7 @@ ro:
     filter_by: Filtează după
     filters: Filtre
     global_search:
+      direct_match: "Potrivire directă"
       empty_state:
         no_results_for_query: Nu am putut găsi nimic care să se potrivească cu "%{query}"
         no_results_found: Nu s-au găsit rezultate
@@ -128,6 +130,8 @@ ro:
         select: Selectează
       results:
         count_of_total: "%{count} din %{total}"
+      search_results: "Rezultatele căutării"
+      searching_on: "Se caută în:"
       show_all_results_for: Arată toate rezultatele pentru
     go_back: Înapoi
     grid_view: Vezi sub formă de grid

--- a/lib/generators/avo/templates/locales/avo.ro.yml
+++ b/lib/generators/avo/templates/locales/avo.ro.yml
@@ -4,7 +4,7 @@ ro:
     action_ran_successfully: Acțiunea a rulat cu succes!
     actions: Acțiuni
     add_filter: Adăugați filtru
-    all: "Toate"
+    all: Toate
     and_x_other_resources: plus alte %{count} recorduri
     appearance:
       accent_picker: Culoare accent
@@ -114,7 +114,7 @@ ro:
     filter_by: Filtează după
     filters: Filtre
     global_search:
-      direct_match: "Potrivire directă"
+      direct_match: Potrivire directă
       empty_state:
         no_results_for_query: Nu am putut găsi nimic care să se potrivească cu "%{query}"
         no_results_found: Nu s-au găsit rezultate
@@ -130,8 +130,8 @@ ro:
         select: Selectează
       results:
         count_of_total: "%{count} din %{total}"
-      search_results: "Rezultatele căutării"
-      searching_on: "Se caută în:"
+      search_results: Rezultatele căutării
+      searching_on: 'Se caută în:'
       show_all_results_for: Arată toate rezultatele pentru
     go_back: Înapoi
     grid_view: Vezi sub formă de grid

--- a/lib/generators/avo/templates/locales/avo.ru.yml
+++ b/lib/generators/avo/templates/locales/avo.ru.yml
@@ -4,6 +4,7 @@ ru:
     action_ran_successfully: Действие успешно выполнено!
     actions: Действия
     add_filter: Добавить фильтр
+    all: "Все"
     and_x_other_resources: и %{count} других ресурсов
     appearance:
       accent_picker: Цвет акцента
@@ -112,6 +113,7 @@ ru:
     filter_by: Фильтровать по
     filters: Фильтры
     global_search:
+      direct_match: "Прямое совпадение"
       empty_state:
         no_results_for_query: Мы не смогли найти ничего, соответствующего "%{query}"
         no_results_found: Результатов не найдено
@@ -127,6 +129,8 @@ ru:
         select: Выбрать
       results:
         count_of_total: "%{count} из %{total}"
+      search_results: "Результаты поиска"
+      searching_on: "Поиск по:"
       show_all_results_for: Показать все результаты для
     go_back: Назад
     grid_view: Сетка

--- a/lib/generators/avo/templates/locales/avo.ru.yml
+++ b/lib/generators/avo/templates/locales/avo.ru.yml
@@ -4,7 +4,7 @@ ru:
     action_ran_successfully: Действие успешно выполнено!
     actions: Действия
     add_filter: Добавить фильтр
-    all: "Все"
+    all: Все
     and_x_other_resources: и %{count} других ресурсов
     appearance:
       accent_picker: Цвет акцента
@@ -113,7 +113,7 @@ ru:
     filter_by: Фильтровать по
     filters: Фильтры
     global_search:
-      direct_match: "Прямое совпадение"
+      direct_match: Прямое совпадение
       empty_state:
         no_results_for_query: Мы не смогли найти ничего, соответствующего "%{query}"
         no_results_found: Результатов не найдено
@@ -129,8 +129,8 @@ ru:
         select: Выбрать
       results:
         count_of_total: "%{count} из %{total}"
-      search_results: "Результаты поиска"
-      searching_on: "Поиск по:"
+      search_results: Результаты поиска
+      searching_on: 'Поиск по:'
       show_all_results_for: Показать все результаты для
     go_back: Назад
     grid_view: Сетка

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -4,6 +4,7 @@ tr:
     action_ran_successfully: Eylem başarıyla gerçekleşti!
     actions: Aksiyonlar
     add_filter: Filtre ekle
+    all: "Tümü"
     and_x_other_resources: ve %{count} diğer kaynak
     appearance:
       accent_picker: Vurgu rengi
@@ -110,6 +111,7 @@ tr:
     filter_by: Tarafından filtre
     filters: Filtreler
     global_search:
+      direct_match: "Doğrudan eşleşme"
       empty_state:
         no_results_for_query: '"%{query}" ile eşleşen hiçbir şey bulamadık'
         no_results_found: Sonuç bulunamadı
@@ -125,6 +127,8 @@ tr:
         select: Seç
       results:
         count_of_total: "%{count} / %{total}"
+      search_results: "Arama sonuçları"
+      searching_on: "Şurada aranıyor:"
       show_all_results_for: Tüm sonuçları göster
     go_back: Geri dön
     grid_view: Grid görünümü

--- a/lib/generators/avo/templates/locales/avo.tr.yml
+++ b/lib/generators/avo/templates/locales/avo.tr.yml
@@ -4,7 +4,7 @@ tr:
     action_ran_successfully: Eylem başarıyla gerçekleşti!
     actions: Aksiyonlar
     add_filter: Filtre ekle
-    all: "Tümü"
+    all: Tümü
     and_x_other_resources: ve %{count} diğer kaynak
     appearance:
       accent_picker: Vurgu rengi
@@ -111,7 +111,7 @@ tr:
     filter_by: Tarafından filtre
     filters: Filtreler
     global_search:
-      direct_match: "Doğrudan eşleşme"
+      direct_match: Doğrudan eşleşme
       empty_state:
         no_results_for_query: '"%{query}" ile eşleşen hiçbir şey bulamadık'
         no_results_found: Sonuç bulunamadı
@@ -127,8 +127,8 @@ tr:
         select: Seç
       results:
         count_of_total: "%{count} / %{total}"
-      search_results: "Arama sonuçları"
-      searching_on: "Şurada aranıyor:"
+      search_results: Arama sonuçları
+      searching_on: 'Şurada aranıyor:'
       show_all_results_for: Tüm sonuçları göster
     go_back: Geri dön
     grid_view: Grid görünümü

--- a/lib/generators/avo/templates/locales/avo.ua.yml
+++ b/lib/generators/avo/templates/locales/avo.ua.yml
@@ -4,6 +4,7 @@ ua:
     action_ran_successfully: Дія успішно виконана!
     actions: Дії
     add_filter: Додати фільтр
+    all: "Усе"
     and_x_other_resources: і ще %{count} інших ресурсів
     appearance:
       accent_picker: Колір акценту
@@ -110,6 +111,7 @@ ua:
     filter_by: Фільтрувати за
     filters: Фільтри
     global_search:
+      direct_match: "Пряме співпадіння"
       empty_state:
         no_results_for_query: We couldn't find anything matching "%{query}"
         no_results_found: No results found
@@ -125,6 +127,8 @@ ua:
         select: Вибрати
       results:
         count_of_total: "%{count} of %{total}"
+      search_results: "Результати пошуку"
+      searching_on: "Пошук у:"
       show_all_results_for: Show all results for
     go_back: Назад
     grid_view: Плитка

--- a/lib/generators/avo/templates/locales/avo.ua.yml
+++ b/lib/generators/avo/templates/locales/avo.ua.yml
@@ -4,7 +4,7 @@ ua:
     action_ran_successfully: Дія успішно виконана!
     actions: Дії
     add_filter: Додати фільтр
-    all: "Усе"
+    all: Усе
     and_x_other_resources: і ще %{count} інших ресурсів
     appearance:
       accent_picker: Колір акценту
@@ -111,7 +111,7 @@ ua:
     filter_by: Фільтрувати за
     filters: Фільтри
     global_search:
-      direct_match: "Пряме співпадіння"
+      direct_match: Пряме співпадіння
       empty_state:
         no_results_for_query: We couldn't find anything matching "%{query}"
         no_results_found: No results found
@@ -127,8 +127,8 @@ ua:
         select: Вибрати
       results:
         count_of_total: "%{count} of %{total}"
-      search_results: "Результати пошуку"
-      searching_on: "Пошук у:"
+      search_results: Результати пошуку
+      searching_on: 'Пошук у:'
       show_all_results_for: Show all results for
     go_back: Назад
     grid_view: Плитка

--- a/lib/generators/avo/templates/locales/avo.zh-TW.yml
+++ b/lib/generators/avo/templates/locales/avo.zh-TW.yml
@@ -4,6 +4,7 @@ zh-TW:
     action_ran_successfully: 操作成功執行！
     actions: 操作
     add_filter: 新增篩選器
+    all: "全部"
     and_x_other_resources: 和 %{count} 個其他資源
     appearance:
       accent_picker: 重點顏色
@@ -108,6 +109,7 @@ zh-TW:
     filter_by: 按...篩選
     filters: 篩選器
     global_search:
+      direct_match: "精確匹配"
       empty_state:
         no_results_for_query: 我們找不到任何與 "%{query}" 匹配的內容
         no_results_found: 未找到結果
@@ -123,6 +125,8 @@ zh-TW:
         select: 選擇
       results:
         count_of_total: "%{count} / %{total}"
+      search_results: "搜尋結果"
+      searching_on: "搜尋範圍："
       show_all_results_for: 顯示所有結果
     go_back: 返回
     grid_view: 網格視圖

--- a/lib/generators/avo/templates/locales/avo.zh-TW.yml
+++ b/lib/generators/avo/templates/locales/avo.zh-TW.yml
@@ -4,7 +4,7 @@ zh-TW:
     action_ran_successfully: 操作成功執行！
     actions: 操作
     add_filter: 新增篩選器
-    all: "全部"
+    all: 全部
     and_x_other_resources: 和 %{count} 個其他資源
     appearance:
       accent_picker: 重點顏色
@@ -109,7 +109,7 @@ zh-TW:
     filter_by: 按...篩選
     filters: 篩選器
     global_search:
-      direct_match: "精確匹配"
+      direct_match: 精確匹配
       empty_state:
         no_results_for_query: 我們找不到任何與 "%{query}" 匹配的內容
         no_results_found: 未找到結果
@@ -125,8 +125,8 @@ zh-TW:
         select: 選擇
       results:
         count_of_total: "%{count} / %{total}"
-      search_results: "搜尋結果"
-      searching_on: "搜尋範圍："
+      search_results: 搜尋結果
+      searching_on: 搜尋範圍：
       show_all_results_for: 顯示所有結果
     go_back: 返回
     grid_view: 網格視圖

--- a/lib/generators/avo/templates/locales/avo.zh.yml
+++ b/lib/generators/avo/templates/locales/avo.zh.yml
@@ -4,7 +4,7 @@ zh:
     action_ran_successfully: 操作成功执行！
     actions: 操作
     add_filter: 添加筛选器
-    all: "全部"
+    all: 全部
     and_x_other_resources: 和 %{count} 个其他资源
     appearance:
       accent_picker: 强调色
@@ -109,7 +109,7 @@ zh:
     filter_by: 按...筛选
     filters: 筛选器
     global_search:
-      direct_match: "精确匹配"
+      direct_match: 精确匹配
       empty_state:
         no_results_for_query: 我们找不到与 "%{query}" 匹配的任何内容
         no_results_found: 未找到结果
@@ -125,8 +125,8 @@ zh:
         select: 选择
       results:
         count_of_total: "%{count} / %{total}"
-      search_results: "搜索结果"
-      searching_on: "搜索范围："
+      search_results: 搜索结果
+      searching_on: 搜索范围：
       show_all_results_for: 显示所有结果
     go_back: 返回
     grid_view: 网格视图

--- a/lib/generators/avo/templates/locales/avo.zh.yml
+++ b/lib/generators/avo/templates/locales/avo.zh.yml
@@ -4,6 +4,7 @@ zh:
     action_ran_successfully: 操作成功执行！
     actions: 操作
     add_filter: 添加筛选器
+    all: "全部"
     and_x_other_resources: 和 %{count} 个其他资源
     appearance:
       accent_picker: 强调色
@@ -108,6 +109,7 @@ zh:
     filter_by: 按...筛选
     filters: 筛选器
     global_search:
+      direct_match: "精确匹配"
       empty_state:
         no_results_for_query: 我们找不到与 "%{query}" 匹配的任何内容
         no_results_found: 未找到结果
@@ -123,6 +125,8 @@ zh:
         select: 选择
       results:
         count_of_total: "%{count} / %{total}"
+      search_results: "搜索结果"
+      searching_on: "搜索范围："
       show_all_results_for: 显示所有结果
     go_back: 返回
     grid_view: 网格视图


### PR DESCRIPTION
## The problem

`avo-advanced_search` ships **no locale file** and renders four keys that no locale file defines anywhere:

| Key | Rendered at |
| --- | --- |
| `avo.global_search.direct_match` | `results_component.html.erb:6` |
| `avo.global_search.search_results` | `global_search_controller.rb:23`, `index.html.erb:6` |
| `avo.global_search.searching_on` | `index.html.erb:77` |
| `avo.all` | `index.html.erb:47` |

Each carries a String `default:`, so English has always rendered correctly and this has never looked broken. But **a key nothing defines cannot be translated.** Every non-English app gets English in these four spots, with no way to change it short of guessing the key names from the source — and nothing tells an app they exist.

## The fix

All four already sit in namespaces core owns — `avo.global_search.*` and the top-level `avo.` string space — and core ships 19 locales. So they belong here rather than in a gem-local root, which would ship English only and leave all 18 other languages to the app.

Added to all 19 locale files, translated. Purely additive: **19 files, 76 insertions, 0 deletions.**

English values are the gem's existing defaults **verbatim**, so nothing renders differently in English. `"Search Results"` keeps its Title Case rather than being normalized to core's sentence case (`No results found`, `Go to`) — changing user-visible wording is not this fix's job, though it's worth a follow-up.

## Why not a gem-local root

The gem could own `avo.advanced_search.*` instead. That trade-off, and the reason it loses here, is written up in the workspace conventions: a core-held string arrives translated in all 19 locales, while a gem-owned root ships English only. These strings are stable UI chrome sitting in a namespace core already owns.

## Verification

- Keys resolve through `I18n`, not just YAML — spot-checked `en`, `fr`, `ja`, `ro`, `ar` (including RTL and the trailing-colon values, which are quoted).
- Core i18n specs: 23 examples, 0 failures.
- Cross-checked against the locale shape guard in [#4711](https://github.com/avo-hq/avo/pull/4711): 25 examples, 0 failures. That guard pins the paths `avo.en.yml` holds as a Hash, so adding leaves is inert by design.

## Notes for review

The 18 translations are unreviewed by native speakers — same footing as any seeded locale here. Corrections welcome; the `fr` value uses the French space-before-colon (`Recherche dans :`) and `zh`/`zh-TW` use the full-width colon.

Independent of [#4711](https://github.com/avo-hq/avo/pull/4711); either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)