### PR TITLE
Memoize visibility detection for performance speedup

### DIFF
--- a/lib/avo/concerns/has_items.rb
+++ b/lib/avo/concerns/has_items.rb
@@ -209,17 +209,35 @@ module Avo
       #
       # It can't be a plain `||=` because the contextual items can change throughout a
       # request lifecycle.
+      #
+      # The context is compared by object identity, so anything *replaced* recomputes.
+      # `items.size` is in there because `Holder#add_item` appends in place: a holder
+      # that gains an item keeps both its own identity and its array's, so the count is
+      # the only cheap signal that the items changed underneath us.
+      #
+      # Request-scoped state (params, context, current_user) is deliberately absent.
+      # `detect_fields` is a `before_action` and assigns a brand-new `Items::Holder`, so
+      # the memo is already cold at the top of every request and none of those can change
+      # within the lifetime of one entry.
       def visible_items
         hydration_resource = is_a?(Avo::Resources::Base) ? self : try(:resource)
-        context = [@items_holder, view.to_s.to_sym, hydration_resource.try(:record)]
+        context = [@items_holder, items.size, view.to_s.to_sym, hydration_resource.try(:record)]
 
         unless @visible_items_context&.zip(context)&.all? { |was, now| was.equal?(now) }
           @visible_items_context = context
-          @visible_items = compute_visible_items
+          # Frozen because every caller now shares one array. Without it a caller that
+          # mutates the result silently corrupts every later read instead of failing.
+          @visible_items = compute_visible_items.freeze
         end
 
         @visible_items
       end
+
+      def is_empty?
+        visible_items.blank?
+      end
+
+      private
 
       def compute_visible_items
         items
@@ -287,12 +305,6 @@ module Avo
             !item.is_a?(Avo::Resources::Items::Sidebar)
           end.compact
       end
-
-      def is_empty?
-        visible_items.blank?
-      end
-
-      private
 
       def set_target_to_top(fields)
         fields.each do |field|

--- a/lib/avo/concerns/has_items.rb
+++ b/lib/avo/concerns/has_items.rb
@@ -202,7 +202,26 @@ module Avo
         items_holder&.items || []
       end
 
+      # Every container asks its children whether they have anything visible, so one
+      # render may call this thousands of times and each call walks the whole subtree.
+      # Memoizing it offers a significant performance boost, particularly for large
+      # resources.
+      #
+      # It can't be a plain `||=` because the contextual items can change throughout a
+      # request lifecycle.
       def visible_items
+        hydration_resource = is_a?(Avo::Resources::Base) ? self : try(:resource)
+        context = [@items_holder, view.to_s.to_sym, hydration_resource.try(:record)]
+
+        unless @visible_items_context&.zip(context)&.all? { |was, now| was.equal?(now) }
+          @visible_items_context = context
+          @visible_items = compute_visible_items
+        end
+
+        @visible_items
+      end
+
+      def compute_visible_items
         items
           .map do |item|
             hydrate_item item

