### PR TITLE
Default use_browser_timezone off in the test environment

### DIFF
--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -205,7 +205,10 @@ module Avo
       @model_generator_hook = true
       @send_metadata = true
       @use_stacked_fields = false
-      @use_browser_timezone = true
+      # Off in the test environment: the first-load cookie handshake soft-reloads
+      # the page through Turbo, which races browser specs (stale nodes, doubled
+      # requests). Apps can still opt in per example.
+      @use_browser_timezone = !Rails.env.test?
       @default_editor_url = "cursor://file/%{path}"
       @sidebar = {}
       @body_classes = []

--- a/lib/avo/skills/avo-admin-config/SKILL.md
+++ b/lib/avo/skills/avo-admin-config/SKILL.md
@@ -56,7 +56,7 @@ Every option below is a `config.<name>` assignment inside `Avo.configure`. Most 
 config.app_name = "Avocadelicious"              # navbar label next to the logo
 config.app_name = -> { I18n.t "app_name" }      # block form for dynamic/i18n names
 config.timezone = "UTC"                          # for date/datetime fields
-config.use_browser_timezone = false              # render everyone in the app's configured zone instead; default true renders each visitor's own zone (cookie-detected, one soft reload + alert)
+config.use_browser_timezone = false              # render everyone in the app's configured zone instead; default true renders each visitor's own zone (cookie-detected, one soft reload + alert). Defaults to false in the test environment — the soft reload races browser specs
 config.currency = "USD"                          # for currency fields
 config.locale   = "en-US"                        # force Avo's UI locale (default: I18n.default_locale)
 ```

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -144,7 +144,7 @@ Avo.configure do |config|
   # config.density = :normal # :tight, :normal, :relaxed
   # config.app_name = 'Avocadelicious'
   # config.timezone = 'UTC'
-  # config.use_browser_timezone = true # set false to render dates/times in the app's configured zone for everyone
+  # config.use_browser_timezone = true # set false to render dates/times in the app's configured zone for everyone; off automatically in the test environment
   # config.currency = 'USD'
   # config.hide_layout_when_printing = false
   # config.container_width = :large # :full, :large, or :small. Hash for per-view: { index: :full, single: :small }

--- a/spec/dummy/config/initializers/avo.rb
+++ b/spec/dummy/config/initializers/avo.rb
@@ -15,10 +15,6 @@ Avo.configure do |config|
 
   ## == App context ==
   config.current_user_method = :current_user
-  # Per-visitor time zones are on by default. Keep the suite deterministic —
-  # the first-load soft reload + flash would race every browser spec. The
-  # browser-timezone specs opt back in themselves.
-  config.use_browser_timezone = false if Rails.env.test?
   # config.is_admin_method = :is_admin?
   # config.is_developer_method = :is_developer?
   config.model_resource_mapping = {

--- a/spec/requests/avo/browser_timezone_request_spec.rb
+++ b/spec/requests/avo/browser_timezone_request_spec.rb
@@ -15,13 +15,12 @@ RSpec.describe "Browser timezone", type: :request do
     allow(Time).to receive(:use_zone).and_call_original
   end
 
-  # The dummy app pins the config off for the whole suite (the first-load soft
-  # reload would race every browser spec), so restore that, and assert the
-  # shipped default on a fresh configuration instead.
+  # The config defaults off in the test environment (the first-load soft
+  # reload would race every browser spec), so restore that after opting in.
   after { Avo.configuration.use_browser_timezone = false }
 
-  it "is on by default" do
-    expect(Avo::Configuration.new.use_browser_timezone).to be true
+  it "is off by default in the test environment" do
+    expect(Avo::Configuration.new.use_browser_timezone).to be false
   end
 
   it "renders the request in the cookie's zone" do


### PR DESCRIPTION
## Description

#4703 turned `config.use_browser_timezone` on by default. Its first-load cookie handshake soft-reloads the page through Turbo — and in a browser/system spec that reload races the assertions: stale element errors, doubled requests, values asserted against the pre-reload DOM. Core's own dummy app pinned the flag off for exactly this reason, and the avo-hq/workspace suite hit the same race across 7 gems the first time its CI rebuilt assets with #4703 included (avo-hq/workspace#181).

Every host app with system specs would need the same pin, so this makes it the default: `use_browser_timezone` is now `false` under `Rails.env.test?` and `true` everywhere else.

- `Configuration`: default is `!Rails.env.test?`
- The dummy app's pin is removed (redundant now); the browser-timezone request specs already opt in per example, and the "default" spec now asserts the test-env default
- Initializer template + `avo-admin-config` skill note the test-env behavior

Docs: avo-hq/docs.avohq.io#639

## Checklist:

- [x] I have performed a self-review of my own code
- [x] Tests: `spec/requests/avo/browser_timezone_request_spec.rb` (6/6) and `spec/lib/avo` (402/402) pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration default and test/docs-only follow-ups; production behavior unchanged and specs can still opt in explicitly.
> 
> **Overview**
> **`config.use_browser_timezone` now defaults to `false` in the test environment** and stays **`true` elsewhere**, so host apps with system specs no longer need to pin the flag off in their initializer.
> 
> The change is in `Avo::Configuration` (`@use_browser_timezone = !Rails.env.test?`), with comments explaining that the browser-timezone cookie handshake triggers a Turbo soft reload that races browser/system specs. Apps can still opt in per example (as the existing request specs do).
> 
> The dummy app’s redundant `config.use_browser_timezone = false if Rails.env.test?` is removed. The initializer template and **avo-admin-config** skill note the test-environment default. **`browser_timezone_request_spec`** now expects a fresh `Configuration` to have the feature off under test instead of on globally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 098d1a5c7489788c765cb9181dd89ce060a85f66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->