### PR TITLE
fix: copyable icon sits beside date_time and time values on Index

### DIFF
--- a/app/components/avo/fields/date_time_field/index_component.html.erb
+++ b/app/components/avo/fields/date_time_field/index_component.html.erb
@@ -1,5 +1,5 @@
 <%= index_field_wrapper(**field_wrapper_args) do %>
-   <%= content_tag :div, data: {
+   <%= content_tag :div, class: "inline-block", data: {
     controller: "date-field",
     date_field_view_value: @view,
     date_field_enable_time_value: true,

--- a/app/components/avo/fields/time_field/index_component.html.erb
+++ b/app/components/avo/fields/time_field/index_component.html.erb
@@ -1,5 +1,5 @@
 <%= index_field_wrapper(**field_wrapper_args) do %>
-   <%= content_tag :div, data: {
+   <%= content_tag :div, class: "inline-block", data: {
     controller: "date-field",
     date_field_view_value: @view,
     date_field_enable_time_value: true,

--- a/spec/system/avo/group_3/date_time_fields/copyable_layout_spec.rb
+++ b/spec/system/avo/group_3/date_time_fields/copyable_layout_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+# The copy-to-clipboard icon has to share a line with the value it copies.
+# Date-ish fields wrap their value in an element of their own so the
+# `date-field` controller can rewrite it, and a block-level wrapper eats the
+# whole cell width, pushing the icon onto the next line (AVO-1776).
+RSpec.describe "Copyable date fields", type: :system do
+  let!(:comment) { create :comment, posted_at: Time.utc(2022, 10, 2, 16, 30) }
+  let!(:course) { create :course, starting_at: Time.utc(2022, 10, 2, 16, 30) }
+
+  after do
+    Avo::Resources::Comment.restore_items_from_backup
+    Avo::Resources::Course.restore_items_from_backup
+  end
+
+  # The icon is beside the value when it starts after the value ends and the two
+  # share a vertical center. A block-level value fills the cell instead, so the
+  # icon starts at the same left edge one line down — which the horizontal
+  # comparison catches and a bare overlap check does not.
+  def clipboard_beside_value?(scope_selector)
+    page.evaluate_script(<<~JS)
+      (() => {
+        const scope = document.querySelector("#{scope_selector}")
+        const v = scope.querySelector('[data-controller="date-field"]').getBoundingClientRect()
+        const c = scope.querySelector('[data-controller="clipboard"]').getBoundingClientRect()
+
+        return c.left >= v.right - 1 && Math.abs((c.top + c.bottom) - (v.top + v.bottom)) <= 8
+      })()
+    JS
+  end
+
+  describe "date_time field" do
+    before do
+      Avo::Resources::Comment.with_temporary_items do
+        field :id, as: :id
+        field :posted_at, as: :date_time, copyable: true
+      end
+    end
+
+    it "renders the copy icon next to the value on index" do
+      visit "/admin/resources/comments"
+
+      expect(field_element_by_resource_id("posted_at", comment.to_param)).to be_present
+      expect(clipboard_beside_value?("[data-resource-id='#{comment.to_param}'] [data-field-id='posted_at']")).to be true
+    end
+
+    it "renders the copy icon next to the value on show" do
+      visit "/admin/resources/comments/#{comment.id}"
+
+      expect(field_wrapper("posted_at")).to be_present
+      expect(clipboard_beside_value?("[data-field-id='posted_at']")).to be true
+    end
+  end
+
+  describe "time field" do
+    before do
+      Avo::Resources::Course.with_temporary_items do
+        field :id, as: :id
+        field :starting_at, as: :time, copyable: true
+      end
+    end
+
+    it "renders the copy icon next to the value on index" do
+      visit "/admin/resources/courses"
+
+      expect(field_element_by_resource_id("starting_at", course.to_param)).to be_present
+      expect(clipboard_beside_value?("[data-resource-id='#{course.to_param}'] [data-field-id='starting_at']")).to be true
+    end
+  end
+end


### PR DESCRIPTION
## What

On Index, `date_time` and `time` fields with `copyable: true` rendered the copy icon on the line **below** the value instead of beside it.

## Why

Those two Index components wrap their value in a block-level `div` so the `date-field` Stimulus controller can rewrite it in the browser's timezone. A block element fills the whole table cell, so the `inline-block` clipboard icon that follows it wraps onto the next line.

`date_field` already carried `inline-block` for exactly this reason — `date_time_field` and `time_field` were missed.

Show was never affected: its wrapper is a flex row, so both children sit side by side regardless.

## Proof

`spec/system/avo/group_3/date_time_fields/copyable_layout_spec.rb` asserts real geometry — the icon's box starts after the value's box ends and shares its vertical center — for `date_time` (Index + Show) and `time` (Index). It uses `with_temporary_items`, so it adds no dummy-app fixture churn.

Verified locally: both Index examples fail on `main` and pass with this change. The Show example passes either way and is there to guard the flex layout from regressing.

Docs and skills need no update — `copyable`'s behavior is unchanged, this is a layout fix, and `lib/avo/skills/avo-fields/SKILL.md` describes the option accurately.

AVO-1776

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYqDrnuoQjC1ny1YSUnqhC
