### PR TITLE
feat: render maps with OpenFreeMap so they work without a Mapbox account

### DIFF
--- a/app/components/avo/index/resource_map_component.rb
+++ b/app/components/avo/index/resource_map_component.rb
@@ -80,7 +80,7 @@ module Avo
       end
 
       def resource_mapkick_options
-        map_options[:mapkick_options] || {}
+        {style: Avo::MapStyles.light}.merge(map_options[:mapkick_options] || {})
       end
 
       def render_table?

--- a/lib/avo/configuration.rb
+++ b/lib/avo/configuration.rb
@@ -11,6 +11,7 @@ module Avo
     attr_writer :exclude_from_status
     attr_writer :persistence
     attr_writer :resource_row_controls_config
+    attr_writer :map_view
     attr_accessor :timezone
     attr_accessor :per_page
     attr_accessor :per_page_steps
@@ -128,6 +129,7 @@ module Avo
       @column_names_mapping = {}
       @column_types_mapping = {}
       @resource_row_controls_config = {}
+      @map_view = {}
       @model_generator_hook = true
     end
 
@@ -141,6 +143,22 @@ module Avo
 
     def resource_row_controls_config
       RESOURCE_ROW_CONTROLS_CONFIG_DEFAULTS.merge @resource_row_controls_config
+    end
+
+    # Map view, and the `location`/`area` fields that render the same maps.
+    #
+    # `styles` is the light/dark pair Avo renders them with. `nil` resolves to
+    # Mapbox when MAPBOX_ACCESS_TOKEN is set and to OpenFreeMap otherwise — pin
+    # one with `:mapbox` / `:open_free_map`, or pass your own `{light:, dark:}`.
+    # See Avo::MapStyles.
+    unless defined?(MAP_VIEW_DEFAULTS)
+      MAP_VIEW_DEFAULTS = {
+        styles: nil
+      }.freeze
+    end
+
+    def map_view
+      MAP_VIEW_DEFAULTS.merge @map_view
     end
 
     # Authorization is enabled when:

--- a/lib/avo/fields/area_field.rb
+++ b/lib/avo/fields/area_field.rb
@@ -3,7 +3,6 @@
 module Avo
   module Fields
     class AreaField < BaseField
-      attr_reader :mapkick_options
       attr_reader :datapoint_options
 
       def initialize(id, **args, &block)
@@ -14,6 +13,10 @@ module Avo
         @geometry = args[:geometry].presence || :polygon # Accepts: `:polygon` or `:multi_polygon`
         @mapkick_options = args[:mapkick_options].presence || {}
         @datapoint_options = args[:datapoint_options].presence || {}
+      end
+
+      def mapkick_options
+        {style: Avo::MapStyles.light}.merge(@mapkick_options)
       end
 
       def map_data

--- a/lib/avo/fields/location_field.rb
+++ b/lib/avo/fields/location_field.rb
@@ -31,7 +31,8 @@ module Avo
           {
             id: "location-map",
             zoom: @args[:zoom]&.to_i || 15,
-            controls: true
+            controls: true,
+            style: Avo::MapStyles.light
           }
         end
 

--- a/lib/avo/map_styles.rb
+++ b/lib/avo/map_styles.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Avo
+  # The light/dark style pair every Avo map defaults to.
+  #
+  # Mapbox stays the default for anyone who has a token. Without one its
+  # `mapbox://` URLs render a blank map, which is why a fresh Avo install used to
+  # need a Mapbox signup before it could show a map at all — so fall back to
+  # OpenFreeMap: no key, no registration, no request cap, commercial use allowed.
+  # Attribution rides along in the TileJSON, so the map's own attribution control
+  # credits OpenFreeMap/OpenMapTiles/OpenStreetMap with nothing extra to wire up.
+  # https://openfreemap.org
+  #
+  # Force one either way with `config.map_view = {styles: :mapbox}` (or
+  # `:open_free_map`), or give it your own `{light:, dark:}` pair.
+  #
+  # Override a single map with `mapkick_options: {style: "..."}`.
+  module MapStyles
+    # Methods rather than constants, mirroring Avo 4: there `lib` is walked by two
+    # autoloaders and a constant here would be assigned twice on every boot.
+    class << self
+      def mapbox
+        {
+          light: "mapbox://styles/mapbox/light-v11",
+          dark: "mapbox://styles/mapbox/dark-v11"
+        }.freeze
+      end
+
+      def open_free_map
+        {
+          light: "https://tiles.openfreemap.org/styles/positron",
+          dark: "https://tiles.openfreemap.org/styles/dark"
+        }.freeze
+      end
+
+      def default
+        resolve(Avo.configuration.map_view[:styles]) || (mapbox_token? ? mapbox : open_free_map)
+      end
+
+      # Avo 3 renders maps in one theme; `dark` is here so a `{light:, dark:}`
+      # pair configured on 3 keeps working on 4, which swaps between them.
+      def light = default[:light]
+
+      private
+
+      def resolve(setting)
+        case setting
+        when :mapbox then mapbox
+        when :open_free_map then open_free_map
+        when Hash then setting
+        end
+      end
+
+      def mapbox_token? = ENV["MAPBOX_ACCESS_TOKEN"].present?
+    end
+  end
+end

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -50,6 +50,12 @@ Avo.configure do |config|
   # }.freeze
   # config.model_resource_mapping = {}
   # config.default_view_type = :table
+  # Map tiles for the map view and the `location`/`area` fields. Defaults to
+  # OpenFreeMap (no account needed), or Mapbox when MAPBOX_ACCESS_TOKEN is set.
+  # `styles` accepts :open_free_map, :mapbox, or your own {light:, dark:} pair.
+  # config.map_view = {
+  #   styles: :open_free_map
+  # }
   # config.per_page = 24
   # config.per_page_steps = [12, 24, 48, 72]
   # config.via_per_page = 8

--- a/spec/dummy/app/avo/resources/city.rb
+++ b/spec/dummy/app/avo/resources/city.rb
@@ -42,14 +42,14 @@ class Avo::Resources::City < Avo::BaseResource
       show_on: :preview,
       stored_as: [:latitude, :longitude],
       mapkick_options: {
-        style: "mapbox://styles/mapbox/satellite-v9",
         markers: {color: "#FFC0CB"}
       }
     field :city_center_area,
       as: :area,
       geometry: :polygon,
       mapkick_options: {
-        style: "mapbox://styles/mapbox/satellite-v9",
+        # A style the resource picked itself, rather than Avo's default.
+        style: "https://tiles.openfreemap.org/styles/liberty",
         controls: true
       },
       datapoint_options: {

--- a/spec/lib/avo/map_styles_spec.rb
+++ b/spec/lib/avo/map_styles_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The point of the whole thing: a fresh install with no Mapbox account must not
+# be handed a `mapbox://` URL, because those render a blank map without a token.
+RSpec.describe Avo::MapStyles do
+  around do |example|
+    original = ENV["MAPBOX_ACCESS_TOKEN"]
+    ENV["MAPBOX_ACCESS_TOKEN"] = nil
+    example.run
+  ensure
+    ENV["MAPBOX_ACCESS_TOKEN"] = original
+  end
+
+  describe ".default" do
+    it "falls back to OpenFreeMap when there is no Mapbox token" do
+      expect(described_class.default).to eq described_class.open_free_map
+      expect(described_class.default.values).to all(start_with("https://tiles.openfreemap.org/"))
+    end
+
+    it "keeps Mapbox for anyone who has a token" do
+      ENV["MAPBOX_ACCESS_TOKEN"] = "pk.test"
+
+      expect(described_class.default).to eq described_class.mapbox
+    end
+  end
+
+  describe "config.map_view" do
+    around do |example|
+      original = Avo.configuration.map_view
+      example.run
+    ensure
+      Avo.configuration.map_view = original
+    end
+
+    it "defaults to leaving the choice to the environment" do
+      expect(Avo.configuration.map_view).to eq(styles: nil)
+      expect(described_class.default).to eq described_class.open_free_map
+    end
+
+    it "forces a provider by name, token or no token" do
+      Avo.configuration.map_view = {styles: :mapbox}
+      expect(described_class.default).to eq described_class.mapbox
+
+      ENV["MAPBOX_ACCESS_TOKEN"] = "pk.test"
+      Avo.configuration.map_view = {styles: :open_free_map}
+      expect(described_class.default).to eq described_class.open_free_map
+    end
+
+    it "takes a custom pair" do
+      pair = {light: "https://example.com/light.json", dark: "https://example.com/dark.json"}
+      Avo.configuration.map_view = {styles: pair}
+
+      expect(described_class.default).to eq pair
+      expect(described_class.light).to eq pair[:light]
+    end
+  end
+
+  describe "the map surfaces" do
+    let(:custom) { "https://tiles.openfreemap.org/styles/liberty" }
+
+    def map_view_style(**mapkick_options)
+      resource = Avo::Resources::City.new
+      resource.map_view = resource.map_view.merge(mapkick_options: mapkick_options)
+
+      Avo::Index::ResourceMapComponent.new(resource: resource, resources: []).resource_mapkick_options[:style]
+    end
+
+    def location_style(**args)
+      Avo::Fields::LocationField.new(:coordinates, **args).default_mapkick_options(false)[:style]
+    end
+
+    def area_style(**args)
+      Avo::Fields::AreaField.new(:city_center_area, **args).mapkick_options[:style]
+    end
+
+    it "defaults every interactive map to a keyless style" do
+      expect(map_view_style).to eq described_class.open_free_map[:light]
+      expect(location_style).to eq described_class.open_free_map[:light]
+      expect(area_style).to eq described_class.open_free_map[:light]
+    end
+
+    it "lets a resource override the style" do
+      expect(map_view_style(style: custom)).to eq custom
+      expect(location_style(mapkick_options: {style: custom})).to eq custom
+      expect(area_style(mapkick_options: {style: custom})).to eq custom
+    end
+
+    it "does not leak the resolved style back into the resource's own config" do
+      resource = Avo::Resources::City.new
+      Avo::Index::ResourceMapComponent.new(resource: resource, resources: []).resource_mapkick_options
+
+      expect(resource.map_view[:mapkick_options]).not_to have_key(:style)
+    end
+  end
+end


### PR DESCRIPTION
Backport of #4746 to 3.x.

You could not see an Avo map at all without signing up to Mapbox. The map view fell through to Mapkick's `mapbox://styles/mapbox/streets-v12`, as did the `location` and `area` fields, and a `mapbox://` URL needs an access token. A fresh install rendered a blank rectangle.

The renderer was never the problem — mapbox-gl 1.13.3 is BSD-3 and only wants a token for `mapbox://` URLs. The default *style* is the blocker.

Avo::MapStyles resolves one light/dark pair for every map: Mapbox when MAPBOX_ACCESS_TOKEN is set, OpenFreeMap otherwise (no account, no API key, no request cap, commercial use allowed). Attribution arrives in the TileJSON, so the map's own control credits OpenFreeMap/OpenMapTiles/ OpenStreetMap with nothing extra to wire up. Anyone who has a token today sees no change at all, and `config.map_view = {styles: ...}` pins a provider — or a pair of your own — when the env var can't say it.

Static maps stay Mapbox-only. `location` with `static: true` and the Preview view go through mapkick-static, which hardcodes api.mapbox.com/styles/v1, and OpenFreeMap has no static-image API.

Left out of the backport, since none of it exists on 3.x: the `map-dark-mode` Stimulus controller and its three bug fixes, the wrapper data attributes that feed it, its system spec, and the shipped skills. Avo 3 renders maps in a single theme. `styles` still takes the same `{light:, dark:}` pair as 4.x so a config written here keeps working after an upgrade.

Closes #2666

# Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!--
  By submitting the Contribution, you acknowledge that you have read the Contributor License Agreement at https://avohq.io/cla and agree to be bound by its terms.
-->

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I tested the design in Light and Dark mode, and all default themes

## Screenshots & recording
<!-- "A picture is worth a thousand words." A video, ten thousand. -->
<!-- Can the behavior touched in this PR be displayed as a screenshot or a recording. Please attach it. It makes the review easier to pass. -->

## Manual review steps
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Step 1
1. Step 2

Manual reviewer: please leave a comment with output from the test if that's the case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI tile-style defaults only; existing Mapbox users keep current behavior when the token is set, and static maps are untouched.
> 
> **Overview**
> Interactive maps (map view, `location`, `area`) now get a default tile style so they render without a Mapbox account. `Avo::MapStyles` picks Mapbox when `MAPBOX_ACCESS_TOKEN` is set, otherwise OpenFreeMap.
> 
> `config.map_view = {styles: ...}` can pin `:mapbox`, `:open_free_map`, or a custom `{light:, dark:}` pair. Per-map `mapkick_options[:style]` still wins. Static maps are unchanged (Mapbox-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21356fb7f444af768a7a71a0f60c05d97661c064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->