### PR TITLE
fix: let `stacked: false` win over sidebar and width defaults

### DIFF
--- a/app/components/avo/field_wrapper_component.rb
+++ b/app/components/avo/field_wrapper_component.rb
@@ -122,11 +122,12 @@ class Avo::FieldWrapperComponent < Avo::BaseComponent
   end
 
   def stacked?
-    # Override on the declaration level
-    return @stacked unless @stacked.nil?
-
-    # Fetch it from the field
+    # The field declaration is the user's explicit intent, so it wins over the
+    # layout default a parent component passes in (sidebars, preview, etc.).
     return @field.stacked unless @field.stacked.nil?
+
+    # Fallback to what the rendering component asked for
+    return @stacked unless @stacked.nil?
 
     # Fallback to defaults
     Avo.configuration.field_wrapper_layout == :stacked

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -117,7 +117,7 @@ module Avo
 
         @width = args[:width] || 100
 
-        if width_option.present? && width_option != 100
+        if @stacked.nil? && width_option.present? && width_option != 100
           @stacked = true
         end
 

--- a/lib/avo/skills/avo-fields/SKILL.md
+++ b/lib/avo/skills/avo-fields/SKILL.md
@@ -143,7 +143,7 @@ Every field accepts these common options (full list + types at the field-options
 - **`copyable:`** — clipboard icon on Show/Index. Copies the **displayed** (formatted) value.
 - **`link_to_record:`** — make the Index cell a link to the record. Only on `:id`, `:text`, `:gravatar`, and `belongs_to`.
 - **`for_attribute:`** — back the field with a different attribute than its id (lets you show one column two ways).
-- **`width:`** / **`stacked:`** — column width (`25/33/50/66/75/100`; any value <100 auto-stacks) and label-above-value layout.
+- **`width:`** / **`stacked:`** — column width (`25/33/50/66/75/100`; any value <100 auto-stacks) and label-above-value layout. `stacked:` on the field wins everywhere, so `stacked: false` opts out of the auto-stacking and of sidebars/preview stacking too.
 - **`html:`** — attach `style`/`classes`/`data` to the field's wrapper/label/input per view (e.g. right-align a number: `html: {index: {wrapper: {classes: "text-right"}}}`). See the html page.
 
 ### Computed (block) fields

--- a/spec/components/avo/field_wrapper_component_spec.rb
+++ b/spec/components/avo/field_wrapper_component_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe Avo::FieldWrapperComponent, type: :component do
     expect(wrapper["data-resizable-editor-storage-key-value"]).to eq("resources.products.fields.description.height")
   end
 
+  it "lets a field-level `stacked: false` win over the component default" do
+    field = Avo::Fields::TextField.new(:name, stacked: false)
+      .hydrate(record:, resource:, view: :show)
+
+    # `stacked: true` is what the sidebar and preview components pass in.
+    render_inline(described_class.new(field:, resource:, stacked: true)) { "Name" }
+
+    expect(page.find("[data-field-id='name']")[:class]).not_to include("field-wrapper--stacked")
+  end
+
   it "does not resize rich text rendered on display views" do
     render_inline(described_class.new(
       field:,


### PR DESCRIPTION
## Problem

`stacked:` is documented as a per-field option, but in two places it is not actually overridable — a field declared `stacked: false` still renders stacked.

**1. Sidebars (and preview, media library, association forms).**
`Avo::ResourceSidebarComponent` passes `stacked: true` down to every field it renders. `FieldWrapperComponent#stacked?` checked that component-passed value *before* the field's own declaration, so the sidebar's default silently beat the user's explicit intent. Every field in a sidebar is stacked, always.

```ruby
sidebar do
  field :name, as: :text, stacked: false # ignored — still stacked
end
```

**2. Any field with a `width` below 100.**
`BaseField#initialize` set `@stacked = true` whenever a custom width was present, overwriting the value the user had just passed in one line above.

```ruby
field :name, as: :text, width: 50, stacked: false # ignored — still stacked
```

The stacked default in both cases is correct and stays. What changes is that you can now opt out of it.

## Solution

Two lines.

**`FieldWrapperComponent#stacked?`** — the field declaration is the user's explicit intent, so it is now consulted first; the value a rendering component passes in becomes the *default* it always meant to be. Precedence is now:

1. `field :name, stacked: false` — the field's own declaration
2. `stacked:` passed by the rendering component (sidebar, preview, media library, association form)
3. `Avo.configuration.field_wrapper_layout`

**`BaseField#initialize`** — the width-based auto-stacking only fires when `stacked:` was not declared (`@stacked.nil?`), so it no longer clobbers an explicit value.

Nothing changes when a field says nothing about `stacked:`, which is every existing sidebar, preview, and width-using field. The only behaviour that changes is the one that was previously broken.

## Testing

- New example in `spec/components/avo/field_wrapper_component_spec.rb`: a field declared `stacked: false` rendered with the component-level `stacked: true` the sidebar passes must not get `field-wrapper--stacked`. Fails on `main`, passes here.
- The existing `spec/features/avo/stacked_wrapper_layout_spec.rb` (8 examples, covering both config layouts on show and edit) still passes untouched.

## Docs & skills

- `docs/4.0/field-options-api.md` — the `stacked` option now states that a field declaration wins over sidebars, preview, and width auto-stacking; the `width` callout notes the `stacked: false` opt-out. **Separate PR in the docs repo, not yet opened.**
- `lib/avo/skills/avo-fields/SKILL.md` — same note, shipped in this PR. `ws audit-skills` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
