### PR TITLE
Sync shipped skills with docs through dee56c8 (2026-08-19)

### DIFF
--- a/lib/avo/skills/docs-index.json
+++ b/lib/avo/skills/docs-index.json
@@ -1,7 +1,7 @@
 {
   "repo": "avo-hq/docs.avohq.io",
   "docs_path": "docs/4.0",
-  "commit": "20f00e3de5ce943e5a869a31afc8e32174c94158",
+  "commit": "dee56c883a189676d46aa2d3ed1915525a5fc16a",
   "date": "2026-08-19",
   "note": "The docs commit these skills were last indexed from. Run ruby lib/avo/skills/bin/docs_drift.rb to see what changed since, and --update after a refresh."
 }


### PR DESCRIPTION
# Description

Scheduled reconciliation of the skills that ship inside the gem (`lib/avo/skills/`) against the docs repo, from the commit recorded in `lib/avo/skills/docs-index.json`.

**Range:** `20f00e3de5ce` → `dee56c883a18` (2026-08-19), 5 pages changed under `docs/4.0`.

**Outcome: no skill text needed an edit.** This is a marker-only refresh, which keeps the next run's diff small.

## Changed pages

| Changed page | Skills citing it | What changed |
| --- | --- | --- |
| `fields-layout.md` (M) | `avo-fields` | **No change needed.** The page corrected "Sidebar fields are always stacked" to "stack by default … a field declaring `stacked: false` keeps its label beside the value even there." `avo-fields` already states this correctly under **Key options**: "`stacked:` on the field wins everywhere, so `stacked: false` opts out of the auto-stacking and of sidebars/preview stacking too." Verified against source — `Avo::FieldWrapperComponent#stacked?` returns `@field.stacked` before falling back to what the rendering component asked for, and `resource_sidebar_component.html.erb` passes `stacked: true` as exactly that fallback. |
| `ai.md` (M) | — | **Out of scope (add-on).** Owned by `avo-ai` / the `avo-ai-tools` skill. See follow-up below. |
| `ai-agents-and-tools.md` (M) | — | **Out of scope (add-on).** Owned by `avo-ai` / `avo-ai-tools`. See follow-up below. |
| `ai-what-you-can-ask.md` (M) | — | **Out of scope (add-on).** Owned by `avo-ai` / `avo-ai-tools`. Scope-boundary rewording: the assistant now takes small talk, jokes, and questions about uploaded/attached files, and declines only *substantial* unrelated work. |
| `calendar-view.md` (M) | — | **Out of scope (add-on).** Owned by `avo-calendar_view`, which ships no skill at all. See follow-up below. |

## Skills edited

None.

## Skills reviewed and left alone

- `avo-fields` — the only skill flagged by `docs_drift.rb`. Reconciled against the `fields-layout.md` diff and the `stacked` reference on `field-options-api.md`; already accurate, so left untouched.

Also grepped every shipped skill for `stacked` to be sure no other skill carried the old "sidebars always stack" claim — `avo-admin-config`, `avo-custom-fields` and `avo-index-views` each mention it in a different, still-correct context.

## Follow-ups for other gems — not resolved here

These are flagged, not guessed at:

1. **`avo-ai` → `avo-ai-tools` skill.** `ai.md` gained a whole ~127-line section, **Choose which tools the assistant gets**, documenting new initializer configuration (`config.ai.excluded_tools`, `config.ai.extra_tools`) plus ejecting a shipped tool into `app/tools/`. `ai-agents-and-tools.md` picked up the knock-on behavior: excluding `rename_conversation` switches the auto-renamer off, excluding `resource_inspector` turns off the inspection gate (queries and writes then proceed uninspected rather than refusing), and the Chats show page's **Agent tools** field now renders a diagnostic error row for a bad `extra_tools` entry. That is new DSL and new gotchas — the `avo-ai-tools` skill almost certainly needs reconciling, and it's out of this repo's scope.
2. **`avo-calendar_view` ships no skill and is absent from `package-map.md`.** `calendar-view.md` documents a paid add-on (`avo-calendar_view`, Beta) with a real DSL (`view_types = [:table, :calendar]`, `on_click:`, `hide_weekends`, `show_on: :preview`), and its diff here documents new **Today** button behavior. No gem in the package map owns it, so no skill will ever be flagged for this page. Worth deciding whether that gem should ship a skill and be allowlisted — I did not create one, per scope.
3. **Nothing contradicted the source, and no option went unverified.** The one behavioral claim in range (`stacked: false` inside a sidebar) was checked against `app/components/avo/field_wrapper_component.rb` rather than taken from the docs.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs) — n/a, this change *follows* the docs rather than leading them
- [x] I have added tests that prove my fix is effective or that my feature works — n/a, no behavior change; the existing `spec/lib/avo/skills` suite is the gate and passes
- [x] I tested the design in Light and Dark mode, and all default themes — n/a, no UI change

## Screenshots & recording

n/a — the diff is one line of JSON.

## Manual review steps

1. Confirm the diff touches only `lib/avo/skills/docs-index.json`, and only its `commit` value.

2. With a `docs.avohq.io` checkout at `dee56c8`, point the drift script at it:

   ```bash
   AVO_DOCS_PATH=/path/to/docs.avohq.io ruby lib/avo/skills/bin/docs_drift.rb
   ```

   It should print `Up to date with dee56c883a18 (2026-08-19).`

3. Confirm no VitePress artifacts were pasted into any skill. The canonical grep is the one in the sync runbook — it alternates `\[!code`, `:::`, and the four VitePress component tags (Option, Image, CustomCode, FieldTypesList), each preceded by an opening angle bracket. Writing that bracket literally here gets it rewritten by GitHub, so run the runbook's version rather than copying from this description. Verified locally: **no matches**.

4. `bundle exec rspec spec/lib/avo/skills` — verified locally: **167 examples, 0 failures**.