### PR TITLE
fix: stop packaging stray files from app/assets/builds

### DIFF
--- a/avo.gemspec
+++ b/avo.gemspec
@@ -33,8 +33,17 @@ Gem::Specification.new do |spec|
 
   # NOTE: `public/` is rejected below — Avo 4 ships precompiled assets from
   # `app/assets/builds`, and a stale `public/avo-assets` dir was what bloated some builds.
+  #
+  # `app/assets/builds` is gitignored and `Dir` does not read .gitignore, so whatever a
+  # releaser's working copy happens to hold there is packaged. Only `app/assets/builds/avo/`
+  # is ours — every build script writes there. 4.2.2 shipped `avo.base.js`, `avo.custom.js`,
+  # `late-registration.js` and `avo.base.css` from the top level: output of the build scripts
+  # as they stood before #3971 moved them into `avo/`, left on one machine since July 2025.
+  # It cost 22MB, and the stray `avo.custom.js` took over that Sprockets logical path in any
+  # host app that had an `avo.custom.js` of its own — silently replacing the host's file.
   spec.files = Dir["{bin,app,config,db,lib,public}/**/*", "Rakefile", "README.md", "avo.gemspec", "Gemfile", "Gemfile.lock", "tailwind.preset.js", "tailwind.custom.js", "safelist.txt"]
     .reject { |f| f.start_with?("public/") }
+    .reject { |f| f.start_with?("app/assets/builds/") && !f.start_with?("app/assets/builds/avo/") }
 
   spec.add_dependency "activerecord", ">= 6.1"
   spec.add_dependency "activesupport", ">= 6.1"

--- a/spec/gemspec_spec.rb
+++ b/spec/gemspec_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+# What the packaged gem carries. Held here because the failure is invisible in this repo —
+# every consumer in the workspace is a path dependency with the whole checkout on disk, so a
+# file that should never have been packaged behaves exactly like one that should.
+#
+# `app/assets/builds` is gitignored, and `Dir` — which `spec.files` uses — does not read
+# .gitignore. Whatever a releaser's working copy holds there gets shipped. 4.2.2 shipped four
+# artifacts of the build scripts as they stood before #3971 (which moved their output into
+# `avo/`), left behind on one machine since July 2025: 22MB of dead weight, and a stray
+# top-level `avo.custom.js` that took over that Sprockets logical path in host apps with an
+# `avo.custom.js` of their own — replacing the host's file with ours, silently.
+RSpec.describe "the avo gem package" do
+  root = Pathname.new(File.expand_path("..", __dir__))
+
+  # Loaded fresh each time rather than through Gem::Specification.load, which memoizes by path
+  # and would hand back the same file list before and after a stray file is planted.
+  def packaged_files(root)
+    Dir.chdir(root) { eval(root.join("avo.gemspec").read, TOPLEVEL_BINDING, root.join("avo.gemspec").to_s).files } # standard:disable Security/Eval
+  end
+
+  it "ships the compiled assets the panel serves" do
+    expect(packaged_files(root)).to include(
+      "app/assets/builds/avo/application.js",
+      "app/assets/builds/avo/application.css",
+      "app/assets/builds/avo/late-registration.js"
+    )
+  end
+
+  # The regression itself: a file directly under app/assets/builds is never ours to ship.
+  it "leaves a stray build artifact out, whatever a working copy holds" do
+    stray = root.join("app", "assets", "builds", "avo.custom.js")
+    raise "#{stray} exists — refusing to overwrite it" if stray.exist?
+
+    stray.write("// planted by #{__FILE__}\n")
+
+    begin
+      expect(packaged_files(root)).not_to include("app/assets/builds/avo.custom.js")
+    ensure
+      stray.delete
+    end
+  end
+end


### PR DESCRIPTION
## What 4.2.2 shipped

Four files nobody meant to ship, at the top level of `app/assets/builds`:

