### PR TITLE
Sync shipped skills with docs through 04da937 (2026-09-11)

### DIFF
--- a/.github/workflows/test-tailwindcss-integration.yml
+++ b/.github/workflows/test-tailwindcss-integration.yml
@@ -41,6 +41,17 @@ jobs:
         # ruby/setup-ruby with bundler-cache runs Bundler in a frozen/deployment-like mode.
         # This step intentionally changes the Gemfile.lock, so we must unfreeze Bundler here.
         bundle config set frozen false
+
+        # The test app runs Rails 7.1, and every ActiveSupport below 8.1.0 calls
+        # JSON.generate(..., quirks_mode: true) in its JSON encoder. json 3.0 removed that
+        # keyword, so any such encode raises `ArgumentError: unknown keyword: quirks_mode` —
+        # which here kills `assets:precompile` inside Propshaft's manifest writer.
+        #
+        # The app's own lockfile has no json entry (it uses Ruby's default json 2.x), but
+        # adding Avo pulls pagy in, and pagy declares `json >= 0`. That materializes json
+        # into the lock, where Bundler resolves it to 3.x. Pin it below 3 so the resolution
+        # matches what the app had before Avo was added.
+        bundle add "json" --version "< 3" --skip-install
         bundle add "avo" --git='https://github.com/avo-hq/avo.git' --ref="${{ github.sha }}"
         bundle install
         bin/rails generate avo:install

--- a/lib/avo/skills/avo-branding-appearance/SKILL.md
+++ b/lib/avo/skills/avo-branding-appearance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: avo-branding-appearance
-description: Brand and theme an Avo admin panel — logos, favicon, color scheme, neutral/accent palettes, chart colors, per-user theme persistence, deep CSS re-skinning, and menu/action icons — starting from the no-build `config.appearance` path in `config/initializers/avo.rb`. Use when the user wants to "brand the admin with our logo and colors", "make the admin match our brand", "add our company logo", "add a favicon", "make the admin default to / support dark mode", "let users switch themes" or "lock the theme", "remember each user's theme", "change the accent/primary color" or "make the buttons blue", "change the sidebar/navbar background", "give the admin a coastal/rose/sunset theme", "our admin looks too generic", "change the dashboard chart colors", or "use a custom icon for this menu item" — whether or not they name Avo.
+description: Brand and theme an Avo admin panel — logos, favicon, color scheme, neutral/accent palettes, fonts, chart colors, per-user theme persistence, deep CSS re-skinning, and menu/action icons — starting from the no-build `config.appearance` path in `config/initializers/avo.rb`. Use when the user wants to "brand the admin with our logo and colors", "make the admin match our brand", "add our company logo", "add a favicon", "make the admin default to / support dark mode", "let users switch themes" or "lock the theme", "remember each user's theme", "change the accent/primary color" or "make the buttons blue", "change the sidebar/navbar background", "give the admin a coastal/rose/sunset theme", "our admin looks too generic", "change the dashboard chart colors", "use our own font/typeface", or "use a custom icon for this menu item" — whether or not they name Avo.
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash, WebFetch
 metadata:
   requires-gem: none — Community
@@ -10,7 +10,7 @@ metadata:
 
 # Avo Branding & Appearance
 
-Make the Avo admin look like your product — logos, favicon, color scheme, brand colors, chart colors, and the deeper CSS chrome (navbar, sidebar, tables). Avo gives you a ladder: start with a few lines of Ruby in `config/initializers/avo.rb` (`config.appearance = { … }`, **no build step**), and only drop to CSS or ejected views when the Ruby layer can't express what you want. **Almost every branding request is satisfied by `config.appearance` alone** — reach for CSS last.
+Make the Avo admin look like your product — logos, favicon, color scheme, brand colors, fonts, chart colors, and the deeper CSS chrome (navbar, sidebar, tables). Avo gives you a ladder: start with a few lines of Ruby in `config/initializers/avo.rb` (`config.appearance = { … }`, **no build step**), and only drop to CSS or ejected views when the Ruby layer can't express what you want. **Almost every branding request is satisfied by `config.appearance` alone** — reach for CSS last.
 
 Files you'll touch, from shallowest to deepest:
 
