### PR TITLE
Sync shipped skills with docs through 3ffed3f (2026-08-17)

### DIFF
--- a/lib/avo/skills/avo-actions/SKILL.md
+++ b/lib/avo/skills/avo-actions/SKILL.md
@@ -204,7 +204,7 @@ silent                                           # suppress the default notifica
 | `download data, "file.csv"` | Trigger a file download. **Pair with `self.turbo = false`** for a real file response. |
 | `keep_modal_open` | Keep the modal + user input (show an error and let them retry). |
 | `close_modal` / `do_nothing` | Close the modal, leave the page as-is. |
-| `reload_records(query)` | Refresh only the affected rows/cards. **Index only — not associations.** |
+| `reload_records` | Refresh only the affected rows/cards via Turbo Streams. Takes an array or a single record; with **no argument** it defaults to the records the action ran on (Avo >= 4.1.2). `reload_record` is an alias. **Index only — not associations.** |
 | `navigate_to_action Other, arguments: {...}` | Chain into another action (see below). |
 | `append_to_response -> { [turbo_stream...] }` | Add your own turbo-stream responses. |
 

--- a/lib/avo/skills/avo-admin-config/SKILL.md
+++ b/lib/avo/skills/avo-admin-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: avo-admin-config
-description: Configure Avo's app-wide admin settings in config/initializers/avo.rb via Avo.configure — app name, timezone/currency, per-page and index behavior, layout width, home redirect, open-in-editor links, and the other global knobs that don't belong to a single feature. Use when the user wants to change how many records per page, rename the admin / change the app name, set the timezone or currency for the admin, default the index to grid view, make the admin full-width, keep clicking a row from opening the record, skip the show view / go straight to edit, open Avo files in Cursor or VS Code from the UI, keep the sidebar always open, redirect the admin home to a dashboard, add a class to the body tag, make rows denser, widen the sidebar or turn off sidebar resizing, persist filters/pagination across requests, or opt out of usage metadata.
+description: Configure Avo's app-wide admin settings in config/initializers/avo.rb via Avo.configure — app name, timezone/currency, per-page and index behavior, layout width, home redirect, open-in-editor links, and the other global knobs that don't belong to a single feature. Use when the user wants to change how many records per page, rename the admin / change the app name, set the timezone or currency for the admin, default the index to grid view, make the admin full-width, keep clicking a row from opening the record, skip the show view / go straight to edit, open Avo files in Cursor or VS Code from the UI, keep the sidebar always open, redirect the admin home to a dashboard, add a class to the body tag, make rows denser, widen the sidebar or turn off sidebar resizing, remove or retune the floating "back to top" button, persist filters/pagination across requests, or opt out of usage metadata.
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash, WebFetch
 metadata:
   requires-gem: none — Community
@@ -42,7 +42,7 @@ Authoritative docs — fetch on demand rather than guessing, and verify every op
 
 ## When this applies
 
-**Explicit (Avo named):** "set `config.app_name`", "change `per_page` in the Avo initializer", "set `default_view_type` to `:grid`", "use `container_width = :full`", "set `resource_default_view = :edit`", "configure `default_editor_url`", "enable `persistence`", "set `body_classes`".
+**Explicit (Avo named):** "set `config.app_name`", "change `per_page` in the Avo initializer", "set `default_view_type` to `:grid`", "use `container_width = :full`", "set `resource_default_view = :edit`", "configure `default_editor_url`", "enable `persistence`", "set `body_classes`", "turn off `back_to_top`".
 
 **Implicit (Rails-shaped, no mention of Avo):** "change how many records show per page in the admin", "rename the admin / change the app name in the top bar", "set the timezone/currency the admin displays", "default the admin list to grid/card view", "make the admin full-width", "clicking a row shouldn't open the record", "skip the show page and go straight to edit", "open the admin's source files in Cursor/VS Code from the UI", "keep the sidebar always open / hide the collapse button", "make the sidebar wider by default", "stop people resizing the sidebar", "send people to a dashboard when they open the admin", "add a CSS class to the `<body>` tag", "make the admin rows denser / tighter", "keep my filters and pagination when I navigate away", "stop the admin from phoning home usage stats".
 
@@ -94,7 +94,10 @@ config.sidebar = {                                        # the sidebar's three 
 }
 config.hide_layout_when_printing = true                   # drop sidebar/navbar/footer when printing
 config.body_classes = "custom-theme compact-layout"       # add classes to <body>; also accepts an Array or a block
