### PR TITLE
fix: scope `use_browser_timezone` to rendering only

### DIFF
--- a/app/controllers/avo/base_application_controller.rb
+++ b/app/controllers/avo/base_application_controller.rb
@@ -18,7 +18,6 @@ module Avo
     before_action :decode_params
     around_action :set_avo_locale
     around_action :set_force_locale, if: -> { params[:force_locale].present? }
-    around_action :set_browser_timezone, if: -> { Avo.configuration.use_browser_timezone }
     before_action :init_app
     before_action :set_active_storage_current_host
     before_action :set_resource_name
@@ -28,6 +27,7 @@ module Avo
     before_action :set_view
     before_action :set_sidebar_open
     before_action :set_sidebar_width
+    before_action :announce_browser_timezone_change, if: -> { Avo.configuration.use_browser_timezone }
 
     rescue_from Avo::NotAuthorizedError, with: :render_unauthorized
     rescue_from ActiveRecord::RecordInvalid, with: :exception_logger
@@ -52,6 +52,24 @@ module Avo
     # Exposing it as public method
     def turbo_frame_request?
       super
+    end
+
+    # `use_browser_timezone` is a *display* setting, so the viewer's zone is
+    # scoped to template rendering and nothing else. Swapping `Time.zone` for
+    # the whole action (an `around_action`) would also reinterpret app code
+    # running inside the request: `Time.zone.local` in an action's `handle`,
+    # `Date.current` in a scope or a filter, ActiveRecord's time-zone-aware
+    # attribute casting on write, model callbacks. Those all keep meaning "the
+    # app's configured zone", the same as everywhere else in Rails.
+    #
+    # `render_to_body` is the common inner path for both `render` (explicit and
+    # implicit, HTML and Turbo Stream) and `render_to_string`, so wrapping it
+    # covers every template and view component without touching anything else.
+    # Kept public to match the visibility it has on the superclass.
+    def render_to_body(options = {})
+      return super if browser_timezone.nil?
+
+      Time.use_zone(browser_timezone) { super }
     end
 
     private
@@ -281,22 +299,27 @@ module Avo
     end
 
     # The browser-timezone Stimulus controller mirrors the viewer's IANA zone
-    # into a cookie (no HTTP header carries it), so every response renders in
-    # the viewer's local zone. `ActiveSupport::TimeZone[]` validates the
-    # user-controlled cookie — junk lookups return nil and we fall back to the
-    # app zone. The one-shot `timezone_changed` cookie is set right before the
-    # controller's Turbo reload, so the reloaded page announces the change once.
-    def set_browser_timezone(&action)
-      zone = ActiveSupport::TimeZone[cookies["#{Avo::COOKIES_KEY}.browser_timezone"].to_s]
-      return yield if zone.nil?
+    # into a cookie (no HTTP header carries it) so responses can be *rendered*
+    # in the viewer's local zone. `ActiveSupport::TimeZone[]` validates the
+    # user-controlled cookie: junk lookups return nil and we fall back to the
+    # app zone.
+    def browser_timezone
+      return @browser_timezone if defined?(@browser_timezone)
 
-      if cookies.delete("#{Avo::COOKIES_KEY}.timezone_changed").present?
-        flash.now[:notice] = t("avo.timezone_changed",
-          timezone: zone.tzinfo.name,
-          default: "Dates and times are now displayed in your time zone (%{timezone}).")
+      @browser_timezone = if Avo.configuration.use_browser_timezone
+        ActiveSupport::TimeZone[cookies["#{Avo::COOKIES_KEY}.browser_timezone"].to_s]
       end
+    end
 
-      Time.use_zone(zone, &action)
+    # The one-shot `timezone_changed` cookie is set right before the Stimulus
+    # controller's Turbo reload, so the reloaded page announces the change once.
+    def announce_browser_timezone_change
+      return if browser_timezone.nil?
+      return if cookies.delete("#{Avo::COOKIES_KEY}.timezone_changed").blank?
+
+      flash.now[:notice] = t("avo.timezone_changed",
+        timezone: browser_timezone.tzinfo.name,
+        default: "Dates and times are now displayed in your time zone (%{timezone}).")
     end
 
     def set_sidebar_open

--- a/lib/avo/skills/avo-admin-config/SKILL.md
+++ b/lib/avo/skills/avo-admin-config/SKILL.md
@@ -56,7 +56,7 @@ Every option below is a `config.<name>` assignment inside `Avo.configure`. Most 
 config.app_name = "Avocadelicious"              # navbar label next to the logo
 config.app_name = -> { I18n.t "app_name" }      # block form for dynamic/i18n names
 config.timezone = "UTC"                          # for date/datetime fields
