### PR TITLE
Sync shipped skills with docs through ee0277f (2026-08-31)

### DIFF
--- a/lib/avo/skills/avo-update/SKILL.md
+++ b/lib/avo/skills/avo-update/SKILL.md
@@ -92,7 +92,7 @@ Guide sections are headed by version (`## Upgrade to 3.22.0`, `## Upgrade from 3
 
 For each section between your before and after versions:
 
-1. **Inventory first.** Grep for the API the section touches *before* changing anything. Most sections won't apply to a given app.
+1. **Inventory first.** Grep for the API the section touches *before* changing anything — and where the section is about how a label or key resolves, grep `config/locales` too, since the trigger can be a key the app already defines rather than anything in its Ruby. Most sections won't apply to a given app.
 2. Mark it **APPLIES / NOT USED / NEEDS REVIEW** in the log. Never apply a change for an API the app doesn't use.
 3. If it applies, make the edit, then boot the app and re-run the tests.
 4. Commit per section, with the version in the message.
@@ -163,6 +163,7 @@ Check the project's own instructions for how — in this order: `AGENTS.md`, `CL
 - **The update alone is not the upgrade.** Bumping the gems and skipping the guide is the single most common way an admin breaks after an "upgrade" — and the breakage often surfaces days later, in a view nobody opened.
 - **Apply sections oldest → newest.** They're written as a chain; applying 4.0.12's change before 4.0.7's can leave you editing code the earlier section was about to rename.
 - **Silent default flips pass tests.** Sections that change a default (authorization strictness, confirmation modals, expanded filters) break nothing visible in CI and change runtime behavior. Call these out individually.
+- **A section can be triggered by the app's locale files, not its Ruby.** Avo has been moving label resolution so a derived i18n key wins *over* the class attribute — actions in `4.0.17`, then cards, dashboards and scopes in `avo-dashboards` / `avo-scopes` `4.1.2`. Nothing in the app's Ruby changed, so grepping for an API name finds nothing; the trigger is a key the app already defines under `avo.action_translations`, `avo.card_translations`, `avo.dashboard_translations` or `avo.scope_translations`. Where one exists the class attribute stops being read **even when it's a lambda**, which is then never called and computes nothing, with no error. Grep those roots in `config/locales`, and move the collision with `self.translation_key` (or a value at the registration site) rather than deleting the key — **avo-i18n**.
 - **Add-on gems version independently.** `avo-kanban 0.1.17 → 0.1.18` has its own section even when Avo core barely moved. Work the lock diff, not just the core version.
 - **Assets after upgrade.** A GitHub-sourced install ships no precompiled assets — re-run `rake avo:build-assets` or the admin renders unstyled (**avo-setup**).
 - **Don't invent a migration.** If a version's change isn't in the guide or the release notes, stop and ask rather than guessing at the new API.

--- a/lib/avo/skills/docs-index.json
+++ b/lib/avo/skills/docs-index.json
@@ -1,7 +1,7 @@
 {
   "repo": "avo-hq/docs.avohq.io",
   "docs_path": "docs/4.0",
-  "commit": "70f1de9c11258f0f376862cc87b68a0d5ea48940",
-  "date": "2026-08-20",
+  "commit": "ee0277f1883e8a01c9d20503e05aa9f26170e93e",
+  "date": "2026-08-31",
   "note": "The docs commit these skills were last indexed from. Run ruby lib/avo/skills/bin/docs_drift.rb to see what changed since, and --update after a refresh."
 }


### PR DESCRIPTION
# Description

Scheduled docs↔skills reconciliation for `lib/avo/skills/`. The marker in `docs-index.json` pointed at docs `70f1de9c1125` (2026-08-20); docs `main` is now `ee0277f1883e` (2026-08-31).

`docs_drift.rb` found **one** changed page under `docs/4.0`.

## What changed

| Changed page | Skills citing it | What I did |
| --- | --- | --- |
| `M upgrade.md` ([docs#674](https://github.com/avo-hq/docs.avohq.io/pull/674)) | `avo-update` | **Edited** — one gotcha bullet + a clause in the inventory step. Details below. |

`upgrade.md` gained two sections documenting a real precedence change: a derived i18n key now wins **over** the class attribute — actions in `4.0.17` (`avo.action_translations.*`), and cards, dashboards and scopes in `avo-dashboards` / `avo-scopes` `4.1.2` (`avo.card_translations.*`, `avo.dashboard_translations.*`, `avo.scope_translations.*`). Where such a key exists the attribute stops being read, **including when it's a lambda**, which is then never called — silently.

`avo-update` doesn't carry a section list (it fetches the upgrade guide at run time), so new guide sections normally need no edit here. What these two *do* expose is a gap in the skill's method: step 5 says to inventory by grepping "the API the section touches", and for these sections nothing in the app's Ruby changed — the trigger is a key already sitting in `config/locales`. A grep for an API name finds nothing and the section gets marked NOT USED. Hence the two small edits, both version-agnostic in wording apart from the concrete examples.

## Skills edited

- **`avo-update`** — added a Gotchas bullet ("A section can be triggered by the app's locale files, not its Ruby") naming the four derived roots, the lambda-never-called consequence, and the `self.translation_key` / registration-site escape hatches, pointing at **avo-i18n**. Extended step 5's "Inventory first" to say grep `config/locales` when a section is about label/key resolution.

## Skills reviewed and left alone

- **`avo-i18n`** — not flagged (`i18n.md` is unchanged since the marker) but checked anyway, since the drifted content is i18n behavior. It already documents the four-layer cascade with the locale key beating the class attribute, all six derived roots, the key map, and `self.translation_key` for resources and actions. Verified the derived action key against the source in this checkout: `lib/avo/base_action.rb:73` — `custom_translation_key || "avo.action_translations.#{class_name.underscore}"`. Current; no edit.
- **`avo-actions`** — carries no i18n/label-resolution guidance to go stale. No edit.
- The other 21 skills — not flagged, not touched.

## Marker

`docs-index.json` moved `70f1de9c1125` → `ee0277f1883e` so the next run diffs from here.

## Flags / follow-ups

- **Add-on-owned pages:** the `avo-dashboards` / `avo-scopes` `4.1.2` half of the change is those gems' own upgrade surface. Their shipped skills should get the same locale-collision gotcha — out of scope for this repo, raising it there.
- **No new pages** appeared, none were deleted or renamed, so no dead docs URLs and no orphan pages needing a new skill.
- **Nothing unresolved** — no contradictions between the docs and the source, and no option name I couldn't verify.
- **Branch name:** this session's harness pins pushes to `claude/peaceful-mayer-ddhm8i`, so the branch isn't the `docs-sync/2026-08-31` the routine nominally asks for. Rename before merge if the naming matters.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — n/a, this PR *is* the docs reconciliation; no customer-facing docs change is needed (the docs led, the skill followed)
- [x] I have added tests that prove my fix is effective or that my feature works — n/a, no new behavior; the existing `spec/lib/avo/skills` suite is the gate and passes
- [ ] I tested the design in Light and Dark mode, and all default themes — n/a, no UI

## Screenshots & recording

n/a — Markdown only, no runtime or UI change.

## Manual review steps

1. Confirm no VitePress artifacts were pasted into the skills. The component names are written as a bracketed character class below so GitHub's HTML sanitizer doesn't eat this section — it is the same expression, and it must print nothing:

   ```bash
   grep -rnE '\[!code|:::|[<](Option|Image|CustomCode|FieldTypesList)' lib/avo/skills/
   ```

   ✅ no output.

2. `bundle exec rspec spec/lib/avo/skills` → **167 examples, 0 failures**. ✅

3. `AVO_DOCS_PATH=/path/to/docs.avohq.io ruby lib/avo/skills/bin/docs_drift.rb` against docs `main` → `Up to date with ee0277f1883e (2026-08-31).` ✅

4. Read the two-line diff in `avo-update/SKILL.md` against the two new sections in `docs/4.0/upgrade.md`.

Diff is 4 insertions / 3 deletions across 2 files, both under `lib/avo/skills/`.

<sub>(Body edited after opening: the original spelling of step 1's grep, plus a path placeholder in step 3, together looked like one unclosed HTML tag and the sanitizer swallowed steps 2–4. Same content, respelled.)</sub>

---

> [!NOTE]
> **Low Risk**
> Markdown-only skill and index metadata; no runtime, auth, or application code changes.
> 
> **Overview**
> Reconciles shipped **avo-update** guidance with docs `main` (`ee0277f`, 2026-08-31) and bumps **`docs-index.json`** so the next drift run diffs from that commit.
> 
> **`avo-update`** now covers upgrade sections whose “action required” shows up only in **`config/locales`**, not in Ruby: step 5’s inventory step says to grep locales when a section is about label/key resolution, and a new Gotcha documents i18n winning over class attributes (actions `4.0.17`, cards/dashboards/scopes in add-ons `4.1.2`), including silent failure when a colliding key shadows a **lambda** attribute — with pointers to **`avo-i18n`** and `self.translation_key`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 159383dac9992fb08b83c0d6456bb6bbb7380569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>