### PR TITLE
fix: render a tab badge once per tab group instead of once per panel

### DIFF
--- a/app/components/avo/tab_group_component.html.erb
+++ b/app/components/avo/tab_group_component.html.erb
@@ -22,7 +22,7 @@
               active: tab_active?(tab_item, tab),
               href: tab_path(tab_item),
               title: tab_item.description,
-              badge: tab_item.badge,
+              badge: rendered_badge(tab_item),
               data: tab_data(tab_item, tab)
             ) %>
           <% end %>

--- a/app/components/avo/tab_group_component.rb
+++ b/app/components/avo/tab_group_component.rb
@@ -130,4 +130,17 @@ class Avo::TabGroupComponent < Avo::BaseComponent
   def tab_active?(tab, current_tab)
     tab.title == current_tab.title
   end
+
+  # A tab's badge is one component instance and the tab bar is rendered once per
+  # panel, so render the badge once and hand every copy the same HTML.
+  # ViewComponent refuses to render an instance twice (ReusedInstanceError).
+  def rendered_badge(tab_item)
+    @rendered_badges ||= {}
+
+    @rendered_badges.fetch(tab_item) do
+      badge = tab_item.badge
+
+      @rendered_badges[tab_item] = badge.respond_to?(:render_in) ? render(badge) : badge
+    end
+  end
 end

--- a/spec/requests/avo/tab_badge_request_spec.rb
+++ b/spec/requests/avo/tab_badge_request_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+# A tab's `badge:` is one component instance, built once when the resource's
+# fields are evaluated. The tab group renders a copy of the tab bar inside every
+# panel, so that single instance is asked to render once per tab. ViewComponent
+# 4.15+ refuses to render an instance twice (ReusedInstanceError,
+# GHSA-8qw7-6phv-7q6p), so the group has to render the badge once and share the
+# result across the copies. The dummy User resource's first tabs group carries
+# `badge: Avo::UI::CountComponent.new(count: 3)` on its "Created at" tab.
+RSpec.describe "Tab badges", type: :request do
+  let(:admin_user) { create :user, roles: {admin: true} }
+
+  before { login_as admin_user }
+
+  def badge_pills
+    response.body.scan(/class="count[^"]*"[^>]*>\s*3\s*</)
+  end
+
+  it "renders a component-instance badge on every copy of the tab bar on new" do
+    get "/admin/resources/users/new"
+
+    expect(response).to have_http_status(:ok)
+    expect(badge_pills.size).to be > 1
+  end
+
+  it "renders a component-instance badge on every copy of the tab bar on show" do
+    get "/admin/resources/users/#{admin_user.slug}"
+
+    expect(response).to have_http_status(:ok)
+    expect(badge_pills.size).to be > 1
+  end
+end


### PR DESCRIPTION
# Description

Any view showing a tab group whose tab has a component `badge:` (documented in fields-layout-api: `tab title: "Orders", badge: Avo::UI::CountComponent.new(count: 3)`) raises:

```
ViewComponent::ReusedInstanceError
ViewComponent instances are single-use; a Avo::UI::CountComponent instance was rendered more than once.
```

The badge is one component instance, built when the resource's fields are evaluated. Since #4664 the tab group renders a copy of the tab bar inside every panel, so that single instance was rendered once per tab. ViewComponent 4.15.0, pulled in by #4755, raises on the second render (GHSA-8qw7-6phv-7q6p) and has no switch to turn the check off.

`Avo::TabGroupComponent` now renders each badge once and memoizes the HTML per tab item, and the template passes that string to every copy of the tab bar. `Avo::UI::Tabs::TabComponent#render_badge` already accepted a pre-rendered string, so nothing else changes. A string badge passes through untouched.

The dummy User resource carries such a badge on its "Created at" tab, so `spec/system/avo/group_3/tabs_spec.rb` has been failing on `main` since the bump. This should turn it green again.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs) — the `badge:` API is unchanged
- [x] I have added tests that prove my fix is effective or that my feature works — `spec/requests/avo/tab_badge_request_spec.rb` fails with `ReusedInstanceError` before this change
- [ ] I tested the design in Light and Dark mode, and all default themes — no visual change

## Manual review steps

1. Open `/admin/resources/users/new` or any user's show page in the dummy app. Before this change it 500s with `ReusedInstanceError`.
2. The "Created at" tab shows its `3` pill in every panel's copy of the tab bar.

https://claude.ai/code/session_014vKq74pjsp29ccdFdY17CL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI rendering fix with memoized HTML; no API or auth/data changes, and `TabComponent` already accepted pre-rendered badge strings.
> 
> **Overview**
> Fixes **500s** from `ViewComponent::ReusedInstanceError` when a tab uses a component `badge:` (e.g. `Avo::UI::CountComponent`) on pages that render the tab bar once per panel.
> 
> `Avo::TabGroupComponent` now **memoizes** each tab’s badge: component badges are rendered **once** via `rendered_badge` and the resulting HTML is passed to every `TabComponent` copy; plain string badges are unchanged. Request specs assert the User resource’s count pill appears on **multiple** tab bars on new/show without error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faba059d96a7f3dbfe9ffe2bc8f251006c267a72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->