### PR TITLE
Sync shipped skills with docs through 70f1de9 (2026-08-20)

### DIFF
--- a/lib/avo/skills/avo-admin-config/SKILL.md
+++ b/lib/avo/skills/avo-admin-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: avo-admin-config
-description: Configure Avo's app-wide admin settings in config/initializers/avo.rb via Avo.configure — app name, timezone/currency, per-page and index behavior, layout width, home redirect, open-in-editor links, and the other global knobs that don't belong to a single feature. Use when the user wants to change how many records per page, rename the admin / change the app name, set the timezone or currency for the admin, default the index to grid view, make the admin full-width, keep clicking a row from opening the record, skip the show view / go straight to edit, open Avo files in Cursor or VS Code from the UI, keep the sidebar always open, redirect the admin home to a dashboard, add a class to the body tag, make rows denser, widen the sidebar or turn off sidebar resizing, remove or retune the floating "Back to top" button, persist filters/pagination across requests, or opt out of usage metadata.
+description: Configure Avo's app-wide admin settings in config/initializers/avo.rb via Avo.configure — app name, timezone/currency, per-page and index behavior, layout width, home redirect, open-in-editor links, and the other global knobs that don't belong to a single feature. Use when the user wants to change how many records per page, rename the admin / change the app name, set the timezone or currency for the admin, default the index to grid view, make the admin full-width, keep clicking a row from opening the record, skip the show view / go straight to edit, open Avo files in Cursor or VS Code from the UI, keep the sidebar always open, redirect the admin home to a dashboard, add a class to the body tag, make rows denser, widen the sidebar or turn off sidebar resizing, remove or retune the floating "Back to top" button, persist filters/pagination across requests, choose which map tiles the admin renders, or opt out of usage metadata.
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash, WebFetch
 metadata:
   requires-gem: none — Community
@@ -42,9 +42,9 @@ Authoritative docs — fetch on demand rather than guessing, and verify every op
 
 ## When this applies
 
-**Explicit (Avo named):** "set `config.app_name`", "change `per_page` in the Avo initializer", "set `default_view_type` to `:grid`", "use `container_width = :full`", "set `resource_default_view = :edit`", "configure `default_editor_url`", "enable `persistence`", "set `body_classes`".
+**Explicit (Avo named):** "set `config.app_name`", "change `per_page` in the Avo initializer", "set `default_view_type` to `:grid`", "use `container_width = :full`", "set `resource_default_view = :edit`", "configure `default_editor_url`", "enable `persistence`", "set `body_classes`", "set `config.map_view` styles".
 
-**Implicit (Rails-shaped, no mention of Avo):** "change how many records show per page in the admin", "rename the admin / change the app name in the top bar", "set the timezone/currency the admin displays", "default the admin list to grid/card view", "make the admin full-width", "clicking a row shouldn't open the record", "skip the show page and go straight to edit", "open the admin's source files in Cursor/VS Code from the UI", "keep the sidebar always open / hide the collapse button", "make the sidebar wider by default", "stop people resizing the sidebar", "send people to a dashboard when they open the admin", "add a CSS class to the `<body>` tag", "make the admin rows denser / tighter", "keep my filters and pagination when I navigate away", "stop the admin from phoning home usage stats".
+**Implicit (Rails-shaped, no mention of Avo):** "change how many records show per page in the admin", "rename the admin / change the app name in the top bar", "set the timezone/currency the admin displays", "default the admin list to grid/card view", "make the admin full-width", "clicking a row shouldn't open the record", "skip the show page and go straight to edit", "open the admin's source files in Cursor/VS Code from the UI", "keep the sidebar always open / hide the collapse button", "make the sidebar wider by default", "stop people resizing the sidebar", "send people to a dashboard when they open the admin", "add a CSS class to the `<body>` tag", "make the admin rows denser / tighter", "keep my filters and pagination when I navigate away", "use different map tiles / stop the admin's maps needing a Mapbox key", "stop the admin from phoning home usage stats".
 
 ## Common settings
 
@@ -70,6 +70,7 @@ config.per_page = 24                             # default page size (default 24
 config.per_page_steps = [12, 24, 48, 72]         # options in the per-page picker
 config.via_per_page = 8                          # page size inside has_many association tables
 config.default_view_type = :grid                 # :table (default), :grid, :map, or a custom view type
+config.map_view = { styles: :open_free_map }     # map tiles for the map view and the location/area fields
 config.first_sorting_option = :asc               # direction on first sort click (default :desc)
 config.density = :tight                          # row height: :tight, :normal (default), :relaxed
 config.field_wrapper_layout = :stacked           # label above value everywhere (default :inline)