+config.back_to_top = { enabled: false }                   # the floating "Back to top" pill; default {enabled: true, threshold: 400}
 ```
+
+`back_to_top` is a hash merged over `{enabled: true, threshold: 400}`, so set only the key you change. The pill sits centered below the navbar and shows once the page is scrolled `threshold` pixels down, hiding again near the top — **scroll direction doesn't matter**. Raise `threshold` to keep it out of the way on long pages; `{enabled: false}` removes it. Its label comes from the `avo.back_to_top` translation key (→ **avo-i18n**).
 
 `config.sidebar` is a hash merged over `{toggle_visible: true, resizable: true, default_width: 256}`, so set only the keys you change. On desktop the sidebar edge is a drag handle: users resize it and the width persists **per browser** (a cookie, not a user preference). `default_width` sets the starting width and is clamped to `200`–`480` — an unparseable value falls back to `256` rather than clamping to the minimum. Both settings apply at `lg` (1024px) and wider only; below that the sidebar is a full-height overlay at the 256px default. A width the user has dragged to wins over `default_width`. The flat `config.sidebar_toggle_visible = false` still works and writes into `config.sidebar[:toggle_visible]`, but the hash is the canonical home.
 
@@ -150,6 +153,7 @@ config.send_metadata = false                              # opt out of usage met
 - **`default_editor_url` defaults to Cursor.** If a user's `</>` icons open Cursor unexpectedly, that's the default — point it at their editor. The icons only render in `development`.
 - **Disable `cache_resources_on_index_view` when fields vary by role.** The index cache key uses the record's `id`/`created_at` and the resource file md5 — **not the current user** — so a resource that shows/hides fields per role (`visibility:`) will serve one user's row layout to another. Turn it off there. For the caching model and cache store, see **avo-performance**; for role-based field visibility, see **avo-authorization**.
 - **Sidebar resizing is a drag-only gesture.** It doesn't satisfy [WCAG 2.2 SC 2.5.7 (Dragging Movements)](https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html), so an app working to an AA conformance claim or a VPAT should set `config.sidebar = {resizable: false}`. Related: sidebar labels now truncate with an ellipsis (plus a hover tooltip) instead of wrapping — if a menu relied on long labels wrapping, shorten them or widen the sidebar.
+- **The "Back to top" pill is on by default (since Avo 4.1.4).** It used to be off and to reveal itself only on an upward scroll; now every app that doesn't configure `back_to_top` gets it, and only `threshold` decides when it appears — the direction-aware reveal is gone. If a user asks why a new floating button showed up after an upgrade, that's it: `config.back_to_top = {enabled: false}`.
 - **`click_row_to_view_record` is JS-enhanced.** Making a `<tr>` behave as a link isn't native HTML; Avo does it with JavaScript, which can have side effects. Disabling it (`false`) reserves navigation for the explicit row controls.
 - **Verify before writing.** Option names and defaults drift between versions and several were renamed in Avo 4 — check the docs URLs above or the app's installed `lib/avo/configuration.rb` rather than trusting memory.
 

--- a/lib/avo/skills/avo-associations/SKILL.md
+++ b/lib/avo/skills/avo-associations/SKILL.md
@@ -33,7 +33,7 @@ These fields live in `app/avo/resources/<model>.rb`, the same place as every oth
 - Docs map: https://docs.avohq.io/4.0/docs-map.md
 - Overview & STI: https://docs.avohq.io/4.0/associations.md
 - Belongs to: https://docs.avohq.io/4.0/associations/belongs_to.md
-- Has one: https://docs.avohq.io/4.0/associations/has_one.md
+- Has one (+ `:through`, `attach_fields`): https://docs.avohq.io/4.0/associations/has_one.md
 - Has many (+ `:through`, `attach_fields`): https://docs.avohq.io/4.0/associations/has_many.md
 - Has and belongs to many: https://docs.avohq.io/4.0/associations/has_and_belongs_to_many.md
 - Searchable associations (guide): https://docs.avohq.io/4.0/associations/searchable.md
@@ -124,7 +124,7 @@ Most options are shared across the association fields; a handful are type-specif
 | `allow_via_detaching` | Keeps the field editable when you reached the record *through* that association (which otherwise disables it). |
 | `link_to_record` | `true` makes the Index cell link to the current row's record instead of the associated one. |
 
-### `has_many :through` and `attach_fields`
+### `:through` associations and `attach_fields`
 
 For a join model with its own columns, expose those columns **at attach time** with `attach_fields` (a lambda that declares fields, evaluated against the join model):
 
@@ -138,7 +138,26 @@ field :members,
   }
 ```
 
-The extra fields render inside the attach modal and their values persist on the join row. `attach_fields` **only persists on `has_many :through`** — it exists but is a no-op on a plain `has_many` / HABTM. If the through model is polymorphic, add the type as a hidden field: `field :membership_type, as: :hidden, default: "TheType"`.
+The extra fields render inside the attach modal and their values persist on the join row. `attach_fields` **only persists on a `:through` association** — `has_many :through` and `has_one :through` both have a join record to write to; on a plain `has_many` / `has_one` / HABTM it exists but is a no-op, because there is nowhere for the values to land. If the through model is polymorphic, add the type as a hidden field: `field :membership_type, as: :hidden, default: "TheType"`.
+
+### `has_one :through`
+
+`as: :has_one` works over a join model too, and there's **no `through:` option on the field** — Avo reads it off the Rails association:
+
+```ruby
+# app/models/team.rb
+class Team < ApplicationRecord
+  has_one :admin_membership, -> { where level: :admin }, class_name: "TeamMembership"
+  has_one :admin, through: :admin_membership, source: :user
+end
+```
+
+```ruby
+# app/avo/resources/team.rb
+field :admin, as: :has_one, attach_fields: -> { field :notes, as: :text }
+```
+
+Attach and detach always go **through the association**, so a scope on it is respected: attaching stamps the scope's attributes on the new join record (`level: "admin"` above, without you saying so), and detaching destroys only the join row that association points at — a `level: "member"` row for the same two records is left alone. Attaching over an existing record **replaces** the join record rather than adding a second one, matching how Rails treats a singular association, and `attach_fields` values are written to that same replaced row. `attach_fields` on `has_one :through` needs Avo >= `4.0.25`. Because a singular association owns exactly one join record, a detach is checked against the record named in the URL — on a stale page where someone else has since attached a different record, the detach is a no-op rather than removing whatever is attached now.
 
 ### Searchable associations
 

--- a/lib/avo/skills/avo-custom-ui/SKILL.md
+++ b/lib/avo/skills/avo-custom-ui/SKILL.md
@@ -404,7 +404,7 @@ Avo's build emits Tailwind **v4** syntax. If you have your own Tailwind pipeline
 
 ## Advanced: package as a plugin
 
-Wrap any of the above into a Rails Engine so it's reusable across apps. Register everything from the **`avo_boot`** hook so it runs once on boot; `avo_init` runs on every request.
+Wrap any of the above into a Rails Engine so it's reusable across apps. Register everything from the **`avo_boot`** hook so it runs once on boot; `avo_init` runs on every request. The one exception is `register_configuration`, which has to run *before* the app's initializers — see below.
 
 ```ruby
 # lib/avo/feed_view/engine.rb
@@ -431,7 +431,35 @@ end
 - `register_field(method_name, klass)` — ship a field *type* from a gem (the plugin-author side of **avo-custom-fields**).
 - `register_menu_item(name, &block)` — a custom menu DSL method for `config.main_menu`. Delegates to `avo-menu`; **no-op when avo-menu isn't installed**, so register unconditionally.
 - `mount_engine(klass, at:)` — mount the engine's routes inside Avo.
+- `register_configuration(name, klass)` — add a `config.<name>` namespace to `Avo::Configuration`, backed by an instance of `klass`, so apps configure your plugin from the same `config/initializers/avo.rb` they already have. **Not from `avo_boot`** — see below.
 - `installed?(name)` — adapt to what else is present.
+
+### Let apps configure your plugin
+
+`register_configuration` puts your settings on Avo's own configuration object, so there's no second initializer and no extra constant for an app to remember. `klass` is a plain class you own, free to hold defaults, coerce values, or fall back to an ENV var:
+
+```ruby
+# lib/avo/feed_view/configuration.rb
+class Avo::FeedView::Configuration
+  attr_accessor :items_per_page
+  attr_writer :api_key
+
+  def initialize = @items_per_page = 25
+
+  def api_key = @api_key || ENV["AVO_FEED_VIEW_API_KEY"]
+end
+```
+
+```ruby
+# lib/avo/feed_view/engine.rb — NOT the avo_boot hook
+initializer "avo-feed-view.register_configuration", before: :load_config_initializers do
+  Avo.plugin_manager.register_configuration :feed_view, Avo::FeedView::Configuration
+end
+```
+
+The app then writes `config.feed_view.items_per_page = 50` inside its `Avo.configure` block, and you read it back off `Avo.configuration.feed_view`. Instances are memoized per configuration object, so replacing `Avo.configuration` resets your plugin's config too — handy for a clean slate in tests.
+
+Namespaces are exclusive: `register_configuration` raises `ArgumentError` if the name collides with a method `Avo::Configuration` **defines itself**, or with a namespace another plugin took first. Re-registering the same name with the same class is fine, so a repeated boot is harmless. Only Avo's own options count — a gem that mixes a helper into every object doesn't reserve anything (`amazing_print` defines `Kernel#ai`, so `Avo::Configuration` responds to `ai` wherever it's bundled, and the name is still yours to take).
 
 Assets from library code go through `Avo.asset_manager` (not the app pipeline); Avo injects them but does **not** compile them — ship compiled builds, e.g. served from `app/assets/builds` via a `Rack::Static` middleware.
 
