### PR TITLE
Sync shipped skills with docs through 8ed88cf (2026-09-07)

### DIFF
--- a/lib/avo/skills/avo-branding-appearance/SKILL.md
+++ b/lib/avo/skills/avo-branding-appearance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: avo-branding-appearance
-description: Brand and theme an Avo admin panel — logos, favicon, color scheme, neutral/accent palettes, chart colors, per-user theme persistence, deep CSS re-skinning, and menu/action icons — starting from the no-build `config.appearance` path in `config/initializers/avo.rb`. Use when the user wants to "brand the admin with our logo and colors", "make the admin match our brand", "add our company logo", "add a favicon", "make the admin default to / support dark mode", "let users switch themes" or "lock the theme", "remember each user's theme", "change the accent/primary color" or "make the buttons blue", "change the sidebar/navbar background", "give the admin a coastal/rose/sunset theme", "our admin looks too generic", "change the dashboard chart colors", or "use a custom icon for this menu item" — whether or not they name Avo.
+description: Brand and theme an Avo admin panel — logos, favicon, color scheme, neutral/accent palettes, fonts, chart colors, per-user theme persistence, deep CSS re-skinning, and menu/action icons — starting from the no-build `config.appearance` path in `config/initializers/avo.rb`. Use when the user wants to "brand the admin with our logo and colors", "make the admin match our brand", "add our company logo", "add a favicon", "make the admin default to / support dark mode", "let users switch themes" or "lock the theme", "remember each user's theme", "change the accent/primary color" or "make the buttons blue", "change the sidebar/navbar background", "change the font" or "use our own typeface / brand font", "give the admin a coastal/rose/sunset theme", "our admin looks too generic", "change the dashboard chart colors", or "use a custom icon for this menu item" — whether or not they name Avo.
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash, WebFetch
 metadata:
   requires-gem: none — Community
@@ -15,7 +15,7 @@ Make the Avo admin look like your product — logos, favicon, color scheme, bran
 Files you'll touch, from shallowest to deepest:
 
 - `config/initializers/avo.rb` → `config.appearance = { … }` — logos, favicon, scheme, palettes, picker/lock, persistence, chart colors. **The default answer.**
-- `app/assets/stylesheets/avo-overrides.css` — no-build CSS-variable re-skin (eject with `rails g avo:eject --partial :avo_overrides_css`). Served as-is.
+- `app/assets/stylesheets/avo-overrides.css` — no-build CSS-variable re-skin, including the font (eject with `rails g avo:eject --partial :avo_overrides_css`). Served as-is.
 - `app/views/avo/partials/_head.html.erb` — inline `<style>` for component variables (eject with `rails g avo:eject --partial :head`).
 - `app/assets/svgs/` — your own SVG icons for menu items / actions.
 - A JSONB column + `load_settings`/`save_settings` procs — only when persisting each user's theme to the database.
