### PR TITLE
Update plugin_manager comment for the Avo::Ai rename

### DIFF
--- a/lib/avo/plugin_manager.rb
+++ b/lib/avo/plugin_manager.rb
@@ -82,7 +82,7 @@ module Avo
     # Register a plugin's configuration namespace on Avo::Configuration so host
     # apps configure the plugin from config/initializers/avo.rb:
     #
-    #   Avo.plugin_manager.register_configuration :ai, Avo::AI::Configuration
+    #   Avo.plugin_manager.register_configuration :ai, Avo::Ai::Configuration
     #
     #   Avo.configure do |config|
     #     config.ai.thinking_effort = "medium"


### PR DESCRIPTION
avo-ai renames its namespace from `Avo::AI` to `Avo::Ai` (avo-hq/workspace#188). This updates the one comment example in core that referenced the old constant. Comment-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation comment only; no executable code or configuration behavior is modified.
> 
> **Overview**
> Updates the **`register_configuration`** doc comment example in `plugin_manager.rb` so it references **`Avo::Ai::Configuration`** instead of **`Avo::AI::Configuration`**, matching the avo-ai namespace rename. **Comment-only**; no behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1520022a8a38b68ebf275fa8937063cb3956da61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->