### PR TITLE
Bring the skills docs-drift checker into the gem

### DIFF
--- a/lib/avo/skills/bin/docs_drift.rb
+++ b/lib/avo/skills/bin/docs_drift.rb
@@ -1,0 +1,91 @@
+#!/usr/bin/env ruby
+# Which docs pages changed since the last indexing run, and which shipped skills
+# cite them. The docs repo already hashes every page for us — its git history
+# *is* the lock file, so `docs-index.json` only has to remember one commit.
+#
+# Audits the skills that ship in this gem (the directories beside this bin/).
+# Add-on gems carry their own skills and are out of this script's scope.
+#
+#   ruby lib/avo/skills/bin/docs_drift.rb               # report; finds the docs checkout itself
+#   ruby lib/avo/skills/bin/docs_drift.rb path/to/docs  # or point it at one ($AVO_DOCS_PATH works too)
+#   ruby lib/avo/skills/bin/docs_drift.rb --update      # mark the checkout's HEAD as indexed
+require "json"
+
+skills_root = File.expand_path("..", __dir__)
+repo_root = File.expand_path("../../..", skills_root)
+marker_path = "#{skills_root}/docs-index.json"
+marker = JSON.parse(File.read(marker_path))
+
+update = ARGV.delete("--update")
+
+def git(dir, *args) = `git -C '#{dir}' #{args.join(" ")}`.strip
+
+# A docs checkout is any clone of the marker's repo that has the docs path in it.
+# Look next to and above this checkout so the script works from whatever layout a
+# machine or CI runner happens to use.
+def find_docs(repo_root, marker)
+  search = ["#{repo_root}/..", "#{repo_root}/../..", "#{repo_root}/../../.."]
+  candidates = search.flat_map { |base| Dir.glob("#{base}/*") }.uniq.sort
+  candidates.find do |dir|
+    next false if dir == repo_root || !Dir.exist?("#{dir}/.git") || !Dir.exist?("#{dir}/#{marker["docs_path"]}")
+
+    git(dir, "remote", "get-url", "origin").include?(marker["repo"])
+  end
+end
+
+docs = ARGV[0] || ENV["AVO_DOCS_PATH"] || find_docs(repo_root, marker)
+
+if docs.nil? || !Dir.exist?("#{docs}/.git")
+  abort "No #{marker["repo"]} checkout found near #{repo_root} — pass its path as an argument or set AVO_DOCS_PATH."
+end
+
+docs = File.expand_path(docs)
+
+head = git(docs, "rev-parse", "HEAD")
+head_date = git(docs, "log", "-1", "--format=%cs", "HEAD")
+
+if update
+  File.write(marker_path, JSON.pretty_generate(marker.merge("commit" => head, "date" => head_date)) + "\n")
+  puts "Indexed at #{head[0, 12]} (#{head_date})."
+  exit
+end
+
+unless git(docs, "cat-file", "-t", marker["commit"]) == "commit"
+  abort "#{docs} doesn't have commit #{marker["commit"]} — `git fetch` it first."
+end
+
+if head == marker["commit"]
+  puts "Up to date with #{head[0, 12]} (#{head_date})."
+  exit
+end
+
+# --no-renames: a renamed page is a delete + an add, which is exactly how a skill
+# citing the old URL has to treat it.
+changed = git(docs, "diff", "--name-status", "--no-renames", "#{marker["commit"]}..HEAD", "--", marker["docs_path"])
+  .lines.map { |line| line.split("\t") }
+  .map { |status, path| [status[0], File.basename(path.strip)] }
+  .reject { |_, page| page == "docs-map.md" }
+  .uniq
+
+# The Docs lines in each SKILL.md are the provenance record. Skills cite pages
+# both with and without the .md extension; normalize to the diff's basename form.
+version = Regexp.escape(File.basename(marker["docs_path"]))
+citations = Dir.glob("#{skills_root}/*/SKILL.md").each_with_object(Hash.new { |h, k| h[k] = [] }) do |path, acc|
+  skill = File.basename(File.dirname(path))
+  File.read(path).scan(%r{docs\.avohq\.io/#{version}/([A-Za-z0-9_/-]+)}).flatten.uniq.each do |page|
+    acc["#{File.basename(page)}.md"] << skill
+  end
+end
+
+puts "#{changed.size} pages changed between #{marker["commit"][0, 12]} (#{marker["date"]}) and #{head[0, 12]} (#{head_date}):", ""
+
+stale = []
+changed.sort_by(&:last).each do |status, page|
+  skills = citations[page]
+  stale.concat(skills)
+  puts "  #{status} #{page.ljust(34)} #{skills.empty? ? "— not cited by any skill" : skills.join(", ")}"
+end
+
+puts "", "Skills to review: #{stale.uniq.sort.join(", ")}" if stale.any?
+puts "", "Commits: git -C #{docs} log --oneline #{marker["commit"][0, 12]}..HEAD -- #{marker["docs_path"]}"
+puts "Then:    ruby lib/avo/skills/bin/docs_drift.rb --update"

--- a/lib/avo/skills/docs-index.json
+++ b/lib/avo/skills/docs-index.json
@@ -1,0 +1,7 @@
+{
+  "repo": "avo-hq/docs.avohq.io",
+  "docs_path": "docs/4.0",
+  "commit": "3350dbef7b2da94b410d6a678f9551e16901411e",
+  "date": "2026-07-28",
+  "note": "The docs commit these skills were last indexed from. Run ruby lib/avo/skills/bin/docs_drift.rb to see what changed since, and --update after a refresh."
+}


### PR DESCRIPTION
## What

When the skills moved from the archived [avo-hq/skills](https://github.com/avo-hq/skills) repo into `lib/avo/skills`, the docs-drift tooling was left behind. This brings it over:

- `lib/avo/skills/bin/docs_drift.rb` — reports which docs pages changed since the last indexing run and which shipped skills cite them; `--update` records a new baseline.
- `lib/avo/skills/docs-index.json` — the marker. The docs repo's git history is the lock file, so it only has to remember one commit.

## Adaptations from the original

- Re-rooted: the skills glob points at the directories beside the script (`lib/avo/skills/*/SKILL.md`), and the docs-checkout auto-discovery starts from this repo, verifying each candidate's `origin` remote against the marker's repo.
- The citation scan now also accepts the extensionless docs URLs some gem skills use (`docs.avohq.io/4.0/fields`) alongside the `.md`-suffixed ones, normalizing both to the diff's basename form.
- The marker is seeded with the archived repo's **last indexed commit** (`3350dbef`, 2026-07-28) rather than today's docs HEAD — the skills were never reconciled against anything newer, and a fresh drift run confirms it: 45 pages changed since, touching 18 of the 24 shipped skills. The first reconcile run should work that list off and then `--update`.

## Usage

```bash
ruby lib/avo/skills/bin/docs_drift.rb               # report; finds the docs checkout next to this repo
ruby lib/avo/skills/bin/docs_drift.rb path/to/docs  # or point it at one ($AVO_DOCS_PATH works too)
ruby lib/avo/skills/bin/docs_drift.rb --update      # mark the checkout's HEAD as indexed
```

Verified locally: report, explicit-path, `--update`, and up-to-date paths all run against a `docs.avohq.io` checkout. The script and marker ship in the gem via the existing `lib/**/*` glob (harmless), skill-dir scanning in `index_integrity_spec` ignores `bin/`, and `validate_skills.rb` did not need to move — `spec/lib/avo/skills/index_integrity_spec.rb` already covers frontmatter validation here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only maintenance tooling with no runtime or security impact; changes are limited to new files under `lib/avo/skills`.
> 
> **Overview**
> Restores the **docs-drift** workflow inside the gem after skills moved from the archived repo. Adds `lib/avo/skills/bin/docs_drift.rb`, which diffs the external `docs.avohq.io` checkout against a stored baseline commit and lists which **4.0** pages changed and which shipped `SKILL.md` files cite them; **`--update`** rewrites the baseline to the docs repo’s current HEAD.
> 
> Adds `lib/avo/skills/docs-index.json` as that baseline (repo, `docs/4.0` path, last indexed commit/date). The script is re-rooted for this layout: it scans `lib/avo/skills/*/SKILL.md`, discovers a nearby docs clone by matching `origin` to the marker, and normalizes both extensionless and `.md` docs URLs when matching citations. The marker is seeded with the **previous** indexed commit so the first run surfaces existing drift rather than pretending skills were reconciled to today’s docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 563e06bfb854b2784ce338ec7c85f53df11b4059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->