### PR TITLE
feat: render maps with OpenFreeMap so they work without a Mapbox account

### DIFF
--- a/app/components/avo/fields/area_field/show_component.html.erb
+++ b/app/components/avo/fields/area_field/show_component.html.erb
@@ -1,10 +1,9 @@
 <%= field_wrapper(**field_wrapper_args, full_width: true) do %>
   <% if field.value.present? %>
-    <div class="w-full" data-controller="map-dark-mode">
+    <%= tag.div class: "w-full", data: field.map_wrapper_data do %>
       <%= area_map field.map_data, **field.mapkick_options %>
-    </div>
+    <% end %>
   <% else %>
     —
   <% end %>
 <% end %>
-

--- a/app/components/avo/fields/location_field/show_component.html.erb
+++ b/app/components/avo/fields/location_field/show_component.html.erb
@@ -2,8 +2,8 @@
   <% if field.static_map?(params) %>
     <%= field.render_map(params) %>
   <% else %>
-    <div class="w-full" data-controller="map-dark-mode">
+    <%= tag.div class: "w-full", data: field.map_wrapper_data do %>
       <%= field.render_map(params) %>
-    </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/avo/view_types/map_component.html.erb
+++ b/app/components/avo/view_types/map_component.html.erb
@@ -1,6 +1,6 @@
 <% if @resources.present? %>
   <div class="map-view-container grid <%= grid_layout_classes %> w-full gap-4">
-    <%= tag.div class: class_names("map-component rounded-2xl overflow-hidden", map_component_order_class), data: { controller: "map-dark-mode" } do %>
+    <%= tag.div class: class_names("map-component rounded-2xl overflow-hidden", map_component_order_class), data: map_wrapper_data do %>
       <%= js_map(resource_location_markers, **resource_mapkick_options) %>
     <% end %>
 

--- a/app/components/avo/view_types/map_component.rb
+++ b/app/components/avo/view_types/map_component.rb
@@ -68,17 +68,14 @@ class Avo::ViewTypes::MapComponent < Avo::ViewTypes::BaseViewTypeComponent
   end
 
   def resource_mapkick_options
-    options = map_options[:mapkick_options] || {}
+    (map_options[:mapkick_options] || {}).merge(
+      height: horizontal_layout? ? "100%" : "26rem",
+      style: custom_style || Avo::MapStyles.light
+    )
+  end
 
-    options[:height] = if horizontal_layout?
-      "100%"
-    else
-      "26rem"
-    end
-
-    options[:style] ||= "mapbox://styles/mapbox/light-v11"
-
-    options
+  def map_wrapper_data
+    Avo::MapStyles.wrapper_data(custom_style:)
   end
 
   def render_table?
@@ -98,6 +95,10 @@ class Avo::ViewTypes::MapComponent < Avo::ViewTypes::BaseViewTypeComponent
 
   def map_options
     @resource.map_view || {}
+  end
+
+  def custom_style
+    map_options.dig(:mapkick_options, :style)
   end
 
   def marker_proc

