### PR TITLE
Show the translated default empty message on boolean filters without options

### DIFF
--- a/app/views/avo/base/_boolean_filter.html.erb
+++ b/app/views/avo/base/_boolean_filter.html.erb
@@ -5,7 +5,7 @@
   data-boolean-filter-keep-filters-panel-open-value="<%= @resource.keep_filters_panel_open %>">
   <div class="flex items-center">
     <% if filter.options.empty? %>
-      <div class="filters-section__empty-state"><%= filter.class.empty_message %></div>
+      <div class="filters-section__empty-state"><%= filter.class.get_empty_message %></div>
     <% else %>
       <div class="filters-boolean-options">
         <% filter.options.each do |value, label| %>

--- a/spec/system/avo/group_2/filters/filters_spec.rb
+++ b/spec/system/avo/group_2/filters/filters_spec.rb
@@ -103,6 +103,19 @@ RSpec.describe "Filters", type: :system do
     end
   end
 
+  describe "Boolean filter without options" do
+    let(:url) { "/admin/resources/projects?view_type=table" }
+
+    it "shows the translated default empty message" do
+      # With no projects, Avo::Filters::ProjectCountryFilter has no options and
+      # no empty_message set, so the translated default should be displayed.
+      visit url
+      open_filters_menu
+
+      expect(page).to have_css(".filters-section__empty-state", text: "No options available")
+    end
+  end
+
   describe "Boolean filter with default" do
     let!(:user) { create :user }
 


### PR DESCRIPTION
## Description

`Avo::Filters::BaseFilter.get_empty_message` falls back to `I18n.t("avo.no_options_available")` when `empty_message` is not set, but nothing called it — the boolean filter template rendered `filter.class.empty_message` directly. A boolean filter whose `options` returned an empty collection with no custom `empty_message` therefore rendered an empty div instead of the translated default the docs promise.

The template now renders `filter.class.get_empty_message`. The `avo.no_options_available` key ships in all 19 locales, so the fallback is translated everywhere.

## Testing

Added a system spec asserting that a boolean filter with empty options and no `empty_message` (the dummy app's `ProjectCountryFilter` with no projects) shows "No options available" in the filters panel. It fails on `main` (the empty-state div renders with no text) and passes with this change, alongside the rest of `filters_spec.rb`.

Part of #4732

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small view and test change to filter empty-state copy only; no auth, data, or query behavior changes.
> 
> **Overview**
> **Boolean filters with no options** now show the documented translated empty state instead of a blank div.
> 
> The boolean filter partial switches from `filter.class.empty_message` to **`filter.class.get_empty_message`**, so when `options` is empty and no custom `empty_message` is set, users see the `avo.no_options_available` fallback (e.g. "No options available") rather than nothing.
> 
> A **system spec** covers the projects boolean filter with zero records and asserts the empty-state text in the filters panel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1423e6048e9208af6c4e957db9bdeaa4bdb51ce6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->