### PR TITLE
Don't treat globally-mixed-in methods as config namespace collisions

### DIFF
--- a/lib/avo/plugin_manager.rb
+++ b/lib/avo/plugin_manager.rb
@@ -99,9 +99,12 @@ module Avo
 
       # Guard against a plugin silently shadowing a core option or another
       # plugin's namespace. Re-registering the same namespace with the same
-      # class is fine — boot runs more than once.
+      # class is fine — boot runs more than once. Only methods Avo::Configuration
+      # defines itself count: gems like amazing_print add helpers to every object
+      # (Kernel#ai), and shadowing those on the configuration is harmless.
       existing = @configuration_namespaces[name]
-      if existing.nil? && Avo::Configuration.method_defined?(name)
+      if existing.nil? && Avo::Configuration.method_defined?(name) &&
+          Avo::Configuration.instance_method(name).owner == Avo::Configuration
         raise ArgumentError, "Avo::Configuration already defines ##{name}; pick a different configuration namespace."
       end
       if !existing.nil? && existing != klass

--- a/spec/lib/avo/plugin_manager_spec.rb
+++ b/spec/lib/avo/plugin_manager_spec.rb
@@ -153,6 +153,15 @@ RSpec.describe Avo::PluginManager do
         .to raise_error(ArgumentError, /already defines/)
     end
 
+    it "allows a namespace that only collides with a method mixed into every object (e.g. amazing_print's Kernel#ai)" do
+      Kernel.module_eval { def my_plugin = nil }
+
+      expect { manager.register_configuration :my_plugin, config_class }.not_to raise_error
+      expect(Avo::Configuration.new.my_plugin).to be_a(config_class)
+    ensure
+      Kernel.module_eval { remove_method :my_plugin }
+    end
+
     it "allows re-registering the same namespace across boots" do
       manager.register_configuration :my_plugin, config_class
 


### PR DESCRIPTION
`register_configuration`'s shadowing guard refused any namespace `Avo::Configuration` responds to — including methods gems mix into **every** object. `amazing_print` defines `Kernel#ai`, so the renamed `avo-ai` plugin cannot boot in any app that also bundles amazing_print:

```
Avo::Configuration already defines #ai; pick a different configuration namespace. (ArgumentError)
```

Only methods `Avo::Configuration` defines itself are real shadowing risks (core options are attr_accessors on the class; plugin namespaces are `define_method`'d on it and separately tracked in `@configuration_namespaces`), so the guard now also checks the method's owner.

Spec added; `spec/lib/avo/plugin_manager_spec.rb` green (15 examples, 0 failures).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard change in plugin registration with a focused spec; no auth, data, or runtime behavior beyond allowing previously blocked namespaces.
> 
> **Overview**
> **`register_configuration`** no longer treats every name `Avo::Configuration` responds to as a forbidden collision. The shadowing check now requires the method’s **owner** to be `Avo::Configuration` itself, so plugin namespaces like `:ai` can register even when gems such as **amazing_print** define `Kernel#ai` on every object.
> 
> Real core options (e.g. `appearance`) still block duplicate namespaces. A spec simulates a globally mixed-in method and asserts registration succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 009b5a2959bfefc7476fa4346a7009206e051e97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->