--- a/app/javascript/js/controllers/map_dark_mode_controller.js
+++ b/app/javascript/js/controllers/map_dark_mode_controller.js
@@ -1,7 +1,16 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
+  static values = { styles: Object }
+
   connect() {
+    // No styles pair means the resource passed its own `style:` through
+    // `mapkick_options`. Avo doesn't retheme a map it didn't style.
+    if (!this.hasStylesValue) return
+
+    // Maps are always built with the light style; nothing has swapped it yet.
+    this.appliedStyle = this.stylesValue.light
+
     this.observer = new MutationObserver(() => this.updateMapStyle())
     this.observer.observe(document.documentElement, {
       attributes: true,
@@ -42,26 +51,31 @@ export default class extends Controller {
   }
 
   updateMapStyle() {
-    const instance = this.mapkickInstance
-    if (!instance?.map) return
+    const map = this.mapkickInstance?.map
+    if (!map) return
 
-    const map = instance.map
-    const style = map.getStyle()
-    if (!style) return
+    // `getStyle()` throws while a style is still loading, and a theme toggle
+    // lands in that window often enough to matter. Wait the load out instead of
+    // dropping the change — nothing else would come along to re-trigger it.
+    if (!map.isStyleLoaded()) {
+      map.once('idle', () => this.updateMapStyle())
+      return
+    }
 
-    const targetStyle = this.isDark
-      ? 'mapbox://styles/mapbox/dark-v11'
-      : 'mapbox://styles/mapbox/light-v11'
+    // A light and a dark style can be indistinguishable once loaded — OpenFreeMap's
+    // pair shares a sprite URL and ships no name — so track what we applied rather
+    // than sniffing it back off the map.
+    const targetStyle = this.isDark ? this.stylesValue.dark : this.stylesValue.light
+    if (targetStyle === this.appliedStyle) return
 
-    // Detect current style from the sprite URL or stylesheet name
-    const styleName = style.name || style.sprite || ''
-    const currentIsDark = /dark/i.test(styleName)
-    if (this.isDark === currentIsDark) return
-
-    // Save custom sources and layers added by Mapkick before the style swap
+    // Save the sources and layers Mapkick added before the style swap wipes them
     const snapshot = this.captureMapkickState(map)
 
-    map.setStyle(targetStyle)
+    this.appliedStyle = targetStyle
+    // `diff: false` forces a full style reload. The default diffing path drops
+    // Mapkick's sources and layers without ever firing `style.load`, so the
+    // markers would vanish with nothing to restore them.
+    map.setStyle(targetStyle, { diff: false })
 
     // Restore sources, layers, and marker images after the new style loads
     map.once('style.load', () => {
@@ -75,10 +89,10 @@ export default class extends Controller {
     const layers = []
     const images = []
 
-    // Capture Mapkick's custom sources (e.g. "objects", "trails", labels)
+    // Mapkick's sources (markers, labels, trails) are the GeoJSON ones; whatever
+    // else is in there belongs to the base map and comes back with the new style.
     for (const [name, source] of Object.entries(style.sources)) {
-      // Skip Mapbox's built-in sources (composite, mapbox-)
-      if (name === 'composite' || name.startsWith('mapbox')) continue
+      if (source.type !== 'geojson') continue
 
       sources[name] = {
         type: source.type,

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -13,6 +13,7 @@ module Avo
     attr_writer :hotkeys
     attr_writer :back_to_top
     attr_writer :associations
+    attr_writer :map_view
     # When unset, Tailwind scans Rails.root.join("app"). Each entry is an absolute path or a path relative to Rails.root.
     attr_writer :tailwindcss_content_sources
     attr_accessor :timezone
@@ -140,6 +141,7 @@ module Avo
       @locale = nil
       @currency = "USD"
       @default_view_type = :table
+      @map_view = {}
       @license_key = nil
       @current_user = proc {}
       @authenticate = proc {}
@@ -272,6 +274,18 @@ module Avo
     # `loading` is the cold-start render mode when a field doesn't set its own
     # `loading:` — `:lazy` (loads on reveal) or `:manual` (placeholder + Load
     # button). `auto_load_for` is the manual memory window (see FrameLoadingMode).
+    # Map view, and the `location`/`area` fields that render the same maps.
+    #
+    # `styles` is the light/dark pair Avo renders them with. `nil` resolves to
+    # Mapbox when MAPBOX_ACCESS_TOKEN is set and to OpenFreeMap otherwise — pin
+    # one with `:mapbox` / `:open_free_map`, or pass your own `{light:, dark:}`.
+    # See Avo::MapStyles.
+    unless defined?(MAP_VIEW_DEFAULTS)
+      MAP_VIEW_DEFAULTS = {
+        styles: nil
+      }.freeze
+    end
+
     unless defined?(ASSOCIATIONS_DEFAULTS)
       ASSOCIATIONS_DEFAULTS = {
         lookup_list_limit: 1000,
@@ -295,6 +309,10 @@ module Avo
 
     def back_to_top
       BACK_TO_TOP_DEFAULTS.merge @back_to_top
+    end
+
+    def map_view
+      MAP_VIEW_DEFAULTS.merge @map_view
     end
 
     def associations

--- a/lib/avo/fields/area_field.rb
+++ b/lib/avo/fields/area_field.rb
@@ -3,7 +3,6 @@
 module Avo
   module Fields
     class AreaField < BaseField
-      attr_reader :mapkick_options
       attr_reader :datapoint_options
 
       def initialize(id, **args, &block)
@@ -14,6 +13,14 @@ module Avo
         @geometry = args[:geometry].presence || :polygon # Accepts: `:polygon` or `:multi_polygon`
         @mapkick_options = args[:mapkick_options].presence || {}
         @datapoint_options = args[:datapoint_options].presence || {}
+      end
+
+      def mapkick_options
+        {style: Avo::MapStyles.light}.merge(@mapkick_options)
+      end
+
+      def map_wrapper_data
+        Avo::MapStyles.wrapper_data(custom_style: @mapkick_options[:style])
       end
 
       def map_data

--- a/lib/avo/fields/location_field.rb
+++ b/lib/avo/fields/location_field.rb
@@ -33,11 +33,16 @@ module Avo
           {
             id: "location-map",
             zoom: @args[:zoom]&.to_i || 15,
-            controls: true
+            controls: true,
+            style: Avo::MapStyles.light
           }
         end
 
         default_options.merge(@args[:mapkick_options] || {})
+      end
+
+      def map_wrapper_data
+        Avo::MapStyles.wrapper_data(custom_style: @args.dig(:mapkick_options, :style))
       end
 
       def value_as_array?

--- a/lib/avo/map_styles.rb
+++ b/lib/avo/map_styles.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Avo
+  # The light/dark style pair every Avo map defaults to.
+  #
+  # Mapbox stays the default for anyone who has a token. Without one its
+  # `mapbox://` URLs render a blank map, which is why a fresh Avo install used to
+  # need a Mapbox signup before it could show a map at all — so fall back to
+  # OpenFreeMap: no key, no registration, no request cap, commercial use allowed.
+  # Attribution rides along in the TileJSON, so the map's own attribution control
+  # credits OpenFreeMap/OpenMapTiles/OpenStreetMap with nothing extra to wire up.
+  # https://openfreemap.org
+  #
+  # Force one either way with `config.map_view = {styles: :mapbox}` (or
+  # `:open_free_map`), or give it your own `{light:, dark:}` pair.
+  #
+  # Override a single map with `mapkick_options: {style: "..."}`. That is one
+  # style rather than a pair, so Avo leaves that map alone in dark mode.
+  module MapStyles
+    # Methods rather than constants: Avo's `lib` is walked by two autoloaders, so
+    # a constant here is assigned twice and Ruby warns on every boot.
+    class << self
+      def mapbox
+        {
+          light: "mapbox://styles/mapbox/light-v11",
+          dark: "mapbox://styles/mapbox/dark-v11"
+        }.freeze
+      end
+
+      def open_free_map
+        {
+          light: "https://tiles.openfreemap.org/styles/positron",
+          dark: "https://tiles.openfreemap.org/styles/dark"
+        }.freeze
+      end
+
+      def default
+        resolve(Avo.configuration.map_view[:styles]) || (mapbox_token? ? mapbox : open_free_map)
+      end
+
+      def light = default[:light]
+
+      # Data attributes for the map wrapper. `map-dark-mode` swaps between the
+      # two styles on theme change; without the pair it leaves the map alone,
+      # which is what we want when the resource picked its own style.
+      def wrapper_data(custom_style: nil)
+        data = {controller: "map-dark-mode"}
+        data[:map_dark_mode_styles_value] = default if custom_style.blank?
+        data
+      end
+
+      private
+
+      def resolve(setting)
+        case setting
+        when :mapbox then mapbox
+        when :open_free_map then open_free_map
+        when Hash then setting
+        end
+      end
+
+      def mapbox_token? = ENV["MAPBOX_ACCESS_TOKEN"].present?
+    end
+  end
+end

--- a/lib/avo/skills/avo-fields/SKILL.md
+++ b/lib/avo/skills/avo-fields/SKILL.md
@@ -210,7 +210,7 @@ end
   - `:lexxy` → `gem "avo-lexxy_field"` (Basecamp's Lexxy editor for Action Text; needs Rails >= 8.0.2)
   - `:markdown` → `gem "marksmith"` + `gem "commonmarker"`
   - `:money` → `gem "avo-money_field"` + `gem "money-rails", "~> 1.12"` (and `monetize :price_cents` on the model)
-  - `:location` / `:area` → `gem "mapkick-rb"` (**not** `mapkick`) + `MAPBOX_ACCESS_TOKEN` env var
+  - `:location` / `:area` → `gem "mapkick-rb"` (**not** `mapkick`). No API key needed — Avo defaults these maps to [OpenFreeMap](https://openfreemap.org), switchable with `config.map_view = {styles: …}`. Set `MAPBOX_ACCESS_TOKEN` only to use Mapbox styles, and for `:location` with `static: true` (which also needs `gem "mapkick-static"` and is Mapbox-only).
   - Reactive fields (`react_on:`) → `gem "avo-reactive_fields"`
   - Some of these gems live on the `packager.dev` source — point the user to the Avo 4 upgrade guide's gems section.
 - **`tip_tap` is deprecated** — use `:rhino` for a WYSIWYG editor.

--- a/lib/avo/skills/avo-index-views/SKILL.md
+++ b/lib/avo/skills/avo-index-views/SKILL.md
@@ -196,7 +196,7 @@ Grid has **no per-card HTML-attribute API** — `row_options` is table-only. `ht
 
 ### Map view
 
-Plot records with geospatial data on a Mapbox map. Enable with `self.map_view`.
+Plot records with geospatial data on a map. Enable with `self.map_view`.
 
 ```ruby
 # app/avo/resources/city.rb
@@ -223,7 +223,7 @@ Options:
 - `table` — `{ visible: true|false }`; default renders no adjacent table.
 - `extra_markers` — Proc returning an array of marker hashes for points not backed by records.
 
-**Requirements** (report these): add the **`mapkick-rb`** gem (NOT `mapkick`) to the `Gemfile`, and set a valid `MAPBOX_ACCESS_TOKEN` env var from a [Mapbox](https://account.mapbox.com/auth/signup/) account.
+**Requirements** (report these): add the **`mapkick-rb`** gem (NOT `mapkick`) to the `Gemfile`. That is all — Avo defaults the map to [OpenFreeMap](https://openfreemap.org), which needs no account, no API key and has no request cap. Set a valid `MAPBOX_ACCESS_TOKEN` from a [Mapbox](https://account.mapbox.com/auth/signup/) account only if you want Mapbox styles; Avo then defaults to those instead. Pin a provider with `config.map_view = {styles: :open_free_map}` (or `:mapbox`), or give `styles` a `{light:, dark:}` pair of style URLs.
 
 Make it the default with `self.default_view_type = :map`.
 
@@ -249,6 +249,6 @@ It works out of the box on the table view; nothing to enable on the resource. Th
 
 Tell the user:
 - Which resource file(s) and attribute(s) you changed (`self.table_view`, `self.grid_view`, `self.map_view`, `self.view_types`, `self.default_view_type`, `self.row_controls_config`, or the initializer).
-- Any external requirements: the `mapkick-rb` gem + `MAPBOX_ACCESS_TOKEN` for maps; the Tailwind integration and/or `@source inline(...)` for custom/dynamic classes; `self.includes` additions to avoid N+1.
+- Any external requirements: the `mapkick-rb` gem for maps (`MAPBOX_ACCESS_TOKEN` only if they want Mapbox styles rather than Avo's keyless OpenFreeMap default); the Tailwind integration and/or `@source inline(...)` for custom/dynamic classes; `self.includes` additions to avoid N+1.
 - If you set a `default_view_type`, confirm the matching view is configured/available so the switcher stays consistent.
 - For select-all or custom-view-type requests, note the cross-linked skill (**avo-actions**, **avo-custom-ui**) that carries the rest of the work.

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -50,6 +50,12 @@ Avo.configure do |config|
   # }.freeze
   # config.model_resource_mapping = {}
   # config.default_view_type = :table
+  # Map tiles for the map view and the `location`/`area` fields. Defaults to
+  # OpenFreeMap (no account needed), or Mapbox when MAPBOX_ACCESS_TOKEN is set.
+  # `styles` accepts :open_free_map, :mapbox, or your own {light:, dark:} pair.
+  # config.map_view = {
+  #   styles: :open_free_map
+  # }
   # config.per_page = 24
   # config.per_page_steps = [12, 24, 48, 72]
   # config.via_per_page = 8

--- a/spec/dummy/app/avo/resources/city.rb
+++ b/spec/dummy/app/avo/resources/city.rb
@@ -45,14 +45,14 @@ class Avo::Resources::City < Avo::BaseResource
       show_on: :preview,
       stored_as: [:latitude, :longitude],
       mapkick_options: {
-        style: "mapbox://styles/mapbox/satellite-v9",
         markers: {color: "#FFC0CB"}
       }
     field :city_center_area,
       as: :area,
       geometry: :polygon,
       mapkick_options: {
-        style: "mapbox://styles/mapbox/satellite-v9",
+        # A style Avo didn't pick: it survives the dark-mode toggle untouched.
+        style: "https://tiles.openfreemap.org/styles/liberty",
         controls: true
       },
       datapoint_options: {

--- a/spec/dummy/public/map_styles/dark.json
+++ b/spec/dummy/public/map_styles/dark.json
@@ -1,0 +1,14 @@
+{
+  "version": 8,
+  "name": "spec-dark",
+  "sources": {},
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "rgb(12,12,12)"
+      }
+    }
+  ]
+}

--- a/spec/dummy/public/map_styles/light.json
+++ b/spec/dummy/public/map_styles/light.json
@@ -1,0 +1,14 @@
+{
+  "version": 8,
+  "name": "spec-light",
+  "sources": {},
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "rgb(242,243,240)"
+      }
+    }
+  ]
+}

--- a/spec/lib/avo/map_styles_spec.rb
+++ b/spec/lib/avo/map_styles_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The point of the whole thing: a fresh install with no Mapbox account must not
+# be handed a `mapbox://` URL, because those render a blank map without a token.
+RSpec.describe Avo::MapStyles do
+  around do |example|
+    original = ENV["MAPBOX_ACCESS_TOKEN"]
+    ENV["MAPBOX_ACCESS_TOKEN"] = nil
+    example.run
+  ensure
+    ENV["MAPBOX_ACCESS_TOKEN"] = original
+  end
+
+  describe ".default" do
+    it "falls back to OpenFreeMap when there is no Mapbox token" do
+      expect(described_class.default).to eq described_class.open_free_map
+      expect(described_class.default.values).to all(start_with("https://tiles.openfreemap.org/"))
+    end
+
+    it "keeps Mapbox for anyone who has a token" do
+      ENV["MAPBOX_ACCESS_TOKEN"] = "pk.test"
+
+      expect(described_class.default).to eq described_class.mapbox
+    end
+  end
+
+  describe "config.map_view" do
+    around do |example|
+      original = Avo.configuration.map_view
+      example.run
+    ensure
+      Avo.configuration.map_view = original
+    end
+
+    it "defaults to leaving the choice to the environment" do
+      expect(Avo.configuration.map_view).to eq(styles: nil)
+      expect(described_class.default).to eq described_class.open_free_map
+    end
+
+    it "forces a provider by name, token or no token" do
+      Avo.configuration.map_view = {styles: :mapbox}
+      expect(described_class.default).to eq described_class.mapbox
+
+      ENV["MAPBOX_ACCESS_TOKEN"] = "pk.test"
+      Avo.configuration.map_view = {styles: :open_free_map}
+      expect(described_class.default).to eq described_class.open_free_map
+    end
+
+    it "takes a custom pair, which keeps the dark-mode swap working" do
+      pair = {light: "https://example.com/light.json", dark: "https://example.com/dark.json"}
+      Avo.configuration.map_view = {styles: pair}
+
+      expect(described_class.default).to eq pair
+      expect(described_class.wrapper_data[:map_dark_mode_styles_value]).to eq pair
+    end
+  end
+
+  describe ".wrapper_data" do
+    it "hands the dark-mode controller both styles when Avo picked the style" do
+      expect(described_class.wrapper_data).to eq(
+        controller: "map-dark-mode",
+        map_dark_mode_styles_value: described_class.open_free_map
+      )
+    end
+
+    it "withholds them when the resource picked its own style, so the map is left alone" do
+      data = described_class.wrapper_data(custom_style: "mapbox://styles/mapbox/satellite-v9")
+
+      expect(data).to eq(controller: "map-dark-mode")
+    end
+  end
+
+  describe "the map surfaces" do
+    let(:custom) { "https://tiles.openfreemap.org/styles/liberty" }
+
+    def map_view_style(**mapkick_options)
+      resource = Avo::Resources::City.new
+      resource.map_view = resource.map_view.merge(mapkick_options: mapkick_options)
+
+      Avo::ViewTypes::MapComponent.new(resource: resource, resources: []).resource_mapkick_options[:style]
+    end
+
+    def location_style(**args)
+      Avo::Fields::LocationField.new(:coordinates, **args).default_mapkick_options(false)[:style]
+    end
+
+    def area_style(**args)
+      Avo::Fields::AreaField.new(:city_center_area, **args).mapkick_options[:style]
+    end
+
+    it "defaults every interactive map to a keyless style" do
+      expect(map_view_style).to eq described_class.open_free_map[:light]
+      expect(location_style).to eq described_class.open_free_map[:light]
+      expect(area_style).to eq described_class.open_free_map[:light]
+    end
+
+    it "lets a resource override the style" do
+      expect(map_view_style(style: custom)).to eq custom
+      expect(location_style(mapkick_options: {style: custom})).to eq custom
+      expect(area_style(mapkick_options: {style: custom})).to eq custom
+    end
+
+    describe "as rendered on the page", type: :feature do
+      let!(:city) { create :city }
+
+      def wrapper_for(field)
+        find_field_element(field).find("[data-controller='map-dark-mode']")
+      end
+
+      it "hands the pair to a map Avo styled and withholds it from one it didn't" do
+        visit "/admin/resources/cities/#{city.id}"
+
+        location = wrapper_for("coordinates")["data-map-dark-mode-styles-value"]
+        expect(JSON.parse(location, symbolize_names: true)).to eq described_class.open_free_map
+
+        # The City resource gives `:area` its own style, so there is nothing to swap.
+        expect(wrapper_for("city_center_area")["data-map-dark-mode-styles-value"]).to be_nil
+      end
+    end
+
+    it "does not leak the resolved style back into the resource's own config" do
+      resource = Avo::Resources::City.new
+      Avo::ViewTypes::MapComponent.new(resource: resource, resources: []).resource_mapkick_options
+
+      expect(resource.map_view[:mapkick_options]).not_to have_key(:style)
+    end
+  end
+end

--- a/spec/system/avo/group_1/map_styles_spec.rb
+++ b/spec/system/avo/group_1/map_styles_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Avo's maps have to render for someone who has never heard of Mapbox, and they
+# have to keep their markers when the color scheme flips.
+RSpec.describe "Map styles", type: :system do
+  let!(:city) { create :city, latitude: 48.8584, longitude: 2.2945, name: "Paris" }
+
+  # Local stand-ins for the OpenFreeMap pair, so the suite doesn't reach the
+  # public internet to prove a swap works. Each is a bare background layer, and
+  # its color is how we tell which one the map has loaded — the real pair is
+  # indistinguishable by name and sprite, which is why the controller tracks
+  # what it applied instead of sniffing the map.
+  let(:backgrounds) { {light: "rgb(242,243,240)", dark: "rgb(12,12,12)"} }
+
+  before do
+    allow(Avo::MapStyles).to receive(:default).and_return(
+      light: "/map_styles/light.json",
+      dark: "/map_styles/dark.json"
+    )
+  end
+
+  def map_state
+    page.evaluate_script(<<~JS)
+      (() => {
+        const map = Object.values(window.Mapkick?.maps || {})[0]?.map
+        // `getStyle()` throws mid-load, which is most of what we're waiting on.
+        if (!map?.isStyleLoaded()) return null
+
+        return {
+          background: map.getPaintProperty("background", "background-color"),
+          // Mapkick's markers live in a GeoJSON source named "objects". A style
+          // swap wipes every source, so these layers are what the dark-mode
+          // controller has to put back.
+          markerLayers: map.getStyle().layers.filter((l) => l.source === "objects").length,
+        }
+      })()
+    JS
+  end
+
+  # A timeout here is a real failure, so leave enough behind to tell which half
+  # broke: the swap, or the restore that puts the markers back.
+  def debug_dump
+    page.evaluate_script(<<~JS)
+      (() => {
+        const map = Object.values(window.Mapkick?.maps || {})[0]?.map
+        const loaded = !!map?.isStyleLoaded()
+        return JSON.stringify({
+          htmlClass: document.documentElement.className,
+          styleLoaded: loaded,
+          background: loaded ? map.getPaintProperty("background", "background-color") : null,
+          layers: loaded ? map.getStyle().layers.map((l) => l.id) : null,
+        })
+      })()
+    JS
+  end
+
+  def wait_for_map(theme)
+    Timeout.timeout(20) do
+      loop do
+        state = map_state
+        break state if state && state["background"] == backgrounds[theme] && state["markerLayers"].positive?
+
+        sleep 0.2
+      end
+    end
+  rescue Timeout::Error
+    raise "timed out waiting for #{theme}: #{debug_dump}"
+  end
+
+  def set_theme(theme)
+    page.execute_script("document.documentElement.classList.#{(theme == :dark) ? "add" : "remove"}('dark')")
+  end
+
+  it "renders without a Mapbox token and keeps its markers across theme swaps" do
+    visit "/admin/resources/cities?view_type=map"
+    expect(page).to have_css("canvas.mapboxgl-canvas")
+
+    set_theme(:light)
+    expect(wait_for_map(:light)["markerLayers"]).to be_positive
+
+    set_theme(:dark)
+    expect(wait_for_map(:dark)["markerLayers"]).to be_positive
+
+    set_theme(:light)
+    expect(wait_for_map(:light)["markerLayers"]).to be_positive
+
+    expect(
+      page.evaluate_script("performance.getEntriesByType('resource').filter((r) => r.name.includes('mapbox.com')).length")
+    ).to eq 0
+  end
+end


### PR DESCRIPTION
# Description

You cannot see an Avo map at all without signing up to Mapbox. Every surface defaults to a `mapbox://` style URL, and those need an access token:

| Surface | Default style before | Set in |
| --- | --- | --- |
| Map view (index) | `mapbox://styles/mapbox/light-v11` | `map_component.rb` |
| `:location` field | `mapbox://styles/mapbox/streets-v12` | Mapkick JS's own fallback |
| `:area` field | `mapbox://styles/mapbox/streets-v12` | Mapkick JS's own fallback |
| Dark mode swap | `mapbox://styles/mapbox/dark-v11` | `map_dark_mode_controller.js` |

A fresh install renders a blank rectangle, and the docs have to tell people to go get a key.

## Why OpenFreeMap and not MapLibre

#2666 asks for MapLibre. Two layers, and only one of them is the blocker:

| Layer | Before | Requires signup? |
| --- | --- | --- |
| **Renderer** | `mapbox-gl@1.13.3` (BSD-3, bundled) | No — v1 only wants a token for `mapbox://` URLs |
| **Tiles + style** | `mapbox://styles/mapbox/*` | **Yes** — this is the blocker |

Swapping the renderer without changing the style would have fixed nothing. Changing the style fixes it without touching the renderer, so **Mapbox stays fully supported**.

Swapping to `maplibre-gl` is worth doing separately — mapbox-gl 1.x has been frozen since 2021 and Mapkick already supports MapLibre — but it is breaking (MapLibre does not resolve `mapbox://` at all, so every customer on a Mapbox style loses their map) and needs `map_dark_mode_controller.js` reworked around a private API that moved. Left out on purpose.

## What this does

`Avo::MapStyles` resolves one light/dark pair for every map: Mapbox when `MAPBOX_ACCESS_TOKEN` is set, [OpenFreeMap](https://openfreemap.org) otherwise — no registration, no API key, no request cap, commercial use allowed. Attribution arrives in the TileJSON, so the map's own attribution control credits OpenFreeMap/OpenMapTiles/OpenStreetMap with nothing extra to wire up.

**Existing installs with a token see no change at all.**

`config.map_view` pins it either way, for what the env var can't express — a token kept only for static maps, or your own tiles:

```ruby
config.map_view = {styles: :open_free_map}   # or :mapbox
config.map_view = {styles: {light: "https://…/light.json", dark: "https://…/dark.json"}}
```

A custom pair keeps the dark-mode swap working, which a per-map `mapkick_options: {style:}` cannot — that's a single style with no dark counterpart, so Avo leaves that map alone.

All three surfaces now resolve through it. Previously only the map view had a default; the fields fell through to Mapkick's own `mapbox://` fallback, so those were blank out of the box too.

## Three dark-mode bugs fixed along the way

All pre-existing. The last two were only reachable once theme swapping started working for people without a token.

1. **A custom style was rethemed on toggle.** The controller replaced any style with Avo's dark one, so a resource on satellite lost it the first time the scheme changed. It now receives the pair as a Stimulus value and gets *no* value when the resource set its own `style:`.
2. **Markers vanished on the first toggle.** `setStyle(url)` defaults to `diff: true`; the diff path drops Mapkick's GeoJSON source and layers *and never fires `style.load`*, so the restore handler never ran. Now `{diff: false}`.
3. **A toggle during a style load was dropped permanently.** The guard returned early while `isStyleLoaded()` was false and nothing re-triggered it, leaving the map on the style nobody asked for. Now it waits for `idle` and retries.

Sources to restore are captured by `type === "geojson"` (Mapkick's own) rather than by excluding Mapbox source names, which no longer identify anything.

## Still Mapbox-only

`:location` with `static: true` and the <Preview /> view go through `mapkick-static`, which hardcodes `api.mapbox.com/styles/v1`. There is no OpenFreeMap static-image API to point it at, so those still need `MAPBOX_ACCESS_TOKEN`. Documented in place rather than left to surprise someone.

Fixes #2666

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I tested the design in Light and Dark mode, and all default themes

Docs PR: avo-hq/docs.avohq.io#667

## Screenshots & recording

Cities map view with no `MAPBOX_ACCESS_TOKEN` set — 40 requests to OpenFreeMap, **0 to mapbox.com**, attribution reading "OpenFreeMap © OpenMapTiles Data from OpenStreetMap", markers intact in both schemes.

## Manual review steps

1. Make sure `MAPBOX_ACCESS_TOKEN` is **unset**.
1. Visit `/admin/resources/cities?view_type=map` — the map renders. Before this PR it was blank.
1. Toggle the color scheme. The map follows, and the Paris marker survives every swap.
1. Open a city's <Show /> view. The `:location` field map renders and follows the scheme; the `:area` field sets its own OpenFreeMap style and so stays put in dark mode.
1. Set `MAPBOX_ACCESS_TOKEN` to a valid `pk.` key and reload — everything is back on Mapbox styles, exactly as before.
1. `bundle exec rspec spec/lib/avo/map_styles_spec.rb spec/system/avo/group_1/map_styles_spec.rb`

The system spec swaps styles in a real browser against two local fixtures under `spec/dummy/public/map_styles/` rather than reaching the public internet, matching what the existing map spec already avoids. It was verified to fail without either JS fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared map rendering and theme-toggle JavaScript used on index, show, and field maps; behavior changes for installs without a Mapbox token, while tokened installs should stay on Mapbox unless configured otherwise.
> 
> **Overview**
> Maps on the **map index view**, **`:location`**, and **`:area`** no longer depend on Mapbox by default. A new **`Avo::MapStyles`** layer picks a light/dark tile pair from **`config.map_view[:styles]`**, **`MAPBOX_ACCESS_TOKEN`**, or **OpenFreeMap** when no token is set. Map view, location, and area surfaces share **`map_wrapper_data`** so the dark-mode Stimulus controller only rethemes maps Avo styled.
> 
> **`map-dark-mode`** now takes an optional styles Stimulus value, skips swapping when a resource sets its own **`mapkick_options: { style: }`**, uses **`setStyle(..., { diff: false })`**, waits out in-flight style loads, and restores **GeoJSON** Mapkick layers after a swap.
> 
> Docs, generator comments, and skills now describe OpenFreeMap as the keyless default; specs cover resolution, wrapper data, and browser theme toggles with local style fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e5890f58967455325593b4de235a41075618cc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->