@@ -448,6 +476,7 @@ Assets from library code go through `Avo.asset_manager` (not the app pipeline); 
 - **Tailwind integration silently stays off** unless `tailwindcss-ruby` is present, and — if you pull Tailwind via `tailwindcss-rails` — that gem is **>= 4.0** (on 3.x the integration is disabled even though `tailwindcss-ruby` is there). Symptom: your utility classes don't exist in the admin.
 - **New JS/CSS not loading?** You skipped the asset-pipeline entrypoint. Run `avo:js:install` (or wire `avo.custom.js` manually) — `self.stimulus_controllers` alone loads nothing.
 - **Plugin registration must be inside `ActiveSupport.on_load(:avo_boot)`**, `register_view_type`'s `component:` should be a **string**, and `register_menu_item` is a no-op without `avo-menu`.
+- **`register_configuration` is the exception — `avo_boot` is too late.** The app's `config/initializers/avo.rb` reads the accessor while initializers run, which is *before* Avo boots, so registering any later blows up inside the app's own initializer. Use an engine initializer ordered `before: :load_config_initializers` (or register at require time).
 
 ## Report
 

--- a/lib/avo/skills/avo-fields/SKILL.md
+++ b/lib/avo/skills/avo-fields/SKILL.md
@@ -111,6 +111,7 @@ Map the need to an `as:` type. All built-in types are **Community (free)**; the 
 | A hover preview icon on the Index row                  | `:preview`                   | `field :preview, as: :preview` |
 | A currency amount ⚠️                                    | `:money`                     | `field :price, as: :money, currencies: %w[USD EUR]` |
 | A rich-text WYSIWYG editor ⚠️ (recommended)            | `:rhino`                     | `field :body, as: :rhino` |
+| Basecamp's Lexxy editor for Action Text ⚠️              | `:lexxy`                     | `field :body, as: :lexxy` |
 | A GitHub-style Markdown editor ⚠️                       | `:markdown`                  | `field :body, as: :markdown` |
 | A simpler Markdown editor ⚠️                            | `:easy_mde`                  | `field :notes, as: :easy_mde` |
 | The Trix editor (ActionText)                           | `:trix`                      | `field :body, as: :trix` |
@@ -161,6 +162,23 @@ end
 ```
 
 Block fields render **only on Index and Show** (they have no input) and **can't use `sortable: true`** (pass a sort lambda instead). Give them an explicit label string as the first argument.
+
+### Rich-text and code editors
+
+Seven types render an editor rather than a plain input — `rhino`, `lexxy`, `trix`, `markdown`, `easy_mde`, the deprecated `tip_tap`, and `code`. Pick by the format you store and the gem you're willing to add:
+
+| Field | Editor | Stores | Needs |
+| --- | --- | --- | --- |
+| `rhino` | Rhino (TipTap) | HTML | `avo-rhino_field` |
+| `lexxy` | Lexxy (Lexical, by Basecamp) | HTML, **Action Text only** | `avo-lexxy_field`, Rails >= 8.0.2 |
+| `trix` | Trix | HTML | built in |
+| `markdown` | Marksmith (GitHub-style) | Markdown | `marksmith` + `commonmarker` |
+| `easy_mde` | EasyMDE | Markdown | built in |
+| `code` | CodeMirror | source code | built in |
+
+They **behave identically on Show**: full panel width with the label beside the value, and the content collapsed to a short faded preview behind a `More content` / `Less content` toggle. Pass `always_show: true` to skip the collapsing and render it all. All of them are hidden on Index.
+
+On forms every editor's viewport can be dragged taller by its bottom-end handle, and the height is remembered per resource and field in the browser's local storage. A custom editor field opts in from its class with `resizable_editor target: "<css-selector-for-the-scrollable-viewport>"`; the selector is resolved inside the field wrapper after the editor boots, so client-rendered editors work too.
 
 ### Layout inside `def fields`
 

--- a/lib/avo/skills/avo-navigation-search/SKILL.md
+++ b/lib/avo/skills/avo-navigation-search/SKILL.md
@@ -175,6 +175,30 @@ query: -> {
 }
 ```
 
+**Only two surfaces accept an Array**, and this is the one case where branching on `search_type` is mandatory rather than an optimization:
+
+| Surface | Array | Relation |
+| --- | --- | --- |
+| Global search (Cmd+K palette and its results page) | yes | yes |
+| Searchable associations | yes | yes |
+| Resource Index search bar | **no** | yes |
+| Kanban board card picker | **no** | yes |
+
+The index and kanban surfaces build a table from database records — sorting, filtering, scoping, paginating — so they need an `ActiveRecord::Relation`. Return the Array only for `:global` and `:association`, and leave the relation as the `else` branch so a surface that doesn't inject `search_type` still gets something usable:
+
+```ruby
+self.search = {
+  query: -> do
+    case search_type
+    when :global, :association
+      [{_id: 1, _label: "Record One", _url: "https://example.com/1"}]
+    else # the Index search bar and the kanban card picker — these require a relation
+      query.ransack(id_eq: params[:q], m: "or").result(distinct: false)
+    end
+  end
+}
+```
+
 ---
 
 ## Breadcrumbs (Community)
