### PR TITLE
chore: bin/dev picks the next free port when 3030 is taken

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,10 +1,15 @@
 #!/usr/bin/env sh
 
+# Use 3030 if free, otherwise walk up to the next free port.
 PORT="${PORT:-3030}"
+while lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; do
+  PORT=$((PORT + 1))
+done
 export PORT
+echo "Starting on port $PORT"
 
 if command -v overmind &> /dev/null; then
-  overmind start -f Procfile.dev "$@"
+  overmind start -f Procfile.dev -p "$PORT" "$@"
 else
-  foreman start -f Procfile.dev "$@"
+  foreman start -f Procfile.dev -p "$PORT" "$@"
 fi


### PR DESCRIPTION
Running `bin/dev` in a second checkout (worktrees, parallel branches) used to collide on port 3030 and the rails process inside overmind would just fail.

Now `bin/dev` probes with `lsof` starting at `$PORT` (default 3030) and walks up to the first free port, then passes it as the base port to overmind/foreman via `-p` (both assign it as `PORT` to the `web` process). `PORT=3040 bin/dev` still works — the probe starts from whatever you set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local dev script only; no production, auth, or data-path changes.
> 
> **Overview**
> **`bin/dev` no longer assumes port 3030 is free.** Before starting overmind or foreman, it loops with `lsof` on listening TCP sockets, incrementing until it finds an open port, then exports that as `PORT` and prints `Starting on port …`.
> 
> Both process managers are started with **`-p "$PORT"`** so the Rails `web` process gets the chosen port. A preset like `PORT=3040 bin/dev` still works—the scan begins from the value you set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49c835d60b8ab998c543db98dc26efaf415e1ca7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->