--- a/spec/lib/avo/concerns/has_items_spec.rb
+++ b/spec/lib/avo/concerns/has_items_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe Avo::Concerns::HasItems do
+  after { Avo::Resources::Person.restore_items_from_backup }
+
+  let(:visible) { create :person, name: "Visible" }
+  let(:hidden) { create :person, name: "Hidden" }
+
+  def ids(resource) = resource.visible_items.map(&:id)
+
+  describe "memoization" do
+    before do
+      Avo::Resources::Person.with_temporary_items do
+        field :name, as: :text
+        field :only_when_visible, as: :text, visible: -> { resource.record&.name == "Visible" }
+        field :only_on_show, as: :text, only_on: :show
+      end
+    end
+
+    it "returns the same items without recomputing them" do
+      resource = Avo::Resources::Person.new(view: :show, record: visible).detect_fields
+
+      expect(ids(resource)).to eq [:name, :only_when_visible, :only_on_show]
+      expect(resource.visible_items).to equal resource.visible_items
+    end
+
+    # BaseController#index builds each row as `@resource.dup`, and `dup` is shallow.
+    it "gives each dup its own visibility even if the prototype was asked first" do
+      prototype = Avo::Resources::Person.new(view: :show).detect_fields
+      prototype.visible_items
+
+      rows = [visible, hidden].map { |record| prototype.dup.hydrate(record: record) }
+
+      expect(rows.map { |row| ids(row) }).to eq [
+        [:name, :only_when_visible, :only_on_show],
+        [:name, :only_on_show]
+      ]
+    end
+
+    it "recomputes when the items are re-hydrated with another record" do
+      resource = Avo::Resources::Person.new(view: :show, record: visible).detect_fields
+      expect(ids(resource)).to include :only_when_visible
+
+      resource.hydrate(record: hidden)
+
+      expect(ids(resource)).not_to include :only_when_visible
+    end
+
+    it "recomputes when the view changes" do
+      resource = Avo::Resources::Person.new(view: :show, record: visible).detect_fields
+      expect(ids(resource)).to include :only_on_show
+
+      resource.hydrate(view: :edit)
+
+      expect(ids(resource)).not_to include :only_on_show
+    end
+
+    # BaseController#show calls `detect_fields` a second time, after hydrating.
+    it "recomputes when detect_fields replaces the items" do
+      resource = Avo::Resources::Person.new(view: :show, record: visible).detect_fields
+      expect(ids(resource)).to include :name
+
+      Avo::Resources::Person.with_temporary_items { field :replaced, as: :text }
+      resource.detect_fields
+
+      expect(ids(resource)).to eq [:replaced]
+    end
+  end
+end

--- a/spec/lib/avo/concerns/has_items_spec.rb
+++ b/spec/lib/avo/concerns/has_items_spec.rb
@@ -65,5 +65,23 @@ RSpec.describe Avo::Concerns::HasItems do
 
       expect(ids(resource)).to eq [:replaced]
     end
+
+    # `Holder#add_item` appends in place, so neither the holder nor its array
+    # changes identity — only the count says the items moved.
+    it "recomputes when an item is added to the holder it already read" do
+      resource = Avo::Resources::Person.new(view: :show, record: visible).detect_fields
+      expect(ids(resource)).to eq [:name, :only_when_visible, :only_on_show]
+
+      resource.items_holder.field :added_later, as: :text
+
+      expect(ids(resource)).to eq [:name, :only_when_visible, :only_on_show, :added_later]
+    end
+
+    it "hands out a frozen array so a caller can't corrupt the memo" do
+      resource = Avo::Resources::Person.new(view: :show, record: visible).detect_fields
+
+      expect { resource.visible_items.clear }.to raise_error FrozenError
+      expect(ids(resource)).to eq [:name, :only_when_visible, :only_on_show]
+    end
   end
 end


### PR DESCRIPTION
# Description
visible_items walks a container's whole item subtree, and every container asks its children whether they have anything visible (IsResourceItem#visible?, VisibleItems#visible?) while the tab and panel components re-derive it as they render. On resources with many fields spread across tabs, the same subtree gets walked thousands of times per request.

This memoizes the result against the context it was built in (the items holder, the view, and the record identity) so it recomputes when any of those change but not otherwise.

Fixes # (issue)

# Checklist:
<!--
  Please go through the steps and complete them if they make sense (add tests if the change requires it, add to the docs, etc.)
  (Mark [x] inside the brackets)
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I tested the design in Light and Dark mode, and all default themes

## Screenshots & recording
N/A

## Manual review steps
The performance benefit scales with tabs x fields.

Using the dummy app in the repo, the Person show page renders ~20% faster.

A resource page with 120 fields and 15 tabs saw a ~45% boost to page load time (122ms to 68ms) and the rendered html is identical.
```
class Avo::Resources::BenchPerson < Avo::BaseResource
  self.model_class = ::Person
  self.title = :name

  def fields
    field :name, as: :text, link_to_record: true

    tabs do
      15.times do |t|
        tab title: "Tab #{t}" do
          panel { card(title: "Card #{t}") { 8.times { |f| field :"b_#{t}_#{f}", as: :text do "v" end } } }
        end
      end
    end
  end
end
```