@@ -239,6 +263,7 @@ Jump-to-menu-item shortcuts go through the menu `hotkey:` option, or `self.hotke
 - **Ransack v4+ needs an allowlist.** Add `ransackable_attributes` (and often `ransackable_associations`) to any model you search, or the query raises.
 - **`search_type` is undefined on Community-only installs and in the kanban picker.** It's injected by the paid search layer for the index/global/association surfaces only. Guard with `defined?(search_type)`; the kanban picker reads `params[:q]` and detects the board via `params[:for_kanban_board]`.
 - **Custom array-result providers aren't auto-capped.** `config.search_results_count` only applies to relations without their own `.limit()` — cap arrays yourself with `.first(N)`.
+- **An Array returned to the Index search bar fails silently.** Only global search and searchable associations render an Array; the Index and the kanban picker need a relation and raise `NoMethodError: undefined method 'order' for an instance of Array`. Typing in the Index search box hides that error — the request fails and the list just keeps showing the previous, unfiltered rows. Branch on `search_type` so the Array only reaches `:global` and `:association`.
 - **`.limit()` in your `query:` proc always wins** over `config.search_results_count`.
 - **`search_on_type` can't be a lambda.** Any Proc is truthy, so it behaves as `true`; use a plain boolean. (`enabled` and `navigation_section` do accept lambdas.)
 - **`self.description` and search `item` titles can render raw HTML** in adjacent surfaces — never interpolate user-editable content (stored-XSS). See **avo-resources**.

--- a/lib/avo/skills/avo-resources/SKILL.md
+++ b/lib/avo/skills/avo-resources/SKILL.md
@@ -107,18 +107,20 @@ class Avo::Resources::Comment < Avo::BaseResource
 end
 ```
 
-Add a message under the resource name with `self.description`, the sidebar icon with `self.icon`, and an image with `self.avatar` (small, on show/forms) or `self.cover` (banner):
+Add a message under the resource name with `self.description`, the sidebar icon with `self.icon`, a tint for that icon with `self.color`, and an image with `self.avatar` (small, on show/forms) or `self.cover` (banner):
 
 ```ruby
 class Avo::Resources::User < Avo::BaseResource
   self.description = "These are the users of the app."
   self.icon = "tabler/outline/user"
+  self.color = :purple
   self.avatar = { source: :avatar, visible_on: [:show, :forms] }
   self.cover  = { source: :cover_photo, size: :md, visible_on: [:show] }
 end
 ```
 
 - `self.description` is rendered as **raw HTML** — never feed it user-editable data (stored-XSS risk). A block gets `record`, `resource`, `view`, `current_user`, `params`.
+- `self.color` (Symbol or String, default `nil`) tints **only the icon stroke** — the label and the hover/active backgrounds stay neutral, so give related resources the same color to group them visually. One of `red`, `orange`, `amber`, `yellow`, `lime`, `green`, `emerald`, `teal`, `cyan`, `sky`, `blue`, `indigo`, `violet`, `purple`, `fuchsia`, `pink`, `rose`; an unknown name falls back to the neutral icon, and the colors adapt to light and dark themes on their own. It follows the resource past the sidebar: the initials chip in the breadcrumbs is tinted too, and with `avo-advanced_search` installed so are the resource group headers in global search. A `color:` on the menu entry (**avo-menu**) overrides it.
 - `self.cover`/`self.avatar` were named `cover_photo`/`profile_photo` in Avo 3. A **Symbol** `source:` renders nothing for unpersisted (new) records — use a block if you want a placeholder on `new`/`index`.
 
 Surface small metadata (timestamps, id, a badge/link) next to the title without spending a field, via `self.discreet_information`:
@@ -232,6 +234,7 @@ For STI, send index clicks to the child record with `self.link_to_child_resource
 | `self.title` | Record display name | `self.title = :name` |
 | `self.description` | Message under the name (raw HTML!) | `self.description = "App users."` |
 | `self.icon` | Sidebar icon | `self.icon = "tabler/outline/user"` |
+| `self.color` | Tint for that icon (stroke only) | `self.color = :purple` |
 | `self.avatar` / `self.cover` | Small photo / banner | `self.cover = { source: :cover_photo, size: :md }` |
 | `self.discreet_information` | Metadata by the title | `self.discreet_information = :timestamps` |
 | `self.model_class` | Model when not inferable / secondary resource | `self.model_class = "Delayed::Job"` |

--- a/lib/avo/skills/avo-setup/SKILL.md
+++ b/lib/avo/skills/avo-setup/SKILL.md
@@ -35,7 +35,7 @@ Authoritative docs — fetch on demand rather than guessing, and verify every op
 
 Avo needs, in the target app:
 
-- Rails **>= 6.1**, Ruby **>= 3.1**.
+- Rails **>= 6.1**, Ruby **>= 3.2**.
 - `config.api_only` **= false** (an API-only app has no views/session/flash for Avo to render — see the docs map's api-only guide).
 - `propshaft` **or** `sprockets` in the Gemfile.
 - A `secret_key_base` (from `ENV["SECRET_KEY_BASE"]`, credentials, or secrets).
@@ -220,6 +220,8 @@ end
 A license authorizes **one app, one production URL** (`Rails.env.production?`). Non-production environments — development, staging, test, QA — need no extra license. To hide the "license request timed out" badge, set `config.display_license_request_timeout_error = false`.
 
 Verify at the **status page**: `https://yourapp.com/<mount-path>/avo_private/status` (e.g. `.../avo/avo_private/status` or `.../admin/avo_private/status`). It shows whether the license authenticated and what the checking server returned; the key is masked unless you set `config.exclude_from_status = []`. The viewing user must be an Avo admin. Deep failure diagnosis (unlicensed after deploy, timeouts, test-suite blocking the check host) is the **avo-troubleshoot** skill.
