### PR TITLE
Sync shipped skills with docs through 738b2d2 (2026-09-03)

### DIFF
--- a/lib/avo/skills/avo-branding-appearance/SKILL.md
+++ b/lib/avo/skills/avo-branding-appearance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: avo-branding-appearance
-description: Brand and theme an Avo admin panel — logos, favicon, color scheme, neutral/accent palettes, chart colors, per-user theme persistence, deep CSS re-skinning, and menu/action icons — starting from the no-build `config.appearance` path in `config/initializers/avo.rb`. Use when the user wants to "brand the admin with our logo and colors", "make the admin match our brand", "add our company logo", "add a favicon", "make the admin default to / support dark mode", "let users switch themes" or "lock the theme", "remember each user's theme", "change the accent/primary color" or "make the buttons blue", "change the sidebar/navbar background", "give the admin a coastal/rose/sunset theme", "our admin looks too generic", "change the dashboard chart colors", or "use a custom icon for this menu item" — whether or not they name Avo.
+description: Brand and theme an Avo admin panel — logos, favicon, color scheme, neutral/accent palettes, fonts, chart colors, per-user theme persistence, deep CSS re-skinning, and menu/action icons — starting from the no-build `config.appearance` path in `config/initializers/avo.rb`. Use when the user wants to "brand the admin with our logo and colors", "make the admin match our brand", "add our company logo", "add a favicon", "make the admin default to / support dark mode", "let users switch themes" or "lock the theme", "remember each user's theme", "change the accent/primary color" or "make the buttons blue", "change the sidebar/navbar background", "give the admin a coastal/rose/sunset theme", "our admin looks too generic", "change the font" or "use our brand typeface", "change the dashboard chart colors", or "use a custom icon for this menu item" — whether or not they name Avo.
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash, WebFetch
 metadata:
   requires-gem: none — Community
@@ -15,7 +15,7 @@ Make the Avo admin look like your product — logos, favicon, color scheme, bran
 Files you'll touch, from shallowest to deepest:
 
 - `config/initializers/avo.rb` → `config.appearance = { … }` — logos, favicon, scheme, palettes, picker/lock, persistence, chart colors. **The default answer.**
-- `app/assets/stylesheets/avo-overrides.css` — no-build CSS-variable re-skin (eject with `rails g avo:eject --partial :avo_overrides_css`). Served as-is.
+- `app/assets/stylesheets/avo-overrides.css` — no-build CSS-variable re-skin: colors, radii, fonts (eject with `rails g avo:eject --partial :avo_overrides_css`). Served as-is.
 - `app/views/avo/partials/_head.html.erb` — inline `<style>` for component variables (eject with `rails g avo:eject --partial :head`).
 - `app/assets/svgs/` — your own SVG icons for menu items / actions.
 - A JSONB column + `load_settings`/`save_settings` procs — only when persisting each user's theme to the database.
@@ -205,7 +205,26 @@ The navbar and sidebar expose **scoped** palette contracts on the `.top-navbar` 
 bin/rails generate avo:eject --partial :head
 ```
 
-The full variable list (navbar, sidebar, table, focus ring, motion) with defaults lives in the CSS variables section of `appearance-api.md` — fetch it before writing component-level overrides. For named-theme requests ("coastal", "rose", "80s sunset"), work in `avo-overrides.css` with matching `:root` and `.dark` values.
+The full variable list (fonts, navbar, sidebar, table, focus ring, motion) with defaults lives in the CSS variables section of `appearance-api.md` — fetch it before writing component-level overrides. For named-theme requests ("coastal", "rose", "80s sunset"), work in `avo-overrides.css` with matching `:root` and `.dark` values.
+
+#### Fonts
+
+Avo self-hosts **Inter** and reads it through the Tailwind theme variable `--font-sans`, which every screen inherits from the root element. Monospace text — code snippets in alerts, file details in the media library — reads `--font-mono` (not bundled; it resolves to the device's monospace font). Point either at another family in `avo-overrides.css` and the whole interface follows, with **no build step**:
+
+```css
+/* app/assets/stylesheets/avo-overrides.css */
+:root {
+  --font-sans: "IBM Plex Sans", system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+}
+```
+
+That is the entire change for a family the visitor's device already has (a system font stack). For any other typeface, load it first:
+
+- **Hosted** — paste the service's stylesheet URL as an `@import url(…)` at the **very top** of `avo-overrides.css`, then set the variable below it. Or, if you'd rather use the service's `<link>` snippet with its `preconnect` hints, eject the `:head` partial and drop the tags there; fonts don't compete in the cascade, so it doesn't matter that `:head` renders after Avo's assets. Either way the variable override still lives in `avo-overrides.css`.
+- **Self-hosted** — put the files under `public/fonts/` and declare them with `@font-face` in `avo-overrides.css`, referencing them by absolute path (`/fonts/…`) so the same file works under Propshaft and Sprockets alike, with no digest lookup. One `@font-face` per weight for static files; a single block with a `font-weight` range for a variable font.
+
+Avo sets text at weights **400, 500, 600, and 700** — load all four (or a variable font covering that range), or the browser synthesizes the missing ones. If the app sets a Content Security Policy, allow the font host in `font-src`, and in `style-src` too when the stylesheet is fetched from there.
 
 ### 8. Icons (menu items, actions)
 
@@ -239,7 +258,7 @@ For **populating menu/resource icons at scale** (migrations, whole-sidebar passe
 | `load_settings` / `save_settings` | DB persistence blocks | Proc; needs a JSON/JSONB column |
 | `chart_colors` | Dashboard chart palette | Array of **hex** Strings |
 
-CSS-only knobs (navbar/sidebar/table/focus/motion variables) are not in this hash — see step 7 and `appearance-api.md`.
+CSS-only knobs (fonts, navbar/sidebar/table/focus/motion variables) are not in this hash — see step 7 and `appearance-api.md`.
 
 ## Gotchas
 
@@ -247,6 +266,7 @@ CSS-only knobs (navbar/sidebar/table/focus/motion variables) are not in this has
 - **`neutral_colors` needs all 12 shades; `accent_colors` needs all 3 tokens.** A missing or `nil` value raises `ArgumentError`.
 - **The navbar is dark in both modes.** The `logo` must read on a dark surface. `logo_dark` is for whole-UI dark mode, not navbar contrast.
 - **`chart_colors` must be hex.** They're passed straight to Chart.js — `oklch()`/`rgb()` won't work there (even though the palettes accept them).
+- **Fonts are CSS variables, not `config.appearance` keys.** Override `--font-sans` / `--font-mono` on `:root` in `avo-overrides.css`. A hosted font's `@import url(…)` must be the **first rule in the file** — CSS ignores an `@import` that follows any other rule, and the font then silently never loads. Load weights 400, 500, 600 and 700, since Avo sets text at all four.
 - **`avo-overrides.css` is served as-is, NOT through the Tailwind build.** Only put plain CSS + variable overrides there — no `@apply`, no arbitrary values. Tailwind directives for your *own* custom UI belong in `app/assets/stylesheets/avo/` (which IS built). See the avo-custom-ui skill.
 - **DB persistence needs a JSONB column and BOTH blocks**, and `save_settings` gets a **partial** `settings` Hash (only the changed keys) — `deep_merge`, never overwrite the whole preferences blob.
 - **`config.branding` was renamed to `config.appearance` in Avo 4.** On a v3 app you may find `config.branding = { … }` — migrate it into `config.appearance`.

--- a/lib/avo/skills/avo-i18n/SKILL.md
+++ b/lib/avo/skills/avo-i18n/SKILL.md
@@ -262,9 +262,9 @@ bin/rails runner 'puts I18n.t("avo").select { |_, v| v.is_a?(String) }.keys.sort
 
 Don't reach for `bin/rails generate avo:locales` just to look — it copies Avo's locale files into `config/locales`, pinning today's wording into the app. Run it only when editable copies are actually wanted. Full rule and the worked collision: https://docs.avohq.io/4.0/i18n.md#safe-keys
 
-### Add-on gems ship English only
+### Add-on gems mostly ship English only
 
-The locale generator covers Avo core. Each add-on keeps its strings under its own namespace inside `avo.*` and ships **English only** — every other language is the app's to supply, in a file per gem or one file carrying all of them (they deep-merge into the same tree).
+The locale generator covers Avo core. Each add-on keeps its strings under its own namespace inside `avo.*`, and **most ship English only** — every other language is then the app's to supply, in a file per gem or one file carrying all of them (they deep-merge into the same tree).
 
 | Gem | Namespace |
 | --- | --- |
@@ -274,9 +274,12 @@ The locale generator covers Avo core. Each add-on keeps its strings under its ow
 | Dynamic Filters | `avo.dynamic_filters.*` |
 | Forms & Pages | `avo.forms.*` |
 | Intelligence | `avo.intelligence.*` |
+| REST API | `avo.api.token.*` |
 | Scopes | `avo.scopes.*` |
 
-Advanced Search is the exception that needs no locale file: everything it renders is under `avo.global_search.*` or is `avo.all`, and core translates all of them in each bundled locale. Four of those — `avo.global_search.direct_match`, `.search_results`, `.searching_on` and `avo.all` — only reached core's locale files **after 4.1.6**; on `4.1.6` and earlier they fall back to English, so define them in the app's own locale file until it's on a newer Avo.
+A gem that ships more says so on its own Localization docs page — check there before assuming you have to translate it. `avo-api` is one: it ships `avo.api.token.*` in every locale core does, so the REST API's token panel is translated with no work from you.
+
+Advanced Search is exempt for a different reason — it ships no locale file at all, and needs none: everything it renders is under `avo.global_search.*` or is `avo.all`, and core translates all of them in each bundled locale. Four of those — `avo.global_search.direct_match`, `.search_results`, `.searching_on` and `avo.all` — only reached core's locale files **after 4.1.6**; on `4.1.6` and earlier they fall back to English, so define them in the app's own locale file until it's on a newer Avo.
 
 ## Key options
 

--- a/lib/avo/skills/avo-update/SKILL.md
+++ b/lib/avo/skills/avo-update/SKILL.md
@@ -94,7 +94,7 @@ For each section between your before and after versions:
 
 1. **Inventory first.** Grep for the API the section touches *before* changing anything — and where the section is about how a label or key resolves, grep `config/locales` too, since the trigger can be a key the app already defines rather than anything in its Ruby. Most sections won't apply to a given app.
 2. Mark it **APPLIES / NOT USED / NEEDS REVIEW** in the log. Never apply a change for an API the app doesn't use.
-3. If it applies, make the edit, then boot the app and re-run the tests.
+3. If it applies, make the change, then boot the app and re-run the tests. **Not every section is a code edit** — some ship a new table and tell you to run a generator and `rails db:migrate`. Run exactly the command the section names: a gem's `install` generator usually pulls in more than the upgrade needs and offers to overwrite files the app has customized, while the narrower generator the section points at leaves them alone.
 4. Commit per section, with the version in the message.
 
 Sections often link a deeper page (i18n, appearance, actions) — fetch and follow it rather than guessing the new API.

--- a/lib/avo/skills/docs-index.json
+++ b/lib/avo/skills/docs-index.json
@@ -1,7 +1,7 @@
 {
   "repo": "avo-hq/docs.avohq.io",
   "docs_path": "docs/4.0",
-  "commit": "ee0277f1883e8a01c9d20503e05aa9f26170e93e",
-  "date": "2026-08-31",
+  "commit": "738b2d22c36840d180011ee9d6ac8e1aa485389d",
+  "date": "2026-09-03",
   "note": "The docs commit these skills were last indexed from. Run ruby lib/avo/skills/bin/docs_drift.rb to see what changed since, and --update after a refresh."
 }

--- a/lib/avo/skills/index.md
+++ b/lib/avo/skills/index.md
@@ -32,7 +32,7 @@ Each entry is a directory beside this file: `<skill>/SKILL.md`.
 
 | Skill | Covers |
 | --- | --- |
-| `avo-branding-appearance` | Logo, favicon, color scheme, palettes, CSS re-skin, icons |
+| `avo-branding-appearance` | Logo, favicon, color scheme, palettes, fonts, CSS re-skin, icons |
 | `avo-menu-icons` | Pick the right Tabler icon and apply it to resources. The menu DSL is `avo-menu`'s own skill |
 | `avo-navigation-search` | Per-resource search, breadcrumbs, keyboard shortcuts, the auto-generated sidebar |
 | `avo-custom-ui` | Custom pages, embedded panels, dynamic/nested forms, ejected views, Stimulus, Tailwind |


### PR DESCRIPTION
# Description

Routine docs-drift reconciliation for the skills shipped in `lib/avo/skills/`. Six pages changed under `docs/4.0` between the recorded marker `ee0277f` (2026-08-31) and docs HEAD `738b2d2` (2026-09-03). Three skills needed a real edit; `docs-index.json` moves to `738b2d2` either way so the next run's diff stays small.

Everything in the diff is under `lib/avo/skills/`.

## Changed pages

| Changed page | Skills citing it | What changed |
| --- | --- | --- |
| `theming.md` (M) | `avo-branding-appearance` | **Edited.** New "Change the font" section: `--font-sans` / `--font-mono` overridden on `:root` in `avo-overrides.css`, hosted loading via `@import` or ejected `:head`, self-hosting from `public/fonts/`. Added as a `#### Fonts` subsection under the existing CSS-variable step. (The other commit touching this page only re-wrapped the three AI-prompt code blocks — no content change.) |
| `appearance-api.md` (M) | `avo-branding-appearance` | **Edited.** New Fonts variable table. Both variables were verified against this checkout before writing: `--font-sans` is declared in `app/assets/stylesheets/application.css:36` with Inter, self-hosted at weights 400/500/600/700 in `app/assets/images/avo/fonts/`; `--font-mono` is not declared by Avo and resolves through Tailwind's own theme via `@import "tailwindcss"`, matching the docs' "not bundled" note. |
| `i18n.md` (M) | `avo-associations`, `avo-i18n` | **Edited `avo-i18n`.** The add-on gem table gained a REST API row (`avo.api.token.*`) and the page dropped its blanket "add-on gems ship English only" claim — `avo-api` ships its tree in every locale core does. The skill asserted the old claim in a section heading, so heading, claim and table are updated. **No change for `avo-associations`** — it cites `i18n.md` once, as a pointer for overriding a `has_many` panel label, and nothing in that area moved. |
| `upgrade.md` (M) | `avo-update` | **Edited.** New `## Upgrade to 4.2.0` section. The skill is procedural and doesn't enumerate versions, so most of it needs nothing — but this is the **first** guide section that requires running a generator and `rails db:migrate` rather than editing code (confirmed: no `rails generate` or `db:migrate` existed anywhere on the page at the marker), and it explicitly warns off the gem's `install` generator because that one offers to overwrite customized files. Added that as one sentence in the per-section loop, stated generically rather than naming `avo-api`'s generator. |
| `rest-api.md` (M) | — not cited by any skill | **No change.** Out of scope — see below. |
| `rest-api-api.md` (A) | — not cited by any skill | **No change.** Out of scope — see below. |

