### PR TITLE
fix(ci): unbreak the TailwindCSS integration test on json 3

### DIFF
--- a/.github/workflows/test-tailwindcss-integration.yml
+++ b/.github/workflows/test-tailwindcss-integration.yml
@@ -41,6 +41,17 @@ jobs:
         # ruby/setup-ruby with bundler-cache runs Bundler in a frozen/deployment-like mode.
         # This step intentionally changes the Gemfile.lock, so we must unfreeze Bundler here.
         bundle config set frozen false
+
+        # The test app runs Rails 7.1, and every ActiveSupport below 8.1.0 calls
+        # JSON.generate(..., quirks_mode: true) in its JSON encoder. json 3.0 removed that
+        # keyword, so any such encode raises `ArgumentError: unknown keyword: quirks_mode` —
+        # which here kills `assets:precompile` inside Propshaft's manifest writer.
+        #
+        # The app's own lockfile has no json entry (it uses Ruby's default json 2.x), but
+        # adding Avo pulls pagy in, and pagy declares `json >= 0`. That materializes json
+        # into the lock, where Bundler resolves it to 3.x. Pin it below 3 so the resolution
+        # matches what the app had before Avo was added.
+        bundle add "json" --version "< 3" --skip-install
         bundle add "avo" --git='https://github.com/avo-hq/avo.git' --ref="${{ github.sha }}"
         bundle install
         bin/rails generate avo:install


### PR DESCRIPTION
## The failure

`TailwindCSS integration test` has failed on **every** run for weeks — main pushes and PRs alike. `assets:precompile` aborts:

```
ArgumentError: unknown keyword: quirks_mode
  json-3.0.2/lib/json/common.rb:382:in 'JSON.generate'
  activesupport-7.1.2/lib/active_support/json/encoding.rb:92:in 'JSONGemEncoder#stringify'
  propshaft-0.8.0/lib/propshaft/processor.rb:35:in 'write_manifest'
```

Worth stressing: the Avo parts of the job were already passing. Both Tailwind builds complete ("Done in 2s") before Propshaft's manifest writer brings the job down. Nothing about Avo's Tailwind integration was broken.

## Root cause

Every ActiveSupport **below 8.1.0** encodes JSON with `JSON.generate(..., quirks_mode: true)`. **json 3.0 removed that keyword.** Verified across every locally available version:

| activesupport | passes `quirks_mode:` |
| --- | --- |
| 7.1.0 → 8.0.5 (every version checked) | yes — breaks with json 3 |
| 8.1.0+ | no — fine |

The fixture app (`avo_tailwindcss_test_repo`) pins `rails ~> 7.1.2`, so it sits squarely in the broken range.

**json is in the lock only because Avo puts it there.** The fixture's own `Gemfile.lock` has no `json` entry — it uses the json that ships with Ruby as a default gem (2.x). Avo depends on `pagy`, and pagy declares `json >= 0`. Adding Avo materializes `json` into the lock, where Bundler resolves it to the newest release (3.0.2).

## The fix

Pin `json < 3` before adding Avo, restoring the resolution the app had beforehand. This keeps the fixture on Rails 7.1 rather than papering over it with a Rails bump, so the workflow still covers an older supported Rails — and the fixture lives in another repo, so changing its Rails version is a separate decision.

## Verification

Reproduced and fixed locally against the same fixture repo and branch, Ruby 3.4.8 and Bundler 2.6.9 (matching CI):

- **Before the pin** — `json (3.0.2)` + `activesupport (7.1.2)`; `assets:precompile` fails with a byte-identical stack trace to CI.
- **After the pin** — `json (2.21.2)`; `assets:precompile` exits 0 and all ten assertions pass:

```
[Avo->] Found aspect-video. … [Avo->] Found to-pink-500.
[Avo->] Found ci-avo-host-stylesheet.
```

## Follow-up worth a separate look

This can also hit real apps: any app on **Rails < 8.1** that adds Avo may get json 3.x pulled into its lock through pagy, and the stack trace points at Propshaft rather than at the cause. Whether Avo should constrain json in the gemspec — or just document it — is its own decision, deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEYwcJCjskoXurMESBM4Uu