### PR TITLE
Sync shipped skills with docs through 70f1de9 (2026-08-20)

### DIFF
--- a/lib/avo/skills/avo-admin-config/SKILL.md
+++ b/lib/avo/skills/avo-admin-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: avo-admin-config
-description: Configure Avo's app-wide admin settings in config/initializers/avo.rb via Avo.configure — app name, timezone/currency, per-page and index behavior, layout width, home redirect, open-in-editor links, and the other global knobs that don't belong to a single feature. Use when the user wants to change how many records per page, rename the admin / change the app name, set the timezone or currency for the admin, default the index to grid view, make the admin full-width, keep clicking a row from opening the record, skip the show view / go straight to edit, open Avo files in Cursor or VS Code from the UI, keep the sidebar always open, redirect the admin home to a dashboard, add a class to the body tag, make rows denser, widen the sidebar or turn off sidebar resizing, remove or retune the floating "Back to top" button, persist filters/pagination across requests, or opt out of usage metadata.
+description: Configure Avo's app-wide admin settings in config/initializers/avo.rb via Avo.configure — app name, timezone/currency, per-page and index behavior, layout width, home redirect, open-in-editor links, and the other global knobs that don't belong to a single feature. Use when the user wants to change how many records per page, rename the admin / change the app name, set the timezone or currency for the admin, default the index to grid view, make the admin full-width, keep clicking a row from opening the record, skip the show view / go straight to edit, open Avo files in Cursor or VS Code from the UI, keep the sidebar always open, redirect the admin home to a dashboard, add a class to the body tag, make rows denser, widen the sidebar or turn off sidebar resizing, remove or retune the floating "Back to top" button, persist filters/pagination across requests, change which map tiles the admin's maps use, or opt out of usage metadata.
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash, WebFetch
 metadata:
   requires-gem: none — Community
@@ -42,9 +42,9 @@ Authoritative docs — fetch on demand rather than guessing, and verify every op
 
 ## When this applies
 
-**Explicit (Avo named):** "set `config.app_name`", "change `per_page` in the Avo initializer", "set `default_view_type` to `:grid`", "use `container_width = :full`", "set `resource_default_view = :edit`", "configure `default_editor_url`", "enable `persistence`", "set `body_classes`".
+**Explicit (Avo named):** "set `config.app_name`", "change `per_page` in the Avo initializer", "set `default_view_type` to `:grid`", "use `container_width = :full`", "set `resource_default_view = :edit`", "configure `default_editor_url`", "enable `persistence`", "set `body_classes`", "set `config.map_view` / pin the map styles".
 
-**Implicit (Rails-shaped, no mention of Avo):** "change how many records show per page in the admin", "rename the admin / change the app name in the top bar", "set the timezone/currency the admin displays", "default the admin list to grid/card view", "make the admin full-width", "clicking a row shouldn't open the record", "skip the show page and go straight to edit", "open the admin's source files in Cursor/VS Code from the UI", "keep the sidebar always open / hide the collapse button", "make the sidebar wider by default", "stop people resizing the sidebar", "send people to a dashboard when they open the admin", "add a CSS class to the `<body>` tag", "make the admin rows denser / tighter", "keep my filters and pagination when I navigate away", "stop the admin from phoning home usage stats".
+**Implicit (Rails-shaped, no mention of Avo):** "change how many records show per page in the admin", "rename the admin / change the app name in the top bar", "set the timezone/currency the admin displays", "default the admin list to grid/card view", "make the admin full-width", "clicking a row shouldn't open the record", "skip the show page and go straight to edit", "open the admin's source files in Cursor/VS Code from the UI", "keep the sidebar always open / hide the collapse button", "make the sidebar wider by default", "stop people resizing the sidebar", "send people to a dashboard when they open the admin", "add a CSS class to the `<body>` tag", "make the admin rows denser / tighter", "keep my filters and pagination when I navigate away", "use OpenFreeMap instead of Mapbox for the admin's maps / change the map tiles", "stop the admin from phoning home usage stats".
 
 ## Common settings
 
@@ -70,6 +70,7 @@ config.per_page = 24                             # default page size (default 24
 config.per_page_steps = [12, 24, 48, 72]         # options in the per-page picker
 config.via_per_page = 8                          # page size inside has_many association tables
 config.default_view_type = :grid                 # :table (default), :grid, :map, or a custom view type
+config.map_view = { styles: :open_free_map }     # map tiles: :open_free_map, :mapbox, or a {light:, dark:} pair
 config.first_sorting_option = :asc               # direction on first sort click (default :desc)
 config.density = :tight                          # row height: :tight, :normal (default), :relaxed
 config.field_wrapper_layout = :stacked           # label above value everywhere (default :inline)
@@ -81,6 +82,8 @@ config.pagination = { type: :countless }         # global pagination defaults; s
 ```
 
 `default_view_type`, `pagination`, and `density` (on dashboard cards) also exist as per-resource class attributes — set globally here, override per resource. Row-control placement (`resource_row_controls_config`) lives on the table-view docs.
+
+`map_view[:styles]` is the light/dark tile pair Avo renders the map view **and** the `location`/`area` fields with. It defaults to `nil`, which resolves to Mapbox when `MAPBOX_ACCESS_TOKEN` is set and to [OpenFreeMap](https://openfreemap.org) — no account, no API key, no request cap — otherwise. Pin one regardless with `:open_free_map` or `:mapbox`, or pass your own `{light:, dark:}` hash of style URLs. Avo swaps between the pair as the color scheme changes; a single map that sets its own `mapkick_options: {style: …}` is one style rather than a pair, so Avo leaves that map alone in dark mode. Maps still need the `mapkick-rb` gem (see **avo-index-views** and **avo-fields**).
 
 ### Layout
 

--- a/lib/avo/skills/avo-index-views/SKILL.md
+++ b/lib/avo/skills/avo-index-views/SKILL.md
@@ -217,7 +217,7 @@ end
 ```
 
 Options:
-- `mapkick_options` — forwarded to the [mapkick gem](https://github.com/ankane/mapkick). Avo sets a default `style` and always controls `height` (any `height` you pass is overwritten).
+- `mapkick_options` — forwarded to the [mapkick gem](https://github.com/ankane/mapkick). Avo sets a default `style` from the resolved light/dark pair (`https://tiles.openfreemap.org/styles/positron`, or `mapbox://styles/mapbox/light-v11` when `MAPBOX_ACCESS_TOKEN` is set) and always controls `height` (any `height` you pass is overwritten). Avo swaps that pair as the color scheme changes — but a `style` you pass is one style rather than a pair, so Avo then leaves that map exactly as you set it, dark mode included.
 - `record_marker` — Proc evaluated per record; must return a hash with `latitude` and `longitude` (optionally `tooltip`, `label`, `color`). Markers missing lat/long are skipped. Default reads `record.coordinates.first`/`.last`. Use this block to source coordinates from anywhere (API, cache), not just the DB.
 - `map` — `{ position: … }` places the map; the table takes the remaining side (`:left`/`:right` side-by-side, `:top`/`:bottom` stacked).
 - `table` — `{ visible: true|false }`; default renders no adjacent table.

--- a/lib/avo/skills/docs-index.json
+++ b/lib/avo/skills/docs-index.json
@@ -1,7 +1,7 @@
 {
   "repo": "avo-hq/docs.avohq.io",
   "docs_path": "docs/4.0",
-  "commit": "dee56c883a189676d46aa2d3ed1915525a5fc16a",
-  "date": "2026-08-19",
+  "commit": "70f1de9c11258f0f376862cc87b68a0d5ea48940",
+  "date": "2026-08-20",
   "note": "The docs commit these skills were last indexed from. Run ruby lib/avo/skills/bin/docs_drift.rb to see what changed since, and --update after a refresh."
 }


### PR DESCRIPTION
# Description

Reconciles the skills shipped inside the gem (`lib/avo/skills/*/SKILL.md`) against `avo-hq/docs.avohq.io` from the recorded marker `dee56c8` (2026-08-19) up to docs HEAD `70f1de9` (2026-08-20), and moves `docs-index.json` forward to that commit.

14 pages changed under `docs/4.0`. Most of the drift was **already reconciled**, because two of the docs commits were companions to core PRs that updated the skills alongside the code — the OpenFreeMap map default (#4746) and the `container_width` rename to Tailwind's scale (#4749). Two genuine gaps remained, both about map styling.

Fixes # (issue) — n/a, scheduled docs-sync run.

## Page-by-page

| Changed page | Skills citing it | What changed |
| --- | --- | --- |
| `customization-api.md` | `avo-admin-config`, `avo-multitenancy` | **Edited `avo-admin-config`.** The page documents a new `config.map_view = {styles: …}` option that the skill never carried. Added it to the "Index view behavior" block with its values, its `nil`-default resolution, and the note that it also styles the `location`/`area` fields. The same page's `container_width` rename was already reconciled (skill line 104). `avo-multitenancy` cites this page only for `config.default_url_options`, untouched by the diff — no change needed. |
| `customization.md` | `avo-admin-config` | No change beyond the above — the new "Map styles" guide section is the prose form of the same `config.map_view` option, now covered. The `container_width` example updates were already reconciled. |
| `map-view.md` | `avo-index-views` | **Edited.** The `mapkick_options` default is no longer one Mapbox style — Avo resolves a light/dark pair and swaps it with the color scheme, and a `style:` you pass opts that map out of the swap. The skill described a single default `style`. The keyless-OpenFreeMap requirement text was already reconciled (skill line 226). |
| `resources-api.md` | `avo-controllers`, `avo-performance`, `avo-resources` | **No change needed.** The diff is one row added to the "dedicated page" index pointing `def chip` at `ai.html#record-chips`. `chip` does not exist anywhere in this checkout's `lib/` or `app/` — it is `avo-ai`'s DSL, so it belongs to that gem's skill, not to core's. The three skills cite this page for `after_create_path`, `cache_hash`, and as the resource API reference; none of those moved. |
| `upgrade.md` | `avo-update` | **No change needed.** The diff adds a 4.1.15 section for the `container_width` rename. `avo-update` is deliberately procedural — it teaches how to work the guide section by section and fetches it at runtime rather than enumerating versions — so a new guide section is exactly what it already handles. |
| `menu-editor.md`, `menu-editor-api.md` | `avo-navigation-search`, `avo-media-library` | **No change needed here — belongs to `avo-menu`.** The change is a real DSL addition (`link_to` now takes a block to nest sub-items, and `active:` is ignored on those sub-items). But `avo-navigation-search` explicitly delegates the whole menu-editor DSL to the `avo-menu` gem's own skill and only links the pages; `avo-media-library` cites the page only for re-adding its own `link_to` item, which is unaffected. See follow-ups. |
| `ai.md`, `ai-agents-and-tools.md`, `ai-what-you-can-ask.md` | — | Not cited by any core skill. Add-on-owned (`avo-ai`). See follow-ups. |
| `forms-and-pages.md`, `forms-and-pages-api.md` | — | Not cited by any core skill. Add-on-owned (`avo-forms`); the diff is the same `container_width` rename applied to `self.container_width` on forms/pages. See follow-ups. |
| `fields/area.md`, `fields/location.md` | — | **No change needed.** Not cited by URL, but `avo-fields` covers both field types. Its map requirements line already states the keyless OpenFreeMap default, `config.map_view = {styles: …}`, and that `static: true` stays Mapbox-only — all still accurate after the diff. |

## Skills edited

- **`avo-admin-config`** — added `config.map_view` to the settings block plus a paragraph on `map_view[:styles]`; added one explicit and one implicit trigger and a description clause so a "change the map tiles" request reaches the skill. Description is 940/1024 chars.
- **`avo-index-views`** — rewrote the `mapkick_options` bullet to describe the resolved light/dark pair and the dark-mode opt-out.

## Skills reviewed and left alone

`avo-multitenancy`, `avo-controllers`, `avo-performance`, `avo-resources`, `avo-update`, `avo-navigation-search`, `avo-media-library`, `avo-fields`.

## Verified against source, not guessed

Every new claim was checked in this checkout rather than taken from the docs page:

- `lib/avo/configuration.rb:303-307` — `MAP_VIEW_DEFAULTS = {styles: nil}`, merged in `#map_view` (line 334).
- `lib/avo/map_styles.rb` — `resolve` accepts `:mapbox`, `:open_free_map`, or a Hash; `default` falls back to Mapbox only when `MAPBOX_ACCESS_TOKEN` is present, OpenFreeMap otherwise; `wrapper_data` omits the style pair when a custom `style` is set, which is what makes a custom style opt out of the dark-mode swap.
- `lib/generators/avo/templates/initializer/avo.tt:53-58` — the option is already in the initializer template, so the skill was the only place missing it.

## Follow-ups for other gems (not actionable here)

- **`avo-menu`** — `menu-editor.md` / `menu-editor-api.md` gained `link_to` taking a block for sub-items (parent stays clickable and is forced active while a child is; `icon:` is not supported on those sub-items; a per-link `active:` is ignored). That gem's shipped skill should pick this up.
- **`avo-ai`** — `ai.md` grew ~255 lines (record chips, Media Library files and conversations as chat context, what a chat starts from, actions found without naming a resource), plus `ai-agents-and-tools.md` and `ai-what-you-can-ask.md`. `resources-api.md` now points `def chip` at that page, so the `chip` resource DSL wants documenting in `avo-ai`'s skill.
- **`avo-forms`** — `forms-and-pages*.md` carry the `container_width` `:large`/`:small` → `:lg`/`:md` rename for `self.container_width` on forms and pages.

## Gaps, not guesses

- No new page appeared that lacks an owning core skill — every uncited changed page maps to an existing add-on gem.
- Nothing in the diff contradicted the source, and no option was written that could not be verified in `lib/`.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs) — this PR *is* the docs-follow-up; no docs change is needed in the other direction
- [x] I have added tests that prove my fix is effective or that my feature works — covered by the existing `spec/lib/avo/skills` integrity suite; no new behavior to test
- [ ] I tested the design in Light and Dark mode, and all default themes — n/a, no UI change

## Screenshots & recording

n/a — Markdown-only change under `lib/avo/skills/`.

## Manual review steps

1. `AVO_DOCS_PATH=<docs checkout> ruby lib/avo/skills/bin/docs_drift.rb` → "Up to date with 70f1de9c1125 (2026-08-20)."
2. `grep -rnE "\[!code|:::|<Option|``&lt;Image|&lt;CustomCode|&lt;FieldTypesList``" lib/avo/skills/` → no matches (no VitePress artifacts pasted in).
3. `bundle exec rspec spec/lib/avo/skills` → **167 examples, 0 failures.**

Manual reviewer: please leave a comment with output from the test if that's the case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxvWQTsMS8SMTyJnimDZCZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only skill documentation and a docs index pointer; no application code or behavior changes.
> 
> **Overview**
> **Docs sync** for gem-shipped agent skills against `docs.avohq.io` 4.0, advancing `docs-index.json` from `dee56c8` (2026-08-19) to **`70f1de9` (2026-08-20)**.
> 
> The substantive gap was **map tile styling** after the OpenFreeMap / `config.map_view` docs landed:
> 
> - **`avo-admin-config`** now documents **`config.map_view = { styles: … }`** (OpenFreeMap, Mapbox, or custom light/dark URLs), how `nil` resolves from `MAPBOX_ACCESS_TOKEN`, and that the same setting applies to index map views and **`location`/`area`** fields. Triggers and the skill description were extended so “change map tiles” routes here.
> - **`avo-index-views`** updates the **`mapkick_options`** note: Avo supplies a **light/dark style pair** and swaps with color scheme; a custom **`style:`** opts that map out of dark-mode swapping.
> 
> No runtime or UI changes—Markdown under `lib/avo/skills/` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ea2b45cfe3ac33f98d40c27f82ba4c32b6a0b5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->