### PR TITLE
Hover flyout for sidebar items whose sub-items aren't listed inline

### DIFF
--- a/app/assets/stylesheets/css/sidebar.css
+++ b/app/assets/stylesheets/css/sidebar.css
@@ -518,3 +518,65 @@
 .sidebar-status:hover .sidebar-status__hint {
   @apply block;
 }
+
+/* ================================================ */
+/* Sidebar Flyout — ItemSwitcherComponent           */
+/* BEM: .sidebar-flyout (block)                     */
+/* ================================================ */
+
+/* A parent item's sub-items, shown on hover for as long as they aren't already
+   listed inline (that is, whenever the parent's own page and its children are
+   all closed). The panel is a native popover: the sidebar body scrolls, so an
+   absolutely positioned panel would be clipped by it — the top layer is the
+   only place this can be drawn. Position comes from CSS anchor positioning,
+   with the per-item `anchor-name` written inline by the component. */
+.sidebar-flyout {
+  @apply w-full;
+}
+
+.sidebar-flyout__panel {
+  @apply m-0 p-1 rounded-lg min-w-48;
+  background-color: var(--sidebar-background);
+  border: 1px solid var(--sidebar-border);
+  box-shadow: var(--box-shadow-card);
+  position-area: inline-end span-block-end;
+  position-try-fallbacks: flip-inline, flip-block, flip-block flip-inline;
+  margin-inline-start: 0.25rem;
+
+  /* Mirrors .popover-menu__panel: the panel is display:none while closed, so
+     `allow-discrete` keeps it in the top layer through the leave transition. */
+  opacity: 0;
+  transition:
+    opacity 75ms ease-out,
+    overlay 75ms ease-out allow-discrete,
+    display 75ms ease-out allow-discrete;
+}
+
+.sidebar-flyout__panel:popover-open {
+  opacity: 1;
+}
+
+@starting-style {
+  .sidebar-flyout__panel:popover-open {
+    opacity: 0;
+  }
+}
+
+/* No parent above the list here, so the indent that lines sub-items up under
+   their parent has nothing to line up with — and neither do the connector bars
+   that run back up to it, hover preview included. */
+.sidebar-flyout__panel .sidebar-subitem__items {
+  @apply ps-0;
+}
+
+/* `!important` because the connectors are drawn by a family of hover rules
+   (`:hover`, `:has(~ .sidebar-subitem:hover)`) whose specificity a container
+   class can't out-weigh without restating every one of them here. */
+.sidebar-flyout__panel .sidebar-subitem::before,
+.sidebar-flyout__panel .sidebar-subitem::after {
+  content: none !important;
+}
+
+.sidebar-flyout__panel::backdrop {
+  @apply bg-transparent;
+}

--- a/app/javascript/js/controllers.js
+++ b/app/javascript/js/controllers.js
@@ -20,6 +20,7 @@ import DateTimeFilterController from './controllers/date_time_filter_controller'
 import DistributionChartController from './controllers/distribution_chart_controller'
 import DropdownController from './controllers/dropdown_menu_controller'
 import PopoverMenuController from './controllers/popover_menu_controller'
+import SidebarFlyoutController from './controllers/sidebar_flyout_controller'
 import EasyMdeController from './controllers/fields/easy_mde_controller'
 import FilterController from './controllers/filter_controller'
 import FormController from './controllers/form_controller'
@@ -131,6 +132,7 @@ application.register('tippy', TippyController)
 application.register('toggle', ToggleController)
 application.register('dropdown-menu', DropdownController)
 application.register('popover-menu', PopoverMenuController)
+application.register('sidebar-flyout', SidebarFlyoutController)
 application.register('trix-body', TrixBodyController)
 
 // Field controllers

--- a/app/javascript/js/controllers/sidebar_flyout_controller.js
+++ b/app/javascript/js/controllers/sidebar_flyout_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Hover flyout for a sidebar item whose sub-items aren't already listed inline.
+// The panel is a native popover, so it renders in the top layer and escapes the
+// sidebar's own `overflow-y: auto` clipping; CSS anchor positioning pins it to
+// the item. Also opens on focus, so the list is reachable by keyboard.
+export default class extends Controller {
+  static targets = ['panel']
+
+  static values = { delay: { type: Number, default: 120 } }
+
+  show() {
+    clearTimeout(this.timeout)
+    if (!this.panelTarget.matches(':popover-open')) this.panelTarget.showPopover()
+  }
+
+  // The panel sits a few pixels off the item, so the pointer is over neither for
+  // a frame on the way across. The delay is what lets it make the crossing.
+  hide() {
+    clearTimeout(this.timeout)
+    this.timeout = setTimeout(() => {
+      if (this.panelTarget.matches(':popover-open')) this.panelTarget.hidePopover()
+    }, this.delayValue)
+  }
+
+  disconnect() {
+    clearTimeout(this.timeout)
+  }
+}


### PR DESCRIPTION
avo-menu's `ItemSwitcherComponent` lists a parent's sub-items inline only while that branch is open. Everywhere else they're unreachable without navigating to the parent first, so the component wraps such a parent in a hover flyout. This is the core half of that: the stylesheet and the Stimulus controller the component reaches for (`data-controller="sidebar-flyout"`, `.sidebar-flyout__panel`).

### Why a popover

The panel is a native popover, so it draws in the top layer. An absolutely positioned one gets clipped by the sidebar body's `overflow-y: auto`, and the top layer is the only place that isn't. Position comes from CSS anchor positioning against a per-item `anchor-name` the component writes inline, with `position-try-fallbacks` covering a sidebar pinned to either edge.

### Details

- Opens on `focusin` as well as hover, so the list is reachable by keyboard.
- The hide is delayed ~120ms: the panel sits a few pixels off the item, so the pointer is over neither for a frame on the way across.
- The leave transition uses `allow-discrete` + `@starting-style`, mirroring `.popover-menu__panel`.
- Inside the panel there's no parent above the list, so the sub-item indent and the connector bars that run back up to it are switched off.
- Colors go through the existing `--sidebar-*` contract, which the panel still inherits — the top layer changes where an element paints, not where it sits in the DOM for inheritance.

### Browser support

`position-area` and `position-try-fallbacks` are Chromium-only today. Elsewhere the panel still opens and is still readable, but sits at its static position rather than anchored to the item.

### Testing

Rendering and behavior are covered on the avo-menu side, where the component lives — `avo-hq/workspace#226` carries `ItemSwitcherComponent#with_flyout` and its component specs. Nothing in this PR is reachable without that component, so the two need to land together.