-config.use_browser_timezone = false              # render everyone in the app's configured zone instead; default true renders each visitor's own zone (cookie-detected, one soft reload + alert). Defaults to false in the test environment — the soft reload races browser specs
+config.use_browser_timezone = false              # render everyone in the app's configured zone instead; default true renders each visitor's own zone (cookie-detected, one soft reload + alert). Display only: your code (actions, scopes, filters, callbacks) keeps config.timezone. Defaults to false in the test environment, the soft reload races browser specs
 config.currency = "USD"                          # for currency fields
 config.locale   = "en-US"                        # force Avo's UI locale (default: I18n.default_locale)
 ```

--- a/lib/generators/avo/templates/initializer/avo.tt
+++ b/lib/generators/avo/templates/initializer/avo.tt
@@ -150,7 +150,7 @@ Avo.configure do |config|
   # config.density = :normal # :tight, :normal, :relaxed
   # config.app_name = 'Avocadelicious'
   # config.timezone = 'UTC'
-  # config.use_browser_timezone = true # set false to render dates/times in the app's configured zone for everyone; off automatically in the test environment
+  # config.use_browser_timezone = true # render dates/times in each visitor's zone; display only, your code keeps config.timezone. Set false to render the app's configured zone for everyone; off automatically in the test environment
   # config.currency = 'USD'
   # config.hide_layout_when_printing = false
   # config.container_width = :lg # :full, :lg, :md, or :sm. Hash for per-view: { index: :full, single: :md }

--- a/spec/requests/avo/browser_timezone_request_spec.rb
+++ b/spec/requests/avo/browser_timezone_request_spec.rb
@@ -2,9 +2,13 @@ require "rails_helper"
 
 # Server half of the browser-timezone feature: the browser-timezone Stimulus
 # controller mirrors the viewer's IANA zone into `avo.browser_timezone`, and
-# BaseApplicationController#set_browser_timezone wraps the request in it. The
+# BaseApplicationController#render_to_body renders the response in it. The
 # one-shot `avo.timezone_changed` cookie (set right before the controller's
 # Turbo reload) makes the reloaded page announce the change once via flash.
+#
+# The zone is scoped to rendering only. App code running in the action itself
+# keeps the app's configured zone, so `Time.zone.local` in an action's `handle`
+# still means what it means everywhere else in Rails.
 RSpec.describe "Browser timezone", type: :request do
   let(:admin_user) { create :user, roles: {admin: true} }
   let(:path) { "/admin/failed_to_load" }
@@ -44,6 +48,38 @@ RSpec.describe "Browser timezone", type: :request do
     expect(Array(response.headers["Set-Cookie"]).join).to include("avo.timezone_changed=;")
     get path
     expect(response.body).not_to include("Dates and times are now displayed")
+  end
+
+  # Regression: the zone used to be applied with an `around_action`, which wrapped
+  # the whole request. App code running in the action then silently reinterpreted
+  # `Time.zone`, so a `Time.zone.local` in an action's `handle` built a timestamp
+  # in the viewer's zone instead of the app's. See avo-hq/avo#4703.
+  it "leaves the action on the app's configured zone" do
+    cookies["avo.browser_timezone"] = "Europe/Bucharest"
+
+    zone_in_action = nil
+    allow_any_instance_of(Avo::BaseApplicationController).to receive(:set_view).and_wrap_original do |original, *args|
+      zone_in_action = Time.zone.name
+      original.call(*args)
+    end
+
+    get path
+
+    expect(response).to have_http_status(:ok)
+    expect(zone_in_action).to eq Time.zone.name
+    expect(zone_in_action).not_to eq "Bucharest"
+
+    # Rendering still gets the viewer's zone.
+    expect(Time).to have_received(:use_zone).with(ActiveSupport::TimeZone["Europe/Bucharest"])
+  end
+
+  it "restores the app zone after the response is rendered" do
+    cookies["avo.browser_timezone"] = "Europe/Bucharest"
+    app_zone = Time.zone.name
+
+    get path
+
+    expect(Time.zone.name).to eq app_zone
   end
 
   it "falls back to the app zone on a junk cookie without raising" do


### PR DESCRIPTION
# Description

Follow-up to #4703, from [@4ndv's report](https://github.com/avo-hq/avo/pull/4703#issuecomment-5414482140) that they lost a couple of hours to it.

`use_browser_timezone` applied the visitor's zone with an `around_action`, so `Time.zone` was swapped for the **entire request**. That is a much bigger blast radius than "render dates and times in the visitor's zone": everything running inside the action saw the swapped zone, including app code Avo knows nothing about.

- `Time.zone.local` in an action's `handle` (the reported case, off by 5 hours)
- `Date.current` / `Time.current` in a scope, filter, or query object
- ActiveRecord's time-zone-aware attribute casting on write
- model callbacks

Nothing raises. The value is just silently wrong by the offset between the app zone and whichever browser happened to make the request, which is why it reads as a data bug rather than a config change.

The option is documented as a display setting, so this applies it as one. The zone now wraps `render_to_body`, the common inner path for `render` (explicit and implicit, HTML and Turbo Stream) and `render_to_string`. Templates and view components still render in the visitor's zone; everything else in the request keeps `config.timezone`, so `Time.zone` means the same thing inside Avo as it does everywhere else in Rails.

The one-shot `timezone_changed` flash moves from the `around_action` to a `before_action`, registered after `_authenticate!` so the user-controlled cookie is not parsed for an unauthenticated request (matching the convention already used for `avo.sidebar.width`).

No config change: the option stays on by default. If you would rather it were opt-in as well, say so and I will add that.

Docs side: avo-hq/docs.avohq.io#672

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I tested the design in Light and Dark mode, and all default themes <!-- no visual change -->

## Screenshots & recording

No visual change.

## Manual review steps

1. In an app with `config.timezone` set to something other than your browser's zone, add an action whose `handle` does `Rails.logger.info Time.zone.name` (or builds a timestamp with `Time.zone.local`).
2. Run it from Avo. Before this change the zone logged is your browser's; after it is `config.timezone`.
3. Confirm display is unaffected: server-rendered dates and times still show in your browser's zone.

Automated:

```
bin/rspec spec/requests/avo/browser_timezone_request_spec.rb   # 8 examples, 0 failures
bin/rspec spec/requests                                        # 104 examples, 0 failures
```

The new `leaves the action on the app's configured zone` example fails against the previous implementation and passes against this one (verified by reverting the controller and re-running).