### PR TITLE
Spell the gem's constant Avo::AI in the register_configuration example

### DIFF
--- a/lib/avo/plugin_manager.rb
+++ b/lib/avo/plugin_manager.rb
@@ -82,7 +82,7 @@ module Avo
     # Register a plugin's configuration namespace on Avo::Configuration so host
     # apps configure the plugin from config/initializers/avo.rb:
     #
-    #   Avo.plugin_manager.register_configuration :ai, Avo::Ai::Configuration
+    #   Avo.plugin_manager.register_configuration :ai, Avo::AI::Configuration
     #
     #   Avo.configure do |config|
     #     config.ai.thinking_effort = "medium"


### PR DESCRIPTION
Follow-up to #4710, which merged before this last commit landed on its branch.

The `register_configuration` doc comment uses the AI gem as its worked example. #4710 updated the config key to `:ai` but left the constant as `Avo::Ai`; the gem's constant is `Avo::AI` ([AVO-1665](https://linear.app/avo-hq/issue/AVO-1665/rename-avo-intelligence-to-avo-ai), avo-hq/workspace#181).

Comment only — one line, no behavior change.

https://claude.ai/code/session_01NyQ2MDutk8VHoxSDQDFmcm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only comment change with no runtime or configuration behavior impact.
> 
> **Overview**
> Updates the **`register_configuration`** doc comment in `plugin_manager.rb` so the worked example references **`Avo::AI::Configuration`** instead of **`Avo::Ai::Configuration`**, matching the AI gem’s actual constant after the rename in #4710.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c74b34f2b2c7e74e01907e6d98a3173144c68476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->