### PR TITLE
Sync shipped skills with docs through 55931cc (2026-09-05)

### DIFF
--- a/lib/avo/skills/avo-branding-appearance/SKILL.md
+++ b/lib/avo/skills/avo-branding-appearance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: avo-branding-appearance
-description: Brand and theme an Avo admin panel — logos, favicon, color scheme, neutral/accent palettes, chart colors, per-user theme persistence, deep CSS re-skinning, and menu/action icons — starting from the no-build `config.appearance` path in `config/initializers/avo.rb`. Use when the user wants to "brand the admin with our logo and colors", "make the admin match our brand", "add our company logo", "add a favicon", "make the admin default to / support dark mode", "let users switch themes" or "lock the theme", "remember each user's theme", "change the accent/primary color" or "make the buttons blue", "change the sidebar/navbar background", "give the admin a coastal/rose/sunset theme", "our admin looks too generic", "change the dashboard chart colors", or "use a custom icon for this menu item" — whether or not they name Avo.
+description: Brand and theme an Avo admin panel — logos, favicon, color scheme, neutral/accent palettes, fonts, chart colors, per-user theme persistence, deep CSS re-skinning, and menu/action icons — starting from the no-build `config.appearance` path in `config/initializers/avo.rb`. Use when the user wants to "brand the admin with our logo and colors", "make the admin match our brand", "add our company logo", "add a favicon", "make the admin default to / support dark mode", "let users switch themes" or "lock the theme", "remember each user's theme", "change the accent/primary color" or "make the buttons blue", "change the sidebar/navbar background", "change the font" or "use our brand typeface in the admin", "give the admin a coastal/rose/sunset theme", "our admin looks too generic", "change the dashboard chart colors", or "use a custom icon for this menu item" — whether or not they name Avo.
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash, WebFetch
 metadata:
   requires-gem: none — Community
@@ -10,12 +10,12 @@ metadata:
 
 # Avo Branding & Appearance
 
-Make the Avo admin look like your product — logos, favicon, color scheme, brand colors, chart colors, and the deeper CSS chrome (navbar, sidebar, tables). Avo gives you a ladder: start with a few lines of Ruby in `config/initializers/avo.rb` (`config.appearance = { … }`, **no build step**), and only drop to CSS or ejected views when the Ruby layer can't express what you want. **Almost every branding request is satisfied by `config.appearance` alone** — reach for CSS last.
+Make the Avo admin look like your product — logos, favicon, color scheme, brand colors, fonts, chart colors, and the deeper CSS chrome (navbar, sidebar, tables). Avo gives you a ladder: start with a few lines of Ruby in `config/initializers/avo.rb` (`config.appearance = { … }`, **no build step**), and only drop to CSS or ejected views when the Ruby layer can't express what you want. **Almost every branding request is satisfied by `config.appearance` alone** — reach for CSS last.
 
 Files you'll touch, from shallowest to deepest:
 
 - `config/initializers/avo.rb` → `config.appearance = { … }` — logos, favicon, scheme, palettes, picker/lock, persistence, chart colors. **The default answer.**
-- `app/assets/stylesheets/avo-overrides.css` — no-build CSS-variable re-skin (eject with `rails g avo:eject --partial :avo_overrides_css`). Served as-is.
+- `app/assets/stylesheets/avo-overrides.css` — no-build CSS-variable re-skin, including the typeface (eject with `rails g avo:eject --partial :avo_overrides_css`). Served as-is.
 - `app/views/avo/partials/_head.html.erb` — inline `<style>` for component variables (eject with `rails g avo:eject --partial :head`).
 - `app/assets/svgs/` — your own SVG icons for menu items / actions.
 - A JSONB column + `load_settings`/`save_settings` procs — only when persisting each user's theme to the database.
@@ -25,7 +25,7 @@ Files you'll touch, from shallowest to deepest:
 Authoritative docs — fetch on demand, verify option names against them (and the app's installed Avo source) before writing; don't inline whole pages:
 
 - Docs map (discover pages): https://docs.avohq.io/4.0/docs-map.md
-- Theming overview (the ladder): https://docs.avohq.io/4.0/theming.md
+- Theming overview (the ladder, incl. changing the font): https://docs.avohq.io/4.0/theming.md
 - Appearance guide: https://docs.avohq.io/4.0/appearance.md — API reference (every option, defaults, CSS variables): https://docs.avohq.io/4.0/appearance-api.md
 - Icons (Tabler / Heroicons / your own SVGs): https://docs.avohq.io/4.0/icons.md
 - Branding → Appearance (Avo 3 `config.branding` was renamed to `config.appearance` in Avo 4): https://docs.avohq.io/4.0/branding.md
@@ -205,9 +205,52 @@ The navbar and sidebar expose **scoped** palette contracts on the `.top-navbar` 
 bin/rails generate avo:eject --partial :head
 ```
 
-The full variable list (navbar, sidebar, table, focus ring, motion) with defaults lives in the CSS variables section of `appearance-api.md` — fetch it before writing component-level overrides. For named-theme requests ("coastal", "rose", "80s sunset"), work in `avo-overrides.css` with matching `:root` and `.dark` values.
+The full variable list (navbar, sidebar, table, focus ring, motion, fonts) with defaults lives in the CSS variables section of `appearance-api.md` — fetch it before writing component-level overrides. For named-theme requests ("coastal", "rose", "80s sunset"), work in `avo-overrides.css` with matching `:root` and `.dark` values.
 
-### 8. Icons (menu items, actions)
+### 8. Fonts
+
+Avo self-hosts **Inter** (Latin subset, weights 400/500/600/700) and reads it through the Tailwind theme variable `--font-sans`, which every screen inherits from the root element. Monospace text — code in alerts, media-library file details, the welcome page's commands — reads `--font-mono`, which Avo does not bundle (it resolves to the device's monospace font). Overriding either on `:root` in `avo-overrides.css` retypes the whole admin, **no build step**:
+
+```css
+/* app/assets/stylesheets/avo-overrides.css */
+:root {
+  --font-sans: "IBM Plex Sans", system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+}
+```
+
+That's the whole change for a family the visitor's device already has (a system font stack). For anything else, load it first — two ways:
+
+**Hosted** — put the service's stylesheet URL in an `@import` at the **very top** of `avo-overrides.css` (CSS requires imports before any other rule), then set the variable below it:
+
+```css
+/* app/assets/stylesheets/avo-overrides.css */
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap");
+
+:root {
+  --font-sans: "IBM Plex Sans", system-ui, sans-serif;
+}
+```
+
+To use the service's own `<link>` snippet (with its `preconnect` hints) instead, eject the `:head` partial and drop the tags there — fonts don't compete in the cascade, so it doesn't matter that `:head` renders after Avo's assets. The variable override still belongs in `avo-overrides.css`. Google Fonts, Bunny Fonts (same library, no tracking), Fontshare, and Adobe Fonts (`https://use.typekit.net/<kit-id>.css`) all hand you such a URL.
+
+**Self-hosted** — drop the files under `public/fonts/` and declare them with `@font-face` in `avo-overrides.css`. An absolute path keeps working under both Propshaft and Sprockets with no digest lookup:
+
+```css
+@font-face {
+  font-family: "IBM Plex Sans";
+  font-style: normal;
+  font-weight: 400 700;   /* one variable font; static files need one rule per weight */
+  font-display: swap;
+  src: url("/fonts/ibm-plex-sans-variable.woff2") format("woff2");
+}
+
+:root {
+  --font-sans: "IBM Plex Sans", system-ui, sans-serif;
+}
+```
+
+### 9. Icons (menu items, actions)
 
 Anywhere Avo takes an `icon:`, pass a path string. **Prefer Tabler in v4** (`tabler/outline/<name>` or `tabler/filled/<name>`); Heroicons (`heroicons/outline/<name>`, also `solid`/`mini`/`micro`) are legacy-supported. Your own SVGs go in `app/assets/svgs/` and are referenced by filename.
 
@@ -239,7 +282,7 @@ For **populating menu/resource icons at scale** (migrations, whole-sidebar passe
 | `load_settings` / `save_settings` | DB persistence blocks | Proc; needs a JSON/JSONB column |
 | `chart_colors` | Dashboard chart palette | Array of **hex** Strings |
 
-CSS-only knobs (navbar/sidebar/table/focus/motion variables) are not in this hash — see step 7 and `appearance-api.md`.
+CSS-only knobs (navbar/sidebar/table/focus/motion variables, and the `--font-sans` / `--font-mono` typefaces) are not in this hash — see steps 7–8 and `appearance-api.md`.
 
 ## Gotchas
 
@@ -247,6 +290,7 @@ CSS-only knobs (navbar/sidebar/table/focus/motion variables) are not in this has
 - **`neutral_colors` needs all 12 shades; `accent_colors` needs all 3 tokens.** A missing or `nil` value raises `ArgumentError`.
 - **The navbar is dark in both modes.** The `logo` must read on a dark surface. `logo_dark` is for whole-UI dark mode, not navbar contrast.
 - **`chart_colors` must be hex.** They're passed straight to Chart.js — `oklch()`/`rgb()` won't work there (even though the palettes accept them).
+- **A font needs weights 400, 500, 600 and 700.** Avo sets text at all four, so load all four (or a variable font spanning them) — otherwise the browser synthesizes the missing ones and the admin looks subtly wrong. An `@import` for a hosted font must be the **first** rule in `avo-overrides.css`, and an app with a Content Security Policy has to allow the font host in `font-src` (and `style-src` when the stylesheet comes from there too).
 - **`avo-overrides.css` is served as-is, NOT through the Tailwind build.** Only put plain CSS + variable overrides there — no `@apply`, no arbitrary values. Tailwind directives for your *own* custom UI belong in `app/assets/stylesheets/avo/` (which IS built). See the avo-custom-ui skill.
 - **DB persistence needs a JSONB column and BOTH blocks**, and `save_settings` gets a **partial** `settings` Hash (only the changed keys) — `deep_merge`, never overwrite the whole preferences blob.
 - **`config.branding` was renamed to `config.appearance` in Avo 4.** On a v3 app you may find `config.branding = { … }` — migrate it into `config.appearance`.

--- a/lib/avo/skills/avo-i18n/SKILL.md
+++ b/lib/avo/skills/avo-i18n/SKILL.md
@@ -262,21 +262,24 @@ bin/rails runner 'puts I18n.t("avo").select { |_, v| v.is_a?(String) }.keys.sort
 
 Don't reach for `bin/rails generate avo:locales` just to look — it copies Avo's locale files into `config/locales`, pinning today's wording into the app. Run it only when editable copies are actually wanted. Full rule and the worked collision: https://docs.avohq.io/4.0/i18n.md#safe-keys
 
-### Add-on gems ship English only
+### Add-on gems mostly ship English only
 
-The locale generator covers Avo core. Each add-on keeps its strings under its own namespace inside `avo.*` and ships **English only** — every other language is the app's to supply, in a file per gem or one file carrying all of them (they deep-merge into the same tree).
+The locale generator covers Avo core. Each add-on keeps its strings under its own namespace inside `avo.*`, and **most ship English only** — every other language is the app's to supply, in a file per gem or one file carrying all of them (they deep-merge into the same tree). A gem that ships more says so on its own Localization page.
 
-| Gem | Namespace |
-| --- | --- |
-| Advanced Search | `avo.global_search.*` |
-| Collaboration | `avo.collaboration.*` |
-| Dashboards & Cards | `avo.cards.*` |
-| Dynamic Filters | `avo.dynamic_filters.*` |
-| Forms & Pages | `avo.forms.*` |
-| Intelligence | `avo.intelligence.*` |
-| Scopes | `avo.scopes.*` |
+| Gem | Namespace | Ships |
+| --- | --- | --- |
+| Advanced Search | `avo.global_search.*` | nothing — core covers it |
+| Collaboration | `avo.collaboration.*` | English only |
+| Dashboards & Cards | `avo.cards.*` | English only |
+| Dynamic Filters | `avo.dynamic_filters.*` | English only |
+| Forms & Pages | `avo.forms.*` | English only |
+| Intelligence | `avo.intelligence.*` | English only |
+| REST API | `avo.api.token.*` | every locale core ships |
+| Scopes | `avo.scopes.*` | English only |
 
 Advanced Search is the exception that needs no locale file: everything it renders is under `avo.global_search.*` or is `avo.all`, and core translates all of them in each bundled locale. Four of those — `avo.global_search.direct_match`, `.search_results`, `.searching_on` and `avo.all` — only reached core's locale files **after 4.1.6**; on `4.1.6` and earlier they fall back to English, so define them in the app's own locale file until it's on a newer Avo.
+
+`avo-api` is the other end of the range: it ships its own tree in every locale core does, so the API tokens panel is translated with no work from the app.
 
 ## Key options
 

--- a/lib/avo/skills/avo-update/SKILL.md
+++ b/lib/avo/skills/avo-update/SKILL.md
@@ -88,13 +88,13 @@ If a gem didn't move as far as expected, the Gemfile constraint from step 2 is c
 
 Fetch the upgrade guide for the major version you're on (4.x → `upgrade.md`; a jump still inside 3.x → the 3.0 page; **3.x → 4.x → stop and use the Avo 3 → Avo 4 guide instead**, that's a much bigger, chapter-by-chapter job with its own procedure).
 
-Guide sections are headed by version (`## Upgrade to 3.22.0`, `## Upgrade from 3.16.2 to 3.16.3`) or by the change itself when a version only shipped one. Some are per-add-on, naming the gem and its version (an "Upgrade to avo-dashboards 4.0.9" heading), and they're interleaved with core's sections in version order rather than grouped at the end. A version section may hold **several named changes**, each with its own "Action required" note — work them all, not just the first. A `## Unreleased — …` section at the very top describes changes that have landed on `main` but aren't in a released gem yet; skip it unless the app tracks Avo from git. Newest is at the top — **read up, then apply down.**
+Guide sections are headed by version (`## Upgrade to 3.22.0`, `## Upgrade from 3.16.2 to 3.16.3`) or by the change itself when a version only shipped one. Some are per-add-on, naming the gem and its version (an "Upgrade to avo-dashboards 4.0.9" heading), and they're interleaved with core's sections in version order rather than grouped at the end. But a **bare version heading is not automatically core-only** — an add-on shipping on the same release train lands under it (every named change under "Upgrade to 4.2.0" is `avo-api`'s), so read each change for the gem it actually names rather than the heading. A version section may hold **several named changes**, each with its own "Action required" note — work them all, not just the first. A `## Unreleased — …` section at the very top describes changes that have landed on `main` but aren't in a released gem yet; skip it unless the app tracks Avo from git. Newest is at the top — **read up, then apply down.**
 
 For each section between your before and after versions:
 
 1. **Inventory first.** Grep for the API the section touches *before* changing anything — and where the section is about how a label or key resolves, grep `config/locales` too, since the trigger can be a key the app already defines rather than anything in its Ruby. Most sections won't apply to a given app.
 2. Mark it **APPLIES / NOT USED / NEEDS REVIEW** in the log. Never apply a change for an API the app doesn't use.
-3. If it applies, make the edit, then boot the app and re-run the tests.
+3. If it applies, make the edit — or run the **generator and migration** the section names, since some sections ship a new table rather than an API change — then boot the app and re-run the tests.
 4. Commit per section, with the version in the message.
 
 Sections often link a deeper page (i18n, appearance, actions) — fetch and follow it rather than guessing the new API.

--- a/lib/avo/skills/docs-index.json
+++ b/lib/avo/skills/docs-index.json
@@ -1,7 +1,7 @@
 {
   "repo": "avo-hq/docs.avohq.io",
   "docs_path": "docs/4.0",
-  "commit": "ee0277f1883e8a01c9d20503e05aa9f26170e93e",
-  "date": "2026-08-31",
+  "commit": "55931cc4a4e9114c529fc3e3881ec2285c7086e7",
+  "date": "2026-09-05",
   "note": "The docs commit these skills were last indexed from. Run ruby lib/avo/skills/bin/docs_drift.rb to see what changed since, and --update after a refresh."
 }

--- a/lib/avo/skills/index.md
+++ b/lib/avo/skills/index.md
@@ -32,7 +32,7 @@ Each entry is a directory beside this file: `<skill>/SKILL.md`.
 
 | Skill | Covers |
 | --- | --- |
-| `avo-branding-appearance` | Logo, favicon, color scheme, palettes, CSS re-skin, icons |
+| `avo-branding-appearance` | Logo, favicon, color scheme, palettes, fonts, CSS re-skin, icons |
 | `avo-menu-icons` | Pick the right Tabler icon and apply it to resources. The menu DSL is `avo-menu`'s own skill |
 | `avo-navigation-search` | Per-resource search, breadcrumbs, keyboard shortcuts, the auto-generated sidebar |
 | `avo-custom-ui` | Custom pages, embedded panels, dynamic/nested forms, ejected views, Stimulus, Tailwind |


### PR DESCRIPTION
# Description

Routine reconciliation of the gem-shipped Claude skills (`lib/avo/skills/*/SKILL.md`) against `avo-hq/docs.avohq.io`, and a move of `docs-index.json` from `ee0277f1883e` (2026-08-31) to `55931cc4a4e9` (2026-09-05).

Nine pages changed under `docs/4.0` in that range. Only one carried a genuine capability change for a core skill (fonts); the rest were add-on-owned or narrow factual corrections.

## Changed pages

| Changed page | Skills citing it | What I did |
| --- | --- | --- |
| `theming.md` (M) | `avo-branding-appearance` | **Edited.** New "Change the font" section — a real capability the skill did not cover. |
| `appearance-api.md` (M) | `avo-branding-appearance` | **Edited.** New Fonts variable table (`--font-sans`, `--font-mono`). Same edit as above. |
| `i18n.md` (M) | `avo-associations`, `avo-i18n` | **Edited `avo-i18n`.** The add-on table no longer claims every gem ships English only, and gained a REST API row. **No change to `avo-associations`** — it cites `i18n.md` once, as a pointer for field labels; nothing it says moved. |
| `upgrade.md` (M) | `avo-update` | **Edited.** New `## Upgrade to 4.2.0` section; two structural facts about it contradict the skill's section-walking method (below). |
| `ai.md` (M) | — | **No change.** `license: addon` — owned by `avo-ai`'s skills. |
| `custom-controls.md` (M) | — | **No change.** `license: addon` — owned by `avo-custom_controls`. |
| `custom-controls-api.md` (M) | — | **No change.** Same. |
| `rest-api.md` (M) | — | **No change.** `license: addon` — owned by `avo-api`. |
| `rest-api-api.md` (A) | — | **No change.** New page, `license: addon` — owned by `avo-api`. |

## Skills edited

**`avo-branding-appearance`** — Avo reads its typeface through the Tailwind theme variable `--font-sans`, so a `:root` override in `avo-overrides.css` retypes the admin with no build step. That rung was missing from the ladder entirely.

- New **step 8, Fonts**: `--font-sans` / `--font-mono`, plus loading a hosted font (`@import` at the top of `avo-overrides.css`, or `<link>` tags in the ejected `:head`) and self-hosting from `public/fonts/`. Icons renumbered 8 → 9; the one downstream cross-reference ("see step 7") was checked and still points where it should.
- New gotcha: Avo sets text at weights 400/500/600/700, so all four must be loaded or the browser synthesizes the rest; `@import` must be the first rule in the file; CSP needs the font host in `font-src`.
- `description` gained "change the font" / "use our brand typeface in the admin" triggers, and "fonts" was added to the capability list (826 → 902 chars, well inside the 1024 cap).
- `index.md`'s one-line summary gained "fonts".

Verified against this checkout rather than taken from the docs: `--font-sans` is defined at `app/assets/stylesheets/application.css:36` with the documented fallback stack; Inter is self-hosted at `app/assets/images/avo/fonts/` in exactly the four weights (`regular`, `500`, `600`, `700`, Latin subset); `--font-mono` is genuinely *not* defined in Avo's CSS, which matches the docs' "not bundled — resolves to the device's monospace font".

**`avo-i18n`** — the section was headed "Add-on gems ship English only", which is now false. Retitled to "mostly", added a **Ships** column to the table (so the two exceptions are visible at a glance rather than only in prose), and added the REST API row: `avo.api.token.*`, shipping every locale core ships. The Advanced Search paragraph and its 4.1.6 caveat are unchanged; the `avo-api` note follows as its own paragraph so the existing "Four of those —" reference still reads against the sentence it belongs to.

**`avo-update`** — the skill deliberately doesn't enumerate versions, so the new 4.2.0 content itself needs no mirroring. Two things about its *shape* do contradict the method the skill teaches:

1. The skill says add-on sections announce themselves by naming the gem in the heading (`## Upgrade to avo-dashboards 4.0.9`). `## Upgrade to 4.2.0` is a bare core-version heading whose every named change is `avo-api`'s — presumably because it shipped on the same release train. Added a clause telling the agent to read each change for the gem it names, not the heading.
2. Step 5's per-section loop said "make the edit". One of these sections needs `rails generate avo_api:tokens` + `rails db:migrate` — a new table, not an API change. Widened to name the generator-and-migration case.

## Skills reviewed and left alone

- **`avo-associations`** — its only `i18n.md` citation is a table cell pointing at field i18n as an alternative to `name:`. Nothing in the i18n diff touches that.

## Not resolved / for follow-up

- **Five pages are add-on-owned and out of scope here.** `rest-api.md` and the new `rest-api-api.md` belong to **`avo-api`**, `ai.md` to **`avo-ai`**, and `custom-controls.md` / `custom-controls-api.md` to **`avo-custom_controls`**. Each gem's own skills need the same reconciliation against this range — the `avo-api` diff in particular is substantial (API tokens, per-token scopes, three refusal shapes, an `edit_scopes?` policy method).
- **`rest-api-api.md` is a new page with no owning core skill**, which is correct — it's an add-on reference. Flagging it only so it isn't mistaken for a gap on core's side. No new core skill was created.
- **`avo.api.token.*` is taken on the word of `i18n.md`.** `avo-api` isn't a dependency of this repo, so I could not verify the namespace or the claim that it ships every locale against that gem's source. Worth a second pair of eyes from whoever owns `avo-api`.
- **Branch name.** The routine asks for `docs-sync/<docs-HEAD-date>`; this session is provisioned with a mandatory branch (`claude/peaceful-mayer-o8mj8e`) and is not permitted to push elsewhere, so the work went there. Rename on merge if the convention matters.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — *inverted here: the docs are the source and the skills are what was brought into line with them.*
- [x] I have added tests that prove my fix is effective or that my feature works — *no new tests; `spec/lib/avo/skills/index_integrity_spec.rb` already covers the invariants this diff could break (frontmatter, description cap, precedence line, index parity) and it passes.*
- [ ] I tested the design in Light and Dark mode, and all default themes — *N/A, documentation-only change with no rendered surface.*

## Screenshots & recording

N/A — Markdown only.

## Manual review steps

1. `AVO_DOCS_PATH=<docs checkout> ruby lib/avo/skills/bin/docs_drift.rb` — should print "Up to date" against a docs checkout at `55931cc`. (Note: the script needs a UTF-8 locale; under `LANG=C`/`US-ASCII` it dies with `invalid byte sequence` reading the skill files.)
2. `grep -rnE "\[!code|:::|<Option|``&lt;Image|&lt;CustomCode|&lt;FieldTypesList``" lib/avo/skills/` — must return nothing. It does.
3. `bundle exec rspec spec/lib/avo/skills` — **167 examples, 0 failures.**
4. Read the fonts section of `avo-branding-appearance/SKILL.md` against `docs/4.0/theming.html#change-the-font` and the Fonts table in `appearance-api.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNNzTC3tYTht3abxieZh3J

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNNzTC3tYTht3abxieZh3J)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only skill and index updates; no runtime, auth, or data-path changes.
> 
> **Overview**
> Reconciles shipped Claude skills in `lib/avo/skills/` with `docs.avohq.io` and bumps `docs-index.json` to commit **55931cc** (2026-09-05).
> 
> **`avo-branding-appearance`** adds the missing **fonts** rung: new step 8 documents `--font-sans` / `--font-mono` overrides in `avo-overrides.css`, hosted (`@import` or ejected `:head`) and self-hosted loading, plus a font-weight/CSP gotcha; icons move to step 9. Triggers and `index.md` now mention fonts.
> 
> **`avo-i18n`** softens “add-ons ship English only” to **mostly**, adds a **Ships** column (Advanced Search covered by core; **REST API** ships all core locales under `avo.api.token.*`), and notes `avo-api` explicitly.
> 
> **`avo-update`** warns that bare version headings (e.g. 4.2.0) can be add-on-only, and that some guide steps require **generators/migrations** rather than code edits alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01a1f15441d30271bcf6083c3aee26f2e48d93a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->