### PR TITLE
Sync shipped skills with docs through bafd4f3 (2026-09-12)

### DIFF
--- a/lib/avo/skills/avo-branding-appearance/SKILL.md
+++ b/lib/avo/skills/avo-branding-appearance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: avo-branding-appearance
-description: Brand and theme an Avo admin panel — logos, favicon, color scheme, neutral/accent palettes, chart colors, per-user theme persistence, deep CSS re-skinning, and menu/action icons — starting from the no-build `config.appearance` path in `config/initializers/avo.rb`. Use when the user wants to "brand the admin with our logo and colors", "make the admin match our brand", "add our company logo", "add a favicon", "make the admin default to / support dark mode", "let users switch themes" or "lock the theme", "remember each user's theme", "change the accent/primary color" or "make the buttons blue", "change the sidebar/navbar background", "give the admin a coastal/rose/sunset theme", "our admin looks too generic", "change the dashboard chart colors", or "use a custom icon for this menu item" — whether or not they name Avo.
+description: Brand and theme an Avo admin panel — logos, favicon, color scheme, neutral/accent palettes, chart colors, fonts, per-user theme persistence, deep CSS re-skinning, and menu/action icons — starting from the no-build `config.appearance` path in `config/initializers/avo.rb`. Use when the user wants to "brand the admin with our logo and colors", "make the admin match our brand", "add our company logo", "add a favicon", "make the admin default to / support dark mode", "let users switch themes" or "lock the theme", "remember each user's theme", "change the accent/primary color" or "make the buttons blue", "change the sidebar/navbar background", "give the admin a coastal/rose/sunset theme", "our admin looks too generic", "change the dashboard chart colors", "use a different font / typeface", "change the admin's font", or "use a custom icon for this menu item" — whether or not they name Avo.
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash, WebFetch
 metadata:
   requires-gem: none — Community
@@ -207,6 +207,17 @@ bin/rails generate avo:eject --partial :head
 
 The full variable list (navbar, sidebar, table, focus ring, motion) with defaults lives in the CSS variables section of `appearance-api.md` — fetch it before writing component-level overrides. For named-theme requests ("coastal", "rose", "80s sunset"), work in `avo-overrides.css` with matching `:root` and `.dark` values.
 
+**Fonts** are two of those variables — `--font-sans` (all interface text) and `--font-mono` (code snippets, media library file details). Override `--font-sans` on `:root` in `avo-overrides.css` and the whole admin follows, no build step:
+
+```css
+/* app/assets/stylesheets/avo-overrides.css */
+:root {
+  --font-sans: "IBM Plex Sans", system-ui, sans-serif;
+}
+```
+
+That's the whole change for a font the visitor's device already has. For anything else, load the font first — either `@import` a hosted stylesheet at the very top of `avo-overrides.css` (before any other rule) or `<link>` it from the ejected `:head` partial, then self-host with `@font-face` + files under `public/fonts/` as a third option. Avo renders text at weights 400/500/600/700, so load all four (or a variable font covering that range) or the browser synthesizes the missing weights. Full walkthrough (font services, CSP note, self-hosting): `theming.md#change-the-font`.
+
 ### 8. Icons (menu items, actions)
 
 Anywhere Avo takes an `icon:`, pass a path string. **Prefer Tabler in v4** (`tabler/outline/<name>` or `tabler/filled/<name>`); Heroicons (`heroicons/outline/<name>`, also `solid`/`mini`/`micro`) are legacy-supported. Your own SVGs go in `app/assets/svgs/` and are referenced by filename.