+
+A **trial is a fully valid license** — every add-on it covers behaves exactly as it does on a paid one, and nothing is gated or degraded while it runs. The **Avo Status** indicator in the sidebar footer reads green when all is well, **amber while a trial needs attention**, and orange when the license is invalid. Amber is not a failure: it means either no payment method is on file (access stops on the trial's end date) or the subscription behind the trial was cancelled (access stops on the cancellation date, and adding a payment method won't change that — the subscription has to be resumed). The status page names which of the two applies; after fixing it on [avohq.io/licenses](https://avohq.io/licenses), press **Refresh license** there, because Avo caches the license response between checks and will otherwise keep showing the older billing state. Trial state needs `avo-licensing` >= `4.0.10`, and the amber indicator needs Avo >= `4.0.20` (an older Avo renders the dot uncolored rather than breaking).
 
 ### 7. (Optional) Append your own routes inside the engine
 

--- a/lib/avo/skills/avo-troubleshoot/SKILL.md
+++ b/lib/avo/skills/avo-troubleshoot/SKILL.md
@@ -187,6 +187,7 @@ Prefer Rails route helpers (with `main_app.` / `avo.`) over hardcoded paths ever
 1. **Key not set on the server.** The most frequent cause. Confirm `config.license_key = ENV["AVO_LICENSE_KEY"]` and that the env var is actually present in **production** (not just locally).
 2. **Check the status page.** Every Avo app exposes `https://yourapp.com/<mount>/avo_private/status` — e.g. `/admin/avo_private/status` if you mounted Avo at `admin`. It shows whether the license authenticated and the raw response from the check server. The viewing user must be an Avo admin.
 3. **Key hidden on the status page.** The key is redacted by default; set `exclude_from_status = []` in the initializer if you need to see it while debugging.
+4. **An amber sidebar indicator is not a license failure.** Green is fine, orange is invalid, **amber is a running trial that needs attention** — either no payment method is on file, or the subscription behind the trial was cancelled. Access continues until the date the status page reports, and the page names which of the two applies. Fix it at [avohq.io/licenses](https://avohq.io/licenses), then press **Refresh license** on the status page: Avo caches the license response, so the app can keep showing older billing state than avohq.io until it re-checks.
 
 → `license-troubleshooting.html`
 

--- a/lib/avo/skills/docs-index.json
+++ b/lib/avo/skills/docs-index.json
@@ -1,7 +1,7 @@
 {
   "repo": "avo-hq/docs.avohq.io",
   "docs_path": "docs/4.0",
-  "commit": "3350dbef7b2da94b410d6a678f9551e16901411e",
-  "date": "2026-07-28",
+  "commit": "3ffed3f76d9f8d20c8be49b2e48fb176ced7ef9a",
+  "date": "2026-08-17",
   "note": "The docs commit these skills were last indexed from. Run ruby lib/avo/skills/bin/docs_drift.rb to see what changed since, and --update after a refresh."
 }


### PR DESCRIPTION
# Description

Routine docs-sync for the skills that ship inside the gem (`lib/avo/skills/*/SKILL.md`). `lib/avo/skills/docs-index.json` was pinned at docs commit `3350dbef` (2026-07-28); docs `main` is now `3ffed3f` (2026-08-17). 45 pages under `docs/4.0` changed in that range. This reconciles the shipped skills against them and moves the marker to `3ffed3f`.

Only files under `lib/avo/skills/` are touched. No skills were created or removed.

> Branch note: this session is pinned to `claude/peaceful-mayer-8ir1el` by its environment, so the work is here rather than on the conventional `docs-sync/2026-08-17`.

## Page-by-page

| Changed page | Skills citing it | What changed here |
| --- | --- | --- |
| `associations.md`, `associations/has_one.md`, `associations/has_many.md` | avo-associations | **Edited.** `attach_fields` persists on any `:through` association, not only `has_many :through` — the skill said the opposite. Added a `has_one :through` section (no `through:` option on the field; attach/detach go through the association so its scope is respected; attaching over an existing record replaces the join row; `attach_fields` >= `4.0.25`). |
| `resources-api.md`, `resources.md` | avo-controllers, avo-performance, avo-resources | **Edited avo-resources**: added `self.color`, its palette, `nil` default, icon-stroke-only scope, and that it also tints breadcrumbs and (with `avo-advanced_search`) search group headers. No change for avo-controllers / avo-performance — `self.color` is the only change on the page and neither skill's subject touches it. |
| `installation.md`, `avo-3-avo-4-upgrade.md` | avo-setup, avo-troubleshoot, avo-update | **Edited avo-setup**: Ruby requirement `>= 3.1` → `>= 3.2`. Verified against `avo.gemspec` (`required_ruby_version = ">= 3.2.0"`). |
| `licensing.md`, `license-troubleshooting.md` | avo-setup, avo-testing, avo-troubleshoot | **Edited avo-setup and avo-troubleshoot**: a trial is a fully valid license, and an **amber** sidebar indicator means a trial needing attention (no payment method, or a cancelled subscription) rather than a license failure — plus the **Refresh license** step, since Avo caches the response. No change for avo-testing: its subject is unblocking the license-check host in the suite, which the new content doesn't touch. |
| `customization-api.md`, `customization.md` | avo-admin-config, avo-multitenancy | **Edited avo-admin-config**: added `back_to_top` (`{enabled: true, threshold: 400}`, on by default since 4.1.4, direction-aware reveal gone) with an upgrade-facing gotcha. `use_browser_timezone` — including its `false` default in the test environment — was **already documented**; no change. No change for avo-multitenancy (neither option is tenancy-related). |
| `actions-api.md` | avo-actions | **Edited.** `reload_records` defaults to the records the action ran on when called with no argument (>= 4.1.2); `reload_record` is an alias. Verified against `lib/avo/base_action.rb` (`def reload_record(records = @query)`). |
| `fields.md`, `fields/lexxy.md` (new), `fields/markdown.md`, `fields/easy_mde.md`, `fields/code.md` | avo-fields | **Edited.** Added the rich-text/code editor comparison table (incl. `lexxy`), their shared collapsed-preview behavior on Show and `always_show: true`, and `resizable_editor target:`. Added a `lexxy` row to the field-type table. |
| `field-options.md`, `field-options-api.md`, `fields-layout.md` | avo-custom-fields, avo-fields | **No change needed.** The only change is `stacked: false` winning over sidebar/width auto-stacking, which avo-fields already documents verbatim. |
| `search-api.md`, `search.md`, `keyboard-shortcuts.md`, `menu-editor.md`, `menu-editor-api.md` | avo-navigation-search | **Edited** for the custom-search-provider Array constraint: only global search and searchable associations render an Array; the Index bar and kanban picker need a relation and fail *silently* (the error is hidden, stale rows stay). Added the surface table, the `search_type` branch, and a gotcha. Menu-entry `color:` is `avo-menu`'s DSL — see follow-ups. `keyboard-shortcuts.md` only renamed Intelligence → Avo AI, an add-on. |
| `plugins.md` | avo-custom-fields, avo-custom-ui | **Edited avo-custom-ui**: added `register_configuration(name, klass)` to the `Avo.plugin_manager` list, a worked "let apps configure your plugin" section, and the collision rule (only methods `Avo::Configuration` defines itself count). Corrected the blanket "register everything from `avo_boot`" — `register_configuration` must run from an engine initializer `before: :load_config_initializers`, or it blows up inside the app's own initializer. Verified against `lib/avo/plugin_manager.rb`. No change for avo-custom-fields, which covers `register_field`. |
| `i18n.md` | avo-associations, avo-i18n | **No change needed.** avo-i18n already carries the safe-keys rule, the six derived roots, the pluralization-hash exception, and scope/card/dashboard translation keys. |
| `scopes.md`, `scopes-api.md`, `dynamic-filters.md`, `dynamic-filters-api.md` | avo-filters | **No change needed.** avo-filters is a router to `avo-scopes` / `avo-dynamic_filters`; the changes are localization detail owned by those gems' own skills. |

**Skills edited (9):** avo-actions, avo-admin-config, avo-associations, avo-custom-ui, avo-fields, avo-navigation-search, avo-resources, avo-setup, avo-troubleshoot.

**Skills reviewed and left alone (7):** avo-controllers, avo-custom-fields, avo-filters, avo-i18n, avo-multitenancy, avo-performance, avo-testing — plus the avo-fields and avo-admin-config sections that were already current, noted above.

## Not resolved here — follow-ups

**Add-on-owned pages (out of scope for the gem's own skills):**

- `ai.md`, `ai-agents-and-tools.md`, `ai-what-you-can-ask.md` (new) — the `avo-intelligence` → **`avo-ai`** rename, the `Avo::AI` constant vs. lowercase paths/config, and the alpha upgrade note. Belongs to `avo-ai`'s skill. No core skill cites these.
- `calendar-view.md` (new), plus its `upgrade.md` entries — the **`avo-calendar`** add-on. No core skill cites it.
- `cards.md`, `cards-api.md`, `dashboards.md`, `dashboards-api.md` — the `avo-dashboards` `4.0.9` change making the per-card refresh control **opt-in** via `self.refresh_button`. Belongs to `avo-dashboards`' skill.
- `dynamic-filters.md` / `dynamic-filters-api.md` — the full `avo.dynamic_filters.*` locale tree and the "`button_label` must be a proc, a String is pinned at boot" gotcha. Belongs to `avo-dynamic_filters`' skill.
- `scopes.md` / `scopes-api.md` — `avo.scope_translations.*` and the gem's own `avo.scopes.record_count` chrome key. Belongs to `avo-scopes`' skill.
- `menu-editor.md` / `menu-editor-api.md` — the menu-entry **`color:`** option on `resource`, `link_to`, `dashboard` and `board` items, which falls back to the resource's `self.color`. The menu DSL is `avo-menu`'s skill; only the resource-side `self.color` landed here.

**New pages with no owning skill:** `ai.md`, `ai-agents-and-tools.md`, `ai-what-you-can-ask.md`, `calendar-view.md`. Flagged rather than acted on — this sync does not create skills.

**Also changed, cited by nothing, no action:** `agentic-engineering.md`, `index.md`, `rest-api.md`, `code.md`, `easy_mde.md`, `always_show.md`.

**Worth a separate look:** `index.md` now documents upgrading with `bin/rails avo:update` rather than `bundle update avo`. avo-update already leads with `bin/rails avo:update`, so nothing drifted — noting it only because the page is cited by no skill and so would go unwatched if it changed again.

No contradictions between the docs and the source were found. Every option written above was checked against this checkout: `avo.gemspec`, `lib/avo/configuration.rb` (`BACK_TO_TOP_DEFAULTS`), `lib/avo/base_action.rb`, `lib/avo/resources/base.rb`, `lib/avo/fields/has_one_field.rb`, `lib/avo/fields/concerns/has_resizable_editor.rb`, and `lib/avo/plugin_manager.rb`.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs) — n/a in reverse: this PR follows docs that are already merged
- [x] I have added tests that prove my fix is effective or that my feature works — covered by the existing `spec/lib/avo/skills` suite
- [ ] I tested the design in Light and Dark mode, and all default themes — n/a, no UI change

## Screenshots & recording

n/a — Markdown-only change to the shipped skills.

## Manual review steps

1. With `docs.avohq.io` at `3ffed3f`, run `AVO_DOCS_PATH=<docs checkout> ruby lib/avo/skills/bin/docs_drift.rb` on this branch — it prints `Up to date with 3ffed3f76d9f (2026-08-17).`
2. `grep -rnE "\[!code|:::|<Option|``&lt;Image|&lt;CustomCode|&lt;FieldTypesList``" lib/avo/skills/` returns nothing — no VitePress artifacts pasted in.
3. `bundle exec rspec spec/lib/avo/skills` → **167 examples, 0 failures**.
4. `git diff --stat main` touches only `lib/avo/skills/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016zEX3nYzCXZpvc9y5cjcFh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only updates to in-gem agent skills; no production Avo behavior changes, only improved guidance for tooling that reads these files.
> 
> **Overview**
> **Docs sync** for `lib/avo/skills/*/SKILL.md` only — `docs-index.json` moves from `3350dbef` to **`3ffed3f` (2026-08-17)**. No new or removed skills; no app/runtime code.
> 
> **avo-actions** — Documents `reload_records` with no args defaulting to the action’s records (Avo ≥ 4.1.2) and notes `reload_record` as an alias.
> 
> **avo-admin-config** — Adds **`config.back_to_top`** (`enabled` / `threshold`), default-on since 4.1.4, and an upgrade gotcha when the floating pill appears unexpectedly.
> 
> **avo-associations** — Corrects **`attach_fields`** to persist on any `:through` association (including `has_one :through`); adds a dedicated **`has_one :through`** section (no field `through:` option, scoped attach/detach, replace semantics).
> 
> **avo-custom-ui** — Documents plugin **`register_configuration`** and that it must run **`before: :load_config_initializers`**, not from `avo_boot`.
> 
> **avo-fields** — Adds **`lexxy`** to the type table and a rich-text/code editor comparison (Show collapse, `always_show`, resizable editors).
> 
> **avo-navigation-search** — Clarifies custom search **Array** results only work for global search and associations; Index/kanban need a relation (silent failure gotcha).
> 
> **avo-resources** — Documents **`self.color`** for sidebar icon stroke (and breadcrumbs / search headers with advanced search).
> 
> **avo-setup** — Ruby requirement **≥ 3.2**; trial licenses and **amber** status indicator vs invalid license.
> 
> **avo-troubleshoot** — Same trial/amber licensing guidance for support scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee69d9aed3d4df0b306574652a3e29b74eaeabc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->