### PR TITLE
Sync shipped skills with docs through 2d2dc9d (2026-08-18)

### DIFF
--- a/lib/avo/skills/avo-actions/SKILL.md
+++ b/lib/avo/skills/avo-actions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: avo-actions
-description: Build Avo actions — Ruby classes in `app/avo/actions/*.rb`, registered on a resource's `def actions` — that run a custom operation on selected records, a single record, or nothing at all, with optional form fields, a confirmation modal, feedback notifications, custom responses, and multi-step flows. Use when the user wants to let admins bulk-approve these orders, mark selected invoices as paid, add a button to export selected users to CSV, deactivate/ban a user from the admin, send a welcome email to selected records, trigger a background job for these records, add a Publish/Approve button on the post page, add a monthly report button, collect a reason when someone does something, add a confirmation dialog before an operation, or build a multi-step form/wizard in the admin.
+description: Build Avo actions — Ruby classes in `app/avo/actions/*.rb`, registered on a resource's `def actions` — that run a custom operation on selected records, a single record, or nothing at all, with optional form fields, a confirmation modal, feedback notifications, custom responses, and multi-step flows. Use when the user wants to let admins bulk-approve these orders, mark selected invoices as paid, add a button to export selected users to CSV, deactivate/ban a user from the admin, send a welcome email to selected records, trigger a background job for these records, add a Publish/Approve button on the post page, add a monthly report button, collect a reason when someone does something, assign the selected records to a user or other associated record from the modal, add a confirmation dialog before an operation, or build a multi-step form/wizard in the admin.
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash, WebFetch
 metadata:
   requires-gem: none — Community
