### PR TITLE
Sync shipped skills with docs through 046e85f (2026-09-02)

### DIFF
--- a/lib/avo/skills/avo-i18n/SKILL.md
+++ b/lib/avo/skills/avo-i18n/SKILL.md
@@ -262,9 +262,9 @@ bin/rails runner 'puts I18n.t("avo").select { |_, v| v.is_a?(String) }.keys.sort
 
 Don't reach for `bin/rails generate avo:locales` just to look — it copies Avo's locale files into `config/locales`, pinning today's wording into the app. Run it only when editable copies are actually wanted. Full rule and the worked collision: https://docs.avohq.io/4.0/i18n.md#safe-keys
 
-### Add-on gems ship English only
+### Add-on gem locales
 
-The locale generator covers Avo core. Each add-on keeps its strings under its own namespace inside `avo.*` and ships **English only** — every other language is the app's to supply, in a file per gem or one file carrying all of them (they deep-merge into the same tree).
+The locale generator covers Avo core. Each add-on keeps its strings under its own namespace inside `avo.*`, and **most ship English only** — every other language is the app's to supply, in a file per gem or one file carrying all of them (they deep-merge into the same tree).
 
 | Gem | Namespace |
 | --- | --- |
@@ -274,9 +274,13 @@ The locale generator covers Avo core. Each add-on keeps its strings under its ow
 | Dynamic Filters | `avo.dynamic_filters.*` |
 | Forms & Pages | `avo.forms.*` |
 | Intelligence | `avo.intelligence.*` |
+| REST API | `avo.api.token.*` |
 | Scopes | `avo.scopes.*` |
 
-Advanced Search is the exception that needs no locale file: everything it renders is under `avo.global_search.*` or is `avo.all`, and core translates all of them in each bundled locale. Four of those — `avo.global_search.direct_match`, `.search_results`, `.searching_on` and `avo.all` — only reached core's locale files **after 4.1.6**; on `4.1.6` and earlier they fall back to English, so define them in the app's own locale file until it's on a newer Avo.
+Two of them need no locale file from the app:
+
+- **Advanced Search** renders only `avo.global_search.*` keys and `avo.all`, and core translates all of them in each bundled locale. Four — `avo.global_search.direct_match`, `.search_results`, `.searching_on` and `avo.all` — only reached core's locale files **after 4.1.6**; on `4.1.6` and earlier they fall back to English, so define them in the app's own locale file until it's on a newer Avo.
+- **REST API** ships its own `avo.api.token.*` tree translated in every locale core supports, so the API-tokens screen follows the panel's language with no work from you. Override any of those strings by defining the same key in the app — you only write the keys you're changing. Its relative-time chips come from Rails' `datetime.distance_in_words`, which Rails ships in English only: add [rails-i18n](https://github.com/svenfuchs/rails-i18n) for translated relative times, or the chips show the exact timestamp instead.
 
 ## Key options
 

--- a/lib/avo/skills/avo-update/SKILL.md
+++ b/lib/avo/skills/avo-update/SKILL.md
@@ -88,13 +88,13 @@ If a gem didn't move as far as expected, the Gemfile constraint from step 2 is c
 
 Fetch the upgrade guide for the major version you're on (4.x → `upgrade.md`; a jump still inside 3.x → the 3.0 page; **3.x → 4.x → stop and use the Avo 3 → Avo 4 guide instead**, that's a much bigger, chapter-by-chapter job with its own procedure).
 
-Guide sections are headed by version (`## Upgrade to 3.22.0`, `## Upgrade from 3.16.2 to 3.16.3`) or by the change itself when a version only shipped one. Some are per-add-on, naming the gem and its version (an "Upgrade to avo-dashboards 4.0.9" heading), and they're interleaved with core's sections in version order rather than grouped at the end. A version section may hold **several named changes**, each with its own "Action required" note — work them all, not just the first. A `## Unreleased — …` section at the very top describes changes that have landed on `main` but aren't in a released gem yet; skip it unless the app tracks Avo from git. Newest is at the top — **read up, then apply down.**
+Guide sections are headed by version (`## Upgrade to 3.22.0`, `## Upgrade from 3.16.2 to 3.16.3`) or by the change itself when a version only shipped one. Some are per-add-on, naming the gem and its version (an "Upgrade to avo-dashboards 4.0.9" heading), and they're interleaved with core's sections in version order rather than grouped at the end. A **core** version heading can also carry an add-on's breaking changes — `## Upgrade to 4.2.0` is entirely about `avo-api` — so don't skip a core section on the grounds that core barely moved, and don't apply one just because core crossed that version: check which gem each named change is actually about. A version section may hold **several named changes**, each with its own "Action required" note — work them all, not just the first. A `## Unreleased — …` section at the very top describes changes that have landed on `main` but aren't in a released gem yet; skip it unless the app tracks Avo from git. Newest is at the top — **read up, then apply down.**
 
 For each section between your before and after versions:
 
 1. **Inventory first.** Grep for the API the section touches *before* changing anything — and where the section is about how a label or key resolves, grep `config/locales` too, since the trigger can be a key the app already defines rather than anything in its Ruby. Most sections won't apply to a given app.
 2. Mark it **APPLIES / NOT USED / NEEDS REVIEW** in the log. Never apply a change for an API the app doesn't use.
