### PR TITLE
Document belongs_to behavior in actions

### DIFF
--- a/lib/avo/skills/avo-actions/SKILL.md
+++ b/lib/avo/skills/avo-actions/SKILL.md
@@ -169,6 +169,30 @@ def handle(query:, fields:, **args)
 end
 ```
 
+#### `belongs_to` fields need a single record
+
+A `belongs_to` field resolves its target model through the current record's association reflection. It works when the action runs from a record's **Show** view or from **Index** with exactly one record selected, because Avo hydrates the action with that record. It does not work when multiple records are selected or on a standalone action, because there is no single record from which to resolve the association.
+
+For a short list, use a select field with lazy options:
+
+```ruby
+field :user_id,
+  as: :select,
+  options: -> { User.order(:name).pluck(:name, :id) }
+```
+
+For a long, searchable list, use a tags field in select mode with [`fetch_values_from`](https://docs.avohq.io/4.0/fields/tags.html#fetch-values-from):
+
+```ruby
+field :user_id,
+  as: :tags,
+  mode: :select,
+  enforce_suggestions: true,
+  fetch_values_from: "/avo/resources/users/action_options"
+```
+
+The endpoint receives the search text in `params[:q]` and must return JSON objects with `value` and `label` keys. In both examples, read the selected ID from `fields[:user_id]` in `handle`.
+
 ### Confirmation modal
 The modal is on by default. Customize its text (each may be a string or a block with access to `resource`, `record`, `view`, `arguments`, `query`), or turn it off for safe actions:
 

--- a/lib/avo/skills/avo-actions/SKILL.md
+++ b/lib/avo/skills/avo-actions/SKILL.md
@@ -181,7 +181,7 @@ field :user_id,
   options: -> { User.order(:name).pluck(:name, :id) }
 ```
 
-For a long, searchable list, use a tags field in select mode with [`fetch_values_from`](https://docs.avohq.io/4.0/fields/tags.html#fetch-values-from):
+For a long, searchable list, use a tags field in select mode with [`fetch_values_from`](https://docs.avohq.io/4.0/fields/tags.html#fetch_values_from):
 
 ```ruby
 field :user_id,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

Documents that `belongs_to` action fields require a single hydrated record, so they work from Show and from Index with one selected record but not for bulk or standalone actions.

Adds lazy `select` and searchable `tags` alternatives for collection actions, including how to consume the selected ID.

Fixes #1951

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (not applicable)
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works (documentation-only change)
- [ ] I tested the design in Light and Dark mode, and all default themes (not applicable)

## Screenshots & recording

Not applicable; documentation-only change.

## Manual review steps

1. Review the `belongs_to` guidance under "Collect input with fields."
2. Confirm the examples distinguish small static option sets from large searchable sets.

## Validation

- `git diff --check origin/main...HEAD`
- The focused shipped-skill specs could not run because Ruby and Bundler are unavailable in the cloud image.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AVO-1739](https://linear.app/avo-hq/issue/AVO-1739/add-docs-about-belongs-to-behavior-on-actions)

<div><a href="https://cursor.com/agents/bc-f0b7b780-31d7-417d-b1a6-da4d7f8b307b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0b7b780-31d7-417d-b1a6-da4d7f8b307b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