## Skills edited

- **`avo-branding-appearance`** — new `#### Fonts` subsection in the CSS-variables step; a gotcha covering the `@import`-must-be-the-first-rule trap and the four weights Avo sets; "fonts" added to the files-you'll-touch line, the CSS-only-knobs note and the key-options footnote. The gained capability also went into the frontmatter `description` (`"change the font"`, `"use our brand typeface"`; 880/1024 chars) and the `index.md` one-liner.
- **`avo-i18n`** — heading, claim and table in the add-on-gems section.
- **`avo-update`** — one sentence in step 5's per-section loop.

## Reviewed and left alone

- **`avo-associations`** — reasoning in the table above.

## Not resolved here

- **`rest-api.md` and `rest-api-api.md` are `avo-api`'s to cover.** `rest-api.md` was substantially rewritten (+688/−177) and `rest-api-api.md` is new (+210), both from the same commit documenting API tokens and per-token scopes. No core skill cites either page, and per the add-on-gem split these belong to `avo-api`'s own shipped skills — **flagging for that gem, not fixed here.** The four `## Upgrade to 4.2.0` items in `upgrade.md` are all `avo-api` behavior changes and want the same treatment there.
- **No new skill was created.** `rest-api-api.md` is a new page with no owning core skill; noted rather than acted on.
- **No dead docs URLs.** No page under `docs/4.0` was deleted or renamed in this range, so no skill's Docs list needed repointing.
- **No contradictions found** between the docs and this checkout. The one thing worth verifying — the two font variables — checked out exactly as documented.

## Branch name

The task called for `docs-sync/2026-09-03`. This session is pinned to the assigned branch `claude/peaceful-mayer-bklhka` and is not permitted to push elsewhere, so the work is there instead. Rename or retarget freely if the `docs-sync/` convention matters for this PR.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs) — n/a, this PR is the documentation-follows-docs direction: it reconciles shipped skills *against* docs.avohq.io, which is already current.
- [x] I have added tests that prove my fix is effective or that my feature works — n/a, no new behavior. The existing `spec/lib/avo/skills` suite covers the constraints this diff has to keep (frontmatter, description cap, precedence line, index parity) and passes.
- [ ] I tested the design in Light and Dark mode, and all default themes — n/a, no UI change.

## Screenshots & recording

n/a — Markdown only.

## Manual review steps

1. `AVO_DOCS_PATH=<docs checkout> ruby lib/avo/skills/bin/docs_drift.rb` on a docs checkout at `738b2d2` prints "Up to date".
2. `bundle exec rspec spec/lib/avo/skills` → **167 examples, 0 failures**.
3. `grep -rnE "\[!code|:::|<Option|``&lt;Image|&lt;CustomCode|&lt;FieldTypesList``" lib/avo/skills/` → empty, no VitePress artifacts pasted in.
4. Read the `#### Fonts` subsection in `avo-branding-appearance` against `docs/4.0/theming.md#change-the-font` and the Fonts table in `docs/4.0/appearance-api.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLQRtAMaZgGLSzaMXcNmUA

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLQRtAMaZgGLSzaMXcNmUA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only skill documentation and a docs index pointer; no runtime or application code changes.
> 
> **Overview**
> **Docs-drift sync** for `lib/avo/skills/` against docs.avohq.io commit `738b2d2` (2026-09-03); `docs-index.json` moves off the prior `ee0277f` marker.
> 
> **`avo-branding-appearance`** gains a **`#### Fonts`** subsection and related callouts: override `--font-sans` / `--font-mono` in `avo-overrides.css`, hosted `@import` or ejected `:head`, self-hosting from `public/fonts/`, weight/CSP/`@import`-first gotchas, plus frontmatter/index mentions of font branding.
> 
> **`avo-i18n`** softens the “add-ons ship English only” claim, adds the REST API namespace row (`avo.api.token.*`), and notes **`avo-api`** ships token strings in every core locale.
> 
> **`avo-update`** step 5 now says some upgrade sections require the named **generator + `db:migrate`**, not a code edit, and to avoid broad `install` generators that overwrite customized files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63d10c4be8cf2fc137cafa1b249554baccfbbd89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->