-3. If it applies, make the edit, then boot the app and re-run the tests.
+3. If it applies, make the edit, then boot the app and re-run the tests. A section may call for a **generator and a migration** rather than a code edit — run exactly the generator it names (an add-on's `install` generator usually regenerates and offers to overwrite files the app has customized, which the narrower upgrade generator leaves alone), then `rails db:migrate`.
 4. Commit per section, with the version in the message.
 
 Sections often link a deeper page (i18n, appearance, actions) — fetch and follow it rather than guessing the new API.

--- a/lib/avo/skills/docs-index.json
+++ b/lib/avo/skills/docs-index.json
@@ -1,7 +1,7 @@
 {
   "repo": "avo-hq/docs.avohq.io",
   "docs_path": "docs/4.0",
-  "commit": "ee0277f1883e8a01c9d20503e05aa9f26170e93e",
-  "date": "2026-08-31",
+  "commit": "046e85ffe0bccb3a4cab82427c898b218157ba06",
+  "date": "2026-09-02",
   "note": "The docs commit these skills were last indexed from. Run ruby lib/avo/skills/bin/docs_drift.rb to see what changed since, and --update after a refresh."
 }


### PR DESCRIPTION
# Description

Routine reconciliation of the skills shipped in `lib/avo/skills/` against `avo-hq/docs.avohq.io`, from the recorded baseline `ee0277f` (2026-08-31) to docs HEAD `046e85f` (2026-09-02). Two skills needed edits; two were reviewed and left alone. `docs-index.json` moves to the reviewed HEAD.

Only files under `lib/avo/skills/` are touched.

## Changed pages

| Changed page | Skills citing it | What changed |
| --- | --- | --- |
| `i18n.md` (M) | `avo-i18n`, `avo-associations` | **`avo-i18n` edited.** The page's add-on table gained a REST API row (`avo.api.token.*`) and now says *most* add-ons ship English only — `avo-api` ships its tree in every locale core does. The skill asserted the blanket "Add-on gems ship English only" in a heading and a lead sentence, which is now wrong for one gem, so the heading is neutral, the table carries the new row, and the "needs no locale file" note became a two-item list (Advanced Search, REST API). **`avo-associations` — no change needed:** its only citation is a generic pointer to the i18n page from the `name` row of an options table; nothing about field i18n moved. |
| `theming.md` (M) | `avo-branding-appearance` | **No change needed.** The whole diff unwraps three hard-wrapped example prompt strings onto single lines. No variable, file path, override mechanism, or ladder step changed. |
| `upgrade.md` (M) | `avo-update` | **`avo-update` edited.** A new `## Upgrade to 4.2.0` section appeared. Two things in it are new *shapes* the skill's method didn't describe: (a) a **core** version heading whose named changes are all about an add-on (`avo-api`) — the skill previously implied add-on changes always sit under a per-gem heading, which would lead an agent either to skip the section or to apply it to an app without the gem; (b) a section whose action is **run a generator, then migrate**, where the add-on's `install` generator would clobber customized files and the narrower upgrade generator won't. Both are stated generically; no `avo-api` command names were copied into core's skill. |
| `rest-api.md` (M) | — | Out of scope — see below. |
| `rest-api-api.md` (A) | — | Out of scope — see below. |

## Skills edited

- `avo-i18n` — add-on locale section
- `avo-update` — step 5 guide-section reading and per-section actions

## Skills reviewed, left alone

- `avo-associations` — generic i18n pointer, unaffected
- `avo-branding-appearance` — `theming.md` diff is reflow only

Frontmatter `description`s and `index.md` summaries were re-checked for both edited skills: neither gained a capability, so both still trigger and still describe themselves correctly.

## Not resolved here — for the `avo-api` gem

`rest-api.md` was substantially rewritten (+688/-192) and `rest-api-api.md` is new, both documenting API tokens and per-token scopes ([docs.avohq.io#651](https://github.com/avo-hq/docs.avohq.io/pull/651)). Per `package-map.md`, `avo-api` ships its own `avo-rest-api` skill, so these pages belong to that gem and are out of scope for this repo. **They need their own reconciliation in `avo-api`** — the new material covers token lifecycle, scope grants, the three refusal shapes, `edit_scopes?`, and the `avo_api:tokens` generator, and the new `rest-api-api.md` reference page is a Docs-list candidate for that skill.

Nothing else was left unresolved: no new core-owned page appeared without an owning skill, and nothing in the docs contradicted the source.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — n/a, this PR *is* the docs reconciliation; it consumes docs changes rather than producing them
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, content edits covered by the existing skills specs
- [ ] I tested the design in Light and Dark mode, and all default themes — n/a, no UI

## Screenshots & recording

n/a — Markdown only.

## Manual review steps

1. `grep -rnE "\[!code|:::|<Option|``&lt;Image|&lt;CustomCode|&lt;FieldTypesList" lib/avo/skills/' — must return nothing (no VitePress artifacts pasted in). Verified empty.·2. 'bundle exec rspec spec/lib/avo/skills' — verified, **167 examples, 0 failures**.·3. 'AVO_DOCS_PATH=&lt;docs checkout&gt; ruby lib/avo/skills/bin/docs_drift.rb' — must print "Up to date``" against a docs checkout at `046e85f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FkEhcmCTs9TSJV26Nc7zV

---
_Generated by [Claude Code](https://claude.ai/code/session_011FkEhcmCTs9TSJV26Nc7zV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only skill and index updates with no runtime or application code changes.
> 
> **Overview**
> Realigns shipped agent skills under `lib/avo/skills/` with **docs.avohq.io** at commit `046e85f` (2026-09-02); `docs-index.json` records the new baseline.
> 
> **`avo-i18n`** no longer claims every add-on is English-only: the add-on table adds **REST API** (`avo.api.token.*`), and a second “no app locale file needed” case documents that gem’s bundled translations plus **rails-i18n** for relative-time chips.
> 
> **`avo-update`** step 5 now warns that a **core** version heading can list only an add-on’s breaking changes (e.g. 4.2.0 / `avo-api`), and that some sections require the named **upgrade generator** plus `db:migrate` instead of hand-editing Ruby.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c33685d5276bf782f8f74d82e2787b94c70d82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->