### PR TITLE
feat(skills): allowlist avo-ai in the skills package map

### DIFF
--- a/lib/avo/skills/package-map.md
+++ b/lib/avo/skills/package-map.md
@@ -14,6 +14,7 @@ The loader reports what is **installed**, never what is **licensed** — license
 | Gem | Skill | Subjects | More |
 | --- | --- | --- | --- |
 | `avo-advanced_search` | `avo-advanced-search` | Cmd+K global search across resources; searchable association pickers | https://avohq.io/addons/global-search |
+| `avo-ai` | `avo-ai-tools` | AI assistant in the admin — the tools the assistant may call, custom tools, ejecting shipped tools | https://docs.avohq.io/4.0/ai.html |
 | `avo-api` | `avo-rest-api` | JSON REST API over every resource, token auth, per-token permission matrix | https://avohq.io/addons/api |
 | `avo-audit_logging` | `avo-audit-logging` | Who changed and viewed what — timeline, diffs, revert | https://avohq.io/pricing |
 | `avo-authorization` | `avo-authorization` | Pundit policies for resources, actions, associations, files | https://avohq.io/addons/authorization |


### PR DESCRIPTION
avo-ai now ships its first agent skill (`avo-ai-tools`, arriving with avo-hq/workspace#205), and the skills loader only reads a package's skills index when the gem has a row in `lib/avo/skills/package-map.md`. This adds that row so the skill actually surfaces in customer apps.

Ship with or before the avo-ai release that carries the skill. Tracked in AVO-1726.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation row in the skills allowlist; no application or loader code changes, only enables loading of an already-shipped skill when the gem is present.
> 
> **Overview**
> **Adds `avo-ai` to the skills package allowlist** in `lib/avo/skills/package-map.md`, mapping gem `avo-ai` to skill `avo-ai-tools` (admin AI assistant tools, custom tools, ejecting shipped tools) with a link to the AI docs.
> 
> Without this row, the loader will not read `avo-ai`’s skills index even when the gem is in `Gemfile.lock`, so the new skill from the upcoming `avo-ai` release would not surface in customer apps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d49de7d00c8792a1299a74385ca9a9e439e77b17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->