### PR TITLE
Sync shipped skills with docs through 70f1de9 (2026-08-20)

### DIFF
--- a/lib/avo/skills/avo-admin-config/SKILL.md
+++ b/lib/avo/skills/avo-admin-config/SKILL.md
@@ -31,6 +31,7 @@ A handful of these have **resource-level equivalents** — set them globally her
 - Menus, global search, breadcrumbs, keyboard shortcuts (`main_menu`, `global_search`, `set_initial_breadcrumbs`, `hotkeys`) → **avo-navigation-search**
 - Caching internals, cache store, N+1 tuning → **avo-performance**
 - Authorization client and policy wiring → **avo-authorization**
+- Map styles / providers (`map_view`) — the map view and the `location`/`area` fields share one setting → **avo-index-views**
 
 ## Docs
 
@@ -164,4 +165,4 @@ When done, tell the user:
 - Any Avo-3 → Avo-4 rename you applied (`container_width`, `resource_default_view`) and the old line it replaced.
 - Follow-ups the change implies: a server restart to reload the initializer; a scalable session store if you enabled `persistence`; disabling `cache_resources_on_index_view` if they gate fields by role.
 - When a setting has a per-resource equivalent (`default_view_type`, `pagination`, `density`), note it so they know they can override it on individual resources.
-- Redirect anything out of scope to the right skill: install/mount/license → **avo-setup**, appearance/theming → **avo-branding-appearance**, menus/search/breadcrumbs/shortcuts → **avo-navigation-search**, caching depth → **avo-performance**, authorization → **avo-authorization**.
+- Redirect anything out of scope to the right skill: install/mount/license → **avo-setup**, appearance/theming → **avo-branding-appearance**, menus/search/breadcrumbs/shortcuts → **avo-navigation-search**, caching depth → **avo-performance**, authorization → **avo-authorization**, map styles (`map_view`) → **avo-index-views**.

--- a/lib/avo/skills/avo-index-views/SKILL.md
+++ b/lib/avo/skills/avo-index-views/SKILL.md
@@ -217,7 +217,7 @@ end
 ```
 
 Options:
-- `mapkick_options` — forwarded to the [mapkick gem](https://github.com/ankane/mapkick). Avo sets a default `style` and always controls `height` (any `height` you pass is overwritten).
+- `mapkick_options` — forwarded to the [mapkick gem](https://github.com/ankane/mapkick). Avo sets a default `style` and always controls `height` (any `height` you pass is overwritten). Passing your own `style` here also opts that map out of the automatic light/dark swap (see the gotcha below).
 - `record_marker` — Proc evaluated per record; must return a hash with `latitude` and `longitude` (optionally `tooltip`, `label`, `color`). Markers missing lat/long are skipped. Default reads `record.coordinates.first`/`.last`. Use this block to source coordinates from anywhere (API, cache), not just the DB.
 - `map` — `{ position: … }` places the map; the table takes the remaining side (`:left`/`:right` side-by-side, `:top`/`:bottom` stacked).
 - `table` — `{ visible: true|false }`; default renders no adjacent table.
@@ -242,6 +242,7 @@ It works out of the box on the table view; nothing to enable on the resource. Th
 - **`row_options` blocks run per row, per render.** Preload every association they touch via `self.includes`, or you get an N+1 across every row. Keep blocks cheap.
 - **Dark mode is your responsibility** for user classes — pair `dark:` variants (`bg-blue-50 dark:bg-blue-950/40`) or use Avo's semantic CSS variables via `style:`. For custom backgrounds, use semitransparent values or explicit `hover:` variants so Avo's row hover/selection overlay still shows through.
 - **Map markers need `latitude` + `longitude`.** Records whose `record_marker` returns a hash missing either are silently dropped from the map.
+- **A custom map `style` stays fixed in dark mode.** Avo follows the color scheme and swaps the map between the light and dark styles of the pair it resolved (`config.map_view[:styles]`, or the OpenFreeMap/Mapbox default). `mapkick_options: {style: "..."}` is a single style rather than a pair, so Avo leaves that map exactly as you set it, dark mode included. Want a custom look that still follows the theme? Set the `{light:, dark:}` pair on `config.map_view` instead of a per-map `style`.
 - **Select-all serialization can break on a model `normalizes` proc.** `normalizes :status, with: ->(s) { s }` combined with a filter on that attribute raises `TypeError: no _dump_data is defined for class Proc`, which auto-disables select-all. For apps created before Rails 7.1, set `config.active_record.marshalling_format_version = 7.1` in `config/application.rb`.
 - **Authoring a brand-new custom view type is out of scope.** Timeline/calendar/kanban views are plugin work (ViewComponent + engine registration). Point the user to the **avo-custom-ui** skill and `https://docs.avohq.io/4.0/custom-view-types.md`; here only enable built-in/registered types.
 

