### PR TITLE
Skills package map: list avo-ai's onboarding skill

### DIFF
--- a/lib/avo/skills/package-map.md
+++ b/lib/avo/skills/package-map.md
@@ -14,7 +14,7 @@ The loader reports what is **installed**, never what is **licensed** — license
 | Gem | Skill | Subjects | More |
 | --- | --- | --- | --- |
 | `avo-advanced_search` | `avo-advanced-search` | Cmd+K global search across resources; searchable association pickers | https://avohq.io/addons/global-search |
-| `avo-ai` | `avo-ai-tools` | AI assistant in the admin — the tools the assistant may call, custom tools, ejecting shipped tools | https://docs.avohq.io/4.0/ai.html |
+| `avo-ai` | `avo-ai-tools`, `avo-ai-onboarding` | AI assistant in the admin — the tools the assistant may call, custom tools, ejecting shipped tools; onboarding the assistant onto the app's own domain | https://docs.avohq.io/4.0/ai.html |
 | `avo-api` | `avo-rest-api` | JSON REST API over every resource, token auth, per-token permission matrix | https://avohq.io/addons/api |
 | `avo-audit_logging` | `avo-audit-logging` | Who changed and viewed what — timeline, diffs, revert | https://avohq.io/pricing |
 | `avo-authorization` | `avo-authorization` | Pundit policies for resources, actions, associations, files | https://avohq.io/addons/authorization |


### PR DESCRIPTION
# Description

Refs AVO-1725. Companion to the avo-hq/workspace PR that adds the `avo-ai-onboarding` skill to `avo-ai`.

One line in `lib/avo/skills/package-map.md`: the `avo-ai` row now names both skills the gem ships (`avo-ai-tools`, `avo-ai-onboarding`) and mentions onboarding in its subjects, so the loader's "not installed" text describes what the gem provides. The row still starts with the gem name the resolver and `index_integrity_spec` key on.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (n/a, markdown row)
- [x] I have made corresponding changes to the documentation (docs PR in avo-hq/docs.avohq.io)
- [ ] I have added tests that prove my fix is effective or that my feature works (n/a; existing `index_integrity_spec` covers the map's shape)
- [ ] I tested the design in Light and Dark mode, and all default themes (n/a)

## Screenshots & recording

n/a

## Manual review steps

1. Run `bash lib/avo/skills/bin/avo-skills-resolve` in an app without `avo-ai`; the "Not installed" list names the gem with the updated subjects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Di9NR9M5cFVYxNiX8icftp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Di9NR9M5cFVYxNiX8icftp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the skills package map; no runtime or security behavior changes beyond more accurate loader text when `avo-ai` is missing.
> 
> **Overview**
> Updates the **`avo-ai`** row in **`package-map.md`** so the skills loader and “not installed” messaging reflect both skills that gem ships: **`avo-ai-tools`** and the new **`avo-ai-onboarding`**.
> 
> The **Subjects** column now also mentions onboarding the assistant onto the app’s domain, alongside the existing tools/custom-tools copy. This aligns the allowlist/miss-path map with the companion **`avo-ai`** workspace change that adds the onboarding skill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfa3e9fd10abe5ae658c4c9daba55254a7719b0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->