@@ -239,7 +250,7 @@ For **populating menu/resource icons at scale** (migrations, whole-sidebar passe
 | `load_settings` / `save_settings` | DB persistence blocks | Proc; needs a JSON/JSONB column |
 | `chart_colors` | Dashboard chart palette | Array of **hex** Strings |
 
-CSS-only knobs (navbar/sidebar/table/focus/motion variables) are not in this hash — see step 7 and `appearance-api.md`.
+CSS-only knobs (navbar/sidebar/table/focus/motion variables, `--font-sans`/`--font-mono`) are not in this hash — see step 7 and `appearance-api.md`.
 
 ## Gotchas
 
@@ -247,6 +258,7 @@ CSS-only knobs (navbar/sidebar/table/focus/motion variables) are not in this has
 - **`neutral_colors` needs all 12 shades; `accent_colors` needs all 3 tokens.** A missing or `nil` value raises `ArgumentError`.
 - **The navbar is dark in both modes.** The `logo` must read on a dark surface. `logo_dark` is for whole-UI dark mode, not navbar contrast.
 - **`chart_colors` must be hex.** They're passed straight to Chart.js — `oklch()`/`rgb()` won't work there (even though the palettes accept them).
+- **A hosted font's `@import` must be the very first rule in `avo-overrides.css`.** CSS requires imports before anything else; put the `--font-sans`/`--font-mono` override below it. Missing a loaded weight (400/500/600/700) makes the browser synthesize it — check the CSP's `font-src`/`style-src` when the font comes from a third-party host.
 - **`avo-overrides.css` is served as-is, NOT through the Tailwind build.** Only put plain CSS + variable overrides there — no `@apply`, no arbitrary values. Tailwind directives for your *own* custom UI belong in `app/assets/stylesheets/avo/` (which IS built). See the avo-custom-ui skill.
 - **DB persistence needs a JSONB column and BOTH blocks**, and `save_settings` gets a **partial** `settings` Hash (only the changed keys) — `deep_merge`, never overwrite the whole preferences blob.
 - **`config.branding` was renamed to `config.appearance` in Avo 4.** On a v3 app you may find `config.branding = { … }` — migrate it into `config.appearance`.

--- a/lib/avo/skills/avo-i18n/SKILL.md
+++ b/lib/avo/skills/avo-i18n/SKILL.md
@@ -265,9 +265,9 @@ bin/rails runner 'puts I18n.t("avo").select { |_, v| v.is_a?(String) }.keys.sort
 
 Don't reach for `bin/rails generate avo:locales` just to look — it copies Avo's locale files into `config/locales`, pinning today's wording into the app. Run it only when editable copies are actually wanted. Full rule and the worked collision: https://docs.avohq.io/4.0/i18n.md#safe-keys
 
-### Add-on gems ship English only
+### Add-on gems: most ship English only
 
-The locale generator covers Avo core. Each add-on keeps its strings under its own namespace inside `avo.*` and ships **English only** — every other language is the app's to supply, in a file per gem or one file carrying all of them (they deep-merge into the same tree).
+The locale generator covers Avo core. Each add-on keeps its strings under its own namespace inside `avo.*`. Most ship **English only** — every other language is the app's to supply, in a file per gem or one file carrying all of them (they deep-merge into the same tree). A gem that ships more says so on its own Localization page.
 
 | Gem | Namespace |
 | --- | --- |
@@ -277,9 +277,13 @@ The locale generator covers Avo core. Each add-on keeps its strings under its ow
 | Dynamic Filters | `avo.dynamic_filters.*` |
 | Forms & Pages | `avo.forms.*` |
 | Intelligence | `avo.intelligence.*` |
+| REST API | `avo.api.token.*` |
 | Scopes | `avo.scopes.*` |
 
-Advanced Search is the exception that needs no locale file: everything it renders is under `avo.global_search.*` or is `avo.all`, and core translates all of them in each bundled locale. Four of those — `avo.global_search.direct_match`, `.search_results`, `.searching_on` and `avo.all` — only reached core's locale files **after 4.1.6**; on `4.1.6` and earlier they fall back to English, so define them in the app's own locale file until it's on a newer Avo.
+Two exceptions ship fully translated, no locale file needed from the app:
+
+- **Advanced Search** — everything it renders is under `avo.global_search.*` or is `avo.all`, and core translates all of them in each bundled locale. Four of those — `avo.global_search.direct_match`, `.search_results`, `.searching_on` and `avo.all` — only reached core's locale files **after 4.1.6**; on `4.1.6` and earlier they fall back to English, so define them in the app's own locale file until it's on a newer Avo.
+- **REST API** (`avo-api`) — ships `avo.api.token.*` in every locale core does, so the tokens panel is translated with no work from you.
 
 ## Key options
 

--- a/lib/avo/skills/docs-index.json
+++ b/lib/avo/skills/docs-index.json
@@ -1,7 +1,7 @@
 {
   "repo": "avo-hq/docs.avohq.io",
   "docs_path": "docs/4.0",
-  "commit": "ee0277f1883e8a01c9d20503e05aa9f26170e93e",
-  "date": "2026-08-31",
+  "commit": "bafd4f3b71c9a57e0aedfe0a8773df9e01146e85",
+  "date": "2026-09-12",
   "note": "The docs commit these skills were last indexed from. Run ruby lib/avo/skills/bin/docs_drift.rb to see what changed since, and --update after a refresh."
 }

--- a/lib/avo/skills/index.md
+++ b/lib/avo/skills/index.md
@@ -32,7 +32,7 @@ Each entry is a directory beside this file: `<skill>/SKILL.md`.
 
 | Skill | Covers |
 | --- | --- |
-| `avo-branding-appearance` | Logo, favicon, color scheme, palettes, CSS re-skin, icons |
+| `avo-branding-appearance` | Logo, favicon, color scheme, palettes, fonts, CSS re-skin, icons |
 | `avo-menu-icons` | Pick the right Tabler icon and apply it to resources. The menu DSL is `avo-menu`'s own skill |
 | `avo-navigation-search` | Per-resource search, breadcrumbs, keyboard shortcuts, the auto-generated sidebar |
 | `avo-custom-ui` | Custom pages, embedded panels, dynamic/nested forms, ejected views, Stimulus, Tailwind |


### PR DESCRIPTION
# Description

Routine reconciliation of `lib/avo/skills/*/SKILL.md` against docs drift in `avo-hq/docs.avohq.io`, per `lib/avo/skills/docs-index.json`. Docs moved from `ee0277f` (2026-08-31) to `bafd4f3` (2026-09-12); `lib/avo/skills/bin/docs_drift.rb` flagged 15 changed pages under `docs/4.0`, 6 of them cited by shipped skills.

| Changed page | Skills citing it | What changed |
| --- | --- | --- |
| `actions.md` | `avo-actions` | No change needed — the skill's "Records deleted after selection are omitted" gotcha already matches the new docs note verbatim. |
| `basic-filters.md` | `avo-filters` | No change needed — the skill's "`encode_filters` only applies filters the resource declares" gotcha already matches. |
| `i18n.md` | `avo-associations`, `avo-i18n` | Resource `description` locale key: already documented in `avo-i18n` (step 2 + Key options). `avo-api`'s REST API tree ships fully translated (not English-only like its siblings) — added a row + exception note to `avo-i18n`'s add-on gems table. `avo-associations` only links the page in passing; unaffected. |
| `appearance-api.md` + `theming.md` | `avo-branding-appearance` | New feature: `--font-sans` / `--font-mono` CSS variables and the "Change the font" workflow (hosted vs. self-hosted, weight loading). Added as a subsection under the CSS re-skin step, plus a gotcha and description/index.md triggers. |
| `rails-engines-paths.md` | `avo-engine-internals` | New MCP Server row in the per-gem mount-point table. No change needed — the skill only documents the generic `avo.`/`main_app.` prefix convention and never mirrored that per-gem table. |
| `resources-api.md` | `avo-controllers`, `avo-performance`, `avo-resources` | Same resource `description` key as above — already documented in `avo-resources` (line 122). The other two only link the page in passing; unaffected. |
| `upgrade.md` | `avo-update` | New 4.2.0/4.3.0 sections (`avo-api` tokens, the scopes→entitlements rename). No change needed — `avo-update` fetches the live guide via WebFetch and never hardcodes per-version content; its one illustrative example (resource-description translation cascade) is already accurate. |

## Skills edited

- `avo-branding-appearance` — added fonts.
- `avo-i18n` — added the REST API exception to the add-on gems table.
- `index.md` — mentions fonts in `avo-branding-appearance`'s one-line summary.
- `docs-index.json` — baseline bumped to `bafd4f3` (2026-09-12).

## Skills reviewed, left alone

`avo-actions`, `avo-filters`, `avo-resources` (already reconciled with these pages by earlier work), `avo-associations`, `avo-controllers`, `avo-performance`, `avo-engine-internals`, `avo-update`.

## Out of scope — add-on-owned pages, not reconciled here

These changed/new pages belong to add-on gems that ship their own skills (per `package-map.md`), or to a gem with no skill yet:

- `ai.md` — owned by `avo-ai`'s own skill (`avo-ai-tools`).
- `custom-controls.md`, `custom-controls-api.md` — owned by `avo-custom_controls`'s own skill (`avo-custom-controls`); the change is "`action` controls honor `visible` and `authorize`".
- `rest-api.md`, `rest-api-api.md` (new) — owned by `avo-api`'s own skill (`avo-rest-api`); the change is the scopes→entitlements rename and the new API reference page.
- `mcp.md`, `mcp-api.md` (new) — **gap**: `avo-mcp_server` is a new add-on with no shipped skill and no entry in `package-map.md` yet. Flagging rather than creating one, per scope.

## Checklist

- [x] I have performed a self-review of my own change
- [x] `grep -rnE "\[!code|:::|<Option|``&lt;Image|&lt;CustomCode|&lt;FieldTypesList" lib/avo/skills/"' — clean, no VitePress artifacts·- [x] 'bundle exec rspec spec/lib/avo/skills' — 167 examples, 0 failures·- [ ] Documentation — N/A, this PR only edits gem-shipped skills, not 'docs/4.0'·- [ ] Screenshots — N/A, no UI change``

## Manual review steps

1. `AVO_DOCS_PATH=<docs checkout> ruby lib/avo/skills/bin/docs_drift.rb` from a fresh `avo` checkout on this branch → should print "Up to date".
2. Read the diff on `avo-branding-appearance/SKILL.md` and `avo-i18n/SKILL.md` against the linked docs commits above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxbrZ3m6VvDoG3C1AovhxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxbrZ3m6VvDoG3C1AovhxA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only updates under `lib/avo/skills/` with no application or runtime code changes.
> 
> **Overview**
> Reconciles gem-shipped Avo agent skills with **docs.avohq.io** through commit `bafd4f3` (2026-09-12), updating `docs-index.json` and editing three skills plus the skills index.
> 
> **`avo-branding-appearance`** now documents custom admin fonts via `--font-sans` / `--font-mono` in `avo-overrides.css` (hosted `@import`, ejected `:head`, self-hosting, weight 400–700), with matching description triggers, key-options note, and a font `@import` gotcha.
> 
> **`avo-i18n`** and **`avo-resources`** clarify that `avo.resource_translations.*.description` **always** overrides `self.description`, including block-based per-record/per-view descriptions—apps needing dynamic text should omit the locale key. **`avo-i18n`** also lists REST API (`avo.api.token.*`) in the add-on namespace table and documents it alongside Advanced Search as add-ons that ship full locale coverage, not English-only.
> 
> **`index.md`** mentions fonts under the branding skill summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c30e8710df0d7fc6d78a147c8c6d746b084fad7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->