### PR TITLE
Hover flyout for sidebar items whose sub-items aren't listed inline

### DIFF
--- a/app/assets/stylesheets/css/sidebar.css
+++ b/app/assets/stylesheets/css/sidebar.css
@@ -518,3 +518,65 @@
 .sidebar-status:hover .sidebar-status__hint {
   @apply block;
 }
+
+/* ================================================ */
+/* Sidebar Flyout — ItemSwitcherComponent           */
+/* BEM: .sidebar-flyout (block)                     */
+/* ================================================ */
+
+/* A parent item's sub-items, shown on hover for as long as they aren't already
+   listed inline (that is, whenever the parent's own page and its children are
+   all closed). The panel is a native popover: the sidebar body scrolls, so an
+   absolutely positioned panel would be clipped by it — the top layer is the
+   only place this can be drawn. Position comes from CSS anchor positioning,
+   with the per-item `anchor-name` written inline by the component. */
+.sidebar-flyout {
+  @apply w-full;
+}
+
+.sidebar-flyout__panel {
+  @apply m-0 p-1 rounded-lg min-w-48;
+  background-color: var(--sidebar-background);
+  border: 1px solid var(--sidebar-border);
+  box-shadow: var(--box-shadow-card);
+  position-area: inline-end span-block-end;
+  position-try-fallbacks: flip-inline, flip-block, flip-block flip-inline;
+  margin-inline-start: 0.25rem;
+
+  /* Mirrors .popover-menu__panel: the panel is display:none while closed, so
+     `allow-discrete` keeps it in the top layer through the leave transition. */
+  opacity: 0;
+  transition:
+    opacity 75ms ease-out,
+    overlay 75ms ease-out allow-discrete,
+    display 75ms ease-out allow-discrete;
+}
+
+.sidebar-flyout__panel:popover-open {
+  opacity: 1;
+}
+
+@starting-style {
+  .sidebar-flyout__panel:popover-open {
+    opacity: 0;
+  }
+}
+
+/* No parent above the list here, so the indent that lines sub-items up under
+   their parent has nothing to line up with — and neither do the connector bars
+   that run back up to it, hover preview included. */
+.sidebar-flyout__panel .sidebar-subitem__items {
+  @apply ps-0;
+}
+
+/* `!important` because the connectors are drawn by a family of hover rules
+   (`:hover`, `:has(~ .sidebar-subitem:hover)`) whose specificity a container
+   class can't out-weigh without restating every one of them here. */
+.sidebar-flyout__panel .sidebar-subitem::before,
+.sidebar-flyout__panel .sidebar-subitem::after {
+  content: none !important;
+}
+
+.sidebar-flyout__panel::backdrop {
+  @apply bg-transparent;
+}

--- a/app/javascript/js/controllers.js
+++ b/app/javascript/js/controllers.js
@@ -20,6 +20,7 @@ import DateTimeFilterController from './controllers/date_time_filter_controller'
 import DistributionChartController from './controllers/distribution_chart_controller'
 import DropdownController from './controllers/dropdown_menu_controller'
 import PopoverMenuController from './controllers/popover_menu_controller'
+import SidebarFlyoutController from './controllers/sidebar_flyout_controller'
 import EasyMdeController from './controllers/fields/easy_mde_controller'
 import FilterController from './controllers/filter_controller'
 import FormController from './controllers/form_controller'
@@ -131,6 +132,7 @@ application.register('tippy', TippyController)
 application.register('toggle', ToggleController)
 application.register('dropdown-menu', DropdownController)
 application.register('popover-menu', PopoverMenuController)
+application.register('sidebar-flyout', SidebarFlyoutController)
 application.register('trix-body', TrixBodyController)
 
 // Field controllers

--- a/app/javascript/js/controllers/sidebar_flyout_controller.js
+++ b/app/javascript/js/controllers/sidebar_flyout_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Hover flyout for a sidebar item whose sub-items aren't already listed inline.
+// The panel is a native popover, so it renders in the top layer and escapes the
+// sidebar's own `overflow-y: auto` clipping; CSS anchor positioning pins it to
+// the item. Also opens on focus, so the list is reachable by keyboard.
+export default class extends Controller {
+  static targets = ['panel']
+
+  static values = { delay: { type: Number, default: 120 } }
+
+  show() {
+    clearTimeout(this.timeout)
+    if (!this.panelTarget.matches(':popover-open')) this.panelTarget.showPopover()
+  }
+
+  // The panel sits a few pixels off the item, so the pointer is over neither for
+  // a frame on the way across. The delay is what lets it make the crossing.
+  hide() {
+    clearTimeout(this.timeout)
+    this.timeout = setTimeout(() => {
+      if (this.panelTarget.matches(':popover-open')) this.panelTarget.hidePopover()
+    }, this.delayValue)
+  }
+
+  disconnect() {
+    clearTimeout(this.timeout)
+  }
+}


### PR DESCRIPTION
The core half of a sidebar hover flyout: a stylesheet block and the Stimulus controller it reaches for. Nothing in core renders it yet — `avo-menu`'s `ItemSwitcherComponent` is the consumer, and that change ships separately.

## Why

A sidebar parent with sub-items lists them inline only while that branch is open. Everywhere else they are unreachable without navigating to the parent first. Hovering the parent now shows the same list in a panel beside it.

## The panel is a native popover, and it has to be

The sidebar body is its own scroll container, so an absolutely positioned panel is clipped by it — the top layer is the only place this can be drawn without a portal. `popover` gets it there, and CSS anchor positioning pins it to the item through a per-item `anchor-name` the consuming component writes inline, with `position-try-fallbacks` for a sidebar pinned to either edge.

`transition-behavior: allow-discrete` mirrors `.popover-menu__panel`: the panel is `display: none` while closed, so without it the leave transition never plays.

## Details worth knowing

- **Opens on focus as well as hover**, so the list is reachable by keyboard.
- **The close is delayed ~120ms.** The panel sits a few pixels off the item, so the pointer is over neither element for a frame on the way across; without the delay the panel closes under the cursor.
- `showPopover()` / `hidePopover()` are guarded by `:popover-open`, so a repeated enter or a leave that races the timeout can't throw.

## Files

| File | What |
| --- | --- |
| `app/assets/stylesheets/css/sidebar.css` | The `.sidebar-flyout` block |
| `app/javascript/js/controllers/sidebar_flyout_controller.js` | Show/hide, with the crossing delay |
| `app/javascript/js/controllers.js` | Registers it |
| `app/assets/stylesheets/css/variables.css`, `.../components/ui/card.css` | Tokens the panel reads |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CSS and a small Stimulus controller with no current call sites in this diff; behavior only activates once the menu component lands.
> 
> **Overview**
> Adds the **core building blocks** for a sidebar hover flyout when a parent’s children aren’t shown inline (branch collapsed). Nothing in core wires this up yet; **`avo-menu`’s `ItemSwitcherComponent`** is expected to consume it in a follow-up.
> 
> **Styles (`sidebar.css`):** New `.sidebar-flyout` / `.sidebar-flyout__panel` use a **native `popover`** in the top layer so the panel isn’t clipped by the sidebar’s `overflow-y: auto`. **CSS anchor positioning** (`position-area`, `position-try-fallbacks`) pins the panel beside the item; enter/leave opacity transitions mirror `.popover-menu__panel` with `allow-discrete` on `display`/`overlay`. Flyout-specific overrides strip sub-item indent and connector pseudo-elements inside the panel.
> 
> **JS:** New **`sidebar-flyout`** Stimulus controller opens the panel on hover/focus via `showPopover()` / `hidePopover()` (guarded with `:popover-open`), with a **~120ms close delay** so the cursor can cross the gap between item and panel without flicker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5fe594555859c23c5b84ae0f55cd3778ca858f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->