@@ -35,6 +35,7 @@ Reach for an action when the request is "let admins **do X** to **records** from
 | "Add a Publish/Approve button on the post page", "ban this user" | [Single-record](#single-record) |
 | "A monthly report button", "run this maintenance job", "export everything to CSV" | [Standalone](#standalone-no-records-needed) |
 | "Collect a reason when someone bans a user", "ask for a message before sending" | [With fields](#collect-input-with-fields) |
+| "Assign the selected records to a user", "pick a related record in the modal" | [Picking an associated record](#collect-input-with-fields) |
 | "Add a confirmation dialog", "make it ask before running" (or skip it) | [Confirmation](#confirmation-modal) |
 | "Then download a file / redirect / refresh just the row" | [Responses](#control-what-happens-after) |
 | "A multi-step form / wizard" | [multi-step flow](#multi-step-flows-wizards) |
@@ -152,7 +153,7 @@ end
 ```
 
 ### Collect input with fields
-Define `fields` to render form inputs in the modal; the submitted values arrive as `fields`. Same field DSL as resources. On a single record the fields are hydrated from it; otherwise they're plain inputs.
+Define `fields` to render form inputs in the modal; the submitted values arrive as `fields`. Same field DSL as resources — *most* field types, anyway. On a single record the fields are hydrated from it; otherwise the fields that don't depend on a record render as plain inputs. Association fields are the exception (see below).
 
 ```ruby
 def fields
@@ -168,6 +169,29 @@ def handle(query:, fields:, **args)
   succeed "Done"
 end
 ```
+
+**Picking an associated record.** A `belongs_to` field needs *one* current record to resolve its association, so it only renders when the action was hydrated with a single record — from **Show**, or with exactly one row checked on **Index**. On a multi-record or standalone action there is no current record and the field can't render. Use a plain input instead:
+
+```ruby
+# Short list — a select with the options loaded when the form renders.
+def fields
+  field :user_id,
+    as: :select,
+    options: -> { User.order(:name).pluck(:name, :id) },
+    include_blank: true
+end
+
+# Long list that needs search — a tags field in select mode.
+def fields
+  field :user_id,
+    as: :tags,
+    mode: :select,
+    enforce_suggestions: true,
+    fetch_values_from: "/avo/resources/users/action_options"
+end
+```
+
+`fetch_values_from` points at an endpoint **you** add (a method on an `Avo::ResourcesController` subclass plus a route); it receives the typed text as `params[:q]` and returns objects with `value` and `label` keys. Either way the chosen ID arrives as `fields[:user_id]`.
 
 ### Confirmation modal
 The modal is on by default. Customize its text (each may be a string or a block with access to `resource`, `record`, `view`, `arguments`, `query`), or turn it off for safe actions:
@@ -235,6 +259,7 @@ When an index spans multiple pages, checking "Select all" offers to select **eve
     URI.parse(request.referer).query.to_s.include?("hey=ya") ? :yes : :no
   }
   ```
+- **`belongs_to` doesn't render in a bulk or standalone action.** It needs a single current record to resolve the association, which a multi-record or standalone action doesn't have. Reach for `as: :select` (short list) or `as: :tags, mode: :select, fetch_values_from: "..."` (long, searchable) and assign the ID yourself in `handle`.
 - **`reload_records` is Index-only.** It doesn't work on association tables — use `reload` there.
 - **Notification bodies truncate at ~320 characters.** Keep `succeed`/`error` messages short; put long output in a `download` or a redirect.
 - **File downloads need `self.turbo = false`.** Otherwise Turbo intercepts the response and the download won't fire.

--- a/lib/avo/skills/docs-index.json
+++ b/lib/avo/skills/docs-index.json
@@ -1,7 +1,7 @@
 {
   "repo": "avo-hq/docs.avohq.io",
   "docs_path": "docs/4.0",
-  "commit": "a1b70eba187a85a390fd2f7e6eead87b4dd0f830",
-  "date": "2026-08-17",
+  "commit": "2d2dc9d83b16fab3f0a08a7fc4b5180fb6de754d",
+  "date": "2026-08-18",
   "note": "The docs commit these skills were last indexed from. Run ruby lib/avo/skills/bin/docs_drift.rb to see what changed since, and --update after a refresh."
 }


### PR DESCRIPTION
# Description

Scheduled reconciliation of the skills shipped inside the gem (`lib/avo/skills/`) against `avo-hq/docs.avohq.io`.

The previous marker was `a1b70eb` (2026-08-17). Three pages under `docs/4.0` changed since; one of them is cited by a shipped skill.

## Changed pages

| Changed page | Skills citing it | What I did |
| --- | --- | --- |
| `actions.md` (M) | `avo-actions` | **Edited.** The guide gained "Choose an associated record in a collection action". Taught the skill that a `belongs_to` field needs one current record to resolve its association and so cannot render in a bulk or standalone action, plus the two documented workarounds (`select` with eager-loaded options; `tags` in select mode with `fetch_values_from`). Also corrected the "Collect input with fields" claim that non-single-record fields are simply "plain inputs" — the guide now qualifies that association fields are the exception. |
| `ai.md` (M) | none | **No change.** Owned by the `avo-ai` gem — RubyLLM 2.0 install steps, `ruby_llm:load_models`, the Models resource's Refresh models action, dropping `model_registry_class` and the `avo_ai/tool_calls` menu entry. Out of scope for core skills; see the note below. |
| `calendar-view.md` (M) | none | **No change.** Owned by the `avo-calendar_view` gem (renamed from `avo-calendar` in this range) — dot-style single-day timed chips. Out of scope for core skills; see the note below. |

## Skills edited

- `avo-actions` — new "Picking an associated record" block under **Collect input with fields**, a matching row in the **When this applies** table, a new **Gotchas** bullet, and one trigger phrase added to the frontmatter `description` so the skill fires on "assign the selected records to a user" (description is 865 chars, well under the 1024 cap). `index.md`'s one-line summary for the skill still fits and was left alone.

## Skills reviewed and left alone

Every other shipped skill. No other skill cites `actions.md`, `ai.md` or `calendar-view.md`, and no page they cite changed in this range — so nothing else was opened for edit. Nothing was reformatted or bulk-edited.

## Verification

Verified the new API surface against the source in this checkout rather than trusting the prose:

- `belongs_to`'s record resolution — `lib/avo/fields/belongs_to_field.rb`, where `foreign_key` and `get_record` both fall back to `@resource.record`.
- The `tags` field's `mode`, `enforce_suggestions` and `fetch_values_from` props — `lib/avo/fields/tags_field.rb` and `app/javascript/js/controllers/fields/tags_field_controller.js`, where the controller sends the typed text as `q`.

The artifact check came back clean — no VitePress markup pasted into the skills:

```bash
grep -rnE "\[!code|:::|<Option|``&lt;Image|&lt;CustomCode|&lt;FieldTypesList" lib/avo/skills/·'''``

`bundle exec rspec spec/lib/avo/skills` — **167 examples, 0 failures.**

Marker moved to `2d2dc9d` (2026-08-18) via `docs_drift.rb --update`.

## Flagged — not resolved here

- **`ai.md` and `calendar-view.md` belong to add-on gems** (`avo-ai`, `avo-calendar_view`) and should be reconciled in those gems' own skill trees. Neither gem is listed in `lib/avo/skills/package-map.md`, so the loader's allowlist would not surface their skills even if they shipped some. Adding a gem to that allowlist grants its text authority over an agent, so I did not add either one on my own — it needs a deliberate call.
- **`avo-calendar` was renamed to `avo-calendar_view`** in this range. No shipped skill references the old gem name (grep is clean), so nothing here is stale — noting it in case the name appears in the add-on gems' own skills.
- **`fetch_values_from` endpoint contract.** The docs example points at `/avo/resources/users/action_options`, which is app-defined (a method on an `Avo::ResourcesController` subclass plus a route), not a built-in Avo endpoint — I grepped `lib/`, `app/` and `config/` and found no such route. I made that explicit in the skill so nobody assumes Avo provides it.
- **No new pages appeared** in this range, so no skill's Docs list needed an addition and no skill gap was found.

## Branch name

This session's environment assigned the branch `claude/peaceful-mayer-pg49j7` and forbids pushing anywhere else, so the work is here rather than on the `docs-sync/2026-08-18` name the routine normally uses.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — n/a, this PR *is* the documentation sync; no docs page changes are needed in the other direction
- [x] I have added tests that prove my fix is effective or that my feature works — n/a, `spec/lib/avo/skills` already covers the invariants these edits could break and passes
- [x] I tested the design in Light and Dark mode, and all default themes — n/a, no UI changes

## Screenshots & recording

n/a — Markdown only, no UI surface.

## Manual review steps

1. Read the diff on `lib/avo/skills/avo-actions/SKILL.md` next to the new "Choose an associated record in a collection action" section in `docs/4.0/actions.md` and confirm the skill states the same constraint and the same two workarounds.
2. Run `bundle exec rspec spec/lib/avo/skills` — expect 167 examples, 0 failures.
3. Optional: with a docs checkout, `AVO_DOCS_PATH=<docs-checkout> ruby lib/avo/skills/bin/docs_drift.rb` should now report "Up to date" against `2d2dc9d`.