### PR TITLE
docs: teach avo-troubleshoot the 4.2.2 custom-JS collision

### DIFF
--- a/lib/avo/skills/avo-troubleshoot/SKILL.md
+++ b/lib/avo/skills/avo-troubleshoot/SKILL.md
@@ -84,6 +84,7 @@ grep -rn "explicit_authorization" "$(bundle show avo)/lib"
 | `No valid predicate for combinator` when filtering | `config.ignore_unknown_conditions` is `false` | [↓](#no-valid-predicate-for-combinator-when-filtering) |
 | `undefined method 'xxx_path'` inside an Avo block | Avo is a Rails engine — needs `main_app.` prefix | [↓](#url-helpers-blow-up-inside-avo-blocks) |
 | Index search box does nothing — the unfiltered rows stay | `self.search[:query]` returns an Array; the index needs a relation | [↓](#the-index-search-box-silently-does-nothing) |
+| Custom JS loads but its Stimulus controllers never register | On `4.2.2` only: the gem packaged its own `avo.custom.js` and won that Sprockets logical path | [↓](#custom-javascript-loads-but-never-runs) |
 | License won't validate / status page errors | Key not set on the server; check the status page | [↓](#license-wont-validate) |
 | Tests fail after adding/upgrading Avo (`WebMock::NetConnectNotAllowedError`) | v4's outbound license check to `clerk-*.avohq.io` is blocked | [↓](#tests-fail-after-adding-or-upgrading-avo) |
 | `bundle install` can't fetch `avo-*` / 401 / 403 | packager.dev token not seen by Bundler, or a blocked host in sandboxes | [↓](#bundle-install-cant-fetch-avo--gems) |
@@ -203,6 +204,22 @@ self.search = {
 ```
 
 → `search-api.html#custom-search-providers`
+
+### Custom JavaScript loads but never runs
+
+The app's own `avo.custom.js` is in the page source and returns 200, but the Stimulus controllers it registers never fire. Nothing raises and the log is clean — the served file simply isn't the app's.
+
+**Check the version before reading any of the app's code:**
+
+```bash
+bundle info avo | head -1
+```
+
+`4.2.2` — and only that release — packaged an `avo.custom.js` of its own by mistake. Sprockets keys assets by logical path, an engine's builds directory shares a load path with the host's, and Avo's manifest compiles after the app's, so `javascript_include_tag "avo.custom"` served the gem's file instead of the app's. `bundle update avo` to `4.2.3` or later; nothing in the app needs changing, and `4.2.1` is unaffected.
+
+On any other version this isn't the cause — check that the entrypoint is loaded from the ejected `_head.html.erb` (or `_pre_head.html.erb`) and, with `javascript_include_tag`, that it passes `defer: true` so it runs in the same order as Avo's own scripts.
+
+→ `upgrade.html#skip-version-4-2-2`, `asset-handling.html`
 
 ### License won't validate
 


### PR DESCRIPTION
# Description

Adds one symptom entry to the `avo-troubleshoot` skill for the packaging leak #4785 fixed.

An app on `4.2.2` whose `avo.custom.js` is served through Sprockets got the gem's stray copy instead of its own: the page loads, the panel renders, and the app's Stimulus controllers never register — no exception, nothing in the log. That is the worst shape a symptom can take for an agent, because there is no reason to suspect the gem's file list; it reads the app's entrypoint, its `_head.html.erb` and its importmap pin, finds all three correct, and has nowhere else to go. avohq.io spent 17 red system specs on it.

The new section says to run `bundle info avo` before reading any of the app's code, and carries the fallback for apps on any other version (entrypoint loaded from the ejected partial, `defer: true` on `javascript_include_tag`) so the entry doesn't dead-end when the version rules it out.

Body-only change to one `SKILL.md` — no frontmatter touched, no skill added, so `index.md` parity and the packaging globs are unchanged. It ships in the gem, so an agent working in a customer's app on `4.2.2` reads it from the version that app has locked.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/avo-hq/docs.avohq.io) — [docs.avohq.io#687](https://github.com/avo-hq/docs.avohq.io/pull/687) adds the matching `## Skip version 4.2.2` upgrade entry and the `asset-handling.md` warning this section links to
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, documentation
- [ ] I tested the design in Light and Dark mode, and all default themes — n/a, no UI

## Manual review steps

1. Open `lib/avo/skills/avo-troubleshoot/SKILL.md` and confirm the new table row's jump link matches the section's generated anchor (`#custom-javascript-loads-but-never-runs`)
2. `bundle exec rspec spec/lib/avo/skills` covers this tree (index integrity, packaging, resolver) — CI runs it here

Note on `ws audit-skills`: it is scoped to `gems/` by design and never reaches core's skills, so it says nothing about this change either way — core's tree is validated by the rspec files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCimkWnjJixrJBs5N5tAGz