@@ -34,7 +34,7 @@ Authoritative docs — fetch on demand, verify option names against them (and th
 
 **Explicit (Avo named):** "set `config.appearance`", "change Avo's logo / logomark / favicon", "set the Avo accent/neutral palette", "lock the Avo theme", "restrict the appearance picker", "persist Avo appearance to the database", "override Avo CSS variables", "eject the `:head` partial", "set an icon on this Avo menu item".
 
-**Implicit (product-shaped, no mention of Avo):** "brand the admin with our logo and colors", "make the admin match our brand", "add our company logo / a favicon", "the admin should default to dark mode" / "support dark mode", "let users switch themes" / "lock it so they can't", "remember each user's theme across devices", "change the accent/primary color" / "make the buttons blue", "change the sidebar/navbar background color", "give the admin a coastal / rose / 80s-sunset theme", "our admin looks too generic", "change the dashboard chart colors", "use a custom icon for this menu item".
+**Implicit (product-shaped, no mention of Avo):** "brand the admin with our logo and colors", "make the admin match our brand", "add our company logo / a favicon", "the admin should default to dark mode" / "support dark mode", "let users switch themes" / "lock it so they can't", "remember each user's theme across devices", "change the accent/primary color" / "make the buttons blue", "change the sidebar/navbar background color", "give the admin a coastal / rose / 80s-sunset theme", "our admin looks too generic", "change the dashboard chart colors", "use our brand's font in the admin" / "swap the typeface", "use a custom icon for this menu item".
 
 ## Workflow
 
@@ -173,7 +173,21 @@ config.appearance = {
 }
 ```
 
-### 7. Deep re-skin — CSS variables (only when `config.appearance` can't reach it)
+### 7. Change the font
+
+Two Tailwind theme variables carry the interface typeface: `--font-sans` (every screen) and `--font-mono` (code snippets, media library file details). Override either on `:root` in `avo-overrides.css` — no build step, and it re-fonts the whole admin at once:
+
+```css
+/* app/assets/stylesheets/avo-overrides.css */
+:root {
+  --font-sans: "IBM Plex Sans", system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+}
+```
+
+That's the whole change for a font the visitor's device already has. For a hosted or self-hosted family, load it first — a hosted font's `@import` goes at the **very top** of `avo-overrides.css` (CSS requires imports before any other rule) or its `<link>` tags go in an ejected `:head` partial; a self-hosted one gets a `@font-face` block in `avo-overrides.css` pointing at files under `public/fonts/`. Avo sets text at weights 400, 500, 600, and 700 — load all four (or a variable font covering that range) or the browser synthesizes the missing ones. Full walkthrough with font-service URLs: [Change the font](https://docs.avohq.io/4.0/theming.html#change-the-font).
+
+### 8. Deep re-skin — CSS variables (only when `config.appearance` can't reach it)
 
 Navbar background, sidebar surfaces, table row hover/selected, focus ring, and motion speeds aren't routed through Ruby — they're CSS custom properties. Avo's whole look is variable-driven, so overriding a handful re-skins everything with **no build step**. Put light-mode values on `:root`, dark-mode overrides on `.dark`.
 
@@ -207,7 +221,7 @@ bin/rails generate avo:eject --partial :head
 
 The full variable list (navbar, sidebar, table, focus ring, motion) with defaults lives in the CSS variables section of `appearance-api.md` — fetch it before writing component-level overrides. For named-theme requests ("coastal", "rose", "80s sunset"), work in `avo-overrides.css` with matching `:root` and `.dark` values.
 
-### 8. Icons (menu items, actions)
+### 9. Icons (menu items, actions)
 
 Anywhere Avo takes an `icon:`, pass a path string. **Prefer Tabler in v4** (`tabler/outline/<name>` or `tabler/filled/<name>`); Heroicons (`heroicons/outline/<name>`, also `solid`/`mini`/`micro`) are legacy-supported. Your own SVGs go in `app/assets/svgs/` and are referenced by filename.
 
@@ -239,12 +253,14 @@ For **populating menu/resource icons at scale** (migrations, whole-sidebar passe
 | `load_settings` / `save_settings` | DB persistence blocks | Proc; needs a JSON/JSONB column |
 | `chart_colors` | Dashboard chart palette | Array of **hex** Strings |
 
-CSS-only knobs (navbar/sidebar/table/focus/motion variables) are not in this hash — see step 7 and `appearance-api.md`.
+CSS-only knobs (fonts, navbar/sidebar/table/focus/motion variables) are not in this hash — see steps 7-8 and `appearance-api.md`.
 
 ## Gotchas
 
 - **`neutral:` / `accent:` must be Symbols.** A String or Hash raises `ArgumentError`. Custom colors go through `neutral_colors:` / `accent_colors:`, and you must also set `neutral: :brand` / `accent: :brand` (or list `"brand"` in `neutrals:`/`accents:`) to select the custom palette.
 - **`neutral_colors` needs all 12 shades; `accent_colors` needs all 3 tokens.** A missing or `nil` value raises `ArgumentError`.
+- **Load all four font weights.** Avo sets text at 400, 500, 600, and 700 — load fewer (or a variable font that doesn't cover the range) and the browser synthesizes the missing weights instead of rendering the real ones.
+- **A hosted font's `@import` must be the first rule in `avo-overrides.css`.** CSS requires `@import` before any other rule in the file; put the `--font-sans`/`--font-mono` override below it, not above.
 - **The navbar is dark in both modes.** The `logo` must read on a dark surface. `logo_dark` is for whole-UI dark mode, not navbar contrast.
 - **`chart_colors` must be hex.** They're passed straight to Chart.js — `oklch()`/`rgb()` won't work there (even though the palettes accept them).
 - **`avo-overrides.css` is served as-is, NOT through the Tailwind build.** Only put plain CSS + variable overrides there — no `@apply`, no arbitrary values. Tailwind directives for your *own* custom UI belong in `app/assets/stylesheets/avo/` (which IS built). See the avo-custom-ui skill.

--- a/lib/avo/skills/avo-i18n/SKILL.md
+++ b/lib/avo/skills/avo-i18n/SKILL.md
@@ -77,7 +77,7 @@ es:
         description: "Los usuarios de la aplicación"
 ```
 
-`description` fills the resource's panel description and, per the cascade, beats `self.description` on the class.
+`description` fills the resource's panel description and, per the cascade, beats `self.description` on the class. Watch the one sharp edge: if `self.description` is a block reading `record` or `view`, don't add the key for that resource — a static translation replaces the block wholesale rather than layering under it.
 
 Omit `self.translation_key` and Avo derives it from the class name, **namespace included** — `Avo::Resources::Galaxy::Planet` defaults to `avo.resource_translations.galaxy/planet`. So for a plain resource you often only need the YAML, no Ruby change.
 

--- a/lib/avo/skills/avo-resources/SKILL.md
+++ b/lib/avo/skills/avo-resources/SKILL.md
@@ -119,7 +119,7 @@ class Avo::Resources::User < Avo::BaseResource
 end
 ```
 
-Avo also resolves `description` below the resource's translation key — `avo.resource_translations.user.description` supplies the User resource description. Per the cascade, the locale file **wins** and `self.description` is the fallback, so an app can keep an English default in code and translate over it — **avo-i18n**.
+Avo also resolves `description` below the resource's translation key — `avo.resource_translations.user.description` supplies the User resource description. Per the cascade, the locale file **wins** and `self.description` is the fallback, so an app can keep an English default in code and translate over it — **avo-i18n**. Skip that key for a resource whose `self.description` is a block reading `record` or `view`: the locale string replaces the block wholesale rather than falling back to it.
 
 - `self.description` is rendered as **raw HTML** — never feed it user-editable data (stored-XSS risk). A block gets `record`, `resource`, `view`, `current_user`, `params`.
 - `self.color` takes a Symbol or String from Avo's palette — `red`, `orange`, `amber`, `yellow`, `lime`, `green`, `emerald`, `teal`, `cyan`, `sky`, `blue`, `indigo`, `violet`, `purple`, `fuchsia`, `pink`, `rose`. It tints the icon **stroke only** (label and hover/active backgrounds stay neutral), adapts to light and dark themes, and an unknown name silently renders the neutral icon. The tint follows the resource to its breadcrumb initials chip and, with Advanced Search installed, to the resource group headers in global search results. A `color:` on the menu entry overrides it.

--- a/lib/avo/skills/avo-troubleshoot/SKILL.md
+++ b/lib/avo/skills/avo-troubleshoot/SKILL.md
@@ -87,6 +87,7 @@ grep -rn "explicit_authorization" "$(bundle show avo)/lib"
 | License won't validate / status page errors | Key not set on the server; check the status page | [↓](#license-wont-validate) |
 | Tests fail after adding/upgrading Avo (`WebMock::NetConnectNotAllowedError`) | v4's outbound license check to `clerk-*.avohq.io` is blocked | [↓](#tests-fail-after-adding-or-upgrading-avo) |
 | `bundle install` can't fetch `avo-*` / 401 / 403 | packager.dev token not seen by Bundler, or a blocked host in sandboxes | [↓](#bundle-install-cant-fetch-avo--gems) |
+| `unknown keyword: quirks_mode` after adding Avo (often in `assets:precompile`) | Adding Avo pulled json 3.x into the lock; ActiveSupport below 8.1 can't use it | [↓](#unknown-keyword-quirks_mode-after-adding-avo) |
 | Exploded / missing icons, or other odd behavior after a version bump | Silent v4 behavior changes and renames | [↓](#v3--v4-upgrade) |
 
 ### A field / resource / action / filter isn't showing
@@ -261,6 +262,36 @@ Paid add-on gems are served from `packager.dev` and need a **Gem Server Token** 
 - **v4 gem split.** In Avo 4 each feature ships as its own add-on gem (`avo-dashboards`, `avo-menu`, `avo-advanced_search`, `avo-authorization`, `avo-record_reordering`, `avo-dynamic_filters`, `avo-nested`, …); the legacy v3 bundle gems (`avo-pro`, `avo-advanced`) are gone. If a feature vanished after upgrading, you likely need to add its specific gem. See the upgrade section.
 
 → `gem-server-authentication.html`
+
+### `unknown keyword: quirks_mode` after adding Avo
+
+The app worked, you added Avo, and now something raises:
+
+```
+ArgumentError: unknown keyword: quirks_mode
+  json-3.x/lib/json/common.rb:… in 'JSON.generate'
+  activesupport-7.x/lib/active_support/json/encoding.rb:… in 'JSONGemEncoder#stringify'
+```
+
+**This is not an Avo bug, and the fix is one line.** Every ActiveSupport below **8.1.0** encodes JSON with `JSON.generate(..., quirks_mode: true)`. **json 3.0 removed that keyword**, so on Rails < 8.1 any ActiveSupport JSON encode raises the moment json 3.x is the resolved version. It commonly surfaces during `assets:precompile` (Propshaft writes its manifest with `to_json`), but it can hit any `to_json` / `render json:` path.
+
+Avo is the trigger, not the cause. Most apps have **no `json` entry in `Gemfile.lock`** — they use the json that ships with Ruby as a default gem (2.x). Avo depends on `pagy`, and pagy declares `json >= 0`; adding Avo materializes `json` into the lock, and Bundler resolves it to the newest release.
+
+Two fixes:
+
+```ruby
+# Gemfile — staying on Rails < 8.1: pin json to what you had before
+gem "json", "< 3"
+```
+
+or upgrade to **Rails 8.1+**, where ActiveSupport no longer passes the keyword and json 3.x is fine.
+
+Confirm which version you resolved, and what dragged it in:
+
+```bash
+bundle list | grep -E "json|activesupport"   # which versions actually resolved
+grep -n -B4 '^      json' Gemfile.lock       # which gem asked for it (expect pagy)
+```
 
 ---
 

--- a/lib/avo/skills/docs-index.json
+++ b/lib/avo/skills/docs-index.json
@@ -1,7 +1,7 @@
 {
   "repo": "avo-hq/docs.avohq.io",
   "docs_path": "docs/4.0",
-  "commit": "ee0277f1883e8a01c9d20503e05aa9f26170e93e",
-  "date": "2026-08-31",
+  "commit": "04da9372af97d0d506bd8107a5d3071cc8e09bc9",
+  "date": "2026-09-11",
   "note": "The docs commit these skills were last indexed from. Run ruby lib/avo/skills/bin/docs_drift.rb to see what changed since, and --update after a refresh."
 }


### PR DESCRIPTION
# Description

Routine reconciliation of the shipped skills in `lib/avo/skills/` against docs drift since the last-indexed docs commit (`ee0277f1` → `04da937`, 2026-08-31 → 2026-09-11). Generated via `lib/avo/skills/bin/docs_drift.rb`; no functional code changes.

## Changed docs pages and what happened

| Changed page | Skills citing it | What changed |
| --- | --- | --- |
| `theming.md` | `avo-branding-appearance` | Added new "Change the font" step (7) to the theming ladder, renumbered the following two steps, added two gotchas (load all four weights; `@import` must lead the stylesheet), and extended the frontmatter description / trigger phrases to cover fonts/typeface requests. |
| `appearance-api.md` | `avo-branding-appearance` | Same edit as above — the new `--font-sans` / `--font-mono` CSS variables are what the new step documents. |
| `i18n.md` | `avo-associations`, `avo-i18n` | `avo-i18n`: added the one sharp edge docs called out — a `self.description` block reading `record`/`view` is replaced wholesale by the locale key, not layered under it. `avo-associations`'s citation is a generic pointer unaffected by this change — left as is. |
| `resources-api.md` | `avo-controllers`, `avo-performance`, `avo-resources` | Same sharp-edge note added to `avo-resources`, next to where it already documents the resource-description locale key. `avo-controllers`/`avo-performance` cite this page for unrelated options (`after_create_path`, `cache_hash`) — left as is. |
| `basic-filters.md` | `avo-filters` | No change needed — the skill's existing gotcha ("`encode_filters` only applies filters the resource declares") already states the same fact the docs update generalized; nothing new to add. |
| `actions.md` | `avo-actions` | No change needed — the skill's existing gotcha ("Records deleted after selection are omitted") already covers this exactly. |
| `upgrade.md` | `avo-update` | No change needed — the new 4.3.0 section (avo-api token scopes renamed to entitlements) is a normal versioned upgrade-guide entry; the skill's generic "fetch and apply the guide section by section" workflow already handles it without needing a version-specific mention. |
| `ai.md` | *(not cited by any skill)* | No owning skill exists; flagged below rather than guessed at. |
| `custom-controls.md`, `custom-controls-api.md` | *(not cited by any core skill)* | Owned by the paid `avo-custom_controls` add-on, whose skill ships from its own gem in `avo-hq/workspace`, out of scope for this repo. Flagged for that gem's maintainers. |
| `rest-api.md`, `rest-api-api.md` (new) | *(not cited by any core skill)* | Owned by the paid `avo-api` add-on, same as above — out of scope here, flagged for that gem. |

## Skills edited

- `lib/avo/skills/avo-branding-appearance/SKILL.md`
- `lib/avo/skills/avo-i18n/SKILL.md`
- `lib/avo/skills/avo-resources/SKILL.md`

## Skills reviewed, left unchanged

`avo-actions`, `avo-associations`, `avo-controllers`, `avo-filters`, `avo-performance`, `avo-update` — each checked against its cited page's diff; the fact was already correctly stated, or the docs change didn't touch anything the skill claims.

## Unresolved / follow-up for others

- `ai.md` changed (chat pages carry no page origin) but no shipped skill here covers Avo's AI/assistant feature — nothing to reconcile against.
- `custom-controls.md` / `custom-controls-api.md` changed (`action` controls now honor `visible`/`authorize`) — belongs to `avo-custom_controls`'s own skill in the workspace monorepo.
- `rest-api.md` / `rest-api-api.md` changed and a new `rest-api-api.md` page was added (scopes renamed to entitlements) — belongs to `avo-api`'s own skill in the workspace monorepo.

`lib/avo/skills/docs-index.json` is bumped to `04da9372af97` (2026-09-11) regardless, per the runbook, so the next drift run starts from a small diff.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (this PR *is* the doc-adjacent skill sync)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A, no code changed
- [ ] I tested the design in Light and Dark mode, and all default themes — N/A, no UI changed

## Manual review steps

1. `grep -rnE "\[!code|:::|<Option|``&lt;Image|&lt;CustomCode|&lt;FieldTypesList``" lib/avo/skills/` — empty (no VitePress artifacts pasted into skills)
2. `bundle exec rspec spec/lib/avo/skills` — 167 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013KHncuxjerZcUS6sDwqga9

---
_Generated by [Claude Code](https://claude.ai/code/session_013KHncuxjerZcUS6sDwqga9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown skill and CI workflow changes only; no runtime Avo product code paths are modified.
> 
> **Overview**
> Reconciles **shipped agent skills** in `lib/avo/skills/` with docs through commit `04da937` (2026-09-11), and keeps the **Tailwind integration CI** working on Rails 7.1 when Avo is added from the PR ref.
> 
> **Branding skill** now documents **custom fonts** via `--font-sans` / `--font-mono` in `avo-overrides.css` (new step 7), renumbers deep re-skin and icons, and adds font-related triggers and gotchas (weights 400–700, `@import` ordering).
> 
> **i18n and resources skills** warn that a static `avo.resource_translations.*.description` **replaces** a dynamic `self.description` block—it does not fall back to it.
> 
> **Troubleshoot skill** adds a symptom row and section for **`ArgumentError: unknown keyword: quirks_mode`** when Avo pulls **json 3.x** via pagy on Rails &lt; 8.1, with **`gem "json", "< 3"`** or Rails 8.1+ as fixes.
> 
> **CI:** the Tailwind test workflow runs **`bundle add "json" --version "< 3"`** before adding Avo so `assets:precompile` does not fail on Propshaft’s manifest JSON encode.
> 
> **`docs-index.json`** is bumped to the new docs commit so the next drift run starts from a small diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdf901802dc36bc5fc11469eeb8c8af625c3d225. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->