@@ -81,6 +82,8 @@ config.pagination = { type: :countless }         # global pagination defaults; s
 ```
 
 `default_view_type`, `pagination`, and `density` (on dashboard cards) also exist as per-resource class attributes — set globally here, override per resource. Row-control placement (`resource_row_controls_config`) lives on the table-view docs.
+
+`config.map_view` sets the tiles every Avo map renders with — the map view and the `location`/`area` fields alike. Its one key is `styles:`, which takes `:open_free_map`, `:mapbox`, or your own `{light:, dark:}` pair of style URLs; left unset it resolves to Mapbox when `MAPBOX_ACCESS_TOKEN` is set and to OpenFreeMap otherwise, so maps work with no account and no API key. Avo swaps the pair as the color scheme changes. Don't confuse it with the resource-level `self.map_view`, which is a different hash entirely (`mapkick_options`, `record_marker`, layout) — see **avo-index-views**.
 
 ### Layout
 

--- a/lib/avo/skills/avo-fields/SKILL.md
+++ b/lib/avo/skills/avo-fields/SKILL.md
@@ -210,7 +210,7 @@ end
   - `:lexxy` → `gem "avo-lexxy_field"` (Basecamp's Lexxy editor for Action Text; needs Rails >= 8.0.2)
   - `:markdown` → `gem "marksmith"` + `gem "commonmarker"`
   - `:money` → `gem "avo-money_field"` + `gem "money-rails", "~> 1.12"` (and `monetize :price_cents` on the model)
-  - `:location` / `:area` → `gem "mapkick-rb"` (**not** `mapkick`). No API key needed — Avo defaults these maps to [OpenFreeMap](https://openfreemap.org), switchable with `config.map_view = {styles: …}`. Set `MAPBOX_ACCESS_TOKEN` only to use Mapbox styles, and for `:location` with `static: true` (which also needs `gem "mapkick-static"` and is Mapbox-only).
+  - `:location` / `:area` → `gem "mapkick-rb"` (**not** `mapkick`). No API key needed — Avo defaults these maps to [OpenFreeMap](https://openfreemap.org), switchable with `config.map_view = {styles: …}`. Set `MAPBOX_ACCESS_TOKEN` only to use Mapbox styles, and for `:location` with `static: true` (which also needs `gem "mapkick-static"` and is Mapbox-only). Preview always renders a static map, so it carries the same Mapbox requirement even when `static:` is unset.
   - Reactive fields (`react_on:`) → `gem "avo-reactive_fields"`
   - Some of these gems live on the `packager.dev` source — point the user to the Avo 4 upgrade guide's gems section.
 - **`tip_tap` is deprecated** — use `:rhino` for a WYSIWYG editor.

--- a/lib/avo/skills/avo-index-views/SKILL.md
+++ b/lib/avo/skills/avo-index-views/SKILL.md
@@ -217,7 +217,7 @@ end
 ```
 
 Options:
-- `mapkick_options` — forwarded to the [mapkick gem](https://github.com/ankane/mapkick). Avo sets a default `style` and always controls `height` (any `height` you pass is overwritten).
+- `mapkick_options` — forwarded to the [mapkick gem](https://github.com/ankane/mapkick). Avo sets a default `style` and always controls `height` (any `height` you pass is overwritten). The default is a light/dark pair Avo swaps as the color scheme changes; a `style` you pass here is a single style, so that map keeps it in dark mode too.
 - `record_marker` — Proc evaluated per record; must return a hash with `latitude` and `longitude` (optionally `tooltip`, `label`, `color`). Markers missing lat/long are skipped. Default reads `record.coordinates.first`/`.last`. Use this block to source coordinates from anywhere (API, cache), not just the DB.
 - `map` — `{ position: … }` places the map; the table takes the remaining side (`:left`/`:right` side-by-side, `:top`/`:bottom` stacked).
 - `table` — `{ visible: true|false }`; default renders no adjacent table.

--- a/lib/avo/skills/avo-navigation-search/SKILL.md
+++ b/lib/avo/skills/avo-navigation-search/SKILL.md
@@ -252,7 +252,7 @@ Jump-to-menu-item shortcuts go through the menu `hotkey:` option, or `self.hotke
 - **`all_resources` respects `index?` authorization.** A resource missing from the menu is usually a policy returning false, not a bug.
 - **Menu `action` items must be standalone.** `self.standalone = true` is required (the menu has no selected record); others are skipped with a log warning. Top-level `action` also needs `resource:`; nested it's inherited.
 - **`profile_menu` and `header_menu` render only `link_to`.** `resource`, `dashboard`, `action`, etc. are silently ignored there. The profile menu adds sign-out for you.
-- **`icon:` isn't universal.** It works on `section` and individual items, **not** on `group` or on sub-items nested inside a `resource` block.
+- **`icon:` isn't universal.** It works on `section` and individual items, **not** on `group` or on sub-items nested inside a `resource` or `link_to` block.
 - **Ransack v4+ needs an allowlist.** Add `ransackable_attributes` (and often `ransackable_associations`) to any model you search, or the query raises.
 - **`search_type` is undefined on Community-only installs and in the kanban picker.** It's injected by the paid search layer for the index/global/association surfaces only. Guard with `defined?(search_type)`; the kanban picker reads `params[:q]` and detects the board via `params[:for_kanban_board]`.
 - **Custom array-result providers aren't auto-capped.** `config.search_results_count` only applies to relations without their own `.limit()` — cap arrays yourself with `.first(N)`.

--- a/lib/avo/skills/docs-index.json
+++ b/lib/avo/skills/docs-index.json
@@ -1,7 +1,7 @@
 {
   "repo": "avo-hq/docs.avohq.io",
   "docs_path": "docs/4.0",
-  "commit": "dee56c883a189676d46aa2d3ed1915525a5fc16a",
-  "date": "2026-08-19",
+  "commit": "70f1de9c11258f0f376862cc87b68a0d5ea48940",
+  "date": "2026-08-20",
   "note": "The docs commit these skills were last indexed from. Run ruby lib/avo/skills/bin/docs_drift.rb to see what changed since, and --update after a refresh."
 }


### PR DESCRIPTION
# Description

Reconciles `lib/avo/skills/` against `avo-hq/docs.avohq.io` and moves the marker from `dee56c8` (2026-08-19) to `70f1de9` (2026-08-20). Fourteen `docs/4.0` pages changed in that range.

Most of the drift was already reconciled before this ran: the container-width rename (#4749) and the OpenFreeMap map default (#4746) each updated the shipped skills inside their own feature PR. `avo-admin-config` already taught `:lg`/`:md`/`:sm` and the `:large`/`:small` deprecation; `avo-index-views` and `avo-fields` already taught the keyless map default. The marker was simply lagging behind them. Four genuine gaps were left, each verified against source in this checkout rather than inferred from the prose.

## Changed pages

| Changed page | Skills citing it | What changed |
| --- | --- | --- |
| `customization-api.md` | `avo-admin-config`, `avo-multitenancy` | **Edited `avo-admin-config`.** The page gained `config.map_view`, a global initializer knob the skill never documented. Added it with its `styles:` values and resolution order. `container_width` rename was already reconciled by #4749. **No change to `avo-multitenancy`** — it cites this page only for `config.default_url_options`, untouched. |
| `customization.md` | `avo-admin-config` | Guide-side mirror of the same two changes. Covered by the `avo-admin-config` edit above. |
| `map-view.md` | `avo-index-views` | **Edited.** Requirements were already current; the page's new dark-mode note was not reflected — the default `style` is a light/dark *pair*, not a single value. |
| `menu-editor.md` | `avo-media-library`, `avo-navigation-search` | **Edited `avo-navigation-search`** — `link_to` now takes a block for sub-items, so the `icon:` gotcha needed to name it. **No change to `avo-media-library`**: it cites this page only for re-adding the Media Library item as a `link_to`, which the block form does not affect. |
| `menu-editor-api.md` | `avo-navigation-search` | Same `link_to`-block change, reference side. Covered above. |
| `resources-api.md` | `avo-controllers`, `avo-performance`, `avo-resources` | **No change needed** — the only diff is one cross-reference row for `def chip`, which is add-on-owned (see Flagged below). |
| `upgrade.md` | `avo-update` | **No change needed.** `avo-update` is a workflow skill: it tells the agent to diff the lock and apply every crossed guide section, and never enumerates versions. The new "Upgrade to 4.1.15" section is picked up by the workflow it already describes. |
| `ai.md`, `ai-agents-and-tools.md`, `ai-what-you-can-ask.md` | — | Out of scope: `avo-ai`-owned. |
| `forms-and-pages.md`, `forms-and-pages-api.md` | — | Out of scope: `avo-forms`-owned. |
| `fields/area.md`, `fields/location.md` | — (not cited by any skill) | **Small edit to `avo-fields`** — see Flagged below. |

## Skills edited

- **`avo-admin-config`** — added `config.map_view` to the index-behavior knobs, with `styles:` accepting `:open_free_map` / `:mapbox` / a `{light:, dark:}` pair, and the unset resolution order (Mapbox when `MAPBOX_ACCESS_TOKEN` is set, OpenFreeMap otherwise). Verified against `Avo::MapStyles.default` and `Avo::Configuration::MAP_VIEW_DEFAULTS`. Added a note that it is **not** the resource-level `self.map_view`, which is a different hash entirely — an easy confusion now that both names exist. Frontmatter `description` and both trigger lists gained a map phrasing; description is 933/1024 chars. `index.md`'s one-line summary ("Global initializer knobs …") still fits, so it is unchanged.
- **`avo-index-views`** — the `mapkick_options` bullet said Avo "sets a default `style`". It sets a light/dark pair it swaps on theme change, and a `style` you pass yourself opts that map out of the swap. Verified against `Avo::MapStyles.wrapper_data`.
- **`avo-fields`** — the map line said static maps are Mapbox-only. Preview is too: `Avo::Fields::LocationField#static_map?` is `params[:action] == "preview" || @args[:static]`, so Preview renders a static map and needs the token even when `static:` is unset.
- **`avo-navigation-search`** — the `icon:` gotcha named only sub-items nested in a `resource` block; `link_to` now nests the same way and carries the same restriction.

## Skills reviewed and left alone

`avo-controllers`, `avo-media-library`, `avo-multitenancy`, `avo-performance`, `avo-resources`, `avo-update` — reasons per page in the table above.

## Flagged — not resolved here

- **`def chip` has no owning skill.** `resources-api.md` gained a row pointing at `ai.html#record-chips`. The DSL is declared on a resource, but core ships no chip support (`grep` for `chip` across `lib/` and `app/` hits only `breadcrumb_element_component.rb`, unrelated), so it belongs to `avo-ai`. The page also marks it **alpha** and warns it will change before it settles. No core skill claims it; `avo-ai`'s own skill should pick it up.
- **`fields/area.md` and `fields/location.md` are cited by no skill.** `avo-fields` covers the same ground in prose but never links either page, so the drift checker will not flag them next time either. Worth adding to `avo-fields`'s Docs list in a follow-up. I made only the one-clause Preview correction rather than restructuring that section here.
- **Add-on-owned pages for their gems' skills:** `ai.md`, `ai-agents-and-tools.md`, `ai-what-you-can-ask.md` (`avo-ai` — the AI chat gained record chips, Media Library files and conversations as chat context, and schema-first answering); `forms-and-pages.md`, `forms-and-pages-api.md` (`avo-forms` — including `self.container_width` on pages/forms, which the same rename touches).
- No contradictions between the docs and the source were found; every option name written here was checked against `lib/`.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs) — n/a, this PR moves in the other direction: it reconciles the shipped skills *to* the docs.
- [x] I have added tests that prove my fix is effective or that my feature works — n/a, no new behavior; the existing `spec/lib/avo/skills` suite covers these files.
- [x] I tested the design in Light and Dark mode, and all default themes — n/a, no UI change.

## Screenshots & recording

n/a — Markdown only, no rendered surface.

## Manual review steps

1. `AVO_DOCS_PATH=<docs checkout> ruby lib/avo/skills/bin/docs_drift.rb` → "Up to date" (docs at `70f1de9`).
1. `grep -rnE "\[!code|:::|<Option|``&lt;Image|&lt;CustomCode|&lt;FieldTypesList``" lib/avo/skills/` → no matches (no VitePress artifacts pasted in).
1. `bundle exec rspec spec/lib/avo/skills` → **167 examples, 0 failures.**

Scope is `lib/avo/skills/` only: 5 files, +11/−8.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFX6FMU4FgKXbjYv39YB8T)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only skill and docs-index updates; no application code or admin behavior changes.
> 
> **Overview**
> **Realigns `lib/avo/skills/` with `avo-hq/docs.avohq.io` at commit `70f1de9` (2026-08-20)** by bumping `docs-index.json` and filling four doc gaps in agent skill markdown—no runtime or UI changes.
> 
> **`avo-admin-config`** now documents global **`config.map_view`** (`styles:` as `:open_free_map`, `:mapbox`, or a `{light:, dark:}` pair), default resolution when unset, and how it differs from resource-level **`self.map_view`**. Trigger text mentions choosing map tiles without a Mapbox key.
> 
> **`avo-index-views`** clarifies that Avo’s default **`mapkick_options`** style is a **light/dark pair** swapped with theme; a custom `style` stays fixed in dark mode.
> 
> **`avo-fields`** adds that **`:location` Preview** always uses a static map, so **Mapbox** applies on preview even when `static:` is unset.
> 
> **`avo-navigation-search`** extends the **`icon:`** gotcha to sub-items under **`link_to`** blocks, matching the menu editor docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee795a2c8c8d2cefc37aa9c337292cfc5b54990d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->