### PR TITLE
Fix clearing the last applied filter when session persistence is enabled

### DIFF
--- a/app/javascript/js/controllers/filter_controller.js
+++ b/app/javascript/js/controllers/filter_controller.js
@@ -81,12 +81,10 @@ export default class extends Controller {
         return obj
       }, {})
 
-    let encodedFilters
-
-    // Encode the filters and their values
-    if (filtered && Object.keys(filtered).length > 0) {
-      encodedFilters = this.encode(filtered)
-    }
+    // Encode the filters and their values. The empty set is encoded too, so
+    // the backend can tell "the user cleared the filters" apart from "the URL
+    // carries no filters" and overwrite the session-persisted value.
+    const encodedFilters = this.encode(filtered)
 
     this.navigateToURLWithFilters(encodedFilters)
   }

--- a/spec/system/avo/group_2/filters/filters_spec.rb
+++ b/spec/system/avo/group_2/filters/filters_spec.rb
@@ -207,7 +207,9 @@ RSpec.describe "Filters", type: :system do
         expect(page).to have_text "Published post"
         expect(page).to have_text "Unpublished post"
         expect(page).to have_select "avo_filters_published_status", selected: "Published or unpublished", options: ["Published or unpublished", "Published", "Unpublished"]
-        expect(current_url).not_to include "encoded_filters="
+        # Clearing the last filter keeps the param around, encoding the empty
+        # set, so session persistence can pick up the cleared state.
+        expect(current_url).to include "encoded_filters=e30"
         expect(page).to have_css(".button--disabled", text: "Reset filters")
 
         select "Unpublished", from: "avo_filters_published_status"

--- a/spec/system/avo/group_2/filters/persist_filters_spec.rb
+++ b/spec/system/avo/group_2/filters/persist_filters_spec.rb
@@ -65,4 +65,45 @@ RSpec.describe "Persist Filters", type: :system do
       end
     end
   end
+
+  describe "With Select filter" do
+    let!(:published_post) { create :post, name: "Published post", published_at: "2019-12-05 08:27:19.295065" }
+    let!(:unpublished_post) { create :post, name: "Unpublished post", published_at: nil }
+
+    let(:url) { "/admin/resources/posts?view_type=table" }
+
+    context "cache resource filter enabled" do
+      around(:each) do |it|
+        Avo.configuration.persistence = {driver: :session}
+        it.run
+        Avo.configuration.persistence = {driver: nil}
+      end
+
+      it "clears the persisted filter when the last filter is emptied" do
+        visit url
+        expect(page).to have_text "Published post"
+        expect(page).to have_text "Unpublished post"
+
+        open_filters_menu
+        select "Published", from: "avo_filters_published_status"
+        wait_for_loaded
+        expect(page).to have_text "Published post"
+        expect(page).not_to have_text "Unpublished post"
+
+        visit url
+        expect(page).to have_text "Published post"
+        expect(page).not_to have_text "Unpublished post"
+
+        open_filters_menu
+        select "Published or unpublished", from: "avo_filters_published_status"
+        wait_for_loaded
+        expect(page).to have_text "Published post"
+        expect(page).to have_text "Unpublished post"
+
+        visit url
+        expect(page).to have_text "Published post"
+        expect(page).to have_text "Unpublished post"
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

With `config.persistence = { driver: :session }`, clearing the last active filter re-applied the persisted value instead of clearing it.

**Root cause:** when the filters hash became empty, `filter_controller.js` left the `encoded_filters` param off the URL entirely. Server-side, `Avo::Concerns::FiltersSessionHandler#fetch_filters` treats an absent param as "no filters in the URL" and falls back to the session, so a cleared state was indistinguishable from a fresh visit and the stale session value won.

**Fix:** the controller now always encodes the filters hash, so clearing the last filter sends the Base64-encoded empty set (`e30=`). That value is `.present?` server-side, so it overwrites the session with the cleared state. All filter types share this controller, so select, multiple select, date and boolean filters are all covered.

The existing assertion in `filters_spec.rb` that expected the param to disappear after clearing was updated to expect the encoded empty set instead — that behavior change is the fix.

## Testing

Added a system spec to `persist_filters_spec.rb` that applies a select filter with session persistence on, clears it via the blank option, and asserts all records return both immediately and after a fresh visit. It fails on `main` (the filter comes back) and passes with this change, alongside the rest of the filters system specs.

Fixes #4731

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to filter URL encoding and test expectations; behavior change is intentional for session persistence and does not touch auth or data handling.
> 
> **Overview**
> Fixes a bug where **clearing the last active filter** with `config.persistence = { driver: :session }` caused the **old session filter to reapply** instead of staying cleared.
> 
> `filter_controller.js` now **always** Base64-encodes the filters hash on change, including when it is empty (`encoded_filters=e30`), so the server can distinguish **“user cleared filters”** from **“URL has no filter param”** and update session persistence accordingly. Previously an empty hash omitted `encoded_filters`, which triggered a session fallback.
> 
> Specs were updated to expect the encoded empty set when the last select filter is cleared, and a new system example in `persist_filters_spec.rb` covers apply → persist → clear → revisit with session persistence on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67c03632a484a04ad76d00c77159ea2d1b5f70b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->