```
avo.base.css
avo.base.js              (+ .map)
avo.custom.js            (+ .map)
late-registration.js     (+ .map)
```

They are not in 4.2.1. The gem went from **24MB to 45MB**.

## Where they came from

They are output of the build scripts as they stood **before #3971** (`refactor: remove sprockets
and use propshaft`, 2025-07-16), which moved everything into `app/assets/builds/avo/`:

| Before #3971 | Produced |
| --- | --- |
| `build:js … --outdir=app/assets/builds` (no `--minify`) | `avo.base.js`, `late-registration.js` |
| `build:custom-js … --minify --outdir=app/assets/builds` | `avo.custom.js` |
| `build:css … -o ./app/assets/builds/avo.base.css` | `avo.base.css` |

`app/javascript/` held `avo.base.js` and `late-registration.js` at that commit, and holds
`application.js` and `late-registration.js` now — which is why there is an `avo.base.js` at all.

The dating is exact: the shipped top-level `late-registration.js` is **un-minified**, while
`avo/late-registration.js` in the same package is minified. `build:js` gained `--minify` in
#3971, so nothing built since July 2025 could have produced that file.

`app/assets/builds` is gitignored, so `git status` never mentioned them and no clean ever removed
them. They sat in one working copy for over a year until a release picked them up.

## Why a release picked them up

`spec.files` uses `Dir[...]`, which does not read `.gitignore`. Whatever a releaser's working copy
holds under `app/assets/builds` is packaged. `ws release` runs `yarn build` and then `rake build`;
neither cleans that directory, and nothing in the pipeline compares the file list against
`git check-ignore`. So this is machine state, not repository state — which is why 4.2.1, cut a day
earlier, is clean, and why it will recur on any machine that ever ran an old build script.

## Why it is worse than 22MB of dead weight

Sprockets keys its precompile manifest by **logical path**, and every engine's builds directory
shares a load path with the host's. A host app with its own `app/assets/builds/avo.custom.js` —
the file `avo:js:install` generates — had **one** manifest entry for both files, and
`avo_manifest.js` compiles after the host's `manifest.js`. So ours replaced theirs, and
`javascript_include_tag "avo.custom"` served this stray instead of the app's own controllers.

Nothing errors. The page loads, the panel renders, and the app's Stimulus controllers simply never
register. avohq.io hit this on the 4.2.2 bump: 17 system specs went red with no error in the log
to explain it.

## The fix

Reject anything directly under `app/assets/builds` that is not under `app/assets/builds/avo/` —
every build script writes there, so nothing else in that directory is ours.

`spec/gemspec_spec.rb` holds it: it plants a stray `app/assets/builds/avo.custom.js` and asserts
the package leaves it out, alongside an assertion that the real `avo/` assets are still shipped.
It fails on `main` today and passes here.

## Verification

- `bundle exec rspec spec/gemspec_spec.rb` — 2 examples, 0 failures; the stray example fails when
  the gemspec change is reverted
- End-to-end: with `avo.custom.js` and `avo.base.js` planted in `app/assets/builds`,
  `gem build avo.gemspec` produces a package whose only `app/assets/builds/` entries are the eight
  real `avo/` ones
- `standardrb` clean

## Not in this PR

- **A release ships the fix.** 4.2.2 is out and still carries the strays; the next release is what
  clears them.
- **`avo-meta` has the same defect, live.** Its `package.json` build script still writes the dummy
  app's `avo.custom.js` to the top level of `app/assets/builds`, and its gemspec has no equivalent
  filter — so it would ship the same colliding file the first time it is released. It is on the
  release train's held-back list today, so nothing has shipped yet.
- **A pipeline-level guard.** A `ws` check comparing each gem's packaged file list against
  `git check-ignore` would catch this class of leak everywhere rather than one gemspec at a time.
  Most gems legitimately ship gitignored build output, so it needs a per-gem allowlist rather than
  a blanket rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVwRVY7cepMF8kUnVbpMbp