--- a/lib/avo/skills/avo-navigation-search/SKILL.md
+++ b/lib/avo/skills/avo-navigation-search/SKILL.md
@@ -252,7 +252,7 @@ Jump-to-menu-item shortcuts go through the menu `hotkey:` option, or `self.hotke
 - **`all_resources` respects `index?` authorization.** A resource missing from the menu is usually a policy returning false, not a bug.
 - **Menu `action` items must be standalone.** `self.standalone = true` is required (the menu has no selected record); others are skipped with a log warning. Top-level `action` also needs `resource:`; nested it's inherited.
 - **`profile_menu` and `header_menu` render only `link_to`.** `resource`, `dashboard`, `action`, etc. are silently ignored there. The profile menu adds sign-out for you.
-- **`icon:` isn't universal.** It works on `section` and individual items, **not** on `group` or on sub-items nested inside a `resource` block.
+- **`icon:` isn't universal.** It works on `section` and individual items, **not** on `group` or on sub-items nested inside a `resource` or `link_to` block. (`link_to` takes a block for sub-items too, not just `resource` — the parent link stays clickable and Avo forces it active while a child is.)
 - **Ransack v4+ needs an allowlist.** Add `ransackable_attributes` (and often `ransackable_associations`) to any model you search, or the query raises.
 - **`search_type` is undefined on Community-only installs and in the kanban picker.** It's injected by the paid search layer for the index/global/association surfaces only. Guard with `defined?(search_type)`; the kanban picker reads `params[:q]` and detects the board via `params[:for_kanban_board]`.
 - **Custom array-result providers aren't auto-capped.** `config.search_results_count` only applies to relations without their own `.limit()` — cap arrays yourself with `.first(N)`.

--- a/lib/avo/skills/docs-index.json
+++ b/lib/avo/skills/docs-index.json
@@ -1,7 +1,7 @@
 {
   "repo": "avo-hq/docs.avohq.io",
   "docs_path": "docs/4.0",
-  "commit": "dee56c883a189676d46aa2d3ed1915525a5fc16a",
-  "date": "2026-08-19",
+  "commit": "70f1de9c11258f0f376862cc87b68a0d5ea48940",
+  "date": "2026-08-20",
   "note": "The docs commit these skills were last indexed from. Run ruby lib/avo/skills/bin/docs_drift.rb to see what changed since, and --update after a refresh."
 }


### PR DESCRIPTION
# Description

Routine reconciliation of the skills shipped inside the gem (`lib/avo/skills/`) against `avo-hq/docs.avohq.io`, run from the marker in `docs-index.json`.

**Range:** `dee56c88` (2026-08-19) → `70f1de9` (2026-08-20) — 14 changed pages under `docs/4.0`, 9 skills flagged as citing them.

Most of the range needed no edit: the feature PRs that shipped OpenFreeMap and the `container_width` rename updated the skills alongside the code, so the skills were already ahead of the docs marker. Three genuine gaps remained, all verified against the source in this checkout before writing.

## Changed pages

| Changed page | Skills citing it | What changed |
| --- | --- | --- |
| `customization-api.md` | avo-admin-config, avo-multitenancy | **Edited avo-admin-config.** New global `config.map_view` option; routed to **avo-index-views** rather than duplicated (see note below). The `container_width` rename to `:lg`/`:md`/`:sm` was already fully documented in the skill, deprecation mapping included — no change. **avo-multitenancy: no change** — it cites this page only for `config.default_url_options`, untouched in this range. |
| `customization.md` | avo-admin-config | No change needed — the guide-side additions (map styles, deprecated width names) are the same two facts as above. |
| `map-view.md` | avo-index-views | **Edited.** New documented behavior: Avo swaps the map between the light and dark styles of the resolved pair, and a per-map `mapkick_options: {style: …}` opts that map out of the swap. Added as a gotcha plus a pointer on the `mapkick_options` bullet. The keyless OpenFreeMap default and `config.map_view = {styles: …}` were already present. |
| `menu-editor.md` | avo-media-library, avo-navigation-search | **Edited avo-navigation-search.** `link_to` now takes a block for sub-items, so the `icon:` gotcha naming only a `resource` block was stale. **avo-media-library: no change** — it cites this page only for re-adding the Media Library item as a plain `link_to` with no block. |
| `menu-editor-api.md` | avo-navigation-search | Covered by the same edit. |
| `resources-api.md` | avo-controllers, avo-performance, avo-resources | **No change to any of the three.** The only diff is one new row pointing `def chip` at `ai.html#record-chips` — add-on-owned (see below). The three skills cite this page for `after_create_path`, `cache_hash`, and the resource API generally, none of which moved. |
| `upgrade.md` | avo-update | No change needed. avo-update is version-agnostic by design: it fetches the guide at runtime and works whatever sections the app's jump crosses. It hardcodes no version list, so the new "Upgrade to 4.1.15" section (the `container_width` rename) is picked up without an edit. |
| `ai.md`, `ai-agents-and-tools.md`, `ai-what-you-can-ask.md` | — | Add-on-owned (`avo-ai`). Out of scope here. |
| `forms-and-pages.md`, `forms-and-pages-api.md` | — | Add-on-owned (`avo-forms`). Out of scope here. |
| `fields/area.md`, `fields/location.md` | — | Not cited by URL from any skill, but checked anyway: **avo-fields** already carries the keyless-OpenFreeMap default, `config.map_view`, and that `static: true` is Mapbox-only. Confirmed current, no change. |

## Skills edited

- **`avo-index-views`** — added the custom-`style`/dark-mode gotcha and a cross-reference on the `mapkick_options` bullet.
- **`avo-navigation-search`** — corrected the `icon:` gotcha: sub-items nest inside a `resource` **or** `link_to` block.
- **`avo-admin-config`** — added `config.map_view` to the router list (and the matching Report line) pointing at **avo-index-views**.

On that last one: `map_view` is a new global initializer knob, so it belongs in this skill's surface. But the skill states it "owns only the genuinely-global knobs" and hands feature-owned settings off rather than duplicating them, and **avo-index-views** already documents `map_view` in full (as does **avo-fields**). A router line naming the option keeps it greppable from the initializer skill without becoming a third copy to drift.

## Reviewed and left alone

`avo-controllers`, `avo-performance`, `avo-resources`, `avo-media-library`, `avo-multitenancy`, `avo-update` — reasons per row above. Also swept **all 24** skills for stale `:large`/`:small`/`.container-large` values and stale Mapbox-is-required claims: none found.

## Flagged, not resolved

- **`def chip` on resources is add-on territory.** `resources-api.md` now links it from the resource API index, but the DSL ships in `avo-ai` and the docs call it alpha. Confirmed absent from core source (`lib/`, `app/`) — the only "chip" in core is the unrelated breadcrumb initials chip. It belongs in **avo-ai**'s own skill; no core skill was changed for it.
- **`link_to` sub-item nesting deserves fuller coverage in `avo-menu`'s skill.** The core skill delegates the menu DSL to that gem and only carries a gotcha, which is now correct. The feature itself (nested block, parent stays clickable, parent forced active while a child is) should be documented where the DSL lives.
- **Add-on pages with no core owner:** `ai.md`, `ai-agents-and-tools.md`, `ai-what-you-can-ask.md` (`avo-ai`) and `forms-and-pages{,-api}.md` (`avo-forms`) — for those gems' own skills.
- No new pages appeared in this range that lack an owning skill, and no contradictions between docs and source were found.

## Branch note

This session is pinned by its harness to `claude/peaceful-mayer-m9tb31`, so the work is there rather than on a `docs-sync/2026-08-20` branch. Rename if the convention matters for merge.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — this PR *is* the documentation sync; no `docs.avohq.io` change is needed (the docs are the source being reconciled against)
- [x] I have added tests that prove my fix is effective or that my feature works — no new tests; `spec/lib/avo/skills` is the existing guard and passes
- [ ] I tested the design in Light and Dark mode, and all default themes — N/A, no UI change

## Screenshots &amp; recording

N/A — Markdown-only change to `lib/avo/skills/`.

## Manual review steps

1. `AVO_DOCS_PATH=&lt;docs checkout&gt; ruby lib/avo/skills/bin/docs_drift.rb` → prints `Up to date` against docs `70f1de9`.
2. `bundle exec rspec spec/lib/avo/skills` → **167 examples, 0 failures.**
3. The VitePress-artifact guard — grep `lib/avo/skills/` for the code-fence marker, the triple-colon container marker, and the `&lt;Option`, `&lt;Image`, `&lt;CustomCode`, `&lt;FieldTypesList` component tags → no matches, nothing pasted in from the docs source.
4. Spot-check the three claims against source: `Avo::MapStyles.wrapper_data` (sets the swap data attribute only when no custom style is given), `Avo::Menu::Builder#link` in `avo-menu` (parses a nested block into subitems), `Avo::Configuration::MAP_VIEW_DEFAULTS`.

&gt; [!NOTE]
&gt; The original description was truncated on creation: step 3 spelled the VitePress component tags literally, and everything from that point — including step 4 — was swallowed as unclosed HTML. Restored above with the angle brackets escaped.

---

&gt; [!NOTE]
&gt; **Low Risk**
&gt; Markdown-only skill documentation and a docs index pointer; no runtime, API, or UI changes in the gem.
&gt; 
&gt; **Overview**
&gt; **Docs reconciliation only** — updates shipped agent skills under `lib/avo/skills/` to match `avo-hq/docs.avohq.io` commit `70f1de9` (2026-08-20); `docs-index.json` marker is bumped accordingly.
&gt; 
&gt; **avo-admin-config** now routes global `config.map_view` (shared with map index view and location/area fields) to **avo-index-views** instead of duplicating it, including the Report hand-off line.
&gt; 
&gt; **avo-index-views** documents map light/dark behavior: Avo swaps between resolved `{light:, dark:}` styles, while a per-map `mapkick_options: { style: ... }` opts out of that swap; the `mapkick_options` bullet and a new gotcha spell out using `config.map_view` for theme-following custom styles.
&gt; 
&gt; **avo-navigation-search** fixes the menu `icon:` gotcha so nested sub-items are described for both `resource` and `link_to` blocks (parent link stays clickable; parent forced active when a child is selected).
&gt; 
&gt; &lt;sup&gt;Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1398f38f491bcb36dde2734afa5246521a7aac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).&lt;/sup&gt;