@@ -32,9 +32,9 @@ Authoritative docs — fetch on demand, verify option names against them (and th
 
 ## When this applies
 
-**Explicit (Avo named):** "set `config.appearance`", "change Avo's logo / logomark / favicon", "set the Avo accent/neutral palette", "lock the Avo theme", "restrict the appearance picker", "persist Avo appearance to the database", "override Avo CSS variables", "eject the `:head` partial", "set an icon on this Avo menu item".
+**Explicit (Avo named):** "set `config.appearance`", "change Avo's logo / logomark / favicon", "set the Avo accent/neutral palette", "lock the Avo theme", "restrict the appearance picker", "persist Avo appearance to the database", "override Avo CSS variables", "set Avo's `--font-sans`", "eject the `:head` partial", "set an icon on this Avo menu item".
 
-**Implicit (product-shaped, no mention of Avo):** "brand the admin with our logo and colors", "make the admin match our brand", "add our company logo / a favicon", "the admin should default to dark mode" / "support dark mode", "let users switch themes" / "lock it so they can't", "remember each user's theme across devices", "change the accent/primary color" / "make the buttons blue", "change the sidebar/navbar background color", "give the admin a coastal / rose / 80s-sunset theme", "our admin looks too generic", "change the dashboard chart colors", "use a custom icon for this menu item".
+**Implicit (product-shaped, no mention of Avo):** "brand the admin with our logo and colors", "make the admin match our brand", "add our company logo / a favicon", "the admin should default to dark mode" / "support dark mode", "let users switch themes" / "lock it so they can't", "remember each user's theme across devices", "change the accent/primary color" / "make the buttons blue", "change the sidebar/navbar background color", "change the font" / "use our brand typeface in the admin", "give the admin a coastal / rose / 80s-sunset theme", "our admin looks too generic", "change the dashboard chart colors", "use a custom icon for this menu item".
 
 ## Workflow
 
@@ -207,7 +207,36 @@ bin/rails generate avo:eject --partial :head
 
 The full variable list (navbar, sidebar, table, focus ring, motion) with defaults lives in the CSS variables section of `appearance-api.md` — fetch it before writing component-level overrides. For named-theme requests ("coastal", "rose", "80s sunset"), work in `avo-overrides.css` with matching `:root` and `.dark` values.
 
-### 8. Icons (menu items, actions)
+### 8. Fonts
+
+Avo's typeface is one variable — `--font-sans`, inherited by every screen through the root element — and monospace text (code in alerts, media-library file details) reads `--font-mono`. Override either on `:root` in `avo-overrides.css` and the whole interface follows, **no build step**:
+
+```css
+/* app/assets/stylesheets/avo-overrides.css */
+:root {
+  --font-sans: "IBM Plex Sans", system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+}
+```
+
+That is the whole change for a family the visitor's device already has (a system font stack). Avo self-hosts **Inter** (Latin subset) at weights 400, 500, 600, and 700 and falls back to the system stack; `--font-mono` is **not** bundled and resolves to the device's monospace font.
+
+For any other typeface, load it first. Either `@import` the service's stylesheet at the **very top** of `avo-overrides.css` — CSS requires imports before any other rule, so a variable override above it kills the import silently:
+
+```css
+/* app/assets/stylesheets/avo-overrides.css */
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap");
+
+:root {
+  --font-sans: "IBM Plex Sans", system-ui, sans-serif;
+}
+```
+
+…or eject the `:head` partial and drop the service's `<link>` snippet there (`:pre_head` works too — fonts don't compete in the cascade, so load order doesn't matter). The variable override still belongs in `avo-overrides.css`. To self-host, put the files under `public/fonts/` and write `@font-face` in `avo-overrides.css` referencing them by **absolute path** — that works under Propshaft and Sprockets alike with no digest lookup.
+
+Avo sets text at 400, 500, 600, and 700: load all four, or a variable font covering that range, or the browser synthesizes the missing weights. Full guide (hosted-font services, self-hosting): https://docs.avohq.io/4.0/theming.md#change-the-font
+
+### 9. Icons (menu items, actions)
 
 Anywhere Avo takes an `icon:`, pass a path string. **Prefer Tabler in v4** (`tabler/outline/<name>` or `tabler/filled/<name>`); Heroicons (`heroicons/outline/<name>`, also `solid`/`mini`/`micro`) are legacy-supported. Your own SVGs go in `app/assets/svgs/` and are referenced by filename.
 
@@ -239,7 +268,7 @@ For **populating menu/resource icons at scale** (migrations, whole-sidebar passe
 | `load_settings` / `save_settings` | DB persistence blocks | Proc; needs a JSON/JSONB column |
 | `chart_colors` | Dashboard chart palette | Array of **hex** Strings |
 
-CSS-only knobs (navbar/sidebar/table/focus/motion variables) are not in this hash — see step 7 and `appearance-api.md`.
+CSS-only knobs (navbar/sidebar/table/focus/motion variables, and the `--font-sans` / `--font-mono` typefaces) are not in this hash — see steps 7–8 and `appearance-api.md`.
 
 ## Gotchas
 
@@ -250,6 +279,8 @@ CSS-only knobs (navbar/sidebar/table/focus/motion variables) are not in this has
 - **`avo-overrides.css` is served as-is, NOT through the Tailwind build.** Only put plain CSS + variable overrides there — no `@apply`, no arbitrary values. Tailwind directives for your *own* custom UI belong in `app/assets/stylesheets/avo/` (which IS built). See the avo-custom-ui skill.
 - **DB persistence needs a JSONB column and BOTH blocks**, and `save_settings` gets a **partial** `settings` Hash (only the changed keys) — `deep_merge`, never overwrite the whole preferences blob.
 - **`config.branding` was renamed to `config.appearance` in Avo 4.** On a v3 app you may find `config.branding = { … }` — migrate it into `config.appearance`.
+- **The font is CSS, not `config.appearance`.** There is no Ruby knob for it — set `--font-sans` (and `--font-mono`) in `avo-overrides.css`. A hosted font's `@import` must be the **first** rule in that file, above the `:root` block, or the browser drops it.
+- **Load every weight Avo uses.** Avo sets text at 400, 500, 600, and 700; a family loaded at fewer weights gets the rest synthesized by the browser.
 - **Avo's `avo/*` icons are a private API.** Use `tabler/*` (preferred), `heroicons/*` (legacy), or your own SVGs in `app/assets/svgs/`.
 - **Verify before writing.** Option names drift between versions — check the docs URLs above or the installed Avo source rather than trusting memory.
 

--- a/lib/avo/skills/avo-i18n/SKILL.md
+++ b/lib/avo/skills/avo-i18n/SKILL.md
@@ -77,7 +77,7 @@ es:
         description: "Los usuarios de la aplicación"
 ```
 
-`description` fills the resource's panel description and, per the cascade, beats `self.description` on the class.
+`description` fills the resource's panel description and, per the cascade, beats `self.description` on the class — so an app can keep an English default in code and translate over it. **One sharp edge:** the translated string replaces `self.description` outright, block and all. If that attribute is a block reading `record` or `view`, don't add the key for that resource — a static translation would take its place.
 
 Omit `self.translation_key` and Avo derives it from the class name, **namespace included** — `Avo::Resources::Galaxy::Planet` defaults to `avo.resource_translations.galaxy/planet`. So for a plain resource you often only need the YAML, no Ruby change.
 
@@ -265,9 +265,9 @@ bin/rails runner 'puts I18n.t("avo").select { |_, v| v.is_a?(String) }.keys.sort
 
 Don't reach for `bin/rails generate avo:locales` just to look — it copies Avo's locale files into `config/locales`, pinning today's wording into the app. Run it only when editable copies are actually wanted. Full rule and the worked collision: https://docs.avohq.io/4.0/i18n.md#safe-keys
 
-### Add-on gems ship English only
+### Add-on gems mostly ship English only
 
-The locale generator covers Avo core. Each add-on keeps its strings under its own namespace inside `avo.*` and ships **English only** — every other language is the app's to supply, in a file per gem or one file carrying all of them (they deep-merge into the same tree).
+The locale generator covers Avo core. Each add-on keeps its strings under its own namespace inside `avo.*`, and **most ship English only** — every other language is then the app's to supply, in a file per gem or one file carrying all of them (they deep-merge into the same tree). A gem that ships more says so on its own Localization page: `avo-api` ships its tree in every locale core does, so its panel is translated with no work from the app.
 
 | Gem | Namespace |
 | --- | --- |
@@ -277,6 +277,7 @@ The locale generator covers Avo core. Each add-on keeps its strings under its ow
 | Dynamic Filters | `avo.dynamic_filters.*` |
 | Forms & Pages | `avo.forms.*` |
 | Intelligence | `avo.intelligence.*` |
+| REST API | `avo.api.token.*` (all locales) |
 | Scopes | `avo.scopes.*` |
 
 Advanced Search is the exception that needs no locale file: everything it renders is under `avo.global_search.*` or is `avo.all`, and core translates all of them in each bundled locale. Four of those — `avo.global_search.direct_match`, `.search_results`, `.searching_on` and `avo.all` — only reached core's locale files **after 4.1.6**; on `4.1.6` and earlier they fall back to English, so define them in the app's own locale file until it's on a newer Avo.
@@ -292,6 +293,7 @@ Advanced Search is the exception that needs no locale file: everything it render
 | `avo.field_translations.<f>` | YAML | Shared field label + `help`/`placeholder`/`include_blank` siblings across all resources. |
 | `avo.resource_translations.<r>.tabs.<t>` | YAML | Tab title, keyed on the parameterized `title:`. Pin a different key with `translation_key:` on the `tab`. |
 | `avo.resource_translations.<r>.panels.<p>` | YAML | Panel title, same convention as tabs; `translation_key:` on the `panel` overrides it. |
+| `avo.resource_translations.<r>.description` | YAML | Resource panel description; beats `self.description`. Replaces the attribute wholesale — don't set it where `self.description` is a block reading `record`/`view`. |
 | `avo.resource_translations.<r>.save` | YAML | Per-resource Save-button text (else global `avo.save`). |
 | `avo.scope_translations.<s>` | YAML | Scope `name`/`description`. Root derived by `avo-scopes`. |
 | `avo.card_translations.<c>` | YAML | Card `label`/`description`/`discreet_description`. Root derived by `avo-dashboards`. |

--- a/lib/avo/skills/avo-resources/SKILL.md
+++ b/lib/avo/skills/avo-resources/SKILL.md
@@ -119,7 +119,7 @@ class Avo::Resources::User < Avo::BaseResource
 end
 ```
 
-Avo also resolves `description` below the resource's translation key — `avo.resource_translations.user.description` supplies the User resource description. Per the cascade, the locale file **wins** and `self.description` is the fallback, so an app can keep an English default in code and translate over it — **avo-i18n**.
+Avo also resolves `description` below the resource's translation key — `avo.resource_translations.user.description` supplies the User resource description. Per the cascade, the locale file **wins** and `self.description` is the fallback, so an app can keep an English default in code and translate over it — **avo-i18n**. The translation replaces the attribute wholesale, so don't add the key for a resource whose `self.description` is a block reading `record` or `view`; a static string would take its place.
 
 - `self.description` is rendered as **raw HTML** — never feed it user-editable data (stored-XSS risk). A block gets `record`, `resource`, `view`, `current_user`, `params`.
 - `self.color` takes a Symbol or String from Avo's palette — `red`, `orange`, `amber`, `yellow`, `lime`, `green`, `emerald`, `teal`, `cyan`, `sky`, `blue`, `indigo`, `violet`, `purple`, `fuchsia`, `pink`, `rose`. It tints the icon **stroke only** (label and hover/active backgrounds stay neutral), adapts to light and dark themes, and an unknown name silently renders the neutral icon. The tint follows the resource to its breadcrumb initials chip and, with Advanced Search installed, to the resource group headers in global search results. A `color:` on the menu entry overrides it.

--- a/lib/avo/skills/docs-index.json
+++ b/lib/avo/skills/docs-index.json
@@ -1,7 +1,7 @@
 {
   "repo": "avo-hq/docs.avohq.io",
   "docs_path": "docs/4.0",
-  "commit": "ee0277f1883e8a01c9d20503e05aa9f26170e93e",
-  "date": "2026-08-31",
+  "commit": "8ed88cf89fc9dd53e07848fd70548f5174e53c39",
+  "date": "2026-09-07",
   "note": "The docs commit these skills were last indexed from. Run ruby lib/avo/skills/bin/docs_drift.rb to see what changed since, and --update after a refresh."
 }

--- a/lib/avo/skills/index.md
+++ b/lib/avo/skills/index.md
@@ -32,7 +32,7 @@ Each entry is a directory beside this file: `<skill>/SKILL.md`.
 
 | Skill | Covers |
 | --- | --- |
-| `avo-branding-appearance` | Logo, favicon, color scheme, palettes, CSS re-skin, icons |
+| `avo-branding-appearance` | Logo, favicon, color scheme, palettes, fonts, CSS re-skin, icons |
 | `avo-menu-icons` | Pick the right Tabler icon and apply it to resources. The menu DSL is `avo-menu`'s own skill |
 | `avo-navigation-search` | Per-resource search, breadcrumbs, keyboard shortcuts, the auto-generated sidebar |
 | `avo-custom-ui` | Custom pages, embedded panels, dynamic/nested forms, ejected views, Stimulus, Tailwind |


### PR DESCRIPTION
# Description

Scheduled reconciliation of the skills shipped in `lib/avo/skills/` against the docs pages they were written from. `docs-index.json` had them indexed at `ee0277f` (2026-08-31); `docs_drift.rb` flagged **11 changed pages under `docs/4.0`** and **8 skills citing them**. Three skills needed an edit, five were reviewed and left alone, and the marker moves to the docs HEAD `8ed88cf` (2026-09-07).

Only files under `lib/avo/skills/` are touched.

Fixes # (issue) — n/a, scheduled maintenance.

## Page-by-page

| Changed page | Skills citing it | What changed there / what I did |
| --- | --- | --- |
| `theming.md` (M) | `avo-branding-appearance` | New "Change the font" section. **Edited** — added a Fonts rung to the ladder. |
| `appearance-api.md` (M) | `avo-branding-appearance` | New Fonts table (`--font-sans`, `--font-mono`). **Edited** — same section, plus key-options note and gotchas. |
| `i18n.md` (M) | `avo-associations`, `avo-i18n` | `description` added under the resource translation key, with the "block gets replaced wholesale" caveat; "add-on gems ship English only" softened for `avo-api`. **Edited `avo-i18n`.** `avo-associations` cites the page only for field-label i18n — **no change needed**. |
| `resources-api.md` (M) | `avo-controllers`, `avo-performance`, `avo-resources` | Info callout that a locale key can supply `self.description`. **Edited `avo-resources`** (added the caveat; the precedence itself was already documented). `avo-controllers` cites the page for `after_create_path`, `avo-performance` for `cache_hash` — neither touched, **no change needed**. |
| `actions.md` (M) | `avo-actions` | Docs added a callout that records deleted after selection are dropped from `query`. **No change needed** — the skill already carries this verbatim in its Gotchas; the docs caught up to the skill, not the other way round. |
| `upgrade.md` (M) | `avo-update` | New `## Upgrade to 4.2.0` section, entirely `avo-api` (token auth in `setup_authentication`, the tokens migration, `403` JSON on policy denial, token scopes). **No change needed** — the skill teaches the procedure for working the guide section by section, and already covers per-add-on sections; it deliberately carries no version list to go stale. |
| `custom-controls.md`, `custom-controls-api.md` (M) | — | `avo-custom_controls`-owned. Out of scope here — see below. |
| `ai.md` (M) | — | `avo-ai`-owned. Out of scope — see below. |
| `rest-api.md` (M), `rest-api-api.md` (**A**) | — | `avo-api`-owned. Out of scope — see below. |

## Skills edited

- **`avo-branding-appearance`** — new step 8, "Fonts": `--font-sans` / `--font-mono` overridden on `:root` in `avo-overrides.css` with no build step; Inter self-hosted at 400/500/600/700 while `--font-mono` is unbundled; loading a hosted family by CSS import (which must be the file's first rule) or via an ejected head partial; self-hosting from `public/fonts/` by absolute path. Icons renumbered 8 → 9. Frontmatter `description` and both trigger lists gained font phrasing, the key-options table notes fonts are CSS-only, and two gotchas were added (import ordering, load every weight).
- **`avo-i18n`** — the resource `description` key now carries its sharp edge (the translation replaces `self.description` outright, so don't set it where that attribute is a block reading `record`/`view`), a row in the key-options table, and a corrected add-on-locale claim now that `avo-api` ships all locales.
- **`avo-resources`** — the same caveat where `self.description` is introduced.
- **`index.md`** — `avo-branding-appearance`'s one-line summary now mentions fonts.

## Skills reviewed and left unchanged

`avo-actions`, `avo-associations`, `avo-controllers`, `avo-performance`, `avo-update` — reasons per page in the table above.

## Verified against source, not the docs

- Resource `description` precedence and the wholesale-replacement behavior: `lib/avo/resources/base.rb:732-737` returns the translated string when present and otherwise falls through to `super`, so a key really does discard the block.
- Font variables: `--font-sans` is defined at `app/assets/stylesheets/application.css:36` with the Inter + system stack, and `app/assets/stylesheets/css/fonts.css` self-hosts Inter at exactly 400/500/600/700. `--font-mono` is not defined in Avo's CSS, matching the docs' "not bundled".

## Flagged — not resolved here

- **Add-on-owned pages with no core skill to update.** `custom-controls.md` / `custom-controls-api.md` (an `action` control now honors the action's `visible` block *and* `authorize` rule — a real behavior reversal), `ai.md` (the assistant's own pages carry no page origin), and `rest-api.md` plus the **new** `rest-api-api.md`. These belong to `avo-custom_controls`, `avo-ai` and `avo-api`, whose skills ship from their own gems. Worth a matching pass in each.
- **No new core skill needed.** Nothing among the changed pages is core subject matter without an owning skill, so no gap to fill here.
- **One unverifiable claim left in place.** `avo-update`'s gotcha about i18n keys overtaking class attributes names "resource descriptions in `4.2.2`". That change is `4abddb28f`, currently on `main` and in **no tag** (this checkout is `4.2.1`), and `upgrade.md`'s newest section is `4.2.0` with no entry for it. The version is a forward guess — correct if the next release is a patch. Left alone as pre-existing and outside this drift, but someone should confirm it at release time.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — inverted here: this PR *is* the docs-following change
- [ ] I have added tests that prove my fix is effective or that my feature works — no new tests; `spec/lib/avo/skills` is the existing gate and covers these files
- [ ] I tested the design in Light and Dark mode, and all default themes — n/a, Markdown only

## Screenshots & recording

n/a — Markdown content only.

## Manual review steps

Run from the avo checkout, with a `docs.avohq.io` clone at docs HEAD `8ed88cf`:

```bash
# 1. No VitePress markup pasted into the skills. Expect no output.
grep -rnE '\[!code|:::|<(Option|Image|CustomCode|FieldTypesList)' lib/avo/skills/

# 2. The integrity gate for frontmatter, index parity and package map.
bundle exec rspec spec/lib/avo/skills

# 3. The marker matches the docs checkout.
AVO_DOCS_PATH=/path/to/docs.avohq.io ruby lib/avo/skills/bin/docs_drift.rb
```

Results on this branch:

1. Grep — no output. ✅
2. Specs — **167 examples, 0 failures**. ✅
3. Drift — `Up to date with 8ed88cf89fc9 (2026-09-07).` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXrLwUzKpvxEmzTrAearkH