### PR TITLE
Merge the skills sync PR automatically when only docs-index.json changed

### DIFF
--- a/.github/workflows/merge-skills-index.yml
+++ b/.github/workflows/merge-skills-index.yml
@@ -1,0 +1,36 @@
+name: Merge skills index
+
+# The docs-sync routine opens a PR whenever it re-indexes the shipped skills.
+# When the docs moved but no skill needed rewording, that PR is a one-line
+# bookkeeping bump to `docs-index.json` and nothing else — no reviewer has an
+# opinion on it, so merge it and stop paging humans. A PR that also touches a
+# SKILL.md is left alone: that one really did change what an agent reads.
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - lib/avo/skills/docs-index.json
+
+jobs:
+  merge:
+    # Same-repo branches only — never auto-merge something a fork pushed.
+    if: github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Merge when the index bump is the only change
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          files=$(gh pr view "$PR" --repo "$GITHUB_REPOSITORY" --json files --jq '[.files[].path] | join(",")')
+          if [ "$files" != "lib/avo/skills/docs-index.json" ]; then
+            echo "Touches more than the index ($files) — leaving it for review."
+            exit 0
+          fi
+          gh pr merge "$PR" --repo "$GITHUB_REPOSITORY" --squash --delete-branch


### PR DESCRIPTION
The docs-sync routine opens a PR every time it re-indexes the shipped skills against docs.avohq.io. When the docs moved but no `SKILL.md` needed rewording, that PR is a one-line bump to `lib/avo/skills/docs-index.json` and nothing else — #4743 is the latest example. Nobody has an opinion on it, so it should merge itself rather than page a human.

This adds `.github/workflows/merge-skills-index.yml`. It re-reads the PR's file list and squash-merges only when the diff is **exactly** `lib/avo/skills/docs-index.json`. A PR that also touches a `SKILL.md` falls through untouched — that one really did change what an agent reads.

Two details worth knowing:

- **Keyed on the diff, not the branch name.** The routine has already used three prefixes (`claude/*`, `chore/sync-skills-docs-*`, `docs-sync/*`), so matching on the branch would rot.
- **Plain squash, not `--auto`.** `main` has no required checks or reviews, so auto-merge can't be enabled on these PRs (`gh` errors with "clean status"). The workflow does what clicking the button does.

Fork branches and drafts are excluded.

Side effect, and a welcome one: merges made by `GITHUB_TOKEN` don't fire downstream workflows, so `merge-message.yml` won't leave its comment on these.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cb8823fc7d6a8e0df8e10b992260cdef9cbd0ed5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->