### PR TITLE
Reformat the stylesheet declarations Prettier had left unwrapped

### DIFF
--- a/app/assets/stylesheets/css/components/ui/card.css
+++ b/app/assets/stylesheets/css/components/ui/card.css
@@ -39,7 +39,7 @@
   /* offset 1px from the wrapper to match the design */
   padding: calc(var(--spacing) - 1px);
   /* prevent scrollIntoView from shifting the table horizontally by the padding amount */
-  scroll-padding-inline: calc(var(--spacing) );
+  scroll-padding-inline: calc(var(--spacing));
 }
 
 /* for pagination we need the padding to be 4px */
@@ -113,9 +113,9 @@
 /* Card footer - full width so pagination can span edge to edge */
 .card__footer {
   @apply w-full;
-    &:has(.pagination) {
-      @apply p-1 pt-0;
-    }
+  &:has(.pagination) {
+    @apply p-1 pt-0;
+  }
 }
 
 /* Responsive adjustments */

--- a/app/assets/stylesheets/css/variables.css
+++ b/app/assets/stylesheets/css/variables.css
@@ -73,8 +73,16 @@
      content wash; selected is a stronger one. All resolve per-scheme via the
      underlying tokens. */
   --color-row-bg: var(--color-primary);
-  --color-row-bg-hover: color-mix(in oklab, var(--color-primary), var(--color-content) 5%);
-  --color-row-bg-selected: color-mix(in oklab, var(--color-primary), var(--color-content) 12%);
+  --color-row-bg-hover: color-mix(
+    in oklab,
+    var(--color-primary),
+    var(--color-content) 5%
+  );
+  --color-row-bg-selected: color-mix(
+    in oklab,
+    var(--color-primary),
+    var(--color-content) 12%
+  );
 
   --color-scheme: var(--color-white);
   --color-scheme-opposite: var(--color-black);
@@ -168,7 +176,6 @@
   color-scheme: dark;
 }
 
-
 /* Dark mode defaults live in @layer theme — same layer as the @theme block
    above — so the brand override (emitted in @layer base by
    Avo::Configuration::Appearance#brand_css_overrides) can win against these
@@ -199,8 +206,11 @@
     --color-brand-accent: oklch(97.31% 0 89.88);
 
     /* Semantic variables */
-    --color-sidebar-background: color-mix(in oklab, var(--color-background), var(--color-scheme) 14%);
-
+    --color-sidebar-background: color-mix(
+      in oklab,
+      var(--color-background),
+      var(--color-scheme) 14%
+    );
   }
 }
 


### PR DESCRIPTION
Formatting only. Both files are byte-identical to `main` once whitespace is stripped:

```
$ git show origin/main:<file> | tr -d ' \n\t'   # vs the same on the branch
IDENTICAL (whitespace-only): app/assets/stylesheets/css/variables.css
IDENTICAL (whitespace-only): app/assets/stylesheets/css/components/ui/card.css
```

- Three `color-mix()` calls wrapped one argument per line (`--color-row-bg-hover`, `--color-row-bg-selected`, and the dark-mode `--color-sidebar-background`).
- `.card__footer`'s nested `&:has(.pagination)` re-indented to its parent — it was indented one level too deep.
- A stray space inside `scroll-padding-inline: calc(var(--spacing))` and a double blank line before the dark-mode comment.

No rules added or removed, no values changed. Split out of #4744 so that one stays reviewable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Whitespace and formatting only; no selectors, properties, or values altered.
> 
> **Overview**
> **Formatting-only** pass on `card.css` and `variables.css`, split out for easier review. Compiled behavior is unchanged (whitespace-stripped content matches `main`).
> 
> In **variables.css**, three `color-mix()` custom properties (`--color-row-bg-hover`, `--color-row-bg-selected`, dark `--color-sidebar-background`) are broken onto multiple lines with one argument per line. A double blank line before the dark-mode `@layer theme` comment is removed.
> 
> In **card.css**, the nested `&:has(.pagination)` under `.card__footer` is re-indented to sit under its parent (it was one level too deep). `scroll-padding-inline` on `.card__wrapper` drops a stray space inside `calc(var(--spacing))`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e724a71c4f9b427a8246e2803